### PR TITLE
Increase outbound conn. wait time for notification response

### DIFF
--- a/at_secondary/at_secondary_server/lib/src/connection/outbound/outbound_client.dart
+++ b/at_secondary/at_secondary_server/lib/src/connection/outbound/outbound_client.dart
@@ -261,7 +261,9 @@ class OutboundClient {
       throw OutBoundConnectionInvalidException('Outbound connection invalid');
     }
     logger.info('waiting for response from outbound connection');
-    var notifyResult = await messageListener.read();
+    // Setting maxWaitMilliSeconds to 30000 to wait 30 seconds for notification
+    // response.
+    var notifyResult = await messageListener.read(maxWaitMilliSeconds: 30000);
     //notifyResult = notifyResult.replaceFirst(RegExp(r'\n\S+'), '');
     logger.info('notifyResult result after format: $notifyResult');
     return notifyResult;


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Incremented the wait time for notification response to 30 seconds.

**- How I did it**
Set the `maxWaitMilliSeconds: 30000` in notify method
**- How to verify it**
The server has to wait for 30 seconds for notification response.
**- Description for the changelog**
Increase wait time for notification response
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->