### PR TITLE
Fix server start time

### DIFF
--- a/at_secondary/at_secondary_server/lib/src/server/at_secondary_impl.dart
+++ b/at_secondary/at_secondary_server/lib/src/server/at_secondary_impl.dart
@@ -247,15 +247,17 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
     // if certs are unavailable then retry max 10 minutes
     while (true) {
       try {
-        if (certsAvailable || retryCount > 60) {
-          break;
-        }
         secCon
             .useCertificateChain(serverContext.securityContext.publicKeyPath());
         secCon.usePrivateKey(serverContext.securityContext.privateKeyPath());
         secCon.setTrustedCertificates(
             serverContext.securityContext.trustedCertificatePath());
         certsAvailable = true;
+
+        if (certsAvailable || retryCount > 60) {
+          break;
+        }
+        
       } on FileSystemException {
         retryCount++;
         logger.info('certs unavailable. Retry count $retryCount');


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
The server, on startup will require SSL certificates to start a SecureSocket. It will retry for certificates if not found for every 10 seconds (sleeps for 10 seconds) for retryCount times.

I have fixed an issue where the server goes to sleep once even if the certificates are available.

**- How I did it**
Moved the break condition in the retry loop to appropriate place.

**- How to verify it**
You can start the server, and check the startup time. It will not take more than 5 seconds now.