### PR TITLE
Add version tag to prod image

### DIFF
--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -391,6 +391,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      # Extract version for docker tag
+      - name: Get version
+        run: echo "VERSION=${GITHUB_REF##*/}" >> $GITHUB_ENV
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1.2.0
 
@@ -420,7 +424,7 @@ jobs:
           tags: |
             atsigncompany/secondary:dess
             atsigncompany/secondary:prod
-            atsigncompany/secondary:prod-gha${{ github.run_number }}
+            atsigncompany/secondary:prod-${{ env.VERSION }}
           platforms: |
             linux/amd64
             linux/arm64/v8


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did** Add version as a tag to docker image of the secondary server when released to prod.

**- How I did it** 

**- How to verify it** A production secondary server docker image should have a release number as a tag 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->