### PR TITLE
Only act on opened issues

### DIFF
--- a/.github/workflows/autobug.yaml
+++ b/.github/workflows/autobug.yaml
@@ -1,12 +1,12 @@
-name: Auto Assign Bugs to Sprint Planning Project Board
+name: Auto Assign Issues to Triage column in Sprint Planning Project Board
 
 on:
   issues:
-    types: [labeled]
+    types: [opened]
 
 jobs:
-  issue_opened_and_reopened:
-    name: issue_opened_and_reopened
+  issue_opened:
+    name: issue_opened
     runs-on: ubuntu-latest
     steps:
       - name: 'Move issue to "Triage"'


### PR DESCRIPTION
@ksanty identified an issue with tickets being moved back to Triage

**- What I did**

Only run the action when an issue is opened (was previously when issue was labelled)

**- How to verify it**

Open a new issue. Move it to a non Triage column. Change its labels.

**- Description for the changelog**

Only act on opened issues