### PR TITLE
Add canary release

### DIFF
--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -7,6 +7,7 @@ on:
   push:
     tags:
       - 'v*.*.*'
+      - 'c*.*.*'
     branches:
       - trunk
   pull_request:
@@ -482,6 +483,49 @@ jobs:
 
       - name: Image digest of secondary server
         run: echo ${{ steps.docker_build_observable_secondary.outputs.digest }}
+
+  # The below jobs run's on completion of 'run_end2end_tests' job.
+  # This job run's on trigger event 'push' and when a canary release is tagged.
+  # The job builds the canary version of secondary server docker image and pushes to docker hub.
+  push_canary_secondary_image:
+    # Runs only after functional tests are completed.
+    needs: [ unit_tests, functional_tests, end2end_tests ]
+    if: ${{ github.repository == 'atsign-foundation/at_server' && github.event_name == 'push' && contains(github.ref, 'refs/tags/c') }}
+    env:
+      working-directory: at_server
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      # Extract version for docker tag
+      - name: Get version
+        run: echo "VERSION=${GITHUB_REF##*/}" >> $GITHUB_ENV
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1.2.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1.6.0
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1.10.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Builds and pushes the secondary server image to docker hub.
+      - name: Build and push secondary image for amd64 and arm64
+        id: docker_build_secondary
+        uses: docker/build-push-action@v2.7.0
+        with:
+          push: true
+          context: at_secondary
+          tags: |
+            atsigncompany/secondary:canary
+            atsigncompany/secondary:canary-${{ env.VERSION }}
+          platforms: |
+            linux/amd64
 
   # The below jobs run's on completion of 'run_end2end_tests' job.
   # This job run's on trigger event 'push' and when a release is tagged.


### PR DESCRIPTION
Related to #371 

**- What I did**

Cloned secondary release section to build an x86 only image tagged :canary that can be used for a subset of production secondaries.

**- How to verify it**

Create a new release with a semver tag starting c

**- Description for the changelog**

Add canary release