### PR TITLE
redis null safety version

### DIFF
--- a/at_root/at_persistence_root_server/pubspec.yaml
+++ b/at_root/at_persistence_root_server/pubspec.yaml
@@ -13,12 +13,7 @@ dependencies:
   at_persistence_spec: ^2.0.0
   at_utils: ^2.0.1
   at_commons: ^2.0.1
-  redis:
-    git:
-      url: https://github.com/atsign-foundation/at_libraries.git
-      path: redis-dart
-      ref: trunk
-      version: 1.4.0-nullsafety
+  redis: ^2.0.0
 
 dev_dependencies:
   pedantic: ^1.11.0


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
     Update to null safe version of redis package

**- How I did it**
     - Removed git reference in pubspec for redis  package
     - add null safe version of redis package
**- How to verify it**
   - Start root server. Check secondary url values for atsign from openssl client connected to root_server
**- Description for the changelog**
