### PR TITLE
Improved YAML parser for correct quotes on strings

### DIFF
--- a/.github/workflows/at_server_trunk.yaml
+++ b/.github/workflows/at_server_trunk.yaml
@@ -245,13 +245,13 @@ jobs:
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip
-          pip3 install jproperties pyyaml argparse
+          pip3 install jproperties ruamel.yaml argparse
 
       # Generates the config.yaml for staging environment
       - name: Generates configuration file
         working-directory: at_secondary/at_secondary_server/config
         run: |
-          echo "root_server.url='${{ secrets.root_server_url }}'" >> config-environment.properties
+          echo "root_server.url=${{ secrets.root_server_url }}" >> config-environment.properties
           chmod +x generate_config.py
           python3 generate_config.py -e environment
 
@@ -265,6 +265,7 @@ jobs:
           tags: |
             atsigncompany/secondary:dev_env
             atsigncompany/secondary:dess_wtf
+            atsigncompany/secondary:dev_env-${{ env.BRANCH }}-gha${{ github.run_number }}
           platforms: |
             linux/amd64
             linux/arm64/v8

--- a/at_secondary/at_secondary_server/config/generate_config.py
+++ b/at_secondary/at_secondary_server/config/generate_config.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python3
 """
 Generates the config.yaml from the config-base.yaml
 The default values in the configurations can be overridden by creating an
@@ -10,7 +11,8 @@ Example:
             python3 generate_config.py -e development
 """
 import argparse
-import yaml
+# pip3 install ruamel.yaml
+import ruamel.yaml
 # pip3 install jproperties
 from jproperties import Properties
 
@@ -35,7 +37,7 @@ except OSError as os:
 
 try:
     with open("config-base.yaml", "r") as yamlFile:
-        yamlMap = yaml.load(yamlFile, Loader=yaml.FullLoader)
+        yamlMap = ruamel.yaml.round_trip_load(yamlFile, preserve_quotes=True)
         # Loop on each of the property in config properties.
         for key in configs.properties:
             fields = key.split('.')
@@ -56,7 +58,7 @@ except OSError as os:
 # write to config file.
 try:
     with open('config.yaml', 'w') as file:
-        documents = yaml.dump(yamlMap, file)
+        documents = ruamel.yaml.round_trip_dump(yamlMap, file, explicit_start=True)
         print('Generated config.yaml file for ' + environment + ' environment successfully.')
     file.close()
 except OSError as os:


### PR DESCRIPTION
closes #150 

**- What I did**

Switched out the PyYAML parser (which handles YAML 1.1) for  ruamel.yaml (which handles YAML 1.2) in generate_config.py and in the pip3 dependencies of the GitHub Action.

Re-added `#!/usr/bin/python3` to start of generate_config.py

Remove quotes from URL when creating environment properties file in GitHub Action.

**- How I did it**

Edits in VSCode and local testing in WSL2

**- How to verify it**

1. cd to config directory
2. `echo "root_server.url=root.atsign.wtf" >> config-environment.properties`
3. `./generate_config.py -e environment`
4. `cat config.yaml | grep url`

Inspect generated config.yaml to confirm correct quote placement:

```yaml
# The @Protocol root server configuration
root_server:
  # The port to connect to root server
  port: 64
  # The url to connect to root server
  url: 'root.atsign.wtf'
```

**- Description for the changelog**

Improved YAML parser for correct quotes on strings