### PR TITLE
Use official Dart Docker image

### DIFF
--- a/at_secondary/Dockerfile
+++ b/at_secondary/Dockerfile
@@ -1,4 +1,4 @@
-FROM atsigncompany/buildimage AS buildimage
+FROM dart AS buildimage
 ENV HOMEDIR=/atsign
 ENV USER_ID=1024
 ENV GROUP_ID=1024

--- a/at_secondary/Dockerfile.observe
+++ b/at_secondary/Dockerfile.observe
@@ -1,4 +1,4 @@
-FROM atsigncompany/buildimage
+FROM dart
 ENV HOMEDIR=/atsign
 ENV USER_ID=1024
 ENV GROUP_ID=1024


### PR DESCRIPTION
Closes #358

We can now use the Dart official image as it has support for Armv7 and Arm64

**- What I did**

```diff
-FROM atsigncompany/buildimage AS buildimage
+FROM dart AS buildimage
```

**- How to verify it**

On merge Actions will build new images

**- Description for the changelog**

Use official Dart Docker image