### PR TITLE
Remove mods to config.yaml for staging secondary

### DIFF
--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -359,33 +359,6 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # Setup python
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.8'
-
-      # Install python packages
-      - name: Install dependencies
-        run: |
-          python3 -m pip install --upgrade pip
-          pip3 install jproperties ruamel.yaml argparse
-
-      # Generates the config.yaml for staging environment
-      - name: Generates configuration file
-        working-directory: at_secondary/at_secondary_server/config
-        run: |
-          echo "root_server.url=${{ secrets.root_server_url }}" >> config-environment.properties
-          chmod +x generate_config.py
-          python3 generate_config.py -e environment
-
-      # Gets the secondary server binary generated from the above "secondary" job.
-      - name: Get secondary server
-        uses: actions/download-artifact@v2
-        with:
-          name: secondary-server
-          path: at_secondary/at_secondary_server
-
       # Builds and pushes the secondary server image to docker hub.
       - name: Build and push secondary image for amd64 and arm64
         id: docker_build_secondary


### PR DESCRIPTION
Fixes #415 

**- What I did**

Removed segment of GitHub Action workflow that changed root server URL to point to staging.

#214 has already taken care of putting the root server config for the staging environment into env variables for their docker service config.

**- How to verify it**

Unpack Docker image to verify that config.yaml points to production. Check staging secondary logs for startup messgae showing that they connect to staging root e.g. `Secondary server started on version : 3.0.9+gha435 on root server : root.atsign.wtf` (obviously the gha number will bump)

**- Description for the changelog**

Remove mods to config.yaml for staging secondary