### PR TITLE
Observable secondary Dockerfile

### DIFF
--- a/at_secondary/Dockerfile.observe
+++ b/at_secondary/Dockerfile.observe
@@ -1,0 +1,28 @@
+FROM atsigncompany/buildimage
+ENV HOMEDIR=/atsign
+ENV USER_ID=1024
+ENV GROUP_ID=1024
+WORKDIR /app
+COPY . .
+RUN \
+  cd at_persistence_secondary_server ; \
+  dart pub get ; \
+  dart pub update ; \
+  cd ../at_secondary_server ; \
+  dart pub get ; \
+  dart pub update ; \
+  mkdir -p $HOMEDIR/storage ; \
+  mkdir -p $HOMEDIR/config ; \
+  mkdir -p /archive ; \
+  addgroup --gid $GROUP_ID atsign ; \
+  useradd --system --uid $USER_ID --gid $GROUP_ID --shell /bin/bash \
+  --home $HOMEDIR atsign ; \
+  chown -R atsign:atsign $HOMEDIR ; \
+  chown -R atsign:atsign /archive ; \
+  chmod -R 755 /usr/lib/dart/ ; \
+  chmod -R 755 /root/ ; \
+  cp config/config.yaml $HOMEDIR/config/ ; \
+  cp pubspec.yaml $HOMEDIR/
+WORKDIR /atsign
+USER atsign
+ENTRYPOINT ["/usr/lib/dart/bin/dart","run","--observe=8181/0.0.0.0","/app/at_secondary_server/bin/main.dart"]


### PR DESCRIPTION
**- What I did**

Added Dockerfile to create an observable secondary.

**- How I did it**

* Single stage build based on our usual build image with the Dart SDK
* No need to compile an AOT binary
* Fixes permissions so that non root user can run dart and access root .pub-cache
* Entrypoint is running:

`/usr/lib/dart/bin/dart run --observe=8181/0.0.0.0 /app/at_secondary_server/bin/main.dart`

NB binding to 0.0.0.0 so that Docker compose can map ports into it

**- How to verify it**

Build the image:

```bash
sudo docker build . -f Dockerfile.observe -t atsigncompany/secondary_obs
```

Modify a dess docker-compose.yaml like this:

```yaml
image: atsigncompany/secondary_obs
    networks:
      second: {}
    ports:
    - published: 6767
      target: 6767
    - published: 8181
      target: 8181
```

Then (re)create a service from that docker-compose.yaml

The start of the service logs will contain the authentication URL for the observatory.

**- Description for the changelog**

Observable secondary Dockerfile