### PR TITLE
Action to automate bug assignment to project board

### DIFF
--- a/.github/workflows/autobug.yaml
+++ b/.github/workflows/autobug.yaml
@@ -1,0 +1,23 @@
+name: Auto Assign Bugs to Sprint Planning Project Board
+
+on:
+  issues:
+    types: [labeled]
+  pull_request:
+    types: [labeled]
+env:
+  MY_GITHUB_TOKEN: ${{ secrets.MY_GITHUB_TOKEN }}
+
+jobs:
+  assign_one_project:
+    runs-on: ubuntu-latest
+    name: Assign to Bugs Column in Sprint Planning Project Board
+    steps:
+    - name: Assign issues and pull requests with `bug` label to project 3
+      uses: srggrs/assign-one-project-github-action@1.2.1
+      if: |
+        contains(github.event.issue.labels.*.name, 'bug') ||
+        contains(github.event.pull_request.labels.*.name, 'bug')
+      with:
+        project: 'https://github.com/orgs/atsign-foundation/projects/3'
+        column_name: 'Bugs'


### PR DESCRIPTION
First repo for #158 

**- What I did**

Added GitHub Action using [srggrs/assign-one-project-github-action](https://github.com/srggrs/assign-one-project-github-action)

**- How I did it**

Tested first in [javagone/bug_to_project](https://github.com/javagone/bug_to_project) then modified to target the [Sprint Planning Project Board](https://github.com/orgs/atsign-foundation/projects/3)

**- How to verify it**

Create a new issue, label it as a bug, wait for action to run, check that it's been added to the Bugs column of the Project Board.

**- Description for the changelog**

Action to automate bug assignment to project board