### PR TITLE
Move new issues to Triage on new project board

### DIFF
--- a/.github/workflows/autobug.yaml
+++ b/.github/workflows/autobug.yaml
@@ -3,21 +3,17 @@ name: Auto Assign Bugs to Sprint Planning Project Board
 on:
   issues:
     types: [labeled]
-  pull_request:
-    types: [labeled]
-env:
-  MY_GITHUB_TOKEN: ${{ secrets.MY_GITHUB_TOKEN }}
 
 jobs:
-  assign_one_project:
+  issue_opened_and_reopened:
+    name: issue_opened_and_reopened
     runs-on: ubuntu-latest
-    name: Assign to Bugs Column in Sprint Planning Project Board
     steps:
-    - name: Assign issues and pull requests with `bug` label to project 3
-      uses: srggrs/assign-one-project-github-action@1.3.1
-      if: |
-        contains(github.event.issue.labels.*.name, 'bug') ||
-        contains(github.event.pull_request.labels.*.name, 'bug')
-      with:
-        project: 'https://github.com/orgs/atsign-foundation/projects/3'
-        column_name: 'Bugs'
+      - name: 'Move issue to "Triage"'
+        uses: leonsteinhaeuser/project-beta-automations@v1.0.1
+        with:
+          gh_token: ${{ secrets.MY_GITHUB_TOKEN }}
+          organization: atsign-foundation
+          project_id: 11
+          resource_node_id: ${{ github.event.issue.node_id }}
+          status_value: "Triage"


### PR DESCRIPTION
**- What I did**

Replaced project automation with new GitHub Action that works with Project Next (beta) boards.

**- How I did it**

New issues will now go to a Triage status so that they can then be allocated to backlog/bugs or straight into a PR.

**- How to verify it**

Create a new issue and see that it's been added to Triage.

**- Description for the changelog**

Move new issues to Triage on new project board