### PR TITLE
don't automate secondary:dev_env

### DIFF
--- a/.github/workflows/at_server_trunk.yaml
+++ b/.github/workflows/at_server_trunk.yaml
@@ -256,6 +256,8 @@ jobs:
           python3 generate_config.py -e environment
 
       # Builds and pushes the secondary server image to docker hub.
+      # atsigncompany/secondary:dev_env removed until we have confidence
+      # in the new slim build
       - name: Build and push secondary image for amd64 and arm64
         id: docker_build_secondary
         uses: docker/build-push-action@v2.4.0
@@ -263,7 +265,6 @@ jobs:
           push: true
           context: at_secondary
           tags: |
-            atsigncompany/secondary:dev_env
             atsigncompany/secondary:dess_wtf
             atsigncompany/secondary:dev_env-${{ env.BRANCH }}-gha${{ github.run_number }}
           platforms: |


### PR DESCRIPTION
**- What I did**

Remove secondary:dev_env build from automation - related to #152 

**- How I did it**

tag line moved to a comment

**- How to verify it**

once this PR is merged there will be a new build without dev_env being changed

**- Description for the changelog**

don't automate secondary:dev_env