### PR TITLE
Fixes for issue #501

### DIFF
--- a/at_end2end_test/pubspec.yaml
+++ b/at_end2end_test/pubspec.yaml
@@ -11,12 +11,7 @@ dependencies:
       url: https://github.com/atsign-foundation/at_demos.git
       path: at_demo_data
       ref: master
-  at_lookup:
-    git:
-      url: https://github.com/atsign-foundation/at_libraries.git
-      path: at_lookup
-      ref: trunk
-      version: ^2.0.4
+  at_lookup: ^3.0.7
 
 dev_dependencies:
   lints: ^1.0.1

--- a/at_end2end_test/test/commons.dart
+++ b/at_end2end_test/test/commons.dart
@@ -26,16 +26,16 @@ void clear() {
 }
 
 ///Secure Socket Connection
-Future<SecureSocket> secure_socket_connection(host, port) async {
+Future<SecureSocket> secure_socket_connection(var host, var port) async {
   var socket;
-  while (true) {
+  while (retryCount > maxRetryCount) {
     try {
       socket = await SecureSocket.connect(host, port);
-      if (socket != null || retryCount > maxRetryCount) {
+      if (socket != null) {
         break;
       }
     } on Exception {
-      print('retrying for connection.. $retryCount');
+      print('retrying "$host:$port" for connection.. $retryCount');
       await Future.delayed(Duration(seconds: 5));
       retryCount++;
     }

--- a/at_end2end_test/test/commons.dart
+++ b/at_end2end_test/test/commons.dart
@@ -28,7 +28,7 @@ void clear() {
 ///Secure Socket Connection
 Future<SecureSocket> secure_socket_connection(var host, var port) async {
   var socket;
-  while (retryCount > maxRetryCount) {
+  while (retryCount < maxRetryCount) {
     try {
       socket = await SecureSocket.connect(host, port);
       if (socket != null) {

--- a/at_secondary/at_secondary_server/lib/src/connection/base_connection.dart
+++ b/at_secondary/at_secondary_server/lib/src/connection/base_connection.dart
@@ -21,10 +21,15 @@ abstract class BaseConnection extends AtConnection {
 
   @override
   Future<void> close() async {
+    // Some defensive code just in case we accidentally call close multiple times
+    if (getMetaData().isClosed) {
+      return;
+    }
+
     try {
       var address = getSocket().remoteAddress;
       var port = getSocket().remotePort;
-      await _socket!.close();
+      _socket!.destroy();
       logger.finer('$address:$port Disconnected');
       getMetaData().isClosed = true;
     } on Exception {

--- a/at_secondary/at_secondary_server/lib/src/connection/base_connection.dart
+++ b/at_secondary/at_secondary_server/lib/src/connection/base_connection.dart
@@ -21,15 +21,10 @@ abstract class BaseConnection extends AtConnection {
 
   @override
   Future<void> close() async {
-    // Some defensive code just in case we accidentally call close multiple times
-    if (getMetaData().isClosed) {
-      return;
-    }
-
     try {
       var address = getSocket().remoteAddress;
       var port = getSocket().remotePort;
-      _socket!.destroy();
+      await _socket!.close();
       logger.finer('$address:$port Disconnected');
       getMetaData().isClosed = true;
     } on Exception {

--- a/at_secondary/at_secondary_server/lib/src/connection/outbound/outbound_client.dart
+++ b/at_secondary/at_secondary_server/lib/src/connection/outbound/outbound_client.dart
@@ -25,6 +25,8 @@ class OutboundClient {
   OutboundConnection? outboundConnection;
 
   String? toAtSign;
+  String? toHost;
+  String? toPort;
 
   bool isConnectionCreated = false;
 
@@ -49,10 +51,10 @@ class OutboundClient {
       // 1. Find secondary url for the toAtSign
       var secondaryUrl = await _findSecondary(toAtSign);
       var secondaryInfo = SecondaryUtil.getSecondaryInfo(secondaryUrl);
-      var host = secondaryInfo[0];
-      var port = secondaryInfo[1];
+      toHost = secondaryInfo[0];
+      toPort = secondaryInfo[1];
       // 2. Create an outbound connection for the host and port
-      var connectResult = await _createOutBoundConnection(host, port, toAtSign);
+      var connectResult = await _createOutBoundConnection(toHost, toPort, toAtSign);
       if (connectResult) {
         isConnectionCreated = true;
       }
@@ -182,7 +184,10 @@ class OutboundClient {
     } on ConnectionInvalidException {
       throw OutBoundConnectionInvalidException('Outbound connection invalid');
     }
+
+    // Actually read the response from the remote secondary
     var lookupResult = await messageListener.read();
+
     if (lookupResult != null) {
       lookupResult = lookupResult.replaceFirst(RegExp(r'\n\S+'), '');
     }
@@ -263,6 +268,7 @@ class OutboundClient {
   }
 
   Future<List>? notifyList(String? atSign, {bool handshake = true}) async {
+    // ignore: prefer_typing_uninitialized_variables
     var notifyResult;
     if (handshake && !isHandShakeDone) {
       throw UnAuthorizedException(

--- a/at_secondary/at_secondary_server/lib/src/connection/outbound/outbound_connection_impl.dart
+++ b/at_secondary/at_secondary_server/lib/src/connection/outbound/outbound_connection_impl.dart
@@ -31,4 +31,32 @@ class OutboundConnectionImpl extends OutboundConnection {
   bool isInValid() {
     return _isIdle() || getMetaData().isClosed || getMetaData().isStale;
   }
+
+  @override
+  Future<void> close() async {
+    // Over-riding BaseConnection.close() (which calls socket.close()), as only want to change
+    // behaviour for outbound connections for now, not inbound connections
+
+    // Some defensive code just in case we accidentally call close multiple times
+    if (getMetaData().isClosed) {
+      return;
+    }
+
+    try {
+      var address = getSocket().remoteAddress;
+      var port = getSocket().remotePort;
+      var socket = getSocket();
+      if (socket != null) {
+        socket.destroy();
+      }
+      logger.finer('$address:$port Disconnected');
+      getMetaData().isClosed = true;
+    } on Exception {
+      getMetaData().isStale = true;
+      // Ignore exception on a connection close
+    } on Error {
+      getMetaData().isStale = true;
+      // Ignore error on a connection close
+    }
+  }
 }

--- a/at_secondary/at_secondary_server/lib/src/connection/outbound/outbound_message_listener.dart
+++ b/at_secondary/at_secondary_server/lib/src/connection/outbound/outbound_message_listener.dart
@@ -60,7 +60,7 @@ class OutboundMessageListener {
   /// Throws [AtConnectException] upon an 'error:...' response from the remote secondary.
   /// Throws [AtConnectException] upon a bad response (not 'data:...', not 'error:...') from remote secondary.
   /// Throws [TimeoutException] If there is no message in queue after [maxWaitMilliSeconds].
-  Future<String?> read({int maxWaitMilliSeconds = 5000}) async {
+  Future<String?> read({int maxWaitMilliSeconds = 3000}) async {
     // ignore: prefer_typing_uninitialized_variables
     var result;
 

--- a/at_secondary/at_secondary_server/lib/src/connection/outbound/outbound_message_listener.dart
+++ b/at_secondary/at_secondary_server/lib/src/connection/outbound/outbound_message_listener.dart
@@ -90,7 +90,7 @@ class OutboundMessageListener {
     }
     // No response ... that's probably bad, so in addition to throwing an exception, let's also close the connection
     _closeOutboundClient();
-    throw TimeoutException("No response after $maxWaitMilliSeconds millis from remote secondary ${outboundClient.toAtSign} at ${outboundClient.toHost}:${outboundClient.toPort}");
+    throw AtTimeoutException("No response after $maxWaitMilliSeconds millis from remote secondary ${outboundClient.toAtSign} at ${outboundClient.toHost}:${outboundClient.toPort}");
   }
 
   /// Logs the error and closes the [OutboundClient]

--- a/at_secondary/at_secondary_server/lib/src/connection/outbound/outbound_message_listener.dart
+++ b/at_secondary/at_secondary_server/lib/src/connection/outbound/outbound_message_listener.dart
@@ -2,31 +2,29 @@ import 'dart:collection';
 import 'dart:convert';
 import 'package:at_commons/at_commons.dart';
 import 'package:at_secondary/src/connection/outbound/outbound_client.dart';
-import 'package:at_server_spec/at_server_spec.dart';
 import 'package:at_utils/at_logger.dart';
 
 ///Listener class for messages received by [OutboundClient]
 class OutboundMessageListener {
-  OutboundClient client;
+  OutboundClient outboundClient;
   var logger = AtSignLogger('OutboundMessageListener');
   final _buffer = ByteBuffer(capacity: 10240000);
   late Queue _queue;
 
-  OutboundMessageListener(this.client);
+  OutboundMessageListener(this.outboundClient);
 
   /// Listens to the underlying connection's socket if the connection is created.
   /// @throws [AtConnectException] if the connection is not yet created
   void listen() {
-    var connection = client.outboundConnection!;
+    var connection = outboundClient.outboundConnection!;
     connection.getSocket().listen(_messageHandler,
         onDone: _finishedHandler, onError: _errorHandler);
     _queue = Queue();
     connection.getMetaData().isListening = true;
   }
 
-  /// Handles messages on the inbound client's connection and calls the verb executor
-  /// Closes the inbound connection in case of any error.
-  /// Throw a [BufferOverFlowException] if buffer is unable to hold incoming data
+  /// Handles responses from the remote secondary, adds to [_queue] for processing in [read] method
+  /// Throws a [BufferOverFlowException] if buffer is unable to hold incoming data
   Future<void> _messageHandler(data) async {
     String result;
     if (!_buffer.isOverFlow(data)) {
@@ -58,44 +56,64 @@ class OutboundMessageListener {
   }
 
   /// Reads the response sent by remote socket from the queue.
-  /// If there is no message in queue after [maxWaitMilliSeconds], return null
+  /// Note: Exceptions thrown here, if not handled anywhere else, will be handled in [AtSecondaryServerImpl._executeVerbCallBack].
+  /// Throws [AtConnectException] upon an 'error:...' response from the remote secondary.
+  /// Throws [AtConnectException] upon a bad response (not 'data:...', not 'error:...') from remote secondary.
+  /// Throws [TimeoutException] If there is no message in queue after [maxWaitMilliSeconds].
   Future<String?> read({int maxWaitMilliSeconds = 5000}) async {
+    // ignore: prefer_typing_uninitialized_variables
     var result;
+
     //wait maxWaitMilliSeconds seconds for response from remote socket
     var loopCount = (maxWaitMilliSeconds / 50).round();
+
     for (var i = 0; i < loopCount; i++) {
       await Future.delayed(Duration(milliseconds: 50));
       var queueLength = _queue.length;
       if (queueLength > 0) {
         result = _queue.removeFirst();
-        // result from another secondary is either data or a @<atSign>@ denoting complete
-        // of the handshake
+        // result from another secondary should be either data: or error: or a @<atSign>@ denoting handshake completion
         if (result.startsWith('data:') ||
             (result.startsWith('@') && result.endsWith('@'))) {
           return result;
+        } else if (result.startsWith('error:')) {
+          // Right now, all callers of this method only expect there ever to be a 'data:' response.
+          // So right now, the right thing to do here is to throw an exception.
+          // We can leave the connection open since an 'error:' response indicates normal functioning on the other end
+          throw AtConnectException("Request to remote secondary ${outboundClient.toAtSign} at ${outboundClient.toHost}:${outboundClient.toPort} received error response '$result'");
         } else {
-          //log any other response and ignore
-          result = '';
+          // any other response is unexpected and bad, so close the connection and throw an exception
+          _closeOutboundClient();
+          throw AtConnectException("Unexpected response '$result' from remote secondary ${outboundClient.toAtSign} at ${outboundClient.toHost}:${outboundClient.toPort}");
         }
       }
     }
-    return result;
+    // No response ... that's probably bad, so in addition to throwing an exception, let's also close the connection
+    _closeOutboundClient();
+    throw TimeoutException("No response after $maxWaitMilliSeconds millis from remote secondary ${outboundClient.toAtSign} at ${outboundClient.toHost}:${outboundClient.toPort}");
   }
 
   /// Logs the error and closes the [OutboundClient]
   void _errorHandler(error) async {
     logger.severe(error.toString());
-    await _closeClient();
+    await _closeOutboundClient();
   }
 
-  /// Closes the [InboundConnection]
+  /// Closes the [OutboundClient]
   void _finishedHandler() async {
-    await _closeClient();
+    await _closeOutboundClient();
   }
 
-  Future<void> _closeClient() async {
-    if (!client.isInValid()) {
-      client.close();
-    }
+  Future<void> _closeOutboundClient() async {
+    // Changed the code here to no longer check if the client is invalid or not, since the outbound client can be
+    // invalid if the *inbound* connection has become invalid, which can happen if the inbound client has closed
+    // its socket immediately after making a request; this would in turn lead to the outbound client here not being
+    // closed, which can't be right.
+    // if (!outboundClient.isInValid()) {
+    //   outboundClient.close();
+    // }
+    //
+    // So, instead, we're just going to call close() on the outboundClient
+    outboundClient.close();
   }
 }

--- a/at_secondary/at_secondary_server/lib/src/exception/global_exception_handler.dart
+++ b/at_secondary/at_secondary_server/lib/src/exception/global_exception_handler.dart
@@ -48,7 +48,7 @@ class GlobalExceptionHandler {
         exception is OutBoundConnectionInvalidException ||
         exception is KeyNotFoundException ||
         exception is AtConnectException ||
-        exception is TimeoutException) {
+        exception is AtTimeoutException) {
       // In case of OutboundConnectionLimitException, LookupException, ConnectionInvalidException
       // SecondaryNotFoundException, HandShakeException, UnAuthorizedException, UnverifiedConnectionException
       // send error code.

--- a/at_secondary/at_secondary_server/lib/src/exception/global_exception_handler.dart
+++ b/at_secondary/at_secondary_server/lib/src/exception/global_exception_handler.dart
@@ -34,8 +34,9 @@ class GlobalExceptionHandler {
       _closeConnection(atConnection);
     } else if (exception is DataStoreException ||
         exception is ConnectionInvalidException) {
-      // In case of DataStoreException
-      // Retry for n number of times and Close connection.
+      // TODO Log the fact that we've had an exception
+      // TODO send a response with appropriate error code
+      // TODO should we keep the connection open rather than closing it?
       _closeConnection(atConnection);
     } else if (exception is InboundConnectionLimitException) {
       await _handleInboundLimit(exception, clientSocket!);
@@ -45,7 +46,9 @@ class GlobalExceptionHandler {
         exception is HandShakeException ||
         exception is UnAuthorizedException ||
         exception is OutBoundConnectionInvalidException ||
-        exception is KeyNotFoundException) {
+        exception is KeyNotFoundException ||
+        exception is AtConnectException ||
+        exception is TimeoutException) {
       // In case of OutboundConnectionLimitException, LookupException, ConnectionInvalidException
       // SecondaryNotFoundException, HandShakeException, UnAuthorizedException, UnverifiedConnectionException
       // send error code.

--- a/at_secondary/at_secondary_server/lib/src/verb/handler/proxy_lookup_verb_handler.dart
+++ b/at_secondary/at_secondary_server/lib/src/verb/handler/proxy_lookup_verb_handler.dart
@@ -50,6 +50,8 @@ class ProxyLookupVerbHandler extends AbstractVerbHandler {
     // If cached key value is null, perform a remote plookup.
     if (result == null) {
       result = await _getRemoteValue(key, atSign, atConnection);
+      // OutboundMessageListener will throw exceptions upon any 'error:' responses, malformed response, or timeouts
+      // So we only have to worry about 'data:' response here
       result = result!.replaceAll('data:', '');
       if (result == 'null') {
         await _removeCachedKey(key);

--- a/at_secondary/at_secondary_server/pubspec.yaml
+++ b/at_secondary/at_secondary_server/pubspec.yaml
@@ -20,12 +20,12 @@ dependencies:
   at_lookup: ^3.0.7
   at_server_spec: ^3.0.1
 
-dependency_overrides:
-  at_commons:
-    git:
-      url: https://github.com/atsign-foundation/at_tools.git
-      path: at_commons
-      ref: trunk
+#dependency_overrides:
+#  at_commons:
+#    git:
+#      url: https://github.com/atsign-foundation/at_tools.git
+#      path: at_commons
+#      ref: trunk
 #  at_persistence_spec:
 #    git:
 #      url: https://github.com/atsign-foundation/at_server.git

--- a/at_secondary/at_secondary_server/pubspec.yaml
+++ b/at_secondary/at_secondary_server/pubspec.yaml
@@ -20,7 +20,12 @@ dependencies:
   at_lookup: ^3.0.7
   at_server_spec: ^3.0.1
 
-#dependency_overrides:
+dependency_overrides:
+  at_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_tools.git
+      path: at_commons
+      ref: trunk
 #  at_persistence_spec:
 #    git:
 #      url: https://github.com/atsign-foundation/at_server.git
@@ -31,11 +36,6 @@ dependencies:
 #       url: https://github.com/atsign-foundation/at_tools.git
 #       path: at_utils
 #       ref: reset_ttl_ttb
-#  at_commons:
-#    git:
-#      url: https://github.com/atsign-foundation/at_tools.git
-#      path: at_commons
-#      ref: trunk
 #  at_persistence_secondary_server:
 #    git:
 #      url: https://github.com/atsign-foundation/at_server.git


### PR DESCRIPTION
Changes to address https://github.com/atsign-foundation/at_server/issues/501#issuecomment-1030029839

* outbound_message_listener.dart - old version would not handle error: responses but timeout after 5 seconds returning empty string
  * Modified read() so
    * it handles `error:...` responses by throwing an AtConnectException but leaves the connection open, as 'error:' is a valid response
    * handles malformed responses by throwing an AtConnectException and **closing** the connection (malformed responses should never occur)
    * changed default timeout from 5 seconds to 3 seconds as per comment from @cconstab 
    * throws a TimeoutException upon timing out, and closes the connection as timeouts are generally bad news
  * Modified _closeClient() so it doesn't check `if (!outboundClient.isInValid())` before calling outboundClient.close() - why? See [comments in code](https://github.com/atsign-foundation/at_server/pull/504/files#diff-1256148a521ddac147864fcc4cfd28c50b9974dfcbde0aa3531d60637233acf2R108)
  * Tidied up method comments for accuracy
  * For readability purposes, renamed instance variable client to outboundClient, and renamed method _closeClient to _closeOutboundClient

* outbound_connection_impl.dart
  * call socket.destroy() instead of socket.close()
  * We already call socket.destroy() in the at_lookup library see https://github.com/atsign-foundation/at_libraries/blob/trunk/at_lookup/lib/src/connection/base_connection.dart#L24 so this is normal behaviour when connecting to secondary servers
    * Originally changed base_connection.dart as well but reverted that just to prevent any unexpected side effects on **inbound_connection_impl** from this PR

* global_exception_handler.dart
  * added handling for AtConnectException and TimeoutException which are now being thrown by outbound_message_listener.dart

* proxy_lookup_verb_handler.dart
  * Added only an explanatory comment, about timeouts, 'error:..' responses and malformed responses being handled downstream in outbound_message_listener.dart

* Modified outbound_client.dart so that outbound_message_listener.dart log messages can include the remote atSign, host and port


**- Description for the changelog**
Changes to address https://github.com/atsign-foundation/at_server/issues/501#issuecomment-1030029839
