### PR TITLE
Fix caching public keys issue

### DIFF
--- a/at_secondary/at_secondary_server/lib/src/verb/handler/proxy_lookup_verb_handler.dart
+++ b/at_secondary/at_secondary_server/lib/src/verb/handler/proxy_lookup_verb_handler.dart
@@ -60,8 +60,11 @@ class ProxyLookupVerbHandler extends AbstractVerbHandler {
       if (operation != 'all') {
         result = SecondaryUtil.prepareResponseData(operation, atData);
       }
-      // Cache the value.
-      await _storeCachedKey(key, atData);
+      // Caching of keys is refrained when looked up the currentAtSign user
+      // Cache keys only if currentAtSign is not equal to atSign
+      if (AtSecondaryServerImpl.getInstance().currentAtSign != atSign) {
+        await _storeCachedKey(key, atData);
+      }
     }
     response.data = result;
     var atAccessLog = await (AtAccessLogManagerImpl.getInstance()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did** When a public key is looked up by the currentAtSign user, do not cache the keys.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->