### PR TITLE
Added 'info' and 'noop' verbs to at_server_spec

### DIFF
--- a/at_server_spec/CHANGELOG.md
+++ b/at_server_spec/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.3
+- Added 'info' and 'noop' verbs
 ## 3.0.2
 - updated dart docs for verbs
 ## 3.0.1

--- a/at_server_spec/lib/src/verb/info.dart
+++ b/at_server_spec/lib/src/verb/info.dart
@@ -1,0 +1,49 @@
+import 'package:at_server_spec/src/verb/verb.dart';
+import 'package:at_commons/at_commons.dart';
+
+/// The "info" verb returns a JSON object as follows:
+/// ```json
+/// {
+///   "version" : "the version being run",
+///   "uptime" : "uptime as string: D days, H hours, M minutes, S seconds",
+///   "features" : [
+///     {
+///       "name" : "name of feature 1",
+///       "status" : "One of Preview, Beta, GA",
+///       "description" : "optional description of feature"
+///     },
+///     {
+///       "name" : "name of feature 2",
+///       "status" : "One of Preview, Beta, GA",
+///       "description" : "optional description of feature"
+///     },
+///     ...
+///   ]
+/// }
+/// ```
+///
+/// This verb _does not_ require authentication.
+///
+/// **Syntax**: info
+class Info extends Verb {
+  @override
+  String name() => 'info';
+
+  @override
+  String syntax() => VerbSyntax.info;
+
+  @override
+  Verb? dependsOn() {
+    return null;
+  }
+
+  @override
+  String usage() {
+    return 'info';
+  }
+
+  @override
+  bool requiresAuth() {
+    return false;
+  }
+}

--- a/at_server_spec/lib/src/verb/noop.dart
+++ b/at_server_spec/lib/src/verb/noop.dart
@@ -15,7 +15,7 @@ class NoOp extends Verb {
   String name() => 'noop';
 
   @override
-  String syntax() => VerbSyntax.noop;
+  String syntax() => VerbSyntax.noOp;
 
   @override
   Verb? dependsOn() {

--- a/at_server_spec/lib/src/verb/noop.dart
+++ b/at_server_spec/lib/src/verb/noop.dart
@@ -1,0 +1,34 @@
+import 'package:at_server_spec/src/verb/verb.dart';
+import 'package:at_commons/at_commons.dart';
+
+/// The "noop" verb takes a single parameter, a duration in milliseconds.
+///
+/// NoOp simply does nothing for the requested number of milliseconds.
+/// The requested number of milliseconds may not be greater than 5000.
+/// Upon completion, the noop verb sends 'OK' as a response to the client.
+///
+/// This verb _does not_ require authentication.
+///
+/// **Syntax**: noop:<durationInMillis>
+class NoOp extends Verb {
+  @override
+  String name() => 'noop';
+
+  @override
+  String syntax() => VerbSyntax.noop;
+
+  @override
+  Verb? dependsOn() {
+    return null;
+  }
+
+  @override
+  String usage() {
+    return 'noop:<durationInMillis>';
+  }
+
+  @override
+  bool requiresAuth() {
+    return false;
+  }
+}

--- a/at_server_spec/pubspec.yaml
+++ b/at_server_spec/pubspec.yaml
@@ -11,12 +11,12 @@ environment:
 dependencies:
   at_commons: ^3.0.2
 
-dependency_overrides:
-  at_commons:
-    git:
-      url: https://github.com/atsign-foundation/at_tools.git
-      path: at_commons
-      ref: info_and_noop_verbs
+#dependency_overrides:
+#  at_commons:
+#    git:
+#      url: https://github.com/atsign-foundation/at_tools.git
+#      path: at_commons
+#      ref: trunk
 
 dev_dependencies:
   lints: ^1.0.1

--- a/at_server_spec/pubspec.yaml
+++ b/at_server_spec/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_server_spec
 description: A Dart library containing abstract classes that defines what implementations of the root and secondary servers are responsible for.
-version: 3.0.2
+version: 3.0.3
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://atsign.dev
 documentation: https://atsign.dev/docs/
@@ -11,12 +11,12 @@ environment:
 dependencies:
   at_commons: ^3.0.2
 
-#dependency_overrides:
-#  at_commons:
-#    git:
-#      url: https://github.com/atsign-foundation/at_tools.git
-#      path: at_commons
-#      ref: trunk
+dependency_overrides:
+  at_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_tools.git
+      path: at_commons
+      ref: info_and_noop_verbs
 
 dev_dependencies:
   lints: ^1.0.1


### PR DESCRIPTION
**- What I did**
Added 'info' and 'noop' verbs to at_server_spec

**- How I did it**
* New files 'info.dart' and 'noop.dart' added to at_server_spec lib/src/verb
* Currently have a dependency override to pick up the required version of at_commons. Once **that** pull request has been approved, merged and published, then when this pull request has been approved I will remove the dependency override, do a new PR, merge the changes and publish

**- Description for the changelog**
Added 'info' and 'noop' verbs to at_server_spec
