### PR TITLE
Add run tags to test and dev image version numbers

### DIFF
--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -208,6 +208,10 @@ jobs:
         with:
           sdk: stable
 
+      - name: Place run number into version within pubspec.yaml
+        working-directory: at_secondary/at_secondary_server
+        run: sed -i "s/version\:.*/&+gha${{ github.run_number }}/" pubspec.yaml
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1.2.0
 
@@ -271,6 +275,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Place run number into version within pubspec.yaml
+        working-directory: at_secondary/at_secondary_server
+        run: sed -i "s/version\:.*/&+gha${{ github.run_number }}/" pubspec.yaml
+
       # Extract branch for docker tag
       - name: Get branch name
         run: echo "BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
@@ -329,6 +337,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
+      - name: Place run number into version within pubspec.yaml
+        working-directory: at_secondary/at_secondary_server
+        run: sed -i "s/version\:.*/&+gha${{ github.run_number }}/" pubspec.yaml
 
       # Extract branch for docker tag
       - name: Get branch name


### PR DESCRIPTION
**- What I did**

Modified automation script to add run number into pubspec.yaml so that test and dev builds can be traced back to the workflow that created them.

**- How to verify it**

Inspect logs on cicd instances to verify that this has been added to end2end tests.

Once merged inspect logs on staging instances.

**- Description for the changelog**

Add run tags to test and dev image version numbers