### PR TITLE
More precise location for Dockerfile(s)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,6 @@ updates:
     schedule:
       interval: "daily"
   - package-ecosystem: "docker"
-    directory: "/"
+    directory: "/at_secondary"
     schedule:
       interval: "daily"


### PR DESCRIPTION
**- What I did**

Renamed dependabot.yaml to dependabot.yml
Specified /at_secondary as location for Dockerfile(s)

**- How to verify it**

Dependabot PR should follow tomorrow.

**- Description for the changelog**

More precise location for Dockerfile(s)