### PR TITLE
Switch cicd VMs to x64

### DIFF
--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -231,7 +231,7 @@ jobs:
             atsigncompany/secondary:dess_cicd
             atsigncompany/secondary:cicd-${{ env.BRANCH }}-gha${{ github.run_number }}
           platforms: |
-            linux/arm64/v8
+            linux/amd64
 
       # Logs into CICD VMs and runs script to update to just pushed image
       - name: update image on cicd VMs
@@ -451,7 +451,7 @@ jobs:
       - name: Create dess-arm64 label
         uses: appleboy/ssh-action@v0.1.4
         with:
-          host: "cicd1.atsign.wtf"
+          host: "arm64cicd.atsign.wtf"
           username: ubuntu
           key: ${{ secrets.CICD_SSH_KEY }}
           script: |

--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -221,7 +221,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # Builds and pushes the secondary server image to docker hub.
-      - name: Build and push secondary image for arm64
+      - name: Build and push secondary image for x64
         id: docker_build_secondary
         uses: docker/build-push-action@v2.6.1
         with:


### PR DESCRIPTION
**- What I did**

Speed up end to end tests by using x64 VMs for cicd

**- How I did it**

New VMs spun up in AWS
Migrated DNS names to new VMs
Migrated cicd config and scripts to new VMs
Created :dess_cicd image to get new services started

**- How to verify it**

Run end to end tests

**- Description for the changelog**

Switch cicd VMs to x64