### PR TITLE
Resequence GitHub Actions

### DIFF
--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -14,7 +14,7 @@ on:
       - trunk
 
 jobs:
-  unit tests:
+  unit_tests:
     env:
       proot-working-directory: ./at_root/at_persistence_root_server
       root-working-directory: ./at_root/at_root_server

--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -198,6 +198,8 @@ jobs:
   
   # The job runs end to end tests between the cicd1 and cicd2 VMs
   end2end_tests:
+    # Don't run on PRs from a fork as the secrets aren't available
+    if: ${{ github.event.pull_request.head.repo.fork == false }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -318,7 +318,7 @@ jobs:
   # The jobs run's on completion of 'run_end2end_tests' job.
   push_staging_secondary_image:
     # Runs only after functional tests are completed.
-    needs: [ unit_tests, functional_tests, end2end_tests 
+    needs: [ unit_tests, functional_tests, end2end_tests ]
     if: ${{ github.repository == 'atsign-foundation/at_server' && github.event_name == 'push' && contains(github.ref, 'trunk') }}
     environment: staging
     env:
@@ -394,7 +394,7 @@ jobs:
   # The job builds the production version of secondary server docker image and pushes to docker hub.
   push_prod_secondary_image:
     # Runs only after functional tests are completed.
-    needs: [ unit_tests, functional_tests, end2end_tests 
+    needs: [ unit_tests, functional_tests, end2end_tests ]
     if: ${{ github.repository == 'atsign-foundation/at_server' && github.event_name == 'push' && contains(github.ref, 'refs/tags/v') }}
     env:
       working-directory: at_server
@@ -481,7 +481,7 @@ jobs:
       
   # Deploy root server image to cluster
   deploy_root_sever:
-    needs: [ unit_tests, functional_tests, end2end_tests 
+    needs: [ unit_tests, functional_tests, end2end_tests ]
     if: ${{ github.repository == 'atsign-foundation/at_server' && github.event_name == 'push' && contains(github.ref, 'trunk') }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -14,76 +14,55 @@ on:
       - trunk
 
 jobs:
-  # Runs dart lint rules and unit tests on at_persistence_root_server
-  test_at_persistence_root_server:
+  unit tests:
     env:
-      working-directory: ./at_root/at_persistence_root_server
+      proot-working-directory: ./at_root/at_persistence_root_server
+      root-working-directory: ./at_root/at_root_server
+      psecondary-working-directory: ./at_secondary/at_persistence_secondary_server
+      secondary-working-directory: ./at_secondary/at_secondary_server
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
-      - uses: dart-lang/setup-dart@v1
+      - uses: dart-lang/setup-dart@v1.2
         with:
           sdk: stable
-
-      - name: Install dependencies in at_persistence_root_server
-        working-directory: ${{ env.working-directory }}
-        run: dart pub get
-
-      - name: Run dart analyzer in at_persistence_root_server
-        working-directory: ${{ env.working-directory }}
-        run: dart analyze
-
-      - name: Run tests in at_persistence_root_server
-        working-directory: ${{ env.working-directory }}
-        run: dart test --concurrency=1
-
-  # Runs dart lint rules and unit tests on at_root_server
-  test_at_root_server:
-    env:
-      working-directory: ./at_root/at_root_server
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-      - uses: dart-lang/setup-dart@v1
-        with:
-          sdk: stable
-
-      - name: Install dependencies in at_root_server
-        working-directory: ${{ env.working-directory }}
-        run: dart pub get
-
-      - name: Run dart analyzer in at_root_server
-        working-directory: ${{ env.working-directory }}
-        run: dart analyze
-
-      - name: Run tests in at_root_server
-        working-directory: ${{ env.working-directory }}
-        run: dart test --concurrency=1
-
-  # Runs dart lint rules and unit tests on at_persistence_secondary_server
-  test_at_persistence_secondary_server:
-    runs-on: ubuntu-latest
-    env:
-      working-directory: ./at_secondary/at_persistence_secondary_server
-    steps:
-      - uses: actions/checkout@v2
-      - uses: dart-lang/setup-dart@v1
-        with:
-          sdk: stable
-
       # Setup python
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: '3.8'
-
       # Install python packages
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip
           pip3 install ruamel.yaml
+
+      # Runs dart lint rules and unit tests on at_persistence_root_server
+      - name: Install dependencies in at_persistence_root_server
+        working-directory: ${{ env.proot-working-directory }}
+        run: dart pub get
+
+      - name: Run dart analyzer in at_persistence_root_server
+        working-directory: ${{ env.proot-working-directory }}
+        run: dart analyze
+
+      - name: Run tests in at_persistence_root_server
+        working-directory: ${{ env.proot-working-directory }}
+        run: dart test --concurrency=1
+
+      # Runs dart lint rules and unit tests on at_root_server
+      - name: Install dependencies in at_root_server
+        working-directory: ${{ env.root-working-directory }}
+        run: dart pub get
+
+      - name: Run dart analyzer in at_root_server
+        working-directory: ${{ env.root-working-directory }}
+        run: dart analyze
+
+      - name: Run tests in at_root_server
+        working-directory: ${{ env.root-working-directory }}
+        run: dart test --concurrency=1
 
       # adds dependency overrides to pubspec.yaml
       # Runs when github action event type is pull_request or push event to trunk branch
@@ -94,39 +73,16 @@ jobs:
           python3 add_dependency_overrides.py -p at_secondary/at_persistence_secondary_server
 
       - name: Install dependencies in at_persistence_secondary_server
-        working-directory: ${{ env.working-directory }}
+        working-directory: ${{ env.psecondary-working-directory }}
         run: dart pub get
 
       - name: Run dart analyzer in at_persistence_secondary_server
-        working-directory: ${{ env.working-directory }}
+        working-directory: ${{ env.psecondary-working-directory }}
         run: dart analyze
 
       - name: Run tests in at_persistence_secondary_server
-        working-directory: ${{ env.working-directory }}
+        working-directory: ${{ env.psecondary-working-directory }}
         run: dart test --concurrency=1
-
-  # Runs dart lint rules and unit tests on at_secondary_server
-  test_at_secondary_server:
-    runs-on: ubuntu-latest
-    env:
-      working-directory: ./at_secondary/at_secondary_server
-    steps:
-      - uses: actions/checkout@v2
-      - uses: dart-lang/setup-dart@v1
-        with:
-          sdk: stable
-
-      # Setup python
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.8'
-
-      # Install python packages
-      - name: Install dependencies
-        run: |
-          python3 -m pip install --upgrade pip
-          pip3 install ruamel.yaml
 
       # adds dependency overrides to pubspec.yaml
       # Runs when github action event type is pull_request or push event to trunk branch
@@ -135,30 +91,28 @@ jobs:
         run: |
           chmod +x add_dependency_overrides.py
           python3 add_dependency_overrides.py -p at_secondary/at_secondary_server
-
+      
+      # Runs dart lint rules and unit tests on at_secondary_server
       - name: Install dependencies in at_secondary_server
-        working-directory: ${{ env.working-directory }}
+        working-directory: ${{ env.secondary-working-directory }}
         run: dart pub get
 
       - name: Run dart analyzer in at_secondary_server
-        working-directory: ${{ env.working-directory }}
+        working-directory: ${{ env.secondary-working-directory }}
         run: dart analyze
 
       - name: Run tests in at_secondary_server
-        working-directory: ${{ env.working-directory }}
+        working-directory: ${{ env.secondary-working-directory }}
         run: dart test --concurrency=1
 
-  # On completed of above jobs, runs functional tests on at_secondary.
+  # Runs functional tests on at_secondary.
   # If tests are successful, uploads root server and secondary server binaries for subsequent jobs
-  run_functional_test:
-    needs: [ test_at_persistence_root_server, test_at_root_server, test_at_persistence_secondary_server, test_at_secondary_server ]
-    env:
-      working-directory: at_server
+  functional_tests:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
-      - uses: dart-lang/setup-dart@v1
+      - uses: dart-lang/setup-dart@v1.2
         with:
           sdk: stable
 
@@ -201,7 +155,7 @@ jobs:
         run: cp at_root/at_root_server/root at_functional_test/lib/root/ && cp at_secondary/at_secondary_server/secondary at_functional_test/lib/secondary/
 
       - name: Build docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v2.6.1
         with:
           file: at_functional_test/lib/Dockerfile
           context: at_functional_test/lib/
@@ -243,15 +197,12 @@ jobs:
         run: docker rmi at_virtual_env:trunk
   
   # The job runs end to end tests between the cicd1 and cicd2 VMs
-  # The job run's on completion of 'run_functional_test' job.
-  run_end2end_tests:
-    # Runs only after functional tests are completed.
-    needs: [ run_functional_test ]
+  end2end_tests:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
-      - uses: dart-lang/setup-dart@v1
+      - uses: dart-lang/setup-dart@v1.2
         with:
           sdk: stable
 
@@ -308,7 +259,7 @@ jobs:
   # The job run's on completion of 'run_end2end_tests' job.
   push_staging_virtual_env_images:
     # Runs only after functional tests are completed.
-    needs: [ run_end2end_tests ]
+    needs: [ unit_tests, functional_tests, end2end_tests ]
     if: ${{ github.repository == 'atsign-foundation/at_server' && github.event_name == 'push' && contains(github.ref, 'trunk') }}
     environment: staging
     env:
@@ -351,7 +302,7 @@ jobs:
       # Builds and pushes the at_virtual_env to docker hub.
       - name: Build and push for trunk branch
         id: docker_build_trunk
-        uses: docker/build-push-action@v2.4.0
+        uses: docker/build-push-action@v2.6.1
         with:
           push: true
           context: at_functional_test/lib/
@@ -367,7 +318,7 @@ jobs:
   # The jobs run's on completion of 'run_end2end_tests' job.
   push_staging_secondary_image:
     # Runs only after functional tests are completed.
-    needs: [ run_end2end_tests ]
+    needs: [ unit_tests, functional_tests, end2end_tests 
     if: ${{ github.repository == 'atsign-foundation/at_server' && github.event_name == 'push' && contains(github.ref, 'trunk') }}
     environment: staging
     env:
@@ -423,7 +374,7 @@ jobs:
       # Builds and pushes the secondary server image to docker hub.
       - name: Build and push secondary image for amd64 and arm64
         id: docker_build_secondary
-        uses: docker/build-push-action@v2.4.0
+        uses: docker/build-push-action@v2.6.1
         with:
           push: true
           context: at_secondary
@@ -443,7 +394,7 @@ jobs:
   # The job builds the production version of secondary server docker image and pushes to docker hub.
   push_prod_secondary_image:
     # Runs only after functional tests are completed.
-    needs: [ run_end2end_tests ]
+    needs: [ unit_tests, functional_tests, end2end_tests 
     if: ${{ github.repository == 'atsign-foundation/at_server' && github.event_name == 'push' && contains(github.ref, 'refs/tags/v') }}
     env:
       working-directory: at_server
@@ -478,7 +429,7 @@ jobs:
       # Builds and pushes the secondary server image to docker hub.
       - name: Build and push secondary image for amd64 and arm64
         id: docker_build_secondary
-        uses: docker/build-push-action@v2.4.0
+        uses: docker/build-push-action@v2.6.1
         with:
           push: true
           context: at_secondary
@@ -530,7 +481,7 @@ jobs:
       
   # Deploy root server image to cluster
   deploy_root_sever:
-    needs: [ run_end2end_tests ]
+    needs: [ unit_tests, functional_tests, end2end_tests 
     if: ${{ github.repository == 'atsign-foundation/at_server' && github.event_name == 'push' && contains(github.ref, 'trunk') }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
**- What I did**

Shorten commit cycle time (to length of end to end tests)

**- How I did it**

Run unit tests, functional tests and end2end tests in parallel

Unit tests have been brought together to reduce number of actions runners we start

End2end tests won't run if a PR originates from a fork, as secrets aren't available, which causes the tests to fail.

**- How to verify it**

See [runs on the fork this comes from](https://github.com/cpswan/at_server/actions/runs/1090369354)

**- Description for the changelog**

Resequence GitHub Actions