### PR TITLE
Don't run e2e tests for dependabot PRs

### DIFF
--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -210,7 +210,7 @@ jobs:
   # The job runs end to end tests between the cicd1 and cicd2 VMs
   end2end_tests:
     # Don't run on PRs from a fork or Dependabot as the secrets aren't available
-    if: ${{ github.event.pull_request.head.repo.fork == false && github.actor!= 'dependabot-preview[bot]'}}
+    if: ${{ github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]'}}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
**- What I did**

Modified parameters for running e2e tests so that they shouldn't run for Dependabot PRs (which will fail for lack of secrets)

**- How to verify it**

Check that e2e tests don't run for next Dependabot PR

**- Description for the changelog**

Don't run e2e tests for dependabot PRs