### PR TITLE
Refactored Dockerfile for FROM scratch approach to thin build

### DIFF
--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -310,7 +310,7 @@ jobs:
         uses: docker/build-push-action@v2.4.0
         with:
           push: true
-          context: at_secondary/at_secondary_server
+          context: at_secondary
           tags: |
             atsigncompany/secondary:dev_env
             atsigncompany/secondary:dess_wtf
@@ -361,9 +361,10 @@ jobs:
         uses: docker/build-push-action@v2.4.0
         with:
           push: true
-          context: at_secondary/at_secondary_server
+          context: at_secondary
           tags: |
             atsigncompany/secondary:dess
+            atsigncompany/secondary:prod
             atsigncompany/secondary:prod-gha${{ github.run_number }}
           platforms: |
             linux/amd64

--- a/at_secondary/Dockerfile
+++ b/at_secondary/Dockerfile
@@ -1,27 +1,30 @@
 FROM atsigncompany/buildimage AS buildimage
-WORKDIR /app
-COPY . .
-WORKDIR /app/build
-RUN ./build.sh
-# Set up the @ environment
-WORKDIR /app
 ENV HOME=/atsign
-RUN mkdir -p $HOME
-RUN mkdir -p /archive
 ENV USER_ID=1024
 ENV GROUP_ID=1024
-RUN addgroup --gid $GROUP_ID atsign
-RUN useradd --system --uid $USER_ID --gid $GROUP_ID --shell /bin/bash --home $HOME atsign
-RUN chown -R atsign:atsign $HOME
-RUN chown -R atsign:atsign /archive
-#USER atsign
-RUN mkdir $HOME/storage
-RUN mkdir $HOME/config
-COPY at_secondary_server/config/* $HOME/config/
-RUN chown -R atsign:atsign $HOME/storage
-WORKDIR $HOME
-# Now go slim with an almost scracth container
-FROM atsigncompany/runimage
+WORKDIR /app
+COPY . .
+RUN \
+  cd at_persistence_secondary_server ; \
+  dart pub get ; \
+  dart pub update ; \
+  cd ../at_secondary_server ; \
+  dart pub get ; \
+  dart pub update ; \
+  dart compile exe bin/main.dart -o secondary ; \
+  mkdir -p $HOME/storage ; \
+  mkdir -p $HOME/config ; \
+  mkdir -p /archive ; \
+  addgroup --gid $GROUP_ID atsign ; \
+  useradd --system --uid $USER_ID --gid $GROUP_ID --shell /bin/bash \
+  --home $HOME atsign ; \
+  chown -R atsign:atsign $HOME ; \
+  chown -R atsign:atsign /archive ; \
+  cp config/config.yaml $HOME/config/ ; \
+  cp pubspec.yaml $HOME/
+# Second stage of build FROM scratch
+FROM scratch
+COPY --from=buildimage /runtime/ /
 COPY --from=buildimage /etc/passwd /etc/passwd
 COPY --from=buildimage /etc/group /etc/group
 COPY --from=buildimage --chown=atsign:atsign /app/at_secondary_server/secondary /usr/local/at/


### PR DESCRIPTION
Closes #152 
Closes #149 
Closes #133 

**- What I did**

New Dockerfile based on approach documented for `FROM scratch` pattern with new official dart image

**- How I did it**

Based on structure of [atsign-company/at_dockerfiles/dartshowplatform/Dockerfile](https://github.com/atsign-company/at_dockerfiles/blob/main/dartshowplatform/Dockerfile) using steps from existing thin Dockerfile

Reverted #160 to use the new Dockerfile

Added :prod as a tag for when we push an image to prod.

**- How to verify it**

On a system with [dess](https://github.com/atsign-foundation/dess) installed and the .env variables exported

```bash
git clone git@github.com:cpswan/at_server.git
cd at_server/at_secondary
sudo docker build -t secondary:testthin .
sudo su atsign
docker run -v /home/atsign/atsign/etc/live/$DOMAIN:/atsign/certs:rw \
-v /home/atsign/atsign/etc/archive/$DOMAIN:/archive/$FQDN:rw \
-v /home/atsign/atsign/$ATSIGN:/atsign/storage:rw -p 6565:6565 \
secondary:testthin -a $ATSIGN -p $PORT -s $SECRET
```

NB this will create an image the points to root.atsign.com if you'd like to test against staging then edit config/config.yaml before doing the `docker build`

**- Description for the changelog**

Refactored Dockerfile for FROM scratch approach to thin build