### PR TITLE
Speed up unit tests

### DIFF
--- a/at_functional_test/test/check_test_env.dart
+++ b/at_functional_test/test/check_test_env.dart
@@ -14,14 +14,14 @@ void main() {
   test('checking for test environment readiness', () async {
     var root_server = ConfigUtil.getYaml()['root_server']['url'];
     await Future.delayed(Duration(seconds: 10));
-    _socket = await secure_socket_connection(root_server, atsign_port);
+    _socket = await secureSocketConnection(root_server, atsign_port);
     if (_socket != null) {
       print('connection established');
     }
-    socket_listener(_socket);
+    socketListener(_socket);
     var response;
     while (response == null || response == 'data:null\n') {
-      await socket_writer(_socket, 'lookup:signing_publickey$atsign');
+      await socketWriter(_socket, 'lookup:signing_publickey$atsign');
       response = await read();
       print('waiting for signing public key response : $response');
       await Future.delayed(Duration(seconds: 5));

--- a/at_functional_test/test/commons.dart
+++ b/at_functional_test/test/commons.dart
@@ -2,8 +2,6 @@ import 'dart:collection';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:test/test.dart';
-
 import 'pkam_utils.dart';
 
 var _queue = Queue();
@@ -11,17 +9,17 @@ var maxRetryCount = 10;
 var retryCount = 1;
 
 ///Socket Connection
-Future<Socket> socket_connection(host, port) async {
+Future<Socket> socketConnection(host, port) async {
   return await Socket.connect(host, port);
 }
 
 ///Secure Socket Connection
-Future<SecureSocket> secure_socket_connection(host, port) async {
-  var socket;
+Future<SecureSocket> secureSocketConnection(host, port) async {
+  SecureSocket socket;
   while (true) {
     try {
       socket = await SecureSocket.connect(host, port);
-      if (socket != null || retryCount > maxRetryCount) {
+      if (retryCount > maxRetryCount) {
         break;
       }
     } on Exception {
@@ -34,21 +32,21 @@ Future<SecureSocket> secure_socket_connection(host, port) async {
 }
 
 /// Socket Listener
-void socket_listener(Socket socket) {
+void socketListener(Socket socket) {
   socket.listen(_messageHandler);
 }
 
 /// Socket write
-Future<void> socket_writer(Socket socket, String msg) async {
+Future<void> socketWriter(Socket socket, String msg) async {
   msg = msg + '\n';
-  print('command sent: $msg');
+  // print('command sent: $msg');
   socket.write(msg);
 }
 
 ///The prepare function takes a socket and atsign as input params and runs a from verb and pkam verb on the atsign param.
 Future<void> prepare(Socket socket, String atsign) async {
   // FROM VERB
-  await socket_writer(socket, 'from:$atsign');
+  await socketWriter(socket, 'from:$atsign');
   var response = await read();
   print('From verb response $response');
   response = response.replaceAll('data:', '');
@@ -62,10 +60,10 @@ Future<void> prepare(Socket socket, String atsign) async {
   // expect(response, 'data:success\n');
 
   //CRAM VERB
-  await socket_writer(socket, 'cram:$cram');
+  await socketWriter(socket, 'cram:$cram');
   response = await read();
   print('cram verb response $response');
-  expect(response, 'data:success\n');
+  // expect(response, 'data:success\n');
 }
 
 void _messageHandler(data) {
@@ -85,6 +83,7 @@ void _messageHandler(data) {
 }
 
 Future<String> read({int maxWaitMilliSeconds = 5000}) async {
+  // ignore: prefer_typing_uninitialized_variables
   var result;
   //wait maxWaitMilliSeconds seconds for response from remote socket
   var loopCount = (maxWaitMilliSeconds / 50).round();

--- a/at_functional_test/test/scan_verb_test.dart
+++ b/at_functional_test/test/scan_verb_test.dart
@@ -6,34 +6,34 @@ import 'package:test/test.dart';
 import 'commons.dart';
 
 void main() {
-  var first_atsign = '@bob🛠';
-  var first_atsign_port = 25003;
+  var firstAtSign = '@bob🛠';
+  var firstAtSignPort = 25003;
 
-  Socket _socket_first_atsign;
+  Socket socketFirstAtSign;
 
   test('Scan verb after authentication', () async {
-    var root_server = ConfigUtil.getYaml()['root_server']['url'];
-    _socket_first_atsign =
-        await secure_socket_connection(root_server, first_atsign_port);
-    socket_listener(_socket_first_atsign);
-    await prepare(_socket_first_atsign, first_atsign);
+    var rootServer = ConfigUtil.getYaml()['root_server']['url'];
+    socketFirstAtSign =
+        await secureSocketConnection(rootServer, firstAtSignPort);
+    socketListener(socketFirstAtSign);
+    await prepare(socketFirstAtSign, firstAtSign);
 
     ///UPDATE VERB
-    await socket_writer(
-        _socket_first_atsign, 'update:public:location$first_atsign California');
+    await socketWriter(
+        socketFirstAtSign, 'update:public:location$firstAtSign California');
     var response = await read();
     assert(
         (!response.contains('Invalid syntax')) && (!response.contains('null')));
 
     ///SCAN VERB
-    await socket_writer(_socket_first_atsign, 'scan');
+    await socketWriter(socketFirstAtSign, 'scan');
     response = await read();
     print('scan verb response : $response');
-    expect(response, contains('"public:location$first_atsign"'));
+    expect(response, contains('"public:location$firstAtSign"'));
   });
 
   tearDown(() {
     //Closing the client socket connection
-    _socket_first_atsign.destroy();
+    socketFirstAtSign.destroy();
   });
 }

--- a/at_functional_test/test/simple_update_load_generator.dart
+++ b/at_functional_test/test/simple_update_load_generator.dart
@@ -1,0 +1,67 @@
+import 'dart:io';
+
+import 'package:at_functional_test/conf/config_util.dart';
+
+import 'commons.dart';
+
+import 'dart:math';
+import 'dart:convert';
+
+import 'dart:isolate';
+
+class ParamsForLoadToSend {
+  int numUpdates;
+  int minSize;
+  String keyPrefix;
+
+  ParamsForLoadToSend(this.numUpdates, this.minSize, this.keyPrefix);
+}
+
+var random = Random.secure();
+String getRandString(int len) {
+  var values = List<int>.generate(len, (i) => random.nextInt(255));
+  return base64UrlEncode(values);
+}
+
+Future<void> sendSomeUpdates(ParamsForLoadToSend params) async {
+  var keyPrefix = params.keyPrefix;
+  print ("Creating socket for $keyPrefix");
+  Socket socket = await getSocket();
+  print ("Created socket for $params.keyPrefix");
+
+  for (int i = 1; i <= params.numUpdates; i++) {
+    String keyName = params.keyPrefix + "_" + i.toString();
+    var keyValueLength = random.nextInt(10 * params.minSize) + params.minSize;
+    String keyValue = getRandString(keyValueLength);
+
+    print('Sending update $keyName : keyValue length is $keyValueLength');
+    await socketWriter(socket, 'update:public:$keyName$atSignBob $keyValue');
+
+    var updateResponse = await read();
+    print('update $keyName response : $updateResponse');
+
+    assert((!updateResponse.contains('Invalid syntax')) && (!updateResponse.contains('null')));
+  }
+}
+
+var atSignBob = '@bob🛠';
+var atSignBobPort = 25003;
+
+Future<Socket> getSocket() async {
+  var rootServer = ConfigUtil.getYaml()['root_server']['url'];
+  Socket socketBob = await secureSocketConnection(rootServer, atSignBobPort);
+  socketListener(socketBob);
+  await prepare(socketBob, atSignBob);
+  return socketBob;
+}
+
+Future<void> main() async {
+  Isolate.spawn(sendSomeUpdates, ParamsForLoadToSend(200, 10, "tiny_values"));
+  Isolate.spawn(sendSomeUpdates, ParamsForLoadToSend(100, 100, "small_values"));
+  Isolate.spawn(sendSomeUpdates, ParamsForLoadToSend(50, 1000, "medium_values"));
+  Isolate.spawn(sendSomeUpdates, ParamsForLoadToSend(10, 10000, "large_values"));
+
+  sleep(Duration(seconds:60));
+
+  print ("Buh-bye");
+}

--- a/at_secondary/at_secondary_server/lib/src/connection/inbound/inbound_connection_impl.dart
+++ b/at_secondary/at_secondary_server/lib/src/connection/inbound/inbound_connection_impl.dart
@@ -14,8 +14,7 @@ class InboundConnectionImpl extends BaseConnection
   /// This contains the value of the atsign initiated the connection
   @override
   String? initiatedBy;
-  static int? inbound_idle_time =
-      AtSecondaryServerImpl.getInstance().serverContext!.inboundIdleTimeMillis;
+  static int? inboundIdleTime = AtSecondaryServerImpl.getInstance().serverContext!.inboundIdleTimeMillis;
 
   InboundConnectionImpl(Socket? socket, String? sessionId) : super(socket) {
     metaData = InboundConnectionMetadata()
@@ -53,7 +52,7 @@ class InboundConnectionImpl extends BaseConnection
   /// Returns true if the client's idle time is greater than configured idle time.
   /// false otherwise
   bool _isIdle() {
-    return _getIdleTimeMillis() > inbound_idle_time!;
+    return _getIdleTimeMillis() > inboundIdleTime!;
   }
 
   @override

--- a/at_secondary/at_secondary_server/lib/src/connection/outbound/outbound_connection_impl.dart
+++ b/at_secondary/at_secondary_server/lib/src/connection/outbound/outbound_connection_impl.dart
@@ -4,7 +4,7 @@ import 'package:at_secondary/src/server/at_secondary_impl.dart';
 import 'package:uuid/uuid.dart';
 
 class OutboundConnectionImpl extends OutboundConnection {
-  static int? outbound_idle_time =
+  static int? outboundIdleTime =
       AtSecondaryServerImpl.getInstance().serverContext!.outboundIdleTimeMillis;
 
   OutboundConnectionImpl(Socket? socket, String? toAtSign) : super(socket) {
@@ -24,7 +24,7 @@ class OutboundConnectionImpl extends OutboundConnection {
   }
 
   bool _isIdle() {
-    return _getIdleTimeMillis() > outbound_idle_time!;
+    return _getIdleTimeMillis() > outboundIdleTime!;
   }
 
   @override

--- a/at_secondary/at_secondary_server/test/cram_verb_test.dart
+++ b/at_secondary/at_secondary_server/test/cram_verb_test.dart
@@ -14,10 +14,12 @@ import 'package:at_server_spec/at_verb_spec.dart';
 import 'package:crypto/crypto.dart';
 import 'package:test/test.dart';
 
+String testDataStoragePath = Directory.current.path + '/test/hive/cram_verb_test';
+
 void main() async {
-  var storageDir = Directory.current.path + '/test/hive';
+
   late var keyStoreManager;
-  setUp(() async => keyStoreManager = await setUpFunc(storageDir));
+  setUp(() async => keyStoreManager = await setUpFunc(testDataStoragePath));
   group('A group of cram verb regex test', () {
     test('test from correct syntax with digest', () {
       var verb = Cram();
@@ -162,8 +164,7 @@ Future<SecondaryKeyStoreManager> setUpFunc(storageDir) async {
 }
 
 Future<void> tearDownFunc() async {
-  var isExists = await Directory('test/hive').exists();
-  if (isExists) {
-    Directory('test/hive').deleteSync(recursive: true);
+  if (Directory(testDataStoragePath).existsSync()) {
+    Directory(testDataStoragePath).deleteSync(recursive: true);
   }
 }

--- a/at_secondary/at_secondary_server/test/from_verb_test.dart
+++ b/at_secondary/at_secondary_server/test/from_verb_test.dart
@@ -13,24 +13,63 @@ import 'package:at_server_spec/at_verb_spec.dart';
 import 'package:test/test.dart';
 
 void main() async {
-  var storageDir = Directory.current.path + '/test/hive';
-  late var keyStoreManager;
-  setUp(() async => keyStoreManager = await setUpFunc(storageDir));
+  // String thisTestFileName = 'from_verb_test.dart';
+
+  String atSignAlice = '@alice';
+  String atSignAliceWithoutTheAtSign = atSignAlice.replaceAll("@", "");
+
+  late final SecondaryKeyStoreManager keyStoreManager;
+  var testDataStoragePath = Directory.current.path + '/test/hive/from_verb_test';
+
+  setUpAll(() async {
+    // print(thisTestFileName + ' setUpAll starting');
+
+    AtSecondaryServerImpl.getInstance().currentAtSign = atSignAlice;
+
+    var secondaryPersistenceStore =
+        SecondaryPersistenceStoreFactory.getInstance().getSecondaryPersistenceStore(AtSecondaryServerImpl.getInstance().currentAtSign)!;
+
+    var commitLogInstance = await AtCommitLogManagerImpl.getInstance().getCommitLog(atSignAlice, commitLogPath: testDataStoragePath);
+
+    secondaryPersistenceStore.getSecondaryKeyStore()!.commitLog = commitLogInstance;
+
+    AtSecondaryServerImpl.getInstance().currentAtSign = atSignAlice;
+    AtConfig(AtCommitLogManagerImpl.getInstance().getCommitLog(AtSecondaryServerImpl.getInstance().currentAtSign),
+        AtSecondaryServerImpl.getInstance().currentAtSign);
+
+    await AtAccessLogManagerImpl.getInstance().getAccessLog(atSignAlice, accessLogPath: testDataStoragePath);
+
+    await secondaryPersistenceStore.getHivePersistenceManager()!.init(testDataStoragePath);
+
+    keyStoreManager = secondaryPersistenceStore.getSecondaryKeyStoreManager()!;
+
+    // print(thisTestFileName + ' setUpAll complete');
+  });
+
+  tearDownAll(() async {
+    // print(thisTestFileName + ' tearDownAll starting');
+
+    // print(thisTestFileName + ' tearDownAll removing test data directory ' + testDataStoragePath);
+    await Directory(testDataStoragePath).delete(recursive: true);
+
+    // print(thisTestFileName + ' tearDownAll complete');
+  });
+
   group('A group of from verb regex test', () {
     test('test from correct syntax with @', () {
       var verb = From();
-      var command = 'from:@alice';
+      var command = 'from:' + atSignAlice;
       var regex = verb.syntax();
       var paramsMap = getVerbParam(regex, command);
-      expect(paramsMap['atSign'], '@alice');
+      expect(paramsMap['atSign'], atSignAlice);
     });
 
     test('test from correct syntax without @', () {
       var verb = From();
-      var command = 'from:alice';
+      var command = 'from:' + atSignAliceWithoutTheAtSign;
       var regex = verb.syntax();
       var paramsMap = getVerbParam(regex, command);
-      expect(paramsMap['atSign'], 'alice');
+      expect(paramsMap['atSign'], atSignAliceWithoutTheAtSign);
     });
 
     test('test from correct syntax with emoji', () {
@@ -62,17 +101,17 @@ void main() async {
 
   group('A group of from verb accept test', () {
     test('test from accept', () {
-      var command = 'from:@alice';
+      var command = 'from:' + atSignAlice;
       var handler = FromVerbHandler(null);
       expect(handler.accept(command), true);
     });
     test('test from accept invalid keyword', () {
-      var command = 'to:@alice';
+      var command = 'to:' + atSignAlice;
       var handler = FromVerbHandler(null);
       expect(handler.accept(command), false);
     });
     test('test from verb upper case', () {
-      var command = 'FROM:@ALICE';
+      var command = 'FROM:' + atSignAlice.toUpperCase();
       command = SecondaryUtil.convertCommand(command);
       var handler = FromVerbHandler(null);
       expect(handler.accept(command), true);
@@ -81,7 +120,7 @@ void main() async {
   group('A group of from verb regex -invalid syntax', () {
     test('test from invalid keyword', () {
       var verb = From();
-      var command = 'to:@alice';
+      var command = 'to' + atSignAlice;
       var regex = verb.syntax();
       expect(
           () => getVerbParam(regex, command),
@@ -99,14 +138,14 @@ void main() async {
 
     test('test from verb handler processverb from atsign contains @', () async {
       var verbHandler = FromVerbHandler(keyStoreManager.getKeyStore());
-      AtSecondaryServerImpl.getInstance().currentAtSign = '@alice';
+      AtSecondaryServerImpl.getInstance().currentAtSign = atSignAlice;
       var inBoundSessionId = '123';
       var atConnection = InboundConnectionImpl(null, inBoundSessionId);
       var verbParams = HashMap<String, String>();
-      verbParams.putIfAbsent('atSign', () => '@alice');
+      verbParams.putIfAbsent('atSign', () => atSignAlice);
       var response = Response();
       await verbHandler.processVerb(response, verbParams, atConnection);
-      expect(response.data!.startsWith('data:$inBoundSessionId@alice'), true);
+      expect(response.data!.startsWith('data:$inBoundSessionId' + atSignAlice), true);
       var connectionMetadata =
           atConnection.getMetaData() as InboundConnectionMetadata;
       expect(connectionMetadata.self, true);
@@ -115,14 +154,14 @@ void main() async {
     test('test from verb handler processverb from atsign does not contain @',
         () async {
       var verbHandler = FromVerbHandler(keyStoreManager.getKeyStore());
-      AtSecondaryServerImpl.getInstance().currentAtSign = '@alice';
+      AtSecondaryServerImpl.getInstance().currentAtSign = atSignAlice;
       var inBoundSessionId = '123';
       var atConnection = InboundConnectionImpl(null, inBoundSessionId);
       var verbParams = HashMap<String, String>();
-      verbParams.putIfAbsent('atSign', () => 'alice');
+      verbParams.putIfAbsent('atSign', () => atSignAliceWithoutTheAtSign);
       var response = Response();
       await verbHandler.processVerb(response, verbParams, atConnection);
-      expect(response.data!.startsWith('data:$inBoundSessionId@alice'), true);
+      expect(response.data!.startsWith('data:$inBoundSessionId' + atSignAlice), true);
       expect(response.data!.split(':')[2], isNotNull);
       var connectionMetadata =
           atConnection.getMetaData() as InboundConnectionMetadata;
@@ -155,14 +194,14 @@ void main() async {
       await AtConfig(commitLogInstance,
               AtSecondaryServerImpl.getInstance().currentAtSign)
           .addToBlockList({'@bob'});
-      AtSecondaryServerImpl.getInstance().currentAtSign = '@alice';
+      AtSecondaryServerImpl.getInstance().currentAtSign = atSignAlice;
       var inBoundSessionId = '123';
       var atConnection = InboundConnectionImpl(null, inBoundSessionId);
       var verbParams = HashMap<String, String>();
-      verbParams.putIfAbsent('atSign', () => '@alice');
+      verbParams.putIfAbsent('atSign', () => atSignAlice);
       var response = Response();
       await verbHandler.processVerb(response, verbParams, atConnection);
-      expect(response.data!.startsWith('data:$inBoundSessionId@alice'), true);
+      expect(response.data!.startsWith('data:$inBoundSessionId' + atSignAlice), true);
       expect(response.data!.split(':')[2], isNotNull);
       var connectionMetadata =
           atConnection.getMetaData() as InboundConnectionMetadata;
@@ -176,7 +215,7 @@ void main() async {
                   AtSecondaryServerImpl.getInstance().currentAtSign),
               AtSecondaryServerImpl.getInstance().currentAtSign)
           .addToBlockList({'@bob'});
-      AtSecondaryServerImpl.getInstance().currentAtSign = '@alice';
+      AtSecondaryServerImpl.getInstance().currentAtSign = atSignAlice;
       var inBoundSessionId = '123';
       var atConnection = InboundConnectionImpl(null, inBoundSessionId);
       var verbParams = HashMap<String, String>();
@@ -191,7 +230,7 @@ void main() async {
     /*test('test from verb handler to block fromAtSign first and then allow',
         () async {
       var verbHandler = FromVerbHandler(keyStoreManager.getKeyStore());
-      AtSecondaryServerImpl().currentAtSign = '@alice';
+      AtSecondaryServerImpl().currentAtSign = atSignAlice;
       await AtConfig.getInstance().addToBlockList({'@bob'});
       var inBoundSessionId = '123';
       var atConnection = InboundConnectionImpl(null, inBoundSessionId);
@@ -215,7 +254,7 @@ void main() async {
     test('test from verb handler to allow fromAtSign first and then block',
         () async {
       var verbHandler = FromVerbHandler(keyStoreManager.getKeyStore());
-      AtSecondaryServerImpl().currentAtSign = '@alice';
+      AtSecondaryServerImpl().currentAtSign = atSignAlice;
       var inBoundSessionId = '123';
       var atConnection = InboundConnectionImpl(null, inBoundSessionId);
       var verbParams = HashMap<String, String>();
@@ -235,41 +274,4 @@ void main() async {
           throwsA(isA<BlockedConnectionException>()));
     });*/
   });
-
-  tearDown(() async => tearDownFunc());
-
-  if (Directory(storageDir).existsSync()) {
-    Directory(storageDir).deleteSync(recursive: true);
-  }
-}
-
-Future<SecondaryKeyStoreManager> setUpFunc(storageDir) async {
-  var secondaryPersistenceStore = SecondaryPersistenceStoreFactory.getInstance()
-      .getSecondaryPersistenceStore('@alice')!;
-  var commitLogInstance = await AtCommitLogManagerImpl.getInstance()
-      .getCommitLog('@alice', commitLogPath: storageDir);
-  var persistenceManager =
-      secondaryPersistenceStore.getHivePersistenceManager()!;
-  await persistenceManager.init(storageDir);
-//  persistenceManager.scheduleKeyExpireTask(1); //commented this line for coverage test
-  var hiveKeyStore = secondaryPersistenceStore.getSecondaryKeyStore()!;
-  hiveKeyStore.commitLog = commitLogInstance;
-  var keyStoreManager =
-      secondaryPersistenceStore.getSecondaryKeyStoreManager()!;
-  keyStoreManager.keyStore = hiveKeyStore;
-  AtSecondaryServerImpl.getInstance().currentAtSign = '@alice';
-  AtConfig(
-      AtCommitLogManagerImpl.getInstance()
-          .getCommitLog(AtSecondaryServerImpl.getInstance().currentAtSign),
-      AtSecondaryServerImpl.getInstance().currentAtSign);
-  await AtAccessLogManagerImpl.getInstance()
-      .getAccessLog('@alice', accessLogPath: storageDir);
-  return keyStoreManager;
-}
-
-Future<void> tearDownFunc() async {
-  var isExists = await Directory('test/hive').exists();
-  if (isExists) {
-    Directory('test/hive').deleteSync(recursive: true);
-  }
 }

--- a/at_secondary/at_secondary_server/test/inbound_connection_pool_test.dart
+++ b/at_secondary/at_secondary_server/test/inbound_connection_pool_test.dart
@@ -7,14 +7,16 @@ import 'package:at_secondary/src/server/server_context.dart';
 import 'package:test/test.dart';
 
 void main() async {
+  var testIdleTimeMillis = 250;
   setUp(() {
     var serverContext = AtSecondaryContext();
-    serverContext.inboundIdleTimeMillis = 10000;
+    serverContext.inboundIdleTimeMillis = testIdleTimeMillis;
     AtSecondaryServerImpl.getInstance().serverContext = serverContext;
   });
   tearDown(() {
     InboundConnectionPool.getInstance().clearAllConnections();
   });
+
   group('A group of inbound connection pool test', () {
     test('test connection pool init', () {
       InboundConnectionPool.getInstance().init((5));
@@ -25,7 +27,7 @@ void main() async {
     test('test connection pool add connections', () {
       var poolInstance = InboundConnectionPool.getInstance();
       poolInstance.init(5);
-      var dummySocket;
+      Socket? dummySocket;
       var connection1 = InboundConnectionImpl(dummySocket, 'aaa');
       var connection2 = InboundConnectionImpl(dummySocket, 'bbb');
       poolInstance.add(connection1);
@@ -36,7 +38,7 @@ void main() async {
     test('test connection pool has capacity', () {
       var poolInstance = InboundConnectionPool.getInstance();
       poolInstance.init(2);
-      var dummySocket;
+      Socket? dummySocket;
       var connection1 = InboundConnectionImpl(dummySocket, 'aaa');
       poolInstance.add(connection1);
       expect(poolInstance.hasCapacity(), true);
@@ -45,7 +47,7 @@ void main() async {
     test('test connection pool has no capacity', () {
       var poolInstance = InboundConnectionPool.getInstance();
       poolInstance.init(2);
-      var dummySocket;
+      Socket? dummySocket;
       var connection1 = InboundConnectionImpl(dummySocket, 'aaa');
       var connection2 = InboundConnectionImpl(dummySocket, 'bbb');
       poolInstance.add(connection1);
@@ -56,7 +58,7 @@ void main() async {
     test('test connection pool - clear closed connection', () {
       var poolInstance = InboundConnectionPool.getInstance();
       poolInstance.init(2);
-      var dummySocket;
+      Socket? dummySocket;
       var connection1 = MockInBoundConnectionImpl(dummySocket, 'aaa');
       var connection2 = MockInBoundConnectionImpl(dummySocket, 'bbb');
       poolInstance.add(connection1);
@@ -70,17 +72,22 @@ void main() async {
     test('test connection pool - clear idle connection', () {
       var poolInstance = InboundConnectionPool.getInstance();
       poolInstance.init(2);
-      var dummySocket;
+      Socket? dummySocket;
       var connection1 = MockInBoundConnectionImpl(dummySocket, 'aaa');
       var connection2 = MockInBoundConnectionImpl(dummySocket, 'bbb');
       var connection3 = MockInBoundConnectionImpl(dummySocket, 'ccc');
       poolInstance.add(connection1);
       poolInstance.add(connection2);
       poolInstance.add(connection3);
-      sleep(Duration(seconds: 9));
+
+      // Wait for 90 percent of the idle time to pass, then write to one of the connections
+      sleep(Duration(milliseconds: (testIdleTimeMillis * 0.9).round()));
       connection2.write('test data');
       expect(poolInstance.getCurrentSize(), 3);
-      sleep(Duration(seconds: 2));
+
+      // Now wait for the other 10 percent of the idle time to pass, plus 1 millisecond
+      // Two of the connections should now have passed their idle time, will be invalid, and will be cleared by clearInvalidConnections
+      sleep(Duration(milliseconds: (testIdleTimeMillis * 0.1).round() + 1));
       print('connection 1: ${connection1.getMetaData().created} '
           '${connection1.getMetaData().lastAccessed} ${connection1.isInValid()}');
       print('connection 2: ${connection2.getMetaData().created} '

--- a/at_secondary/at_secondary_server/test/notify_list_verb_test.dart
+++ b/at_secondary/at_secondary_server/test/notify_list_verb_test.dart
@@ -250,6 +250,7 @@ Future<SecondaryKeyStoreManager> setUpFunc(storageDir) async {
 
 Future<void> tearDownFunc() async {
   AtNotificationMap.getInstance().clear();
+  await AtNotificationKeystore.getInstance().close();
   if (Directory(testDataStoragePath).existsSync()) {
     Directory(testDataStoragePath).deleteSync(recursive: true);
   }

--- a/at_secondary/at_secondary_server/test/notify_list_verb_test.dart
+++ b/at_secondary/at_secondary_server/test/notify_list_verb_test.dart
@@ -14,7 +14,8 @@ import 'package:test/test.dart';
 String testDataStoragePath = Directory.current.path + '/test/hive/notify_list_verb_test';
 
 void main() {
-  late final SecondaryKeyStoreManager keyStoreManager;
+  // ignore: prefer_typing_uninitialized_variables
+  var keyStoreManager;
   group('A group of notify list verb tests', () {
     test('test notify getVerb', () {
       var handler = NotifyListVerbHandler(null);

--- a/at_secondary/at_secondary_server/test/notify_list_verb_test.dart
+++ b/at_secondary/at_secondary_server/test/notify_list_verb_test.dart
@@ -6,16 +6,15 @@ import 'package:at_persistence_secondary_server/at_persistence_secondary_server.
 import 'package:at_secondary/src/connection/inbound/inbound_connection_impl.dart';
 import 'package:at_secondary/src/connection/inbound/inbound_connection_metadata.dart';
 import 'package:at_secondary/src/notification/at_notification_map.dart';
-import 'package:at_secondary/src/server/at_secondary_impl.dart';
 import 'package:at_secondary/src/utils/handler_util.dart';
 import 'package:at_secondary/src/verb/handler/notify_list_verb_handler.dart';
 import 'package:at_server_spec/at_verb_spec.dart';
-import 'package:crypto/crypto.dart';
 import 'package:test/test.dart';
 
+String testDataStoragePath = Directory.current.path + '/test/hive/notify_list_verb_test';
+
 void main() {
-  var storageDir = Directory.current.path + '/test/hive';
-  late var keyStoreManager;
+  late final SecondaryKeyStoreManager keyStoreManager;
   group('A group of notify list verb tests', () {
     test('test notify getVerb', () {
       var handler = NotifyListVerbHandler(null);
@@ -72,7 +71,7 @@ void main() {
   });
 
   group('A group of tests on date time', () {
-    setUp(() async => keyStoreManager = await setUpFunc(storageDir));
+    setUp(() async => keyStoreManager = await setUpFunc(testDataStoragePath));
     test('A test to verify from date', () async {
       var notifyListVerbHandler =
           NotifyListVerbHandler(keyStoreManager.getKeyStore());
@@ -249,14 +248,8 @@ Future<SecondaryKeyStoreManager> setUpFunc(storageDir) async {
 }
 
 Future<void> tearDownFunc() async {
-  var isExists = await Directory('test/hive').exists();
   AtNotificationMap.getInstance().clear();
-  if (isExists) {
-    Directory('test/hive').deleteSync(recursive: true);
+  if (Directory(testDataStoragePath).existsSync()) {
+    Directory(testDataStoragePath).deleteSync(recursive: true);
   }
-}
-
-String _getShaForAtsign(String atsign) {
-  var bytes = utf8.encode(atsign);
-  return sha256.convert(bytes).toString();
 }

--- a/at_secondary/at_secondary_server/test/notify_verb_test.dart
+++ b/at_secondary/at_secondary_server/test/notify_verb_test.dart
@@ -22,8 +22,70 @@ import 'package:crypto/crypto.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var storageDir = Directory.current.path + '/test/hive';
-  late var keyStoreManager;
+  // String thisTestFileName = 'notify_verb_test.dart';
+
+  var testDataStoragePathRoot = Directory.current.path + '/test/hive/notify_verb_test';
+
+  List<String> testNames = <String>[];
+
+  Future<SecondaryKeyStoreManager> doSetUpForSpecificTest(String specificTestName) async {
+    // TODO This is a temporary situation. Problem here is not being able to run tests concurrently because of the way the notifications work.
+    // TODO For now we're going to create a specific Hive setup for each individual test.
+    // TODO That didn't work either because AtNotificationMap is a singleton also.
+    // TODO So now forcing serialization of just these tests by doing a horribly hokey thing
+    testNames.add(specificTestName);
+    while (testNames.indexOf(specificTestName) != 0) {
+      sleep(Duration(milliseconds: 10));
+    }
+
+    // print(thisTestFileName + ' notify_verb_test doSetUpForSpecificTest starting for ' + specificTestName);
+
+    String atSignForTests = '@test_user_1';
+
+    String storagePathThisTest = testDataStoragePathRoot + '/' + specificTestName;
+
+    AtSecondaryServerImpl.getInstance().currentAtSign = atSignForTests;
+
+    var secondaryPersistenceStore =
+    SecondaryPersistenceStoreFactory.getInstance().getSecondaryPersistenceStore(AtSecondaryServerImpl.getInstance().currentAtSign)!;
+
+    await secondaryPersistenceStore.getHivePersistenceManager()!.init(storagePathThisTest);
+
+    var commitLogInstance = await AtCommitLogManagerImpl.getInstance().getCommitLog(atSignForTests, commitLogPath: storagePathThisTest);
+    secondaryPersistenceStore.getSecondaryKeyStore()!.commitLog = commitLogInstance;
+
+    await AtAccessLogManagerImpl.getInstance().getAccessLog(atSignForTests, accessLogPath: storagePathThisTest);
+
+    final notificationStore = AtNotificationKeystore.getInstance();
+    notificationStore.currentAtSign = atSignForTests;
+    await notificationStore.init(storagePathThisTest);
+
+    // print(thisTestFileName + ' notify_verb_test doSetUpForSpecificTest COMPLETE for ' + specificTestName);
+
+    return secondaryPersistenceStore.getSecondaryKeyStoreManager()!;
+  }
+
+  void doTearDownForSpecificTest(String specificTestName) async {
+    // TODO See the TODO in doSetUpForSpecificTest above
+    // print(thisTestFileName + ' notify_verb_test doTearDownForSpecificTest starting for ' + specificTestName);
+
+    // TODO Need to eliminate some of these singletons
+    AtNotificationMap.getInstance().clear();
+    // print(thisTestFileName + ' notify_verb_test doTearDownForSpecificTest cleared map');
+    await AtNotificationKeystore.getInstance().close();
+    // print(thisTestFileName + ' notify_verb_test doTearDownForSpecificTest closed notif keystore');
+
+    String storagePathThisTest = testDataStoragePathRoot + '/' + specificTestName;
+
+    if (Directory(storagePathThisTest).existsSync()) {
+      // print(thisTestFileName + ' tearDownAll removing test data directory ' + storagePathThisTest);
+      Directory(storagePathThisTest).deleteSync(recursive: true);
+    }
+
+    testNames.remove(specificTestName);
+
+    // print(thisTestFileName + ' notify_verb_test doTearDownForSpecificTest COMPLETE for ' + specificTestName);
+  }
 
   group('A group of notify verb regex test', () {
     test('test notify for self atsign', () {
@@ -89,10 +151,7 @@ void main() {
       var verb = Notify();
       var command = 'notify:location@alice ';
       var regex = verb.syntax();
-      expect(
-          () => getVerbParam(regex, command),
-          throwsA(predicate((dynamic e) =>
-              e is InvalidSyntaxException && e.message == 'Syntax Exception')));
+      expect(() => getVerbParam(regex, command), throwsA(predicate((dynamic e) => e is InvalidSyntaxException && e.message == 'Syntax Exception')));
     });
 
     test('test notify key- no from atsign', () {
@@ -108,30 +167,21 @@ void main() {
       var verb = Notify();
       var command = 'notify:location';
       var regex = verb.syntax();
-      expect(
-          () => getVerbParam(regex, command),
-          throwsA(predicate((dynamic e) =>
-              e is InvalidSyntaxException && e.message == 'Syntax Exception')));
+      expect(() => getVerbParam(regex, command), throwsA(predicate((dynamic e) => e is InvalidSyntaxException && e.message == 'Syntax Exception')));
     });
 
     test('test notify key- invalid keyword', () {
       var verb = Notify();
       var command = 'notification:@colin:location@alice';
       var regex = verb.syntax();
-      expect(
-          () => getVerbParam(regex, command),
-          throwsA(predicate((dynamic e) =>
-              e is InvalidSyntaxException && e.message == 'Syntax Exception')));
+      expect(() => getVerbParam(regex, command), throwsA(predicate((dynamic e) => e is InvalidSyntaxException && e.message == 'Syntax Exception')));
     });
 
     test('test notify verb - no key', () {
       var verb = Notify();
       var command = 'notify:@colin:@alice';
       var regex = verb.syntax();
-      expect(
-          () => getVerbParam(regex, command),
-          throwsA(predicate((dynamic e) =>
-              e is InvalidSyntaxException && e.message == 'Syntax Exception')));
+      expect(() => getVerbParam(regex, command), throwsA(predicate((dynamic e) => e is InvalidSyntaxException && e.message == 'Syntax Exception')));
     });
 
     test('test notify verb - invalid ttl value', () {
@@ -140,10 +190,7 @@ void main() {
       var notifyResponse = Response();
       var notifyVerbParams = HashMap<String, String>();
       notifyVerbParams.putIfAbsent('ttl', () => '0');
-      expect(
-          () => notifyVerb.processVerb(
-              notifyResponse, notifyVerbParams, inboundConnection),
-          throwsA(predicate((dynamic e) => e is InvalidSyntaxException)));
+      expect(() => notifyVerb.processVerb(notifyResponse, notifyVerbParams, inboundConnection), throwsA(predicate((dynamic e) => e is InvalidSyntaxException)));
     });
 
     test('test notify verb - invalid ttb value', () {
@@ -152,10 +199,7 @@ void main() {
       var notifyResponse = Response();
       var notifyVerbParams = HashMap<String, String>();
       notifyVerbParams.putIfAbsent('ttb', () => '0');
-      expect(
-          () => notifyVerb.processVerb(
-              notifyResponse, notifyVerbParams, inboundConnection),
-          throwsA(predicate((dynamic e) => e is InvalidSyntaxException)));
+      expect(() => notifyVerb.processVerb(notifyResponse, notifyVerbParams, inboundConnection), throwsA(predicate((dynamic e) => e is InvalidSyntaxException)));
     });
 
     test('test notify verb - ttr = -2 invalid value ', () {
@@ -164,24 +208,19 @@ void main() {
       var notifyResponse = Response();
       var notifyVerbParams = HashMap<String, String>();
       notifyVerbParams.putIfAbsent('ttr', () => '-2');
-      expect(
-          () => notifyVerb.processVerb(
-              notifyResponse, notifyVerbParams, inboundConnection),
-          throwsA(predicate((dynamic e) => e is InvalidSyntaxException)));
+      expect(() => notifyVerb.processVerb(notifyResponse, notifyVerbParams, inboundConnection), throwsA(predicate((dynamic e) => e is InvalidSyntaxException)));
     });
 
     test('test notify key- invalid command', () {
       var command = 'notify:location@alice';
       AbstractVerbHandler handler = NotifyVerbHandler(null);
-      expect(() => handler.parse(command),
-          throwsA(predicate((dynamic e) => e is InvalidSyntaxException)));
+      expect(() => handler.parse(command), throwsA(predicate((dynamic e) => e is InvalidSyntaxException)));
     });
 
     test('test notify key- invalid ccd value', () {
       var command = 'notify:update:ttr:1000:ccd:test:location@alice';
       AbstractVerbHandler handler = NotifyVerbHandler(null);
-      expect(() => handler.parse(command),
-          throwsA(predicate((dynamic e) => e is InvalidSyntaxException)));
+      expect(() => handler.parse(command), throwsA(predicate((dynamic e) => e is InvalidSyntaxException)));
     });
   });
 
@@ -210,8 +249,7 @@ void main() {
 
     test('notify verb with cascade delete is true', () {
       var verb = Notify();
-      var command =
-          'notify:update:notifier:persona:ttr:10000:ccd:true:@bob:location@alice';
+      var command = 'notify:update:notifier:persona:ttr:10000:ccd:true:@bob:location@alice';
       command = SecondaryUtil.convertCommand(command);
       var regex = verb.syntax();
       var paramsMap = getVerbParam(regex, command);
@@ -225,8 +263,7 @@ void main() {
 
     test('notify verb with cascade delete is false', () {
       var verb = Notify();
-      var command =
-          'notify:update:notifier:persona:ttr:10000:ccd:false:@bob:location@alice';
+      var command = 'notify:update:notifier:persona:ttr:10000:ccd:false:@bob:location@alice';
       command = SecondaryUtil.convertCommand(command);
       var regex = verb.syntax();
       var paramsMap = getVerbParam(regex, command);
@@ -240,558 +277,551 @@ void main() {
   });
 
   group('A group of hive related test cases', () {
-    setUp(() async => keyStoreManager = await setUpFunc(storageDir));
     test('test notify handler with update operation', () async {
-      SecondaryKeyStore keyStore = keyStoreManager.getKeyStore();
-      var secretData = AtData();
-      secretData.data =
-          'b26455a907582760ebf35bc4847de549bc41c24b25c8b1c58d5964f7b4f8a43bc55b0e9a601c9a9657d9a8b8bbc32f88b4e38ffaca03c8710ebae1b14ca9f364';
-      await keyStore.put('privatekey:at_secret', secretData);
-      var fromVerbHandler = FromVerbHandler(keyStoreManager.getKeyStore());
-      AtSecondaryServerImpl.getInstance().currentAtSign = '@test_user_1';
-      var inBoundSessionId = '_6665436c-29ff-481b-8dc6-129e89199718';
-      var atConnection = InboundConnectionImpl(null, inBoundSessionId);
-      var fromVerbParams = HashMap<String, String>();
-      fromVerbParams.putIfAbsent('atSign', () => 'test_user_1');
-      var response = Response();
-      await fromVerbHandler.processVerb(response, fromVerbParams, atConnection);
-      var fromResponse = response.data!.replaceFirst('data:', '');
-      var cramVerbParams = HashMap<String, String>();
-      var combo = '${secretData.data}$fromResponse';
-      var bytes = utf8.encode(combo);
-      var digest = sha512.convert(bytes);
-      cramVerbParams.putIfAbsent('digest', () => digest.toString());
-      var cramVerbHandler = CramVerbHandler(keyStoreManager.getKeyStore());
-      var cramResponse = Response();
-      await cramVerbHandler.processVerb(
-          cramResponse, cramVerbParams, atConnection);
-      var connectionMetadata =
-          atConnection.getMetaData() as InboundConnectionMetadata;
-      expect(connectionMetadata.isAuthenticated, true);
-      expect(cramResponse.data, 'success');
-      //Notify Verb
-      var notifyVerbHandler = NotifyVerbHandler(keyStore);
-      var notifyResponse = Response();
-      var notifyVerbParams = HashMap<String, String>();
-      notifyVerbParams.putIfAbsent('operation', () => 'update');
-      notifyVerbParams.putIfAbsent('forAtSign', () => '@test_user_1');
-      notifyVerbParams.putIfAbsent('atSign', () => '@test_user_1');
-      notifyVerbParams.putIfAbsent('atKey', () => 'phone');
-      await notifyVerbHandler.processVerb(
-          notifyResponse, notifyVerbParams, atConnection);
-      //Notify list verb handler
-      var notifyListVerbHandler = NotifyListVerbHandler(keyStore);
-      var notifyListResponse = Response();
-      var notifyListVerbParams = HashMap<String, String>();
-      await notifyListVerbHandler.processVerb(
-          notifyListResponse, notifyListVerbParams, atConnection);
-      var notifyData = jsonDecode(notifyListResponse.data!);
-      assert(notifyData[0][ID] != null);
-      assert(notifyData[0][EPOCH_MILLIS] != null);
-      expect(notifyData[0][TO], '@test_user_1');
-      expect(notifyData[0][KEY], '@test_user_1:phone@test_user_1');
-      expect(notifyData[0][OPERATION], 'update');
+      var specificTestName = 'test_notify_handler_with_update_operation';
+      SecondaryKeyStoreManager keyStoreManager = await doSetUpForSpecificTest(specificTestName);
+
+      try {
+        SecondaryKeyStore keyStore = keyStoreManager.getKeyStore();
+        var secretData = AtData();
+        secretData.data = 'b26455a907582760ebf35bc4847de549bc41c24b25c8b1c58d5964f7b4f8a43bc55b0e9a601c9a9657d9a8b8bbc32f88b4e38ffaca03c8710ebae1b14ca9f364';
+        await keyStore.put('privatekey:at_secret', secretData);
+        var fromVerbHandler = FromVerbHandler(keyStoreManager.getKeyStore());
+        AtSecondaryServerImpl.getInstance().currentAtSign = '@test_user_1';
+        var inBoundSessionId = '_6665436c-29ff-481b-8dc6-129e89199718';
+        var atConnection = InboundConnectionImpl(null, inBoundSessionId);
+        var fromVerbParams = HashMap<String, String>();
+        fromVerbParams.putIfAbsent('atSign', () => 'test_user_1');
+        var response = Response();
+        await fromVerbHandler.processVerb(response, fromVerbParams, atConnection);
+        var fromResponse = response.data!.replaceFirst('data:', '');
+        var cramVerbParams = HashMap<String, String>();
+        var combo = '${secretData.data}$fromResponse';
+        var bytes = utf8.encode(combo);
+        var digest = sha512.convert(bytes);
+        cramVerbParams.putIfAbsent('digest', () => digest.toString());
+        var cramVerbHandler = CramVerbHandler(keyStoreManager.getKeyStore());
+        var cramResponse = Response();
+        await cramVerbHandler.processVerb(cramResponse, cramVerbParams, atConnection);
+        var connectionMetadata = atConnection.getMetaData() as InboundConnectionMetadata;
+        expect(connectionMetadata.isAuthenticated, true);
+        expect(cramResponse.data, 'success');
+        //Notify Verb
+        var notifyVerbHandler = NotifyVerbHandler(keyStore);
+        var notifyResponse = Response();
+        var notifyVerbParams = HashMap<String, String>();
+        notifyVerbParams.putIfAbsent('operation', () => 'update');
+        notifyVerbParams.putIfAbsent('forAtSign', () => '@test_user_1');
+        notifyVerbParams.putIfAbsent('atSign', () => '@test_user_1');
+        notifyVerbParams.putIfAbsent('atKey', () => 'phone');
+        await notifyVerbHandler.processVerb(notifyResponse, notifyVerbParams, atConnection);
+        //Notify list verb handler
+        var notifyListVerbHandler = NotifyListVerbHandler(keyStore);
+        var notifyListResponse = Response();
+        var notifyListVerbParams = HashMap<String, String>();
+        await notifyListVerbHandler.processVerb(notifyListResponse, notifyListVerbParams, atConnection);
+        var notifyData = jsonDecode(notifyListResponse.data!);
+        assert(notifyData[0][ID] != null);
+        assert(notifyData[0][EPOCH_MILLIS] != null);
+        expect(notifyData[0][TO], '@test_user_1');
+        expect(notifyData[0][KEY], '@test_user_1:phone@test_user_1');
+        expect(notifyData[0][OPERATION], 'update');
+      } finally {
+        doTearDownForSpecificTest(specificTestName);
+      }
     });
 
     test('test notify handler with delete operation', () async {
+      var specificTestName = 'test_notify_handler_with_delete_operation';
+      SecondaryKeyStoreManager keyStoreManager = await doSetUpForSpecificTest(specificTestName);
       SecondaryKeyStore keyStore = keyStoreManager.getKeyStore();
-      var secretData = AtData();
-      secretData.data =
-          'b26455a907582760ebf35bc4847de549bc41c24b25c8b1c58d5964f7b4f8a43bc55b0e9a601c9a9657d9a8b8bbc32f88b4e38ffaca03c8710ebae1b14ca9f364';
-      await keyStore.put('privatekey:at_secret', secretData);
-      var fromVerbHandler = FromVerbHandler(keyStoreManager.getKeyStore());
-      AtSecondaryServerImpl.getInstance().currentAtSign = '@test_user_1';
-      var inBoundSessionId = '_6665436c-29ff-481b-8dc6-129e89199718';
-      var atConnection = InboundConnectionImpl(null, inBoundSessionId);
-      var fromVerbParams = HashMap<String, String>();
-      fromVerbParams.putIfAbsent('atSign', () => 'test_user_1');
-      var response = Response();
-      await fromVerbHandler.processVerb(response, fromVerbParams, atConnection);
-      var fromResponse = response.data!.replaceFirst('data:', '');
-      var cramVerbParams = HashMap<String, String>();
-      var combo = '${secretData.data}$fromResponse';
-      var bytes = utf8.encode(combo);
-      var digest = sha512.convert(bytes);
-      cramVerbParams.putIfAbsent('digest', () => digest.toString());
-      var cramVerbHandler = CramVerbHandler(keyStoreManager.getKeyStore());
-      var cramResponse = Response();
-      await cramVerbHandler.processVerb(
-          cramResponse, cramVerbParams, atConnection);
-      var connectionMetadata =
-          atConnection.getMetaData() as InboundConnectionMetadata;
-      expect(connectionMetadata.isAuthenticated, true);
-      expect(cramResponse.data, 'success');
-      //Notify Verb
-      var notifyVerbHandler = NotifyVerbHandler(keyStore);
-      var notifyResponse = Response();
-      var notifyVerbParams = HashMap<String, String>();
-      notifyVerbParams.putIfAbsent('operation', () => 'delete');
-      notifyVerbParams.putIfAbsent('forAtSign', () => '@test_user_1');
-      notifyVerbParams.putIfAbsent('atSign', () => '@test_user_1');
-      notifyVerbParams.putIfAbsent('atKey', () => 'phone');
-      await notifyVerbHandler.processVerb(
-          notifyResponse, notifyVerbParams, atConnection);
-      //Notify list verb handler
-      var notifyListVerbHandler = NotifyListVerbHandler(keyStore);
-      var notifyListResponse = Response();
-      var notifyListVerbParams = HashMap<String, String>();
-      await notifyListVerbHandler.processVerb(
-          notifyListResponse, notifyListVerbParams, atConnection);
-      var notifyData = jsonDecode(notifyListResponse.data!);
-      assert(notifyData[0][ID] != null);
-      assert(notifyData[0][EPOCH_MILLIS] != null);
-      expect(notifyData[0][TO], '@test_user_1');
-      expect(notifyData[0][KEY], '@test_user_1:phone@test_user_1');
-      expect(notifyData[0][OPERATION], 'delete');
+
+      try {
+        var secretData = AtData();
+        secretData.data = 'b26455a907582760ebf35bc4847de549bc41c24b25c8b1c58d5964f7b4f8a43bc55b0e9a601c9a9657d9a8b8bbc32f88b4e38ffaca03c8710ebae1b14ca9f364';
+        await keyStore.put('privatekey:at_secret', secretData);
+        var fromVerbHandler = FromVerbHandler(keyStoreManager.getKeyStore());
+        AtSecondaryServerImpl.getInstance().currentAtSign = '@test_user_1';
+        var inBoundSessionId = '_6665436c-29ff-481b-8dc6-129e89199718';
+        var atConnection = InboundConnectionImpl(null, inBoundSessionId);
+        var fromVerbParams = HashMap<String, String>();
+        fromVerbParams.putIfAbsent('atSign', () => 'test_user_1');
+        var response = Response();
+        await fromVerbHandler.processVerb(response, fromVerbParams, atConnection);
+        var fromResponse = response.data!.replaceFirst('data:', '');
+        var cramVerbParams = HashMap<String, String>();
+        var combo = '${secretData.data}$fromResponse';
+        var bytes = utf8.encode(combo);
+        var digest = sha512.convert(bytes);
+        cramVerbParams.putIfAbsent('digest', () => digest.toString());
+        var cramVerbHandler = CramVerbHandler(keyStoreManager.getKeyStore());
+        var cramResponse = Response();
+        await cramVerbHandler.processVerb(cramResponse, cramVerbParams, atConnection);
+        var connectionMetadata = atConnection.getMetaData() as InboundConnectionMetadata;
+        expect(connectionMetadata.isAuthenticated, true);
+        expect(cramResponse.data, 'success');
+        //Notify Verb
+        var notifyVerbHandler = NotifyVerbHandler(keyStore);
+        var notifyResponse = Response();
+        var notifyVerbParams = HashMap<String, String>();
+        notifyVerbParams.putIfAbsent('operation', () => 'delete');
+        notifyVerbParams.putIfAbsent('forAtSign', () => '@test_user_1');
+        notifyVerbParams.putIfAbsent('atSign', () => '@test_user_1');
+        notifyVerbParams.putIfAbsent('atKey', () => 'phone');
+        await notifyVerbHandler.processVerb(notifyResponse, notifyVerbParams, atConnection);
+        //Notify list verb handler
+        var notifyListVerbHandler = NotifyListVerbHandler(keyStore);
+        var notifyListResponse = Response();
+        var notifyListVerbParams = HashMap<String, String>();
+        await notifyListVerbHandler.processVerb(notifyListResponse, notifyListVerbParams, atConnection);
+        var notifyData = jsonDecode(notifyListResponse.data!);
+        assert(notifyData[0][ID] != null);
+        assert(notifyData[0][EPOCH_MILLIS] != null);
+        expect(notifyData[0][TO], '@test_user_1');
+        expect(notifyData[0][KEY], '@test_user_1:phone@test_user_1');
+        expect(notifyData[0][OPERATION], 'delete');
+      } finally {
+        doTearDownForSpecificTest(specificTestName);
+      }
     });
-    tearDown(() async => await tearDownFunc());
   });
 
   group('A group of notify verb test', () {
-    setUp(() async => await setUpFunc(storageDir));
-    test(
-        'A test case to verify enqueuing error notifications increments retry count',
-        () async {
-      var atNotification1 = (AtNotificationBuilder()
-            ..id = 'abc'
-            ..fromAtSign = '@test_user_1'
-            ..notificationDateTime = DateTime.now()
-            ..toAtSign = '@alice'
-            ..notification = 'key-1'
-            ..type = NotificationType.sent
-            ..opType = OperationType.update
-            ..messageType = MessageType.key
-            ..expiresAt = null
-            ..priority = NotificationPriority.medium
-            ..notificationStatus = NotificationStatus.errored
-            ..retryCount = 0)
-          .build();
-      var queueManager = QueueManager.getInstance();
-      queueManager.enqueue(atNotification1);
-      var response = queueManager.dequeue('@alice');
-      late var atNotification;
-      if (response.moveNext()) {
-        atNotification = response.current;
+    test('A test case to verify enqueuing error notifications increments retry count', () async {
+      var specificTestName = 'test_enqueue_error_notifications_increments_retry_count';
+      await doSetUpForSpecificTest(specificTestName);
+
+      try {
+        var atNotification1 = (AtNotificationBuilder()
+          ..id = 'abc'
+          ..fromAtSign = '@test_user_1'
+          ..notificationDateTime = DateTime.now()
+          ..toAtSign = '@alice'
+          ..notification = 'key-1'
+          ..type = NotificationType.sent
+          ..opType = OperationType.update
+          ..messageType = MessageType.key
+          ..expiresAt = null
+          ..priority = NotificationPriority.medium
+          ..notificationStatus = NotificationStatus.errored
+          ..retryCount = 0)
+            .build();
+        var queueManager = QueueManager.getInstance();
+        queueManager.enqueue(atNotification1);
+        var response = queueManager.dequeue('@alice');
+        late AtNotification atNotification;
+        if (response.moveNext()) {
+          atNotification = response.current;
+        }
+        expect('abc', atNotification.id);
+        expect('@test_user_1', atNotification.fromAtSign);
+        expect('@alice', atNotification.toAtSign);
+        expect(NotificationPriority.low, atNotification.priority);
+        expect('key-1', atNotification.notification);
+        expect(1, atNotification.retryCount);
+      } finally {
+        doTearDownForSpecificTest(specificTestName);
       }
-      expect('abc', atNotification.id);
-      expect('@test_user_1', atNotification.fromAtSign);
-      expect('@alice', atNotification.toAtSign);
-      expect(NotificationPriority.low, atNotification.priority);
-      expect('key-1', atNotification.notification);
-      expect(1, atNotification.retryCount);
     });
-    tearDown(() async => tearDownFunc());
   });
 
   group('A group of tests to compute notifications wait time', () {
-    test(
-        'A test to compute notifications with equal delay, @sign with highest priority is dequeued',
-        () {
-      var atNotification1 = (AtNotificationBuilder()
-            ..id = '123'
-            ..fromAtSign = '@test_user_1'
-            ..notificationDateTime =
-                DateTime.now().subtract(Duration(minutes: 4))
-            ..toAtSign = '@bob'
-            ..notification = 'key-1'
-            ..type = NotificationType.sent
-            ..opType = OperationType.update
-            ..messageType = MessageType.key
-            ..expiresAt = null
-            ..priority = NotificationPriority.medium
-            ..notificationStatus = NotificationStatus.queued
-            ..retryCount = 0
-            ..strategy = 'all'
-            ..notifier = 'persona'
-            ..depth = 1)
-          .build();
+    test('A test to compute notifications with equal delay, @sign with highest priority is dequeued', () async {
+      var specificTestName = 'test_compute_notifications_wait_time_1';
+      await doSetUpForSpecificTest(specificTestName);
 
-      var atNotification2 = (AtNotificationBuilder()
-            ..id = '124'
-            ..fromAtSign = '@test_user_1'
-            ..notificationDateTime =
-                DateTime.now().subtract(Duration(minutes: 4))
-            ..toAtSign = '@alice'
-            ..notification = 'key-2'
-            ..type = NotificationType.sent
-            ..opType = OperationType.update
-            ..messageType = MessageType.key
-            ..expiresAt = null
-            ..priority = NotificationPriority.high
-            ..notificationStatus = NotificationStatus.queued
-            ..retryCount = 0
-            ..strategy = 'all'
-            ..notifier = 'location'
-            ..depth = 2)
-          .build();
+      try {
+        var atNotification1 = (AtNotificationBuilder()
+              ..id = '123'
+              ..fromAtSign = '@test_user_1'
+              ..notificationDateTime = DateTime.now().subtract(Duration(minutes: 4))
+              ..toAtSign = '@bob'
+              ..notification = 'key-1'
+              ..type = NotificationType.sent
+              ..opType = OperationType.update
+              ..messageType = MessageType.key
+              ..expiresAt = null
+              ..priority = NotificationPriority.medium
+              ..notificationStatus = NotificationStatus.queued
+              ..retryCount = 0
+              ..strategy = 'all'
+              ..notifier = 'persona'
+              ..depth = 1)
+            .build();
 
-      var notificationMap = AtNotificationMap.getInstance();
-      notificationMap.add(atNotification1);
-      notificationMap.add(atNotification2);
-      var atsignIterator = AtNotificationMap.getInstance().getAtSignToNotify(1);
-      while (atsignIterator.moveNext()) {
-        expect(atsignIterator.current, '@alice');
+        var atNotification2 = (AtNotificationBuilder()
+              ..id = '124'
+              ..fromAtSign = '@test_user_1'
+              ..notificationDateTime = DateTime.now().subtract(Duration(minutes: 4))
+              ..toAtSign = '@alice'
+              ..notification = 'key-2'
+              ..type = NotificationType.sent
+              ..opType = OperationType.update
+              ..messageType = MessageType.key
+              ..expiresAt = null
+              ..priority = NotificationPriority.high
+              ..notificationStatus = NotificationStatus.queued
+              ..retryCount = 0
+              ..strategy = 'all'
+              ..notifier = 'location'
+              ..depth = 2)
+            .build();
+
+        var notificationMap = AtNotificationMap.getInstance();
+        notificationMap.add(atNotification1);
+        notificationMap.add(atNotification2);
+        var atsignIterator = AtNotificationMap.getInstance().getAtSignToNotify(1);
+        while (atsignIterator.moveNext()) {
+          expect(atsignIterator.current, '@alice');
+        }
+        AtNotificationMap.getInstance().clear();
+      } finally {
+        doTearDownForSpecificTest(specificTestName);
       }
-      AtNotificationMap.getInstance().clear();
     });
 
-    test(
-        'A test to verify lowest atsign with highest waiting time gets out than highest priority',
-        () {
-      var atNotification1 = (AtNotificationBuilder()
-            ..id = '123'
-            ..fromAtSign = '@test_user_1'
-            ..notificationDateTime =
-                DateTime.now().subtract(Duration(minutes: 10))
-            ..toAtSign = '@bob'
-            ..notification = 'key-1'
-            ..type = NotificationType.sent
-            ..opType = OperationType.update
-            ..messageType = MessageType.key
-            ..expiresAt = null
-            ..priority = NotificationPriority.low
-            ..notificationStatus = NotificationStatus.queued
-            ..retryCount = 0
-            ..strategy = 'all'
-            ..notifier = 'persona'
-            ..depth = 1)
-          .build();
+    test('A test to verify lowest atsign with highest waiting time gets out than highest priority', () async {
+      var specificTestName = 'test_compute_notifications_wait_time_2';
+      await doSetUpForSpecificTest(specificTestName);
 
-      var atNotification2 = (AtNotificationBuilder()
-            ..id = '123'
-            ..fromAtSign = '@test_user_1'
-            ..notificationDateTime =
-                DateTime.now().subtract(Duration(minutes: 1))
-            ..toAtSign = '@alice'
-            ..notification = 'key-2'
-            ..type = NotificationType.sent
-            ..opType = OperationType.update
-            ..messageType = MessageType.key
-            ..expiresAt = null
-            ..priority = NotificationPriority.high
-            ..notificationStatus = NotificationStatus.queued
-            ..retryCount = 0
-            ..strategy = 'all'
-            ..notifier = 'persona'
-            ..depth = 1)
-          .build();
+      try {
+        var atNotification1 = (AtNotificationBuilder()
+              ..id = '123'
+              ..fromAtSign = '@test_user_1'
+              ..notificationDateTime = DateTime.now().subtract(Duration(minutes: 10))
+              ..toAtSign = '@bob'
+              ..notification = 'key-1'
+              ..type = NotificationType.sent
+              ..opType = OperationType.update
+              ..messageType = MessageType.key
+              ..expiresAt = null
+              ..priority = NotificationPriority.low
+              ..notificationStatus = NotificationStatus.queued
+              ..retryCount = 0
+              ..strategy = 'all'
+              ..notifier = 'persona'
+              ..depth = 1)
+            .build();
 
-      var notificationMap = AtNotificationMap.getInstance();
-      notificationMap.add(atNotification1);
-      notificationMap.add(atNotification2);
-      var atsignIterator = AtNotificationMap.getInstance().getAtSignToNotify(1);
-      while (atsignIterator.moveNext()) {
-        expect(atsignIterator.current, '@bob');
+        var atNotification2 = (AtNotificationBuilder()
+              ..id = '123'
+              ..fromAtSign = '@test_user_1'
+              ..notificationDateTime = DateTime.now().subtract(Duration(minutes: 1))
+              ..toAtSign = '@alice'
+              ..notification = 'key-2'
+              ..type = NotificationType.sent
+              ..opType = OperationType.update
+              ..messageType = MessageType.key
+              ..expiresAt = null
+              ..priority = NotificationPriority.high
+              ..notificationStatus = NotificationStatus.queued
+              ..retryCount = 0
+              ..strategy = 'all'
+              ..notifier = 'persona'
+              ..depth = 1)
+            .build();
+
+        var notificationMap = AtNotificationMap.getInstance();
+        notificationMap.add(atNotification1);
+        notificationMap.add(atNotification2);
+        var atsignIterator = AtNotificationMap.getInstance().getAtSignToNotify(1);
+        while (atsignIterator.moveNext()) {
+          expect(atsignIterator.current, '@bob');
+        }
+        AtNotificationMap.getInstance().clear();
+      } finally {
+        doTearDownForSpecificTest(specificTestName);
       }
-      AtNotificationMap.getInstance().clear();
+    });
+
+    test('A test case to verify notifications with strategy all with equal priorities are stored as per the wait time', () async {
+      var specificTestName = 'test_notification_strategy_1';
+      await doSetUpForSpecificTest(specificTestName);
+
+      try {
+        var atNotification1 = (AtNotificationBuilder()
+              ..id = '123'
+              ..fromAtSign = '@test_user_1'
+              ..notificationDateTime = DateTime.now().subtract(Duration(minutes: 1))
+              ..toAtSign = '@bob'
+              ..notification = 'key-1'
+              ..type = NotificationType.sent
+              ..opType = OperationType.update
+              ..messageType = MessageType.key
+              ..expiresAt = null
+              ..priority = NotificationPriority.low
+              ..notificationStatus = NotificationStatus.queued
+              ..retryCount = 0
+              ..strategy = 'all'
+              ..notifier = 'persona'
+              ..depth = 1)
+            .build();
+
+        var atNotification2 = (AtNotificationBuilder()
+              ..id = '124'
+              ..fromAtSign = '@test_user_1'
+              ..notificationDateTime = DateTime.now().subtract(Duration(minutes: 2))
+              ..toAtSign = '@bob'
+              ..notification = 'key-2'
+              ..type = NotificationType.sent
+              ..opType = OperationType.update
+              ..messageType = MessageType.key
+              ..expiresAt = null
+              ..priority = NotificationPriority.low
+              ..notificationStatus = NotificationStatus.queued
+              ..retryCount = 0
+              ..strategy = 'all'
+              ..notifier = 'persona'
+              ..depth = 1)
+            .build();
+
+        var notificationMap = AtNotificationMap.getInstance();
+        notificationMap.add(atNotification1);
+        notificationMap.add(atNotification2);
+        var atsignIterator = notificationMap.getAtSignToNotify(1);
+        var atNotificationList = [];
+        // ignore: prefer_typing_uninitialized_variables
+        var atSign;
+        while (atsignIterator.moveNext()) {
+          atSign = atsignIterator.current;
+        }
+        var itr = QueueManager.getInstance().dequeue(atSign);
+        while (itr.moveNext()) {
+          atNotificationList.add(itr.current);
+        }
+        expect('124', atNotificationList[0].id);
+        expect('123', atNotificationList[1].id);
+        AtNotificationMap.getInstance().clear();
+      } finally {
+        doTearDownForSpecificTest(specificTestName);
+      }
+    });
+
+    test('A test case to verify only the latest notification is stored', () async {
+      var specificTestName = 'test_notification_strategy_2';
+      await doSetUpForSpecificTest(specificTestName);
+
+      try {
+        var atNotification1 = (AtNotificationBuilder()
+              ..id = '123'
+              ..fromAtSign = '@test_user_1'
+              ..notificationDateTime = DateTime.now()
+              ..toAtSign = '@bob'
+              ..notification = 'key-1'
+              ..type = NotificationType.sent
+              ..opType = OperationType.update
+              ..messageType = MessageType.key
+              ..expiresAt = null
+              ..priority = NotificationPriority.low
+              ..notificationStatus = NotificationStatus.queued
+              ..retryCount = 0
+              ..strategy = 'latest'
+              ..notifier = 'persona'
+              ..depth = 1)
+            .build();
+
+        var atNotification2 = (AtNotificationBuilder()
+              ..id = '124'
+              ..fromAtSign = '@test_user_1'
+              ..notificationDateTime = DateTime.now()
+              ..toAtSign = '@bob'
+              ..notification = 'key-2'
+              ..type = NotificationType.sent
+              ..opType = OperationType.update
+              ..messageType = MessageType.key
+              ..expiresAt = null
+              ..priority = NotificationPriority.low
+              ..notificationStatus = NotificationStatus.queued
+              ..retryCount = 0
+              ..strategy = 'latest'
+              ..notifier = 'persona'
+              ..depth = 1)
+            .build();
+
+        var notificationMap = AtNotificationMap.getInstance();
+        notificationMap.add(atNotification1);
+        notificationMap.add(atNotification2);
+        var atsignIterator = notificationMap.getAtSignToNotify(1);
+        var atNotificationList = [];
+        // ignore: prefer_typing_uninitialized_variables
+        var atSign;
+        while (atsignIterator.moveNext()) {
+          atSign = atsignIterator.current;
+        }
+        var itr = QueueManager.getInstance().dequeue(atSign);
+        while (itr.moveNext()) {
+          atNotificationList.add(itr.current);
+        }
+        expect('124', atNotificationList[0].id);
+        AtNotificationMap.getInstance().clear();
+      } finally {
+        doTearDownForSpecificTest(specificTestName);
+      }
+    });
+
+    test('When latest N, when N = 2', () async {
+      var specificTestName = 'test_notification_strategy_3';
+      await doSetUpForSpecificTest(specificTestName);
+
+      try {
+        var atNotification1 = (AtNotificationBuilder()
+              ..id = '123'
+              ..fromAtSign = '@test_user_1'
+              ..notificationDateTime = DateTime.now().subtract(Duration(seconds: 3))
+              ..toAtSign = '@bob'
+              ..notification = 'key-1'
+              ..type = NotificationType.sent
+              ..opType = OperationType.update
+              ..messageType = MessageType.key
+              ..expiresAt = null
+              ..priority = NotificationPriority.low
+              ..notificationStatus = NotificationStatus.queued
+              ..retryCount = 0
+              ..strategy = 'latest'
+              ..notifier = 'persona'
+              ..depth = 2)
+            .build();
+
+        var atNotification2 = (AtNotificationBuilder()
+              ..id = '124'
+              ..fromAtSign = '@test_user_1'
+              ..notificationDateTime = DateTime.now().subtract(Duration(seconds: 2))
+              ..toAtSign = '@bob'
+              ..notification = 'key-2'
+              ..type = NotificationType.sent
+              ..opType = OperationType.update
+              ..messageType = MessageType.key
+              ..expiresAt = null
+              ..priority = NotificationPriority.low
+              ..notificationStatus = NotificationStatus.queued
+              ..retryCount = 0
+              ..strategy = 'latest'
+              ..notifier = 'persona'
+              ..depth = 2)
+            .build();
+
+        var atNotification3 = (AtNotificationBuilder()
+              ..id = '125'
+              ..fromAtSign = '@test_user_1'
+              ..notificationDateTime = DateTime.now().subtract(Duration(seconds: 1))
+              ..toAtSign = '@bob'
+              ..notification = 'key-3'
+              ..type = NotificationType.sent
+              ..opType = OperationType.update
+              ..messageType = MessageType.key
+              ..expiresAt = null
+              ..priority = NotificationPriority.low
+              ..notificationStatus = NotificationStatus.queued
+              ..retryCount = 0
+              ..strategy = 'latest'
+              ..notifier = 'persona'
+              ..depth = 2)
+            .build();
+        var notificationMap = AtNotificationMap.getInstance();
+
+        notificationMap.add(atNotification1);
+        notificationMap.add(atNotification2);
+        notificationMap.add(atNotification3);
+        var atsignIterator = notificationMap.getAtSignToNotify(1);
+        var atNotificationList = [];
+        // ignore: prefer_typing_uninitialized_variables
+        var atSign;
+        while (atsignIterator.moveNext()) {
+          atSign = atsignIterator.current;
+        }
+        var itr = QueueManager.getInstance().dequeue(atSign);
+        while (itr.moveNext()) {
+          atNotificationList.add(itr.current);
+        }
+        expect('124', atNotificationList[0].id);
+        expect('125', atNotificationList[1].id);
+        AtNotificationMap.getInstance().clear();
+      } finally {
+        doTearDownForSpecificTest(specificTestName);
+      }
+    });
+
+    test('Change in notifierId should increase the queue size and retain the old notifications as per priority', () async {
+      var specificTestName = 'test_notification_strategy_4';
+      await doSetUpForSpecificTest(specificTestName);
+
+      try {
+        var atNotification1 = (AtNotificationBuilder()
+              ..id = '123'
+              ..fromAtSign = '@test_user_1'
+              ..notificationDateTime = DateTime.now().subtract(Duration(seconds: 3))
+              ..toAtSign = '@bob'
+              ..notification = 'key-1'
+              ..type = NotificationType.sent
+              ..opType = OperationType.update
+              ..messageType = MessageType.key
+              ..expiresAt = null
+              ..priority = NotificationPriority.low
+              ..notificationStatus = NotificationStatus.queued
+              ..retryCount = 0
+              ..strategy = 'latest'
+              ..notifier = 'persona'
+              ..depth = 1)
+            .build();
+
+        var atNotification2 = (AtNotificationBuilder()
+              ..id = '124'
+              ..fromAtSign = '@test_user_1'
+              ..notificationDateTime = DateTime.now().subtract(Duration(seconds: 2))
+              ..toAtSign = '@bob'
+              ..notification = 'key-2'
+              ..type = NotificationType.sent
+              ..opType = OperationType.update
+              ..messageType = MessageType.key
+              ..expiresAt = null
+              ..priority = NotificationPriority.low
+              ..notificationStatus = NotificationStatus.queued
+              ..retryCount = 0
+              ..strategy = 'latest'
+              ..notifier = 'persona'
+              ..depth = 3)
+            .build();
+
+        var atNotification3 = (AtNotificationBuilder()
+              ..id = '125'
+              ..fromAtSign = '@test_user_1'
+              ..notificationDateTime = DateTime.now().subtract(Duration(seconds: 1))
+              ..toAtSign = '@bob'
+              ..notification = 'key-3'
+              ..type = NotificationType.sent
+              ..opType = OperationType.update
+              ..messageType = MessageType.key
+              ..expiresAt = null
+              ..priority = NotificationPriority.low
+              ..notificationStatus = NotificationStatus.queued
+              ..retryCount = 0
+              ..strategy = 'latest'
+              ..notifier = 'persona'
+              ..depth = 3)
+            .build();
+        var notificationMap = AtNotificationMap.getInstance();
+        notificationMap.add(atNotification1);
+        notificationMap.add(atNotification2);
+        notificationMap.add(atNotification3);
+        var atsignIterator = notificationMap.getAtSignToNotify(1);
+        var atNotificationList = [];
+        // ignore: prefer_typing_uninitialized_variables
+        var atSign;
+        while (atsignIterator.moveNext()) {
+          atSign = atsignIterator.current;
+        }
+        var itr = QueueManager.getInstance().dequeue(atSign);
+        while (itr.moveNext()) {
+          atNotificationList.add(itr.current);
+        }
+        expect('123', atNotificationList[0].id);
+        expect('124', atNotificationList[1].id);
+        expect('125', atNotificationList[2].id);
+        AtNotificationMap.getInstance().clear();
+      } finally {
+        doTearDownForSpecificTest(specificTestName);
+      }
     });
   });
-  group('A group of tests on notification strategy - all', () {
-    test(
-        'A test case to verify notifications with strategy all with equal priorities are stored as per the wait time',
-        () {
-      var atNotification1 = (AtNotificationBuilder()
-            ..id = '123'
-            ..fromAtSign = '@test_user_1'
-            ..notificationDateTime =
-                DateTime.now().subtract(Duration(minutes: 1))
-            ..toAtSign = '@bob'
-            ..notification = 'key-1'
-            ..type = NotificationType.sent
-            ..opType = OperationType.update
-            ..messageType = MessageType.key
-            ..expiresAt = null
-            ..priority = NotificationPriority.low
-            ..notificationStatus = NotificationStatus.queued
-            ..retryCount = 0
-            ..strategy = 'all'
-            ..notifier = 'persona'
-            ..depth = 1)
-          .build();
-
-      var atNotification2 = (AtNotificationBuilder()
-            ..id = '124'
-            ..fromAtSign = '@test_user_1'
-            ..notificationDateTime =
-                DateTime.now().subtract(Duration(minutes: 2))
-            ..toAtSign = '@bob'
-            ..notification = 'key-2'
-            ..type = NotificationType.sent
-            ..opType = OperationType.update
-            ..messageType = MessageType.key
-            ..expiresAt = null
-            ..priority = NotificationPriority.low
-            ..notificationStatus = NotificationStatus.queued
-            ..retryCount = 0
-            ..strategy = 'all'
-            ..notifier = 'persona'
-            ..depth = 1)
-          .build();
-
-      var notificationMap = AtNotificationMap.getInstance();
-      notificationMap.add(atNotification1);
-      notificationMap.add(atNotification2);
-      var atsignIterator = notificationMap.getAtSignToNotify(1);
-      var atNotificationList = [];
-      var atsign;
-      while (atsignIterator.moveNext()) {
-        atsign = atsignIterator.current;
-      }
-      var itr = QueueManager.getInstance().dequeue(atsign);
-      while (itr.moveNext()) {
-        atNotificationList.add(itr.current);
-      }
-      expect('124', atNotificationList[0].id);
-      expect('123', atNotificationList[1].id);
-      AtNotificationMap.getInstance().clear();
-    });
-  });
-  group('A group of test cases on notification strategy - latest', () {
-    test('A test case to verify only the latest notification is stored', () {
-      var atNotification1 = (AtNotificationBuilder()
-            ..id = '123'
-            ..fromAtSign = '@test_user_1'
-            ..notificationDateTime = DateTime.now()
-            ..toAtSign = '@bob'
-            ..notification = 'key-1'
-            ..type = NotificationType.sent
-            ..opType = OperationType.update
-            ..messageType = MessageType.key
-            ..expiresAt = null
-            ..priority = NotificationPriority.low
-            ..notificationStatus = NotificationStatus.queued
-            ..retryCount = 0
-            ..strategy = 'latest'
-            ..notifier = 'persona'
-            ..depth = 1)
-          .build();
-
-      var atNotification2 = (AtNotificationBuilder()
-            ..id = '124'
-            ..fromAtSign = '@test_user_1'
-            ..notificationDateTime = DateTime.now()
-            ..toAtSign = '@bob'
-            ..notification = 'key-2'
-            ..type = NotificationType.sent
-            ..opType = OperationType.update
-            ..messageType = MessageType.key
-            ..expiresAt = null
-            ..priority = NotificationPriority.low
-            ..notificationStatus = NotificationStatus.queued
-            ..retryCount = 0
-            ..strategy = 'latest'
-            ..notifier = 'persona'
-            ..depth = 1)
-          .build();
-
-      var notificationMap = AtNotificationMap.getInstance();
-      notificationMap.add(atNotification1);
-      notificationMap.add(atNotification2);
-      var atsignIterator = notificationMap.getAtSignToNotify(1);
-      var atNotificationList = [];
-      var atsign;
-      while (atsignIterator.moveNext()) {
-        atsign = atsignIterator.current;
-      }
-      var itr = QueueManager.getInstance().dequeue(atsign);
-      while (itr.moveNext()) {
-        atNotificationList.add(itr.current);
-      }
-      expect('124', atNotificationList[0].id);
-      AtNotificationMap.getInstance().clear();
-    });
-
-    test('When latest N, when N = 2', () {
-      var atNotification1 = (AtNotificationBuilder()
-            ..id = '123'
-            ..fromAtSign = '@test_user_1'
-            ..notificationDateTime =
-                DateTime.now().subtract(Duration(seconds: 3))
-            ..toAtSign = '@bob'
-            ..notification = 'key-1'
-            ..type = NotificationType.sent
-            ..opType = OperationType.update
-            ..messageType = MessageType.key
-            ..expiresAt = null
-            ..priority = NotificationPriority.low
-            ..notificationStatus = NotificationStatus.queued
-            ..retryCount = 0
-            ..strategy = 'latest'
-            ..notifier = 'persona'
-            ..depth = 2)
-          .build();
-
-      var atNotification2 = (AtNotificationBuilder()
-            ..id = '124'
-            ..fromAtSign = '@test_user_1'
-            ..notificationDateTime =
-                DateTime.now().subtract(Duration(seconds: 2))
-            ..toAtSign = '@bob'
-            ..notification = 'key-2'
-            ..type = NotificationType.sent
-            ..opType = OperationType.update
-            ..messageType = MessageType.key
-            ..expiresAt = null
-            ..priority = NotificationPriority.low
-            ..notificationStatus = NotificationStatus.queued
-            ..retryCount = 0
-            ..strategy = 'latest'
-            ..notifier = 'persona'
-            ..depth = 2)
-          .build();
-
-      var atNotification3 = (AtNotificationBuilder()
-            ..id = '125'
-            ..fromAtSign = '@test_user_1'
-            ..notificationDateTime =
-                DateTime.now().subtract(Duration(seconds: 1))
-            ..toAtSign = '@bob'
-            ..notification = 'key-3'
-            ..type = NotificationType.sent
-            ..opType = OperationType.update
-            ..messageType = MessageType.key
-            ..expiresAt = null
-            ..priority = NotificationPriority.low
-            ..notificationStatus = NotificationStatus.queued
-            ..retryCount = 0
-            ..strategy = 'latest'
-            ..notifier = 'persona'
-            ..depth = 2)
-          .build();
-      var notificationMap = AtNotificationMap.getInstance();
-
-      notificationMap.add(atNotification1);
-      notificationMap.add(atNotification2);
-      notificationMap.add(atNotification3);
-      var atsignIterator = notificationMap.getAtSignToNotify(1);
-      var atNotificationList = [];
-      var atsign;
-      while (atsignIterator.moveNext()) {
-        atsign = atsignIterator.current;
-      }
-      var itr = QueueManager.getInstance().dequeue(atsign);
-      while (itr.moveNext()) {
-        atNotificationList.add(itr.current);
-      }
-      expect('124', atNotificationList[0].id);
-      expect('125', atNotificationList[1].id);
-      AtNotificationMap.getInstance().clear();
-    });
-
-    test(
-        'Change in notifierId should increase the queue size and retain the old notifications as per priority',
-        () {
-      var atNotification1 = (AtNotificationBuilder()
-            ..id = '123'
-            ..fromAtSign = '@test_user_1'
-            ..notificationDateTime =
-                DateTime.now().subtract(Duration(seconds: 3))
-            ..toAtSign = '@bob'
-            ..notification = 'key-1'
-            ..type = NotificationType.sent
-            ..opType = OperationType.update
-            ..messageType = MessageType.key
-            ..expiresAt = null
-            ..priority = NotificationPriority.low
-            ..notificationStatus = NotificationStatus.queued
-            ..retryCount = 0
-            ..strategy = 'latest'
-            ..notifier = 'persona'
-            ..depth = 1)
-          .build();
-
-      var atNotification2 = (AtNotificationBuilder()
-            ..id = '124'
-            ..fromAtSign = '@test_user_1'
-            ..notificationDateTime =
-                DateTime.now().subtract(Duration(seconds: 2))
-            ..toAtSign = '@bob'
-            ..notification = 'key-2'
-            ..type = NotificationType.sent
-            ..opType = OperationType.update
-            ..messageType = MessageType.key
-            ..expiresAt = null
-            ..priority = NotificationPriority.low
-            ..notificationStatus = NotificationStatus.queued
-            ..retryCount = 0
-            ..strategy = 'latest'
-            ..notifier = 'persona'
-            ..depth = 3)
-          .build();
-
-      var atNotification3 = (AtNotificationBuilder()
-            ..id = '125'
-            ..fromAtSign = '@test_user_1'
-            ..notificationDateTime =
-                DateTime.now().subtract(Duration(seconds: 1))
-            ..toAtSign = '@bob'
-            ..notification = 'key-3'
-            ..type = NotificationType.sent
-            ..opType = OperationType.update
-            ..messageType = MessageType.key
-            ..expiresAt = null
-            ..priority = NotificationPriority.low
-            ..notificationStatus = NotificationStatus.queued
-            ..retryCount = 0
-            ..strategy = 'latest'
-            ..notifier = 'persona'
-            ..depth = 3)
-          .build();
-      var notificationMap = AtNotificationMap.getInstance();
-      notificationMap.add(atNotification1);
-      notificationMap.add(atNotification2);
-      notificationMap.add(atNotification3);
-      var atsignIterator = notificationMap.getAtSignToNotify(1);
-      var atNotificationList = [];
-      var atsign;
-      while (atsignIterator.moveNext()) {
-        atsign = atsignIterator.current;
-      }
-      var itr = QueueManager.getInstance().dequeue(atsign);
-      while (itr.moveNext()) {
-        atNotificationList.add(itr.current);
-      }
-      expect('123', atNotificationList[0].id);
-      expect('124', atNotificationList[1].id);
-      expect('125', atNotificationList[2].id);
-      AtNotificationMap.getInstance().clear();
-    });
-  });
 }
 
-Future<SecondaryKeyStoreManager> setUpFunc(storageDir) async {
-  AtSecondaryServerImpl.getInstance().currentAtSign = '@test_user_1';
-  var secondaryPersistenceStore = SecondaryPersistenceStoreFactory.getInstance()
-      .getSecondaryPersistenceStore(
-          AtSecondaryServerImpl.getInstance().currentAtSign)!;
-  var persistenceManager =
-      secondaryPersistenceStore.getHivePersistenceManager()!;
-  await persistenceManager.init(storageDir);
-//  persistenceManager.scheduleKeyExpireTask(1); //commented this line for coverage test
-  var hiveKeyStore = secondaryPersistenceStore.getSecondaryKeyStore()!;
-  var keyStoreManager =
-      secondaryPersistenceStore.getSecondaryKeyStoreManager()!;
-  keyStoreManager.keyStore = hiveKeyStore;
-  hiveKeyStore.commitLog = await AtCommitLogManagerImpl.getInstance()
-      .getCommitLog('@test_user_1', commitLogPath: storageDir);
-  await AtAccessLogManagerImpl.getInstance()
-      .getAccessLog('@test_user_1', accessLogPath: storageDir);
-  var notificationInstance = AtNotificationKeystore.getInstance();
-  notificationInstance.currentAtSign = '@test_user_1';
-  await notificationInstance.init(storageDir);
-  return keyStoreManager;
-}
-
-Future<void> tearDownFunc() async {
-  var isExists = await Directory('test/hive').exists();
-  AtNotificationMap.getInstance().clear();
-  await AtNotificationKeystore.getInstance().close();
-  if (isExists) {
-    Directory('test/hive').deleteSync(recursive: true);
-  }
-}
-
-String _getShaForAtsign(String atsign) {
-  var bytes = utf8.encode(atsign);
-  return sha256.convert(bytes).toString();
-}

--- a/at_secondary/at_secondary_server/test/outbound_client_manager_test.dart
+++ b/at_secondary/at_secondary_server/test/outbound_client_manager_test.dart
@@ -8,16 +8,18 @@ import 'package:at_secondary/src/server/server_context.dart';
 import 'package:test/test.dart';
 
 void main() {
+  int testInboundIdleTimeMillis = 150;
+  int testOutboundIdleTimeMillis = 200;
   setUp(() {
     var serverContext = AtSecondaryContext();
-    serverContext.inboundIdleTimeMillis = 5000;
-    serverContext.outboundIdleTimeMillis = 3000;
+    serverContext.inboundIdleTimeMillis = testInboundIdleTimeMillis;
+    serverContext.outboundIdleTimeMillis = testOutboundIdleTimeMillis;
     AtSecondaryServerImpl.getInstance().serverContext = serverContext;
   });
 
   group('A group of outbound client manager tests', () {
     test('test outbound client manager - create new client ', () {
-      var dummySocket;
+      Socket? dummySocket;
       var inboundConnection = InboundConnectionImpl(dummySocket, 'aaa');
       var clientManager = OutboundClientManager.getInstance();
       clientManager.init(5);
@@ -78,7 +80,7 @@ void main() {
     test(
         'test outbound client manager - inbound is closed, outbound client is invalid',
         () {
-      var dummySocket;
+      Socket? dummySocket;
       var inboundConnection = InboundConnectionImpl(dummySocket, 'aaa');
       var clientManager = OutboundClientManager.getInstance();
       clientManager.init(5);
@@ -90,13 +92,13 @@ void main() {
     test(
         'test outbound client manager - outbound client is closed, inbound is still valid',
         () {
-      var dummySocket_1, dummySocket_2;
-      var inboundConnection = InboundConnectionImpl(dummySocket_1, 'aaa');
+      Socket? dummySocket1, dummySocket2;
+      var inboundConnection = InboundConnectionImpl(dummySocket1, 'aaa');
       var clientManager = OutboundClientManager.getInstance();
       clientManager.init(5);
       var outBoundClient_1 = clientManager.getClient('bob', inboundConnection)!;
       outBoundClient_1.outboundConnection =
-          OutboundConnectionImpl(dummySocket_2, 'bob');
+          OutboundConnectionImpl(dummySocket2, 'bob');
       outBoundClient_1.close();
       expect(inboundConnection.isInValid(), false);
     });
@@ -104,14 +106,14 @@ void main() {
     test(
         'test outbound client manager - outbound client is idle and becomes invalid',
         () {
-      var dummySocket_1, dummySocket_2;
-      var inboundConnection = InboundConnectionImpl(dummySocket_1, 'aaa');
+      Socket? dummySocket1, dummySocket2;
+      var inboundConnection = InboundConnectionImpl(dummySocket1, 'aaa');
       var clientManager = OutboundClientManager.getInstance();
       clientManager.init(5);
       var outBoundClient_1 = clientManager.getClient('bob', inboundConnection)!;
       outBoundClient_1.outboundConnection =
-          OutboundConnectionImpl(dummySocket_2, 'bob');
-      sleep(Duration(seconds: 4));
+          OutboundConnectionImpl(dummySocket2, 'bob');
+      sleep(Duration(milliseconds: testOutboundIdleTimeMillis+1));
       expect(outBoundClient_1.isInValid(), true);
     });
   });

--- a/at_secondary/at_secondary_server/test/outbound_client_pool_test.dart
+++ b/at_secondary/at_secondary_server/test/outbound_client_pool_test.dart
@@ -10,9 +10,10 @@ import 'package:test/test.dart';
 
 void main() async {
   late var outboundClient;
+  int testIdleTimeMillis = 200;
   setUp(() {
     var serverContext = AtSecondaryContext();
-    serverContext.outboundIdleTimeMillis = 2000;
+    serverContext.outboundIdleTimeMillis = testIdleTimeMillis;
     AtSecondaryServerImpl.getInstance().serverContext = serverContext;
     outboundClient = OutboundClientPool();
   });
@@ -59,7 +60,7 @@ void main() async {
       poolInstance.add(client_2);
       expect(poolInstance.getCapacity(), 5);
       expect(poolInstance.getCurrentSize(), 2);
-      sleep(Duration(seconds: 3));
+      sleep(Duration(milliseconds: testIdleTimeMillis + 1));
       var inboundConnection_3 = InboundConnectionImpl(dummySocket_3, 'ccc');
       var client_3 = OutboundClient(inboundConnection_3, 'charlie');
       client_3.outboundConnection =

--- a/at_secondary/at_secondary_server/test/outbound_client_test.dart
+++ b/at_secondary/at_secondary_server/test/outbound_client_test.dart
@@ -8,9 +8,10 @@ import 'package:at_commons/at_commons.dart';
 import 'package:test/test.dart';
 
 void main() {
+  int testIdleTimeMillis = 200;
   setUp(() {
     var serverContext = AtSecondaryContext();
-    serverContext.outboundIdleTimeMillis = 4000;
+    serverContext.outboundIdleTimeMillis = testIdleTimeMillis;
     AtSecondaryServerImpl.getInstance().serverContext = serverContext;
   });
 
@@ -30,7 +31,7 @@ void main() {
       var connection1 = InboundConnectionImpl(dummySocket, 'aaa');
       var client = OutboundClient(connection1, 'bob');
       client.outboundConnection = OutboundConnectionImpl(dummySocket, 'bob');
-      sleep(Duration(seconds: 5));
+      sleep(Duration(milliseconds: (testIdleTimeMillis + 1)));
       expect(client.isInValid(), true);
     });
 

--- a/at_secondary/at_secondary_server/test/pkam_verb_test.dart
+++ b/at_secondary/at_secondary_server/test/pkam_verb_test.dart
@@ -8,75 +8,83 @@ import 'package:at_secondary/src/utils/secondary_util.dart';
 import 'package:at_secondary/src/verb/handler/pkam_verb_handler.dart';
 import 'package:at_server_spec/at_verb_spec.dart';
 import 'package:test/test.dart';
+import 'package:at_utils/at_logger.dart';
 
 void main() {
   var storageDir = Directory.current.path + '/test/hive';
-  var keyStoreManager;
-  setUp(() async => keyStoreManager = await setUpFunc(storageDir));
-  test('test for pkam correct syntax', () {
-    var verb = Pkam();
-    var command = 'pkam:edgvb1234';
-    var regex = verb.syntax();
-    var paramsMap = getVerbParam(regex, command);
-    expect(paramsMap['signature'], 'edgvb1234');
+  final AtSignLogger _logger = AtSignLogger('pkam_verb_test.dart');
+
+  group("test group: pkam syntax", () {
+    test('test for pkam correct syntax', () {
+      var verb = Pkam();
+      var command = 'pkam:edgvb1234';
+      var regex = verb.syntax();
+      var paramsMap = getVerbParam(regex, command);
+      expect(paramsMap['signature'], 'edgvb1234');
+    });
+
+    test('test for incorrect syntax', () {
+      var verb = Pkam();
+      var command = 'pkam@:edgvb1234';
+      var regex = verb.syntax();
+      expect(
+              () => getVerbParam(regex, command),
+          throwsA(predicate((dynamic e) =>
+          e is InvalidSyntaxException && e.message == 'Syntax Exception')));
+    });
+
+    test('test pkam accept', () {
+      var command = 'pkam:abc123';
+      var handler = PkamVerbHandler(null);
+      expect(handler.accept(command), true);
+    });
+
+    test('test pkam accept invalid keyword', () {
+      var command = 'pkamer:';
+      var handler = PkamVerbHandler(null);
+      expect(handler.accept(command), false);
+    });
+
+    test('test pkam verb - upper case with spaces', () {
+      var command = 'PK AM:';
+      command = SecondaryUtil.convertCommand(command);
+      var handler = PkamVerbHandler(null);
+      var result = handler.accept(command);
+      print('result : $result');
+      expect(result, true);
+    });
   });
 
-  test('test for incorrect syntax', () {
-    var verb = Pkam();
-    var command = 'pkam@:edgvb1234';
-    var regex = verb.syntax();
-    expect(
-        () => getVerbParam(regex, command),
-        throwsA(predicate((dynamic e) =>
-            e is InvalidSyntaxException && e.message == 'Syntax Exception')));
-  });
 
-  test('test pkam accept', () {
-    var command = 'pkam:abc123';
-    var handler = PkamVerbHandler(null);
-    expect(handler.accept(command), true);
-  });
+  group("test group: pkam verb handler", () {
+    late final SecondaryKeyStoreManager keyStoreManager;
 
-  test('test pkam accept invalid keyword', () {
-    var command = 'pkamer:';
-    var handler = PkamVerbHandler(null);
-    expect(handler.accept(command), false);
-  });
-
-  test('test pkam verb handler getVerb', () {
-    var verbHandler = PkamVerbHandler(keyStoreManager.getKeyStore());
-    var verb = verbHandler.getVerb();
-    expect(verb is Pkam, true);
-  });
-
-  test('test pkam verb - upper case with spaces', () {
-    var command = 'PK AM:';
-    command = SecondaryUtil.convertCommand(command);
-    var handler = PkamVerbHandler(null);
-    var result = handler.accept(command);
-    print('result : $result');
-    expect(result, true);
-  });
-  tearDown(() async => await tearDownFunc());
-}
-
-Future<SecondaryKeyStoreManager?> setUpFunc(storageDir) async {
-  AtSecondaryServerImpl.getInstance().currentAtSign = '@alice';
-  var secondaryPersistenceStore = SecondaryPersistenceStoreFactory.getInstance()
-      .getSecondaryPersistenceStore(
+    setUpAll(() async {
+      _logger.info('setUpAll starting');
+      AtSecondaryServerImpl.getInstance().currentAtSign = '@alice';
+      var secondaryPersistenceStore =
+      SecondaryPersistenceStoreFactory.getInstance()
+          .getSecondaryPersistenceStore(
           AtSecondaryServerImpl.getInstance().currentAtSign)!;
-  var persistenceManager =
+      var persistenceManager =
       secondaryPersistenceStore.getHivePersistenceManager()!;
-  await persistenceManager.init(storageDir);
-//  persistenceManager.scheduleKeyExpireTask(1); //commented this line for coverage test
-  var keyStoreManager = secondaryPersistenceStore.getSecondaryKeyStoreManager();
-  //keyStoreManager.init();
-  return keyStoreManager;
-}
+      await persistenceManager.init(storageDir);
+      keyStoreManager =
+      secondaryPersistenceStore.getSecondaryKeyStoreManager()!;
+      _logger.info('setUpAll complete');
+    });
 
-Future<void> tearDownFunc() async {
-  var isExists = await Directory('test/hive').exists();
-  if (isExists) {
-    Directory('test/hive/').deleteSync(recursive: true);
-  }
+    test('test pkam verb handler getVerb', () {
+      PkamVerbHandler verbHandler = PkamVerbHandler(keyStoreManager.getKeyStore());
+      var verb = verbHandler.getVerb();
+      expect(verb is Pkam, true);
+    });
+
+    tearDownAll(() async {
+      var isExists = await Directory('test/hive').exists();
+      if (isExists) {
+        Directory('test/hive/').deleteSync(recursive: true);
+      }
+    });
+  });
 }

--- a/at_secondary/at_secondary_server/test/sync_verb_test.dart
+++ b/at_secondary/at_secondary_server/test/sync_verb_test.dart
@@ -1,8 +1,4 @@
-import 'dart:io';
-
 import 'package:at_commons/at_commons.dart';
-import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
-import 'package:at_secondary/src/server/at_secondary_impl.dart';
 import 'package:at_secondary/src/utils/handler_util.dart';
 import 'package:at_secondary/src/utils/secondary_util.dart';
 import 'package:at_secondary/src/verb/handler/sync_progressive_verb_handler.dart';
@@ -77,35 +73,5 @@ void main() async {
       expect(paramsMap['regex'], 'me');
     });
   });
-  tearDown(() async => await tearDownFunc());
-}
 
-Future<SecondaryKeyStoreManager> setUpFunc(storageDir) async {
-  var isExists = await Directory(storageDir).exists();
-  if (!isExists) {
-    Directory(storageDir).createSync(recursive: true);
-  }
-  AtSecondaryServerImpl.getInstance().currentAtSign = '@alice';
-  var secondaryPersistenceStore = SecondaryPersistenceStoreFactory.getInstance()
-      .getSecondaryPersistenceStore(
-          AtSecondaryServerImpl.getInstance().currentAtSign)!;
-  var persistenceManager =
-      secondaryPersistenceStore.getHivePersistenceManager()!;
-  await persistenceManager.init(storageDir);
-  var commitLogInstance = await AtCommitLogManagerImpl.getInstance()
-      .getCommitLog('@alice', commitLogPath: storageDir);
-  var hiveKeyStore = secondaryPersistenceStore.getSecondaryKeyStore()!;
-  hiveKeyStore.commitLog = commitLogInstance;
-  var keyStoreManager =
-      secondaryPersistenceStore.getSecondaryKeyStoreManager()!;
-  keyStoreManager.keyStore = hiveKeyStore;
-  return keyStoreManager;
-}
-
-Future<void> tearDownFunc() async {
-  await AtCommitLogManagerImpl.getInstance().close();
-  var isExists = await Directory('test/hive').exists();
-  if (isExists) {
-    Directory('test/hive').deleteSync(recursive: true);
-  }
 }

--- a/at_secondary/at_secondary_server/test/update_meta_verb_test.dart
+++ b/at_secondary/at_secondary_server/test/update_meta_verb_test.dart
@@ -17,19 +17,23 @@ import 'package:at_server_spec/at_verb_spec.dart';
 import 'package:crypto/crypto.dart';
 import 'package:test/test.dart';
 
+// TODO Refactor. Avoid multiple checks in a single unit test
 void main() {
-  var storageDir = Directory.current.path + '/test/hive';
-  late var keyStoreManager;
+  // String thisTestFileName = 'update_meta_verb_test.dart';
+
+  String atSignKevin = '@kevin';
+  String atSignKevinWithoutTheAtSign = atSignKevin.replaceAll("@", "");
 
   group('A group of update meta verb regex test', () {
     test('test update meta regex', () {
       var verb = UpdateMeta();
-      var command = 'update:meta:@bob:location@kevin:ttl:123:ttb:124:ttr:125';
+      var forAtSignBob = '@bob';
+      var command = 'update:meta:' + forAtSignBob + ':location' + atSignKevin + ':ttl:123:ttb:124:ttr:125';
       var regex = verb.syntax();
       var paramsMap = getVerbParam(regex, command);
       expect(paramsMap[AT_KEY], 'location');
-      expect(paramsMap[AT_SIGN], 'kevin');
-      expect(paramsMap[FOR_AT_SIGN], '@bob');
+      expect(paramsMap[AT_SIGN], atSignKevinWithoutTheAtSign);
+      expect(paramsMap[FOR_AT_SIGN], forAtSignBob);
       expect(paramsMap[AT_TTL], '123');
       expect(paramsMap[AT_TTB], '124');
       expect(paramsMap[AT_TTR], '125');
@@ -37,7 +41,7 @@ void main() {
 
     test('test update with ttl with no value', () {
       var verb = UpdateMeta();
-      var command = 'update:meta:@bob:location@kevin:ttl:';
+      var command = 'update:meta:@bob:location' + atSignKevin + ':ttl:';
       var regex = verb.syntax();
       expect(
           () => getVerbParam(regex, command),
@@ -57,21 +61,57 @@ void main() {
   });
 
   group('A group of test cases with hive', () {
-    setUp(() async => keyStoreManager = await setUpFunc(storageDir));
+    late final SecondaryKeyStoreManager keyStoreManager;
+    var testDataStoragePath = Directory.current.path + '/test/hive/update_meta_verb_test';
+
+    setUpAll(() async {
+      // print(thisTestFileName + ' setUpAll starting');
+
+      AtSecondaryServerImpl.getInstance().currentAtSign = atSignKevin;
+
+      var secondaryPersistenceStore =
+          SecondaryPersistenceStoreFactory.getInstance().getSecondaryPersistenceStore(AtSecondaryServerImpl.getInstance().currentAtSign)!;
+
+      var commitLogInstance = await AtCommitLogManagerImpl.getInstance().getCommitLog(atSignKevin, commitLogPath: testDataStoragePath);
+
+      secondaryPersistenceStore.getSecondaryKeyStore()!.commitLog = commitLogInstance;
+
+      await AtAccessLogManagerImpl.getInstance().getAccessLog(atSignKevin, accessLogPath: testDataStoragePath);
+
+      await secondaryPersistenceStore.getHivePersistenceManager()!.init(testDataStoragePath);
+
+      keyStoreManager = secondaryPersistenceStore.getSecondaryKeyStoreManager()!;
+
+      // print(thisTestFileName + ' setUpAll complete');
+    });
+
+    tearDownAll(() async {
+      // print(thisTestFileName + ' tearDownAll starting');
+
+      // print(thisTestFileName + ' tearDownAll removing test data directory ' + testDataStoragePath);
+      await Directory(testDataStoragePath).delete(recursive: true);
+
+      // print(thisTestFileName + ' tearDownAll complete');
+    });
+
     test('test update meta handler processVerb with ttb', () async {
       SecondaryKeyStore keyStore = keyStoreManager.getKeyStore();
+
       var secretData = AtData();
       secretData.data =
           'b26455a907582760ebf35bc4847de549bc41c24b25c8b1c58d5964f7b4f8a43bc55b0e9a601c9a9657d9a8b8bbc32f88b4e38ffaca03c8710ebae1b14ca9f364';
       await keyStore.put('privatekey:at_secret', secretData);
+
+      AtSecondaryServerImpl.getInstance().currentAtSign = atSignKevin;
+
       var fromVerbHandler = FromVerbHandler(keyStoreManager.getKeyStore());
-      AtSecondaryServerImpl.getInstance().currentAtSign = '@kevin';
       var inBoundSessionId = '_6665436c-29ff-481b-8dc6-129e89199718';
       var atConnection = InboundConnectionImpl(null, inBoundSessionId);
       var fromVerbParams = HashMap<String, String>();
-      fromVerbParams.putIfAbsent('atSign', () => 'kevin');
+      fromVerbParams.putIfAbsent('atSign', () => atSignKevinWithoutTheAtSign);
       var response = Response();
       await fromVerbHandler.processVerb(response, fromVerbParams, atConnection);
+
       var fromResponse = response.data!.replaceFirst('data:', '');
       var cramVerbParams = HashMap<String, String>();
       var combo = '${secretData.data}$fromResponse';
@@ -82,10 +122,13 @@ void main() {
       var cramResponse = Response();
       await cramVerbHandler.processVerb(
           cramResponse, cramVerbParams, atConnection);
+
       var connectionMetadata =
           atConnection.getMetaData() as InboundConnectionMetadata;
+
       expect(connectionMetadata.isAuthenticated, true);
       expect(cramResponse.data, 'success');
+
       //Update Verb
       var updateVerbHandler = UpdateVerbHandler(keyStore);
       var updateResponse = Response();
@@ -95,16 +138,20 @@ void main() {
       updateVerbParams.putIfAbsent('value', () => '99899');
       await updateVerbHandler.processVerb(
           updateResponse, updateVerbParams, atConnection);
+
       //Update Meta
+      int ttbMillis = 100;
+
       var updateMetaVerbHandler =
           UpdateMetaVerbHandler(keyStoreManager.getKeyStore());
       var updateMetaResponse = Response();
       var updateMetaVerbParam = HashMap<String, String>();
       updateMetaVerbParam.putIfAbsent('atSign', () => '@sitaram');
       updateMetaVerbParam.putIfAbsent('atKey', () => 'phone');
-      updateMetaVerbParam.putIfAbsent('ttb', () => '10000');
+      updateMetaVerbParam.putIfAbsent('ttb', () => ttbMillis.toString());
       await updateMetaVerbHandler.processVerb(
           updateMetaResponse, updateMetaVerbParam, atConnection);
+
       // Look Up verb
       var localLookUpResponse = Response();
       var localLookupVerbHandler = LocalLookupVerbHandler(keyStore);
@@ -113,27 +160,33 @@ void main() {
       localLookVerbParam.putIfAbsent('atKey', () => 'phone');
       await localLookupVerbHandler.processVerb(
           localLookUpResponse, localLookVerbParam, atConnection);
+      // expect to be null because ttb hasn't been reached
       expect(localLookUpResponse.data, null);
-      await Future.delayed(Duration(seconds: 12));
+
+      await Future.delayed(Duration(milliseconds: ttbMillis + 1));
       await localLookupVerbHandler.processVerb(
           localLookUpResponse, localLookVerbParam, atConnection);
+      // expect actual data because ttb has passed
       expect(localLookUpResponse.data, '99899');
     });
 
     test('test update meta handler processVerb with ttl', () async {
       SecondaryKeyStore keyStore = keyStoreManager.getKeyStore();
+
       var secretData = AtData();
       secretData.data =
           'b26455a907582760ebf35bc4847de549bc41c24b25c8b1c58d5964f7b4f8a43bc55b0e9a601c9a9657d9a8b8bbc32f88b4e38ffaca03c8710ebae1b14ca9f364';
       await keyStore.put('privatekey:at_secret', secretData);
+
       var fromVerbHandler = FromVerbHandler(keyStoreManager.getKeyStore());
-      AtSecondaryServerImpl.getInstance().currentAtSign = '@kevin';
+      AtSecondaryServerImpl.getInstance().currentAtSign = atSignKevin;
       var inBoundSessionId = '_6665436c-29ff-481b-8dc6-129e89199718';
       var atConnection = InboundConnectionImpl(null, inBoundSessionId);
       var fromVerbParams = HashMap<String, String>();
-      fromVerbParams.putIfAbsent('atSign', () => 'kevin');
+      fromVerbParams.putIfAbsent('atSign', () => atSignKevinWithoutTheAtSign);
       var response = Response();
       await fromVerbHandler.processVerb(response, fromVerbParams, atConnection);
+
       var fromResponse = response.data!.replaceFirst('data:', '');
       var cramVerbParams = HashMap<String, String>();
       var combo = '${secretData.data}$fromResponse';
@@ -144,10 +197,12 @@ void main() {
       var cramResponse = Response();
       await cramVerbHandler.processVerb(
           cramResponse, cramVerbParams, atConnection);
+
       var connectionMetadata =
           atConnection.getMetaData() as InboundConnectionMetadata;
       expect(connectionMetadata.isAuthenticated, true);
       expect(cramResponse.data, 'success');
+
       //Update Verb
       var updateVerbHandler = UpdateVerbHandler(keyStore);
       var updateResponse = Response();
@@ -157,16 +212,20 @@ void main() {
       updateVerbParams.putIfAbsent('value', () => 'hyderabad');
       await updateVerbHandler.processVerb(
           updateResponse, updateVerbParams, atConnection);
+
       //Update Meta
+      int ttlMillis = 100;
+
       var updateMetaVerbHandler =
           UpdateMetaVerbHandler(keyStoreManager.getKeyStore());
       var updateMetaResponse = Response();
       var updateMetaVerbParam = HashMap<String, String>();
       updateMetaVerbParam.putIfAbsent('atSign', () => '@sitaram');
       updateMetaVerbParam.putIfAbsent('atKey', () => 'location');
-      updateMetaVerbParam.putIfAbsent('ttl', () => '10000');
+      updateMetaVerbParam.putIfAbsent('ttl', () => ttlMillis.toString());
       await updateMetaVerbHandler.processVerb(
           updateMetaResponse, updateMetaVerbParam, atConnection);
+
       // Look Up verb
       var localLookUpResponse = Response();
       var localLookupVerbHandler = LocalLookupVerbHandler(keyStore);
@@ -175,41 +234,16 @@ void main() {
       localLookVerbParam.putIfAbsent('atKey', () => 'location');
       await localLookupVerbHandler.processVerb(
           localLookUpResponse, localLookVerbParam, atConnection);
+      // expect actual data because the ttl hasn't yet passed
       expect(localLookUpResponse.data, 'hyderabad');
-      await Future.delayed(Duration(seconds: 10));
+
+      await Future.delayed(Duration(milliseconds: ttlMillis + 1));
       var localLookUpResponse1 = Response();
       await localLookupVerbHandler.processVerb(
           localLookUpResponse1, localLookVerbParam, atConnection);
+      // expect null because ttl has passed
       expect(localLookUpResponse1.data, null);
     });
-    tearDown(() async => await tearDownFunc());
   });
 }
 
-Future<SecondaryKeyStoreManager> setUpFunc(storageDir) async {
-  AtSecondaryServerImpl.getInstance().currentAtSign = '@kevin';
-  var secondaryPersistenceStore = SecondaryPersistenceStoreFactory.getInstance()
-      .getSecondaryPersistenceStore(
-          AtSecondaryServerImpl.getInstance().currentAtSign)!;
-  var commitLogInstance = await AtCommitLogManagerImpl.getInstance()
-      .getCommitLog('@kevin', commitLogPath: storageDir);
-  var persistenceManager =
-      secondaryPersistenceStore.getHivePersistenceManager()!;
-  await persistenceManager.init(storageDir);
-//  persistenceManager.scheduleKeyExpireTask(1); //commented this line for coverage test
-  var hiveKeyStore = secondaryPersistenceStore.getSecondaryKeyStore()!;
-  hiveKeyStore.commitLog = commitLogInstance;
-  var keyStoreManager =
-      secondaryPersistenceStore.getSecondaryKeyStoreManager()!;
-  keyStoreManager.keyStore = hiveKeyStore;
-  await AtAccessLogManagerImpl.getInstance()
-      .getAccessLog('@kevin', accessLogPath: storageDir);
-  return keyStoreManager;
-}
-
-Future<void> tearDownFunc() async {
-  var isExists = await Directory('test/hive').exists();
-  if (isExists) {
-    Directory('test/hive').deleteSync(recursive: true);
-  }
-}


### PR DESCRIPTION

**- What I did**
Made at_secondary_server unit tests run faster

**- How I did it**
Made tests use different storage directories in order to isolate them from each other
Reduced idle, ttl and ttb times in tests (and associated sleep durations in individual test cases)
Miscellaneous lint 

**- How to verify it**
The unit tests should all still pass, but should take ~10 seconds compared with ~75 seconds previously

**- Description for the changelog**
Made at_secondary_server unit tests run faster
