### PR TITLE
[Closed] Enable v3.0.11+ servers to interoperate with v3.0.10 servers for notify verb

### DIFF
--- a/at_secondary/at_secondary_server/lib/src/verb/handler/notify_verb_handler.dart
+++ b/at_secondary/at_secondary_server/lib/src/verb/handler/notify_verb_handler.dart
@@ -87,13 +87,18 @@ class NotifyVerbHandler extends AbstractVerbHandler {
       opType = SecondaryUtil.getOperationType(operation);
     }
     try {
-      ttl_ms = AtMetadataUtil.validateTTL(verbParams[AT_TTL]);
-      if (verbParams[AT_TTL_NOTIFICATION] == null || verbParams[AT_TTL_NOTIFICATION] == '0') {
+      if (AtMetadataUtil.validateTTL(verbParams[AT_TTL]) > 0) {
+        ttl_ms = AtMetadataUtil.validateTTL(verbParams[AT_TTL]);
+      }
+      if (verbParams[AT_TTL_NOTIFICATION] == null ||
+          verbParams[AT_TTL_NOTIFICATION] == '0') {
         ttln_ms = Duration(hours: 24).inMilliseconds;
       } else {
         ttln_ms = AtMetadataUtil.validateTTL(verbParams[AT_TTL_NOTIFICATION]);
       }
-      ttb_ms = AtMetadataUtil.validateTTB(verbParams[AT_TTB]);
+      if (AtMetadataUtil.validateTTB(verbParams[AT_TTB]) > 0) {
+        ttb_ms = AtMetadataUtil.validateTTB(verbParams[AT_TTB]);
+      }
       if (verbParams[AT_TTR] != null) {
         ttr_ms = AtMetadataUtil.validateTTR(int.parse(verbParams[AT_TTR]!));
       }

--- a/at_secondary/at_secondary_server/lib/src/verb/handler/notify_verb_handler.dart
+++ b/at_secondary/at_secondary_server/lib/src/verb/handler/notify_verb_handler.dart
@@ -88,7 +88,11 @@ class NotifyVerbHandler extends AbstractVerbHandler {
     }
     try {
       ttl_ms = AtMetadataUtil.validateTTL(verbParams[AT_TTL]);
-      ttln_ms = AtMetadataUtil.validateTTL(verbParams[AT_TTL_NOTIFICATION]);
+      if (verbParams[AT_TTL_NOTIFICATION] == null || verbParams[AT_TTL_NOTIFICATION] == '0') {
+        ttln_ms = Duration(hours: 24).inMilliseconds;
+      } else {
+        ttln_ms = AtMetadataUtil.validateTTL(verbParams[AT_TTL_NOTIFICATION]);
+      }
       ttb_ms = AtMetadataUtil.validateTTB(verbParams[AT_TTB]);
       if (verbParams[AT_TTR] != null) {
         ttr_ms = AtMetadataUtil.validateTTR(int.parse(verbParams[AT_TTR]!));


### PR DESCRIPTION
**- What I did**
Enable v3.0.11+ servers to interoperate with v3.0.10 servers for notify verb

**- How I did it**
Added some defensive code to notify_verb_handler.dart to set ttln to default value of 24 hours if it is null or 0. This is necessary in order to preserve backwards compatibility with version 3.0.10 servers, which will reject ttln of 0. We can remove this code again once all servers are at 3.0.11+

**- How to verify it**
* Tests should pass
* However since our test environment currently doesn't have interop tests between different server versions, the real verification will be to build a new canary 3.0.11 release and verify that the problem is no longer occurring. See https://github.com/atsign-foundation/apps/issues/495 for context

**- Description for the changelog**
Enable v3.0.11+ servers to interoperate with v3.0.10 servers for notify verb
