### PR TITLE
Switch to recommended lints

### DIFF
--- a/at_end2end_test/analysis_options.yaml
+++ b/at_end2end_test/analysis_options.yaml
@@ -1,7 +1,7 @@
 # Defines a default set of lint rules enforced for
 # projects at Google. For details and rationale,
 # see https://github.com/dart-lang/pedantic#enabled-lints.
-include: package:pedantic/analysis_options.yaml
+include: package:lints/recommended.yaml
 
 # For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
 # Uncomment to specify additional rules.

--- a/at_end2end_test/pubspec.yaml
+++ b/at_end2end_test/pubspec.yaml
@@ -19,5 +19,5 @@ dependencies:
       version: ^2.0.4
 
 dev_dependencies:
-  pedantic: ^1.9.0
+  lints: ^1.0.1
   test: ^1.14.4

--- a/at_functional_test/analysis_options.yaml
+++ b/at_functional_test/analysis_options.yaml
@@ -1,7 +1,7 @@
 # Defines a default set of lint rules enforced for
 # projects at Google. For details and rationale,
 # see https://github.com/dart-lang/pedantic#enabled-lints.
-include: package:pedantic/analysis_options.yaml
+include: package:lints/recommended.yaml
 
 # For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
 # Uncomment to specify additional rules.

--- a/at_functional_test/pubspec.yaml
+++ b/at_functional_test/pubspec.yaml
@@ -27,5 +27,5 @@ dependencies:
 #    path: ../../at_tools/at_utils
 
 dev_dependencies:
-  pedantic: ^1.9.0
+  lints: ^1.0.1
   test: ^1.14.4

--- a/at_persistence/at_persistence_spec/analysis_options.yaml
+++ b/at_persistence/at_persistence_spec/analysis_options.yaml
@@ -1,7 +1,7 @@
 # Defines a default set of lint rules enforced for
 # projects at Google. For details and rationale,
 # see https://github.com/dart-lang/pedantic#enabled-lints.
-include: package:pedantic/analysis_options.yaml
+include: package:lints/recommended.yaml
 
 # For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
 # Uncomment to specify additional rules.

--- a/at_persistence/at_persistence_spec/pubspec.yaml
+++ b/at_persistence/at_persistence_spec/pubspec.yaml
@@ -9,4 +9,4 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dev_dependencies:
-  pedantic: ^1.11.0
+  lints: ^1.0.1

--- a/at_root/at_persistence_root_server/analysis_options.yaml
+++ b/at_root/at_persistence_root_server/analysis_options.yaml
@@ -1,7 +1,7 @@
 # Defines a default set of lint rules enforced for
 # projects at Google. For details and rationale,
 # see https://github.com/dart-lang/pedantic#enabled-lints.
-include: package:pedantic/analysis_options.yaml
+include: package:lints/recommended.yaml
 
 # For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
 # Uncomment to specify additional rules.

--- a/at_root/at_persistence_root_server/pubspec.yaml
+++ b/at_root/at_persistence_root_server/pubspec.yaml
@@ -19,6 +19,5 @@ dev_dependencies:
   lints: ^1.0.1
   test: ^1.17.3
   mockito: ^5.0.7
-  lints: ^1.0.1
   # commenting test coverage since null safe version is not available
 #  test_coverage: ^0.4.1

--- a/at_root/at_persistence_root_server/pubspec.yaml
+++ b/at_root/at_persistence_root_server/pubspec.yaml
@@ -16,8 +16,9 @@ dependencies:
   redis: ^2.0.0
 
 dev_dependencies:
-  pedantic: ^1.11.0
+  lints: ^1.0.1
   test: ^1.17.3
   mockito: ^5.0.7
+  lints: ^1.0.1
   # commenting test coverage since null safe version is not available
 #  test_coverage: ^0.4.1

--- a/at_root/at_root_server/pubspec.yaml
+++ b/at_root/at_root_server/pubspec.yaml
@@ -25,5 +25,5 @@ dependencies:
 dev_dependencies:
   # Adding test_cov for generating the test coverage.
   test_cov: ^1.0.1
-  pedantic: ^1.11.0
+  lints: ^1.0.1
   test: ^1.17.3

--- a/at_secondary/at_persistence_secondary_server/analysis_options.yaml
+++ b/at_secondary/at_persistence_secondary_server/analysis_options.yaml
@@ -1,7 +1,7 @@
 # Defines a default set of lint rules enforced for
 # projects at Google. For details and rationale,
 # see https://github.com/dart-lang/pedantic#enabled-lints.
-include: package:pedantic/analysis_options.yaml
+include: package:lints/recommended.yaml
 
 # For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
 # Uncomment to specify additional rules.

--- a/at_secondary/at_persistence_secondary_server/pubspec.yaml
+++ b/at_secondary/at_persistence_secondary_server/pubspec.yaml
@@ -37,5 +37,5 @@ dependencies:
 #      ref: trunk
 
 dev_dependencies:
-  pedantic: ^1.11.0
+  lints: ^1.0.1
   test: ^1.17.1

--- a/at_secondary/at_secondary_server/analysis_options.yaml
+++ b/at_secondary/at_secondary_server/analysis_options.yaml
@@ -1,7 +1,7 @@
 # Defines a default set of lint rules enforced for
 # projects at Google. For details and rationale,
 # see https://github.com/dart-lang/pedantic#enabled-lints.
-include: package:pedantic/analysis_options.yaml
+include: package:lints/recommended.yaml
 
 # For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
 # Uncomment to specify additional rules.

--- a/at_secondary/at_secondary_server/pubspec.yaml
+++ b/at_secondary/at_secondary_server/pubspec.yaml
@@ -51,3 +51,4 @@ dev_dependencies:
   test: ^1.17.3
   #  test_coverage: ^0.5.0
   mockito: ^5.0.7
+  lints: ^1.0.1

--- a/at_server_spec/analysis_options.yaml
+++ b/at_server_spec/analysis_options.yaml
@@ -1,7 +1,7 @@
 # Defines a default set of lint rules enforced for
 # projects at Google. For details and rationale,
 # see https://github.com/dart-lang/pedantic#enabled-lints.
-include: package:pedantic/analysis_options.yaml
+include: package:lints/recommended.yaml
 
 # For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
 # Uncomment to specify additional rules.

--- a/at_server_spec/pubspec.yaml
+++ b/at_server_spec/pubspec.yaml
@@ -19,4 +19,4 @@ dependencies:
 #      ref: trunk
 
 dev_dependencies:
-  pedantic: ^1.11.0
+  lints: ^1.0.1


### PR DESCRIPTION
Unit tests have been failing with:

```
warning - analysis_options.yaml:4:10 - The include file 'package:pedantic/analysis_options.yaml' in '/home/runner/work/at_server/at_server/at_secondary/at_secondary_server/analysis_options.yaml' can't be found when analyzing '/home/runner/work/at_server/at_server/at_secondary/at_secondary_server'. - include_file_not_found
```

It seems that pedantic has been deprecated:

![image](https://user-images.githubusercontent.com/478926/135997895-69c71b8e-85a6-4ac1-a199-6b92d7ac8beb.png)


**- What I did**

Replaced `include: package:pedantic/analysis_options.yaml` with `include: package:lints/recommended.yaml` per guidance from [dart-lang/lints](https://github.com/dart-lang/lints#migrating-from-packagepedantic)

**- How to verify it**

Unit tests should run again.

**- Description for the changelog**

Switch to recommended lints