### PR TITLE
revert secondary image to use thick build

### DIFF
--- a/.github/workflows/at_server_trunk.yaml
+++ b/.github/workflows/at_server_trunk.yaml
@@ -261,7 +261,7 @@ jobs:
         uses: docker/build-push-action@v2.4.0
         with:
           push: true
-          context: at_secondary
+          context: at_secondary/at_secondary_server
           tags: |
             atsigncompany/secondary:dev_env
             atsigncompany/secondary:dess_wtf


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did** Use the old docker file to build a thick secondary image

**- How I did it**

**- How to verify it** 

**- Description for the changelog** Revert secondary image to thick build.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->