### PR TITLE
Fix hostname for armv7 build pi

### DIFF
--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -578,7 +578,7 @@ jobs:
       - name: Create dess-arm image
         uses: appleboy/ssh-action@v0.1.4
         with:
-          host: "70.167.220.138"
+          host: "arm32cicd.atsign.wtf"
           username: pi
           key: ${{ secrets.CICD_SSH_KEY }}
           script: |


### PR DESCRIPTION
Fixes Armv7 build segment not working due to pi IP change

**- What I did**

Replaced hard coded IP with DNS name (after updating A record to new IP)

**- How to verify it**

Create another prod release (3.0.11a) that will cause release pipeline to run.

**- Description for the changelog**

Fix hostname for armv7 build pi