### PR TITLE
backward compatibility for sync stream

### DIFF
--- a/at_secondary/at_secondary_server/lib/src/verb/handler/response/sync_stream_response_handler.dart
+++ b/at_secondary/at_secondary_server/lib/src/verb/handler/response/sync_stream_response_handler.dart
@@ -1,6 +1,6 @@
 import 'package:at_secondary/src/verb/handler/response/base_response_handler.dart';
 
-class SyncResponseHandler extends BaseResponseHandler {
+class SyncStreamResponseHandler extends BaseResponseHandler {
   @override
   String? getResponseMessage(String? verbResult, String prompt) {
     return '';

--- a/at_secondary/at_secondary_server/lib/src/verb/handler/sync_stream_verb_handler.dart
+++ b/at_secondary/at_secondary_server/lib/src/verb/handler/sync_stream_verb_handler.dart
@@ -1,0 +1,71 @@
+import 'dart:collection';
+import 'dart:convert';
+
+import 'package:at_commons/at_commons.dart';
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_secondary/src/server/at_secondary_impl.dart';
+import 'package:at_secondary/src/verb/handler/sync_verb_handler.dart';
+import 'package:at_secondary/src/verb/verb_enum.dart';
+import 'package:at_server_spec/at_server_spec.dart';
+import 'package:at_server_spec/at_verb_spec.dart';
+
+class SyncStreamVerbHandler extends SyncVerbHandler {
+  static SyncStream syncStream = SyncStream();
+
+  SyncStreamVerbHandler(SecondaryKeyStore? keyStore) : super(keyStore);
+
+  @override
+  bool accept(String command) =>
+      command.startsWith(getName(VerbEnum.sync) + ':');
+
+  @override
+  Verb getVerb() {
+    return syncStream;
+  }
+
+  @override
+  Future<void> processVerb(
+      Response response,
+      HashMap<String, String?> verbParams,
+      InboundConnection atConnection) async {
+    var commit_sequence = verbParams[AT_FROM_COMMIT_SEQUENCE]!;
+    var atCommitLog = await (AtCommitLogManagerImpl.getInstance()
+        .getCommitLog(AtSecondaryServerImpl.getInstance().currentAtSign));
+    var regex = verbParams[AT_REGEX];
+    var commit_changes =
+        atCommitLog?.getChanges(int.parse(commit_sequence), regex);
+    logger.finer(
+        'number of changes since commitId: $commit_sequence is ${commit_changes?.length}');
+    commit_changes?.removeWhere((entry) =>
+        entry.atKey!.startsWith('privatekey:') ||
+        entry.atKey!.startsWith('private:'));
+    if (regex != null && regex != 'null') {
+      logger.finer('regex for sync : $regex');
+      commit_changes
+          ?.removeWhere((entry) => !isRegexMatches(entry.atKey!, regex));
+    }
+    var distinctKeys = <String>{};
+    var syncResultList = [];
+    //sort log by commitId descending
+    commit_changes?.sort(
+        (entry1, entry2) => entry2.commitId!.compareTo(entry1.commitId!));
+    // for each latest key entry in commit log, get the value
+    if (commit_changes != null) {
+      await Future.forEach(commit_changes,
+          (dynamic entry) => processEntry(entry, distinctKeys, syncResultList));
+    }
+    logger.finer(
+        'number of changes after removing old entries: ${syncResultList.length}');
+    //sort the result by commitId ascending
+    syncResultList.sort(
+        (entry1, entry2) => entry1['commitId'].compareTo(entry2['commitId']));
+    if (syncResultList.isNotEmpty) {
+      syncResultList.forEach((element) {
+        logger.info('Syncing element on server ${element['atKey']}');
+        atConnection
+            .write('${jsonEncode(element).length}~${jsonEncode(element)}\$');
+      });
+    }
+    return;
+  }
+}

--- a/at_secondary/at_secondary_server/lib/src/verb/handler/sync_verb_handler.dart
+++ b/at_secondary/at_secondary_server/lib/src/verb/handler/sync_verb_handler.dart
@@ -16,7 +16,7 @@ class SyncVerbHandler extends AbstractVerbHandler {
 
   @override
   bool accept(String command) =>
-      command.startsWith(getName(VerbEnum.sync) + ':') && !command.contains('stream');
+      command.startsWith(getName(VerbEnum.sync) + ':') && !command.contains('sync:stream');
 
   @override
   Verb getVerb() {

--- a/at_secondary/at_secondary_server/lib/src/verb/handler/sync_verb_handler.dart
+++ b/at_secondary/at_secondary_server/lib/src/verb/handler/sync_verb_handler.dart
@@ -16,7 +16,7 @@ class SyncVerbHandler extends AbstractVerbHandler {
 
   @override
   bool accept(String command) =>
-      command.startsWith(getName(VerbEnum.sync) + ':');
+      command.startsWith(getName(VerbEnum.sync) + ':') && !command.contains('stream');
 
   @override
   Verb getVerb() {
@@ -42,7 +42,7 @@ class SyncVerbHandler extends AbstractVerbHandler {
     if (regex != null && regex != 'null') {
       logger.finer('regex for sync : $regex');
       commit_changes
-          ?.removeWhere((entry) => !_isRegexMatches(entry.atKey!, regex));
+          ?.removeWhere((entry) => !isRegexMatches(entry.atKey!, regex));
     }
     var distinctKeys = <String>{};
     var syncResultList = [];
@@ -51,28 +51,23 @@ class SyncVerbHandler extends AbstractVerbHandler {
         (entry1, entry2) => entry2.commitId!.compareTo(entry1.commitId!));
     // for each latest key entry in commit log, get the value
     if (commit_changes != null) {
-      await Future.forEach(
-          commit_changes,
-          (dynamic entry) =>
-              _processEntry(entry, distinctKeys, syncResultList));
+      await Future.forEach(commit_changes,
+          (dynamic entry) => processEntry(entry, distinctKeys, syncResultList));
     }
     logger.finer(
         'number of changes after removing old entries: ${syncResultList.length}');
     //sort the result by commitId ascending
     syncResultList.sort(
         (entry1, entry2) => entry1['commitId'].compareTo(entry2['commitId']));
+    var result;
     if (syncResultList.isNotEmpty) {
-      syncResultList.forEach((element) {
-        logger.info('Syncing element on server ${element['atKey']}');
-        atConnection
-            .write('${jsonEncode(element).length}~${jsonEncode(element)}\$');
-      });
+      result = jsonEncode(syncResultList);
     }
-
+    response.data = result;
     return;
   }
 
-  Future<void> _processEntry(entry, distinctKeys, syncResultList) async {
+  Future<void> processEntry(entry, distinctKeys, syncResultList) async {
     var isKeyLatest = distinctKeys.add(entry.atKey);
     var resultMap = entry.toJson();
     // update value only for latest entry for duplicate keys in the commit log
@@ -83,13 +78,13 @@ class SyncVerbHandler extends AbstractVerbHandler {
       } else if (entry.operation == CommitOp.UPDATE_ALL ||
           entry.operation == CommitOp.UPDATE_META) {
         resultMap.putIfAbsent('value', () => value?.data);
-        _populateMetadata(value, resultMap);
+        populateMetadata(value, resultMap);
       }
       syncResultList.add(resultMap);
     }
   }
 
-  void _populateMetadata(value, resultMap) {
+  void populateMetadata(value, resultMap) {
     var metaDataMap = <String, dynamic>{};
     AtMetaData? metaData = value?.metaData;
     if (metaData != null) {
@@ -130,7 +125,7 @@ class SyncVerbHandler extends AbstractVerbHandler {
     }
   }
 
-  bool _isRegexMatches(String atKey, String regex) {
+  bool isRegexMatches(String atKey, String regex) {
     var result = false;
     if ((RegExp(regex).hasMatch(atKey)) ||
         atKey.contains(AT_ENCRYPTION_SHARED_KEY) ||

--- a/at_secondary/at_secondary_server/lib/src/verb/manager/response_handler_manager.dart
+++ b/at_secondary/at_secondary_server/lib/src/verb/manager/response_handler_manager.dart
@@ -6,7 +6,7 @@ import 'package:at_secondary/src/verb/handler/response/pol_response_handler.dart
 import 'package:at_secondary/src/verb/handler/response/response_handler.dart';
 import 'package:at_secondary/src/verb/handler/response/stats_response_handler.dart';
 import 'package:at_secondary/src/verb/handler/response/stream_response_handler.dart';
-import 'package:at_secondary/src/verb/handler/response/sync_response_handler.dart';
+import 'package:at_secondary/src/verb/handler/response/sync_stream_response_handler.dart';
 import 'package:at_server_spec/at_verb_spec.dart';
 
 abstract class ResponseHandlerManager {
@@ -24,7 +24,7 @@ class DefaultResponseHandlerManager implements ResponseHandlerManager {
   static final _monitorHandler = MonitorResponseHandler();
   static final _streamHandler = StreamResponseHandler();
   static final _notifyAllHandler = NotifyAllResponseHandler();
-  static final _syncHandler = SyncResponseHandler();
+  static final _syncStreamHandler = SyncStreamResponseHandler();
 
   @override
   ResponseHandler getResponseHandler(Verb verb) {
@@ -40,8 +40,8 @@ class DefaultResponseHandlerManager implements ResponseHandlerManager {
       return _streamHandler;
     } else if (verb is NotifyAll) {
       return _notifyAllHandler;
-    } else if (verb is Sync) {
-      return _syncHandler;
+    } else if (verb is SyncStream) {
+      return _syncStreamHandler;
     }
     return _defaultHandler;
   }

--- a/at_secondary/at_secondary_server/lib/src/verb/manager/verb_handler_manager.dart
+++ b/at_secondary/at_secondary_server/lib/src/verb/manager/verb_handler_manager.dart
@@ -18,6 +18,7 @@ import 'package:at_secondary/src/verb/handler/proxy_lookup_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/scan_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/stats_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/stream_verb_handler.dart';
+import 'package:at_secondary/src/verb/handler/sync_stream_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/sync_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/update_meta_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/update_verb_handler.dart';
@@ -81,6 +82,7 @@ class DefaultVerbHandlerManager implements VerbHandlerManager {
     _verbHandlers.add(BatchVerbHandler((keyStore)));
     _verbHandlers.add(NotifyStatusVerbHandler(keyStore));
     _verbHandlers.add(NotifyAllVerbHandler(keyStore));
+    _verbHandlers.add(SyncStreamVerbHandler(keyStore));
     return _verbHandlers;
   }
 }

--- a/at_secondary/at_secondary_server/test/sync_stream_verb_test.dart
+++ b/at_secondary/at_secondary_server/test/sync_stream_verb_test.dart
@@ -1,0 +1,55 @@
+import 'package:at_secondary/src/utils/handler_util.dart';
+import 'package:at_server_spec/at_verb_spec.dart';
+import 'package:test/test.dart';
+import 'package:at_commons/at_commons.dart';
+
+void main() {
+  group('A group of sync verb regex test', () {
+    test('test sync correct syntax', () {
+      var verb = SyncStream();
+      var command = 'sync:stream:5';
+      var regex = verb.syntax();
+      var paramsMap = getVerbParam(regex, command);
+      expect(paramsMap['from_commit_seq'], '5');
+    });
+
+    test('test sync correct syntax with regex', () {
+      var verb = SyncStream();
+      var command = 'sync:stream:5:.buzz';
+      var regex = verb.syntax();
+      var paramsMap = getVerbParam(regex, command);
+      expect(paramsMap['from_commit_seq'], '5');
+      expect(paramsMap['regex'], '.buzz');
+    });
+
+    test('test sync incorrect no sequence number', () {
+      var verb = Sync();
+      var command = 'sync:stream:';
+      var regex = verb.syntax();
+      expect(
+          () => getVerbParam(regex, command),
+          throwsA(predicate((e) =>
+              e is InvalidSyntaxException && e.message == 'Syntax Exception')));
+    });
+
+    test('test sync incorrect multiple sequence number', () {
+      var verb = Sync();
+      var command = 'sync:stream:5 6 7';
+      var regex = verb.syntax();
+      expect(
+          () => getVerbParam(regex, command),
+          throwsA(predicate((e) =>
+              e is InvalidSyntaxException && e.message == 'Syntax Exception')));
+    });
+
+    test('test sync incorrect sequence number with alphabet', () {
+      var verb = Sync();
+      var command = 'sync:stream:5a';
+      var regex = verb.syntax();
+      expect(
+          () => getVerbParam(regex, command),
+          throwsA(predicate((e) =>
+              e is InvalidSyntaxException && e.message == 'Syntax Exception')));
+    });
+  });
+}

--- a/at_server_spec/lib/src/verb/sync_stream.dart
+++ b/at_server_spec/lib/src/verb/sync_stream.dart
@@ -1,0 +1,28 @@
+import 'package:at_server_spec/src/verb/verb.dart';
+import 'package:at_commons/at_commons.dart';
+
+/// The "syncStream" verb is used to fetch all the changes after a given commit sequence number from the commit log on the server
+///
+/// Syntax: sync:stream:<from_commit_seq>
+class SyncStream extends Verb {
+  @override
+  String name() => 'sync:stream';
+
+  @override
+  String syntax() => VerbSyntax.syncStream;
+
+  @override
+  Verb? dependsOn() {
+    return null;
+  }
+
+  @override
+  String usage() {
+    return 'syntax sync:stream:@<from_commit_seq>\n e.g sync:stream:10';
+  }
+
+  @override
+  bool requiresAuth() {
+    return true;
+  }
+}

--- a/at_server_spec/lib/verbs.dart
+++ b/at_server_spec/lib/verbs.dart
@@ -20,3 +20,4 @@ export 'package:at_server_spec/src/verb/sync.dart';
 export 'package:at_server_spec/src/verb/update.dart';
 export 'package:at_server_spec/src/verb/update_meta.dart';
 export 'package:at_server_spec/src/verb/verb.dart';
+export 'package:at_server_spec/src/verb/sync_stream.dart';


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did** Provide backward compatibility for stream sync verb.

**- How I did it** Move stream sync to a new verb handler - sync:stream and have sync for regular sync process.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->