### PR TITLE
Adding test code coverage report generation

### DIFF
--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -102,9 +102,19 @@ jobs:
         working-directory: ${{ env.secondary-working-directory }}
         run: dart analyze
 
-      - name: Run tests in at_secondary_server
+      - name: Run tests in at_secondary_server, with coverage
         working-directory: ${{ env.secondary-working-directory }}
-        run: dart test --concurrency=1
+        run: dart test --concurrency=1 --coverage="coverage"
+
+      - name: Convert coverage to ICOV
+        working-directory: ${{ env.secondary-working-directory }}
+        run: pub run coverage:format_coverage --lcov --in=coverage --out=coverage.lcov --packages=.packages --report-on=lib
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1.0.2
+        with:
+          token: ${{secrets.CODECOV_TOKEN_AT_SERVER}}
+          file: ${{ env.secondary-working-directory }}/coverage.lcov
 
   # Runs functional tests on at_secondary.
   # If tests are successful, uploads root server and secondary server binaries for subsequent jobs

--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -106,15 +106,17 @@ jobs:
         working-directory: ${{ env.secondary-working-directory }}
         run: dart test --concurrency=1 --coverage="coverage"
 
-      - name: Convert coverage to ICOV
+      - name: Convert coverage to LCOV format
         working-directory: ${{ env.secondary-working-directory }}
         run: pub run coverage:format_coverage --lcov --in=coverage --out=coverage.lcov --packages=.packages --report-on=lib
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1.0.2
         with:
-          # Commenting out as there is an assertion that the token isn't required for public repos
+          # Testing assertion that the token isn't required for public repos
+          # See https://docs.codecov.com/docs/frequently-asked-questions#:~:text=The%20upload%20token%20is%20required,CI%2C%20Azure%2C%20Github%20Actions
           # token: ${{secrets.CODECOV_TOKEN_AT_SERVER}}
+          token: ""
           file: ${{ env.secondary-working-directory }}/coverage.lcov
 
   # Runs functional tests on at_secondary.

--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -113,10 +113,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1.0.2
         with:
-          # Testing assertion that the token isn't required for public repos
-          # See https://docs.codecov.com/docs/frequently-asked-questions#:~:text=The%20upload%20token%20is%20required,CI%2C%20Azure%2C%20Github%20Actions
-          # token: ${{secrets.CODECOV_TOKEN_AT_SERVER}}
-          token: ""
+          token: ${{secrets.CODECOV_TOKEN_AT_SERVER}}
           file: ${{ env.secondary-working-directory }}/coverage.lcov
 
   # Runs functional tests on at_secondary.

--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -113,7 +113,8 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1.0.2
         with:
-          token: ${{secrets.CODECOV_TOKEN_AT_SERVER}}
+          # Commenting out as there is an assertion that the token isn't required for public repos
+          # token: ${{secrets.CODECOV_TOKEN_AT_SERVER}}
           file: ${{ env.secondary-working-directory }}/coverage.lcov
 
   # Runs functional tests on at_secondary.

--- a/at_root/at_persistence_root_server/pubspec.yaml
+++ b/at_root/at_persistence_root_server/pubspec.yaml
@@ -23,5 +23,4 @@ dev_dependencies:
   lints: ^1.0.1
   test: ^1.17.3
   mockito: ^5.0.7
-  # commenting test coverage since null safe version is not available
-#  test_coverage: ^0.4.1
+  coverage: ^1.0.3

--- a/at_root/at_root_server/pubspec.yaml
+++ b/at_root/at_root_server/pubspec.yaml
@@ -35,3 +35,4 @@ dev_dependencies:
   test_cov: ^1.0.1
   lints: ^1.0.1
   test: ^1.17.3
+  coverage: ^1.0.3

--- a/at_secondary/at_persistence_secondary_server/pubspec.yaml
+++ b/at_secondary/at_persistence_secondary_server/pubspec.yaml
@@ -39,3 +39,4 @@ dependency_overrides:
 dev_dependencies:
   lints: ^1.0.1
   test: ^1.17.1
+  coverage: ^1.0.3

--- a/at_secondary/at_secondary_server/.gitignore
+++ b/at_secondary/at_secondary_server/.gitignore
@@ -29,3 +29,7 @@ certs
 storage
 *.lock
 */hive/
+
+# code coverage related
+coverage
+coverage.lcov

--- a/at_secondary/at_secondary_server/pubspec.yaml
+++ b/at_secondary/at_secondary_server/pubspec.yaml
@@ -49,6 +49,6 @@ dependency_overrides:
 
 dev_dependencies:
   test: ^1.17.3
-  #  test_coverage: ^0.5.0
+  coverage: ^1.0.3
   mockito: ^5.0.7
   lints: ^1.0.1


### PR DESCRIPTION
**- What I did**
Added test code coverage report generation - initially, for at_secondary_server unit tests - integrated with codecov.io

**- How I did it**
* Signed up at codecov.io and got token for at_server repo, added the token as `CODECOV_TOKEN_AT_SERVER` to github secrets
* Added `coverage: ^1.03` to dev_dependencies section of the pubspec.yaml files in at_root_server, at_persistence_root_server, at_secondary_server and at_persistence_secondary_server
* Modified at_server.yaml workflow adding steps to generate code coverage info **during unit test run for at_secondary_server** , and upload to codecov.io. Added the Codecov token CODECOV_TOKEN_AT_SERVER to github secrets
* Modified .gitignore to ignore files generated by coverage tooling if running coverage locally

**- How to verify it**
This seems unlikely to work first time but if it does then the report should be visible at https://app.codecov.io/gh/atsign-foundation/at_server

**- Description for the changelog**
Added test code coverage report generation - initially, for at_secondary_server unit tests - integrated with codecov.io
