### PR TITLE
Fixed Missing Return Statement

### DIFF
--- a/at_secondary/at_secondary_server/lib/src/server/at_secondary_config.dart
+++ b/at_secondary/at_secondary_server/lib/src/server/at_secondary_config.dart
@@ -569,7 +569,7 @@ class AtSecondaryConfig {
 
   static bool _getBoolEnvVar(String envVar) {
     if (_envVars.containsKey(envVar)) {
-      (_envVars[envVar].toLowerCase() == 'true') ? true : false;
+      return _envVars[envVar].toLowerCase() == 'true';
     }
     return null;
   }


### PR DESCRIPTION
Fixed missing return statement in at_secondary/at_secondary_server/lib/src/server/at_secondary_config.dart.

This issue would only be observed when the configuration is read from environment variables.