### PR TITLE
Don't run end to end tests on Dependabot PRs

### DIFF
--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -198,8 +198,8 @@ jobs:
   
   # The job runs end to end tests between the cicd1 and cicd2 VMs
   end2end_tests:
-    # Don't run on PRs from a fork as the secrets aren't available
-    if: ${{ github.event.pull_request.head.repo.fork == false }}
+    # Don't run on PRs from a fork or Dependabot as the secrets aren't available
+    if: ${{ github.event.pull_request.head.repo.fork == false && github.actor!= 'dependabot-preview[bot]'}}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
**- What I did**

Added conditional to prevent running end2end tests on Dependabot PRs as these keep failing due to lack of secrets

**- How to verify it**

End2end tests should be skipped on next Dependabot PR

**- Description for the changelog**

Don't run end to end tests on Dependabot PRs