### PR TITLE
Handle sync key does not exist in keystore.

### DIFF
--- a/at_secondary/at_secondary_server/lib/src/verb/handler/sync_progressive_verb_handler.dart
+++ b/at_secondary/at_secondary_server/lib/src/verb/handler/sync_progressive_verb_handler.dart
@@ -52,7 +52,7 @@ class SyncProgressiveVerbHandler extends AbstractVerbHandler {
         // If commitOperation is update (or) update_all (or) update_meta and key does not
         // exist in keystore, skip the key to sync and continue.
         if (!keyStore!.isKeyExists(itr.current.key)) {
-          logger.info(
+          logger.finer(
               '${itr.current.key} does not exist in the keystore. skipping the key to sync');
           continue;
         }

--- a/at_secondary/at_secondary_server/lib/src/verb/handler/sync_progressive_verb_handler.dart
+++ b/at_secondary/at_secondary_server/lib/src/verb/handler/sync_progressive_verb_handler.dart
@@ -49,14 +49,20 @@ class SyncProgressiveVerbHandler extends AbstractVerbHandler {
       keyStoreEntry.commitId = itr.current.value.commitId;
       keyStoreEntry.operation = itr.current.value.operation;
       if (itr.current.value.operation != CommitOp.DELETE) {
+        // If commitOperation is update (or) update_all (or) update_meta and key does not
+        // exist in keystore, skip the key to sync and continue.
+        if (!keyStore!.isKeyExists(itr.current.key)) {
+          logger.info(
+              '${itr.current.key} does not exist in the keystore. skipping the key to sync');
+          continue;
+        }
         var atData = await keyStore!.get(itr.current.key);
         if (atData == null) {
           logger.info('atData is null for ${itr.current.key}');
+          continue;
         }
-        if (atData != null) {
-          keyStoreEntry.value = atData.data;
-          keyStoreEntry.atMetaData = _populateMetadata(atData);
-        }
+        keyStoreEntry.value = atData.data;
+        keyStoreEntry.atMetaData = _populateMetadata(atData);
       }
       // If syncBuffer reaches the limit, break the loop.
       if (syncBuffer.isOverFlow(utf8.encode(jsonEncode(keyStoreEntry)))) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did** Handle KeyNotFoundException in SyncProgressiveVerbHandler when getting key value in for sync response

**- How I did it** Verify if key exists prior to getting value of a key.

**- How to verify it** Sync should complete successfully even if key does not exist. However, when key does not exist, log a message secondary server log.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->