### PR TITLE
Better inbound connection management

### DIFF
--- a/at_secondary/at_secondary_server/config/config.yaml
+++ b/at_secondary/at_secondary_server/config/config.yaml
@@ -39,9 +39,11 @@ hive:
 
 # The @Protocol connection configurations.
 connection:
-  # The maximum time in milli seconds for an inbound connection to expire.
+  # The maximum time in milliseconds for an inbound connection to expire.
+  # This should NEVER be set to less than 60 seconds. Internally, the effective
+  # value used is reduced progressively as the number of connections approaches the max limit
   inbound_idle_time_millis: 600000
-  # The maximum time in milli seconds for an outbound connection to expire.
+  # The maximum time in milliseconds for an outbound connection to expire.
   outbound_idle_time_millis: 600000
   # Creates an inbound connection and adds the connection to inbound connection pool. At any point, at most [inbound_max_limit] connections can only be created.
   # When all connections are active, additional connection requested can be served upon one of the active connection is closed.

--- a/at_secondary/at_secondary_server/lib/src/connection/inbound/inbound_connection_impl.dart
+++ b/at_secondary/at_secondary_server/lib/src/connection/inbound/inbound_connection_impl.dart
@@ -5,6 +5,7 @@ import 'package:at_secondary/src/connection/base_connection.dart';
 import 'package:at_secondary/src/connection/inbound/inbound_connection_metadata.dart';
 import 'package:at_secondary/src/connection/inbound/inbound_connection_pool.dart';
 import 'package:at_secondary/src/connection/inbound/inbound_message_listener.dart';
+import 'package:at_secondary/src/server/server_context.dart';
 import 'package:at_secondary/src/server/at_secondary_impl.dart';
 import 'package:at_server_spec/at_server_spec.dart';
 
@@ -30,16 +31,19 @@ class InboundConnectionImpl extends BaseConnection implements InboundConnection 
       ..created = DateTime.now().toUtc()
       ..isCreated = true;
 
+    AtSecondaryContext? secondaryContext = AtSecondaryServerImpl.getInstance().serverContext;
+    // In test harnesses, secondary context may not yet have been set, in which case create a default AtSecondaryContext instance
+    secondaryContext ??= AtSecondaryContext();
     // We have one value set in config : inboundIdleTimeMillis
-    maxAllowableInboundIdleTimeMillis = AtSecondaryServerImpl.getInstance().serverContext!.inboundIdleTimeMillis;
-    lowWaterMarkRatio = AtSecondaryServerImpl.getInstance().serverContext!.inboundConnectionLowWaterMarkRatio;
-    unauthenticatedMinAllowableIdleTimeMillis = AtSecondaryServerImpl.getInstance().serverContext!.unauthenticatedMinAllowableIdleTimeMillis;
+    maxAllowableInboundIdleTimeMillis = secondaryContext.inboundIdleTimeMillis;
+    lowWaterMarkRatio = secondaryContext.inboundConnectionLowWaterMarkRatio;
+    unauthenticatedMinAllowableIdleTimeMillis = secondaryContext.unauthenticatedMinAllowableIdleTimeMillis;
 
     // minAllowableIdleTimeMillis for authenticated connections should be a lot more generous.
     // if configured inboundIdleTimeMillis is 600,000 then authenticated min allowable will be 120,000
     // if configured inboundIdleTimeMillis is 60,000 then authenticated min allowable will be 30,000
     authenticatedMinAllowableIdleTimeMillis = (maxAllowableInboundIdleTimeMillis / 5).floor();
-    progressivelyReduceAllowableInboundIdleTime = AtSecondaryServerImpl.getInstance().serverContext!.progressivelyReduceAllowableInboundIdleTime;
+    progressivelyReduceAllowableInboundIdleTime = secondaryContext.progressivelyReduceAllowableInboundIdleTime;
   }
 
   /// Returns true if the underlying socket is not null and socket's remote address and port match.

--- a/at_secondary/at_secondary_server/lib/src/connection/inbound/inbound_connection_impl.dart
+++ b/at_secondary/at_secondary_server/lib/src/connection/inbound/inbound_connection_impl.dart
@@ -1,45 +1,116 @@
 import 'dart:io';
+import 'dart:math';
 
 import 'package:at_secondary/src/connection/base_connection.dart';
 import 'package:at_secondary/src/connection/inbound/inbound_connection_metadata.dart';
+import 'package:at_secondary/src/connection/inbound/inbound_connection_pool.dart';
 import 'package:at_secondary/src/connection/inbound/inbound_message_listener.dart';
 import 'package:at_secondary/src/server/at_secondary_impl.dart';
 import 'package:at_server_spec/at_server_spec.dart';
 
-class InboundConnectionImpl extends BaseConnection
-    implements InboundConnection {
+class InboundConnectionImpl extends BaseConnection implements InboundConnection {
   @override
   bool? isMonitor = false;
 
   /// This contains the value of the atsign initiated the connection
   @override
   String? initiatedBy;
-  static int? inbound_idle_time =
-      AtSecondaryServerImpl.getInstance().serverContext!.inboundIdleTimeMillis;
 
-  InboundConnectionImpl(Socket? socket, String? sessionId) : super(socket) {
+  InboundConnectionPool? owningPool;
+
+  late int maxAllowableInboundIdleTimeMillis;
+  late double lowWaterMarkRatio;
+  late int unauthenticatedMinAllowableIdleTimeMillis;
+  late int authenticatedMinAllowableIdleTimeMillis;
+  late bool progressivelyReduceAllowableInboundIdleTime;
+
+  InboundConnectionImpl(Socket? socket, String? sessionId, {this.owningPool}) : super(socket) {
     metaData = InboundConnectionMetadata()
       ..sessionID = sessionId
       ..created = DateTime.now().toUtc()
       ..isCreated = true;
+
+    // We have one value set in config : inboundIdleTimeMillis
+    maxAllowableInboundIdleTimeMillis = AtSecondaryServerImpl.getInstance().serverContext!.inboundIdleTimeMillis;
+    lowWaterMarkRatio = AtSecondaryServerImpl.getInstance().serverContext!.inboundConnectionLowWaterMarkRatio;
+    unauthenticatedMinAllowableIdleTimeMillis = AtSecondaryServerImpl.getInstance().serverContext!.unauthenticatedMinAllowableIdleTimeMillis;
+
+    // minAllowableIdleTimeMillis for authenticated connections should be a lot more generous.
+    // if configured inboundIdleTimeMillis is 600,000 then authenticated min allowable will be 120,000
+    // if configured inboundIdleTimeMillis is 60,000 then authenticated min allowable will be 30,000
+    authenticatedMinAllowableIdleTimeMillis = (maxAllowableInboundIdleTimeMillis / 5).floor();
+    progressivelyReduceAllowableInboundIdleTime = AtSecondaryServerImpl.getInstance().serverContext!.progressivelyReduceAllowableInboundIdleTime;
   }
 
   /// Returns true if the underlying socket is not null and socket's remote address and port match.
   @override
   bool equals(InboundConnection connection) {
     var result = false;
-    if (getSocket().remoteAddress.address ==
-            connection.getSocket().remoteAddress.address &&
+    if (getSocket().remoteAddress.address == connection.getSocket().remoteAddress.address &&
         getSocket().remotePort == connection.getSocket().remotePort) {
       result = true;
     }
     return result;
   }
 
+  /// Returning true indicates to the caller that this connection **can** be closed if needed
   @override
   bool isInValid() {
-    return _isIdle() || getMetaData().isClosed || getMetaData().isStale;
+    if (getMetaData().isClosed || getMetaData().isStale) {
+      return true;
+    }
+
+    // If we don't know our owning pool, OR we've disabled the new logic, just use old logic
+    if (owningPool == null || progressivelyReduceAllowableInboundIdleTime == false) {
+      var retVal = _idleForLongerThanMax();
+      return retVal;
+    }
+
+    // We do know our owning pool, so we'll use fancier logic.
+    // Unauthenticated connections should be reaped increasingly aggressively as we approach max connections
+    // Authenticated connections should also be reaped as we approach max connections, but a lot less aggressively
+    // Ultimately, the caller (e.g. [InboundConnectionManager] decides **whether** to reap or not.
+    int? poolMaxConnections = owningPool!.getCapacity();
+    int lowWaterMark = (poolMaxConnections! * lowWaterMarkRatio).floor();
+    int numConnectionsOverLwm = max(owningPool!.getCurrentSize() - lowWaterMark, 0);
+
+    // We're past the low water mark. Let's use some fancier logic to mark connections invalid increasingly aggressively.
+    double idleTimeReductionFactor = 1 - (numConnectionsOverLwm / (poolMaxConnections - lowWaterMark));
+    if (!getMetaData().isAuthenticated && !getMetaData().isPolAuthenticated) {
+      // For **unauthenticated** connections, we deem invalid if idle time is greater than
+      // ((maxIdleTime - minIdleTime) * (1 - numConnectionsOverLwm / (maxConnections - connectionsLowWaterMark))) + minIdleTime
+      //
+      // i.e. as the current number of connections grows past low-water-mark, the tolerated idle time reduces
+      // Given: Max connections of 50, lwm of 25, max idle time of 605 seconds, min idle time of 5 seconds
+      // When: current == 25, idle time allowable = (605-5) * (1 - 0/25) + 5 i.e. 600 * 1.0 + 5 i.e. 605
+      // When: current == 40, idle time allowable = (605-5) * (1 - 15/25) + 5 i.e. 600 * 0.4 + 5 i.e. 245
+      // When: current == 49, idle time allowable = (605-5) * (1 - 24/25) + 5 i.e. 600 * 0.04 + 5 i.e. 24 + 5 i.e. 29
+      // When: current == 50, idle time allowable = (605-5) * (1 - 25/25) + 5 i.e. 600 * 0.0 + 5 i.e. 0 + 5 i.e. 5
+      //
+      // Given: Max connections of 50, lwm of 10, max idle time of 605 seconds, min idle time of 5 seconds
+      // When: current == 10, idle time allowable = (605-5) * (1 - (10-10)/(50-10)) + 5 i.e. 600 * (1 - 0/40) + 5 i.e. 605
+      // When: current == 20, idle time allowable = (605-5) * (1 - (20-10)/(50-10)) + 5 i.e. 600 * (1 - 10/40) + 5 i.e. 455
+      // When: current == 30, idle time allowable = (605-5) * (1 - (30-10)/(50-10)) + 5 i.e. 600 * (1 - 20/40) + 5 i.e. 305
+      // When: current == 40, idle time allowable = (605-5) * (1 - (40-10)/(50-10)) + 5 i.e. 600 * (1 - 30/40) + 5 i.e. 155
+      // When: current == 49, idle time allowable = (605-5) * (1 - (49-10)/(50-10)) + 5 i.e. 600 * (1 - 39/40) + 5 i.e. 600 * .025 + 5 i.e. 20
+      // When: current == 50, idle time allowable = (605-5) * (1 - (50-10)/(50-10)) + 5 i.e. 600 * (1 - 40/40) + 5 i.e. 600 * 0 + 5 i.e. 5
+      int allowableIdleTime = calcAllowableIdleTime(idleTimeReductionFactor, unauthenticatedMinAllowableIdleTimeMillis);
+      var actualIdleTime = _getIdleTimeMillis();
+      var retVal = actualIdleTime > allowableIdleTime;
+      return retVal;
+    } else {
+      // For authenticated connections
+      // TODO (1) if the connection has a request in progress, we should never mark it as invalid
+      // (2) otherwise, we will mark as invalid using same algorithm as above, but using authenticatedMinAllowableIdleTimeMillis
+      int allowableIdleTime = calcAllowableIdleTime(idleTimeReductionFactor, authenticatedMinAllowableIdleTimeMillis);
+      var actualIdleTime = _getIdleTimeMillis();
+      var retVal = actualIdleTime > allowableIdleTime;
+      return retVal;
+    }
   }
+
+  int calcAllowableIdleTime(double idleTimeReductionFactor, int minAllowableIdleTimeMillis) =>
+      (((maxAllowableInboundIdleTimeMillis - minAllowableIdleTimeMillis) * idleTimeReductionFactor) + minAllowableIdleTimeMillis).floor();
 
   /// Get the idle time of the inbound connection since last write operation
   int _getIdleTimeMillis() {
@@ -52,13 +123,12 @@ class InboundConnectionImpl extends BaseConnection
 
   /// Returns true if the client's idle time is greater than configured idle time.
   /// false otherwise
-  bool _isIdle() {
-    return _getIdleTimeMillis() > inbound_idle_time!;
+  bool _idleForLongerThanMax() {
+    return _getIdleTimeMillis() > maxAllowableInboundIdleTimeMillis;
   }
 
   @override
-  void acceptRequests(Function(String, InboundConnection) callback,
-      Function(List<int>, InboundConnection) streamCallBack) {
+  void acceptRequests(Function(String, InboundConnection) callback, Function(List<int>, InboundConnection) streamCallBack) {
     var listener = InboundMessageListener(this);
     listener.listen(callback, streamCallBack);
   }
@@ -67,4 +137,33 @@ class InboundConnectionImpl extends BaseConnection
   Socket? receiverSocket;
 
   bool? isStream;
+
+  @override
+  Future<void> close() async {
+    // Over-riding BaseConnection.close() (which calls socket.close()), as may want to keep different
+    // behaviours for inbound and outbound connections
+    // (Note however that, at time of writing, outbound_connection_impl also calls socket.destroy)
+
+    // Some defensive code just in case we accidentally call close multiple times
+    if (getMetaData().isClosed) {
+      return;
+    }
+
+    try {
+      var address = getSocket().remoteAddress;
+      var port = getSocket().remotePort;
+      var socket = getSocket();
+      if (socket != null) {
+        socket.destroy();
+      }
+      logger.finer('$address:$port Disconnected');
+      getMetaData().isClosed = true;
+    } on Exception {
+      getMetaData().isStale = true;
+      // Ignore exception on a connection close
+    } on Error {
+      getMetaData().isStale = true;
+      // Ignore error on a connection close
+    }
+  }
 }

--- a/at_secondary/at_secondary_server/lib/src/connection/inbound/inbound_connection_pool.dart
+++ b/at_secondary/at_secondary_server/lib/src/connection/inbound/inbound_connection_pool.dart
@@ -1,12 +1,12 @@
 import 'dart:collection';
 
 import 'package:at_server_spec/at_server_spec.dart';
+import 'package:at_utils/at_logger.dart';
 
 /// Pool to hold [InboundConnection]
 class InboundConnectionPool {
-  static final InboundConnectionPool _singleton =
-      InboundConnectionPool._internal();
-  int? _size;
+  static final InboundConnectionPool _singleton = InboundConnectionPool._internal();
+  late int _size;
 
   factory InboundConnectionPool.getInstance() {
     return _singleton;
@@ -14,35 +14,42 @@ class InboundConnectionPool {
 
   InboundConnectionPool._internal();
 
+  var logger = AtSignLogger('InboundConnectionPool');
+
   late List<InboundConnection> _connections;
 
-  void init(int? size) {
+  void init(int size) {
     _size = size;
     _connections = [];
   }
 
   bool hasCapacity() {
-    return _connections.length < _size!;
+    return _connections.length < _size;
   }
 
+  bool passedEightyFivePercent = false;
+  bool passedNinetyFivePercent = false;
   void add(InboundConnection inboundConnection) {
     _connections.add(inboundConnection);
+    _checkWarningStatesOnAdd();
   }
 
   void remove(InboundConnection inboundConnection) {
     _connections.remove(inboundConnection);
+    _checkWarningStatesOnRemove();
   }
 
   void clearInvalidConnections() {
     var invalidConnections = [];
     //dart doesn't support iterator.remove(). So use forEach + removeWhere
-    _connections.forEach((connection) {
+    for (var connection in _connections) {
       if (connection.isInValid()) {
         invalidConnections.add(connection);
         connection.close();
       }
-    });
+    }
     _connections.removeWhere((client) => invalidConnections.contains(client));
+    _checkWarningStatesOnRemove();
   }
 
   int getCurrentSize() {
@@ -54,14 +61,37 @@ class InboundConnectionPool {
   }
 
   bool clearAllConnections() {
-    _connections.forEach((connection) {
+    for (var connection in _connections) {
       connection.close();
-    });
+    }
     _connections.clear();
+    _checkWarningStatesOnRemove();
     return true;
   }
 
   UnmodifiableListView<InboundConnection> getConnections() {
     return UnmodifiableListView<InboundConnection>(_connections);
+  }
+
+  void _checkWarningStatesOnAdd() {
+    if (_connections.length >= _size * 0.85 && !passedEightyFivePercent) {
+      logger.warning('InboundConnectionPool >= 85% full');
+      passedEightyFivePercent = true;
+    }
+    if (_connections.length >= _size * 0.95 && !passedNinetyFivePercent) {
+      logger.severe('InboundConnectionPool >= 95% full');
+      passedNinetyFivePercent = true;
+    }
+  }
+
+  void _checkWarningStatesOnRemove() {
+    if (_connections.length < _size * 0.95 && passedNinetyFivePercent) {
+      logger.info('InboundConnectionPool < 95% full');
+      passedNinetyFivePercent = false;
+    }
+    if (_connections.length < _size * 0.85 && passedEightyFivePercent) {
+      logger.info('InboundConnectionPool < 85% full');
+      passedEightyFivePercent = false;
+    }
   }
 }

--- a/at_secondary/at_secondary_server/lib/src/server/at_secondary_config.dart
+++ b/at_secondary/at_secondary_server/lib/src/server/at_secondary_config.dart
@@ -47,10 +47,10 @@ class AtSecondaryConfig {
   static int? _runRefreshJobHour = 3;
 
   //Connection
-  static final int? _inbound_max_limit = 10;
-  static final int? _outbound_max_limit = 10;
-  static final int? _inbound_idletime_millis = 600000;
-  static final int? _outbound_idletime_millis = 600000;
+  static final int _inbound_max_limit = 10;
+  static final int _outbound_max_limit = 10;
+  static final int _inbound_idletime_millis = 600000;
+  static final int _outbound_idletime_millis = 600000;
 
   //Lookup
   static final int? _lookup_depth_of_resolution = 3;
@@ -354,7 +354,7 @@ class AtSecondaryConfig {
   }
 
   // ignore: non_constant_identifier_names
-  static int? get outbound_idletime_millis {
+  static int get outbound_idletime_millis {
     var result = _getIntEnvVar('outbound_idletime_millis');
     if (result != null) {
       return result;
@@ -367,7 +367,7 @@ class AtSecondaryConfig {
   }
 
   // ignore: non_constant_identifier_names
-  static int? get inbound_idletime_millis {
+  static int get inbound_idletime_millis {
     var result = _getIntEnvVar('inbound_idletime_millis');
     if (result != null) {
       return result;
@@ -380,7 +380,7 @@ class AtSecondaryConfig {
   }
 
   // ignore: non_constant_identifier_names
-  static int? get outbound_max_limit {
+  static int get outbound_max_limit {
     var result = _getIntEnvVar('outbound_max_limit');
     if (result != null) {
       return result;
@@ -393,7 +393,7 @@ class AtSecondaryConfig {
   }
 
   // ignore: non_constant_identifier_names
-  static int? get inbound_max_limit {
+  static int get inbound_max_limit {
     var result = _getIntEnvVar('inbound_max_limit');
     if (result != null) {
       return result;

--- a/at_secondary/at_secondary_server/lib/src/server/at_secondary_impl.dart
+++ b/at_secondary/at_secondary_server/lib/src/server/at_secondary_impl.dart
@@ -196,8 +196,7 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
 
     // Initialize inbound factory and outbound manager
     inboundConnectionFactory.init(serverContext!.inboundConnectionLimit);
-    OutboundClientManager.getInstance()
-        .init(serverContext!.outboundConnectionLimit);
+    OutboundClientManager.getInstance().init(serverContext!.outboundConnectionLimit);
 
     // Starts StatsNotificationService to keep monitor connections alive
     StatsNotificationService.getInstance().schedule();

--- a/at_secondary/at_secondary_server/lib/src/server/bootstrapper.dart
+++ b/at_secondary/at_secondary_server/lib/src/server/bootstrapper.dart
@@ -13,11 +13,11 @@ import 'package:at_utils/at_utils.dart';
 class SecondaryServerBootStrapper {
   var arguments;
   static final bool? useSSL = AtSecondaryConfig.useSSL;
-  static final int? inbound_max_limit = AtSecondaryConfig.inbound_max_limit;
-  static final int? outbound_max_limit = AtSecondaryConfig.outbound_max_limit;
-  static final int? inbound_idletime_millis =
+  static final int inbound_max_limit = AtSecondaryConfig.inbound_max_limit;
+  static final int outbound_max_limit = AtSecondaryConfig.outbound_max_limit;
+  static final int inbound_idletime_millis =
       AtSecondaryConfig.inbound_idletime_millis;
-  static final int? outbound_idletime_millis =
+  static final int outbound_idletime_millis =
       AtSecondaryConfig.outbound_idletime_millis;
 
   SecondaryServerBootStrapper(this.arguments);

--- a/at_secondary/at_secondary_server/lib/src/server/server_context.dart
+++ b/at_secondary/at_secondary_server/lib/src/server/server_context.dart
@@ -6,10 +6,14 @@ class AtSecondaryContext extends AtServerContext {
   String host = 'localhost';
   late int port;
   bool isKeyStoreInitialized = false;
-  int? inboundConnectionLimit = 10;
-  int? outboundConnectionLimit = 10;
-  int? inboundIdleTimeMillis = 600000;
-  int? outboundIdleTimeMillis = 600000;
+  int inboundConnectionLimit = 50;
+  int outboundConnectionLimit = 50;
+  int inboundIdleTimeMillis = 600000;
+  int outboundIdleTimeMillis = 600000;
+
+  int unauthenticatedMinAllowableIdleTimeMillis = 5000; // have to allow time for connection handshakes // TODO Run tests to identify a p99.999 value
+  double inboundConnectionLowWaterMarkRatio = 0.5;
+  bool progressivelyReduceAllowableInboundIdleTime = true;
   String? currentAtSign;
   String? sharedSecret;
   AtSecurityContext? securityContext;

--- a/at_secondary/at_secondary_server/test/inbound_connection_pool_test.dart
+++ b/at_secondary/at_secondary_server/test/inbound_connection_pool_test.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:math';
 
 import 'package:at_secondary/src/connection/inbound/inbound_connection_impl.dart';
 import 'package:at_secondary/src/connection/inbound/inbound_connection_pool.dart';
@@ -6,11 +7,15 @@ import 'package:at_secondary/src/server/at_secondary_impl.dart';
 import 'package:at_secondary/src/server/server_context.dart';
 import 'package:test/test.dart';
 
+var serverContext = AtSecondaryContext();
+
 void main() async {
-  setUp(() {
-    var serverContext = AtSecondaryContext();
-    serverContext.inboundIdleTimeMillis = 10000;
+  setUpAll(() {
+    serverContext.inboundIdleTimeMillis = 1000;
+    serverContext.inboundConnectionLowWaterMarkRatio = 0.5;
+    serverContext.unauthenticatedMinAllowableIdleTimeMillis = 20;
     AtSecondaryServerImpl.getInstance().serverContext = serverContext;
+    InboundConnectionPool.getInstance().init(10);
   });
   tearDown(() {
     InboundConnectionPool.getInstance().clearAllConnections();
@@ -25,7 +30,7 @@ void main() async {
     test('test connection pool add connections', () {
       var poolInstance = InboundConnectionPool.getInstance();
       poolInstance.init(5);
-      var dummySocket;
+      Socket? dummySocket;
       var connection1 = InboundConnectionImpl(dummySocket, 'aaa');
       var connection2 = InboundConnectionImpl(dummySocket, 'bbb');
       poolInstance.add(connection1);
@@ -36,7 +41,7 @@ void main() async {
     test('test connection pool has capacity', () {
       var poolInstance = InboundConnectionPool.getInstance();
       poolInstance.init(2);
-      var dummySocket;
+      Socket? dummySocket;
       var connection1 = InboundConnectionImpl(dummySocket, 'aaa');
       poolInstance.add(connection1);
       expect(poolInstance.hasCapacity(), true);
@@ -45,7 +50,7 @@ void main() async {
     test('test connection pool has no capacity', () {
       var poolInstance = InboundConnectionPool.getInstance();
       poolInstance.init(2);
-      var dummySocket;
+      Socket? dummySocket;
       var connection1 = InboundConnectionImpl(dummySocket, 'aaa');
       var connection2 = InboundConnectionImpl(dummySocket, 'bbb');
       poolInstance.add(connection1);
@@ -56,7 +61,7 @@ void main() async {
     test('test connection pool - clear closed connection', () {
       var poolInstance = InboundConnectionPool.getInstance();
       poolInstance.init(2);
-      var dummySocket;
+      Socket? dummySocket;
       var connection1 = MockInBoundConnectionImpl(dummySocket, 'aaa');
       var connection2 = MockInBoundConnectionImpl(dummySocket, 'bbb');
       poolInstance.add(connection1);
@@ -69,18 +74,18 @@ void main() async {
 
     test('test connection pool - clear idle connection', () {
       var poolInstance = InboundConnectionPool.getInstance();
-      poolInstance.init(2);
-      var dummySocket;
+      poolInstance.init(10);
+      Socket? dummySocket;
       var connection1 = MockInBoundConnectionImpl(dummySocket, 'aaa');
       var connection2 = MockInBoundConnectionImpl(dummySocket, 'bbb');
       var connection3 = MockInBoundConnectionImpl(dummySocket, 'ccc');
       poolInstance.add(connection1);
       poolInstance.add(connection2);
       poolInstance.add(connection3);
-      sleep(Duration(seconds: 9));
+      sleep(Duration(milliseconds: (serverContext.inboundIdleTimeMillis * 0.9).floor()));
       connection2.write('test data');
       expect(poolInstance.getCurrentSize(), 3);
-      sleep(Duration(seconds: 2));
+      sleep(Duration(milliseconds: (serverContext.inboundIdleTimeMillis * 0.2).floor()));
       print('connection 1: ${connection1.getMetaData().created} '
           '${connection1.getMetaData().lastAccessed} ${connection1.isInValid()}');
       print('connection 2: ${connection2.getMetaData().created} '
@@ -90,22 +95,135 @@ void main() async {
       poolInstance.clearInvalidConnections();
       expect(poolInstance.getCurrentSize(), 1);
     });
+
+    /// Verify that, at lowWaterMark, allowable idle time is still as configured by inboundIdleTimeMillis
+    test('test connection pool - at lowWaterMark - clear idle connection', () {
+      int maxPoolSize = 10;
+
+      var poolInstance = InboundConnectionPool.getInstance();
+      poolInstance.init(maxPoolSize);
+      var connections = [];
+
+      int lowWaterMark = (maxPoolSize * serverContext.inboundConnectionLowWaterMarkRatio).floor();
+      for (int i = 0; i < lowWaterMark; i++) {
+        var mockConnection = MockInBoundConnectionImpl(null, 'mock session $i');
+        connections.add(mockConnection);
+        poolInstance.add(mockConnection);
+      }
+
+      sleep(Duration(milliseconds: (serverContext.inboundIdleTimeMillis * 0.9).floor()));
+
+      connections[1].write('test data');
+      expect(poolInstance.getCurrentSize(), lowWaterMark);
+      sleep(Duration(milliseconds: ((serverContext.inboundIdleTimeMillis * 0.1) + 1).floor()));
+
+      poolInstance.clearInvalidConnections();
+      expect(poolInstance.getCurrentSize(), 1);
+    });
+
+    /// Verify that, beyond lowWaterMark, allowable idle time progressively reduces
+    test('test connection pool - 90% capacity - clear idle connection', () {
+      int maxPoolSize = 100; // Please don't change this
+
+      var poolInstance = InboundConnectionPool.getInstance();
+      poolInstance.init(maxPoolSize);
+      var connections = [];
+
+      int desiredPoolSize = (maxPoolSize * 0.9).floor();
+      int numAuthenticated = 0;
+      int numUnauthenticated = 0;
+      for (int i = 0; i < desiredPoolSize; i++) {
+        var mockConnection = MockInBoundConnectionImpl(null, 'mock session $i');
+        if (i.isEven) {
+          mockConnection.getMetaData().isAuthenticated = true;
+          numAuthenticated++;
+        } else {
+          numUnauthenticated++;
+        }
+        connections.add(mockConnection);
+        poolInstance.add(mockConnection);
+      }
+
+
+      int unauthenticatedMinAllowableIdleTimeMillis = serverContext.unauthenticatedMinAllowableIdleTimeMillis;
+      int authenticatedMinAllowableIdleTimeMillis = (serverContext.inboundIdleTimeMillis / 5).floor();
+
+      // Actual allowable idle time should be as per InboundConnectionImpl.dart - i.e.
+      int unauthenticatedActualAllowableIdleTime = calcActualAllowableIdleTime(poolInstance, maxPoolSize, unauthenticatedMinAllowableIdleTimeMillis);
+
+      print ("unAuth actual allowed: $unauthenticatedActualAllowableIdleTime");
+
+      int now = DateTime.now().millisecondsSinceEpoch;
+      int startTime = now;
+
+      // Before simulating activity, let's first sleep for 90% of the currently allowable idle time for UNAUTHENTICATED connections
+      sleep(Duration(milliseconds: (unauthenticatedActualAllowableIdleTime * 0.9).floor()));
+
+      int numAuthToWriteTo = 3;
+      int numUnAuthToWriteTo = 10;
+      // Let's write to a few authenticated connections, and some more unauthenticated connections
+      for (int i = 0; i < numAuthToWriteTo; i++) {
+        connections[i*2].write('test data'); // evens are authenticated
+      }
+      for (int i = 0; i < numUnAuthToWriteTo; i++) {
+        connections[i*2+1].write('test data'); // odds are not authenticated
+      }
+
+      // pool size should be as expected before checking invalidity
+      expect(poolInstance.getCurrentSize(), desiredPoolSize);
+      poolInstance.clearInvalidConnections();
+      // no invalid connections should have yet been cleared
+      expect(poolInstance.getCurrentSize(), desiredPoolSize);
+
+      // now let's sleep until the unused connections will have been idle for longer than the currently allowable idle time for UNAUTHENTICATED connections
+      sleep(Duration(milliseconds: ((unauthenticatedActualAllowableIdleTime * 0.1) + 1).floor()));
+      // now when we clear invalid connections, we're going to see all of the unused unauthenticated connections returned to pool
+      // Since we wrote to 10 unauthenticated connections, that means we will clean up numUnauthenticated - 10
+      poolInstance.clearInvalidConnections();
+      int expected = desiredPoolSize - (numUnauthenticated - numUnAuthToWriteTo);
+      now = DateTime.now().millisecondsSinceEpoch;
+      int elapsed = now - startTime;
+      print ('After $elapsed : expect pool size after unauthenticated clean up to be $expected (pre-clear size was $desiredPoolSize)');
+      expect(poolInstance.getCurrentSize(), expected);
+
+      // now let's sleep until the unused connections will have been idle for longer than the currently allowable idle time for AUTHENTICATED connections
+      int authenticatedActualAllowableIdleTime = calcActualAllowableIdleTime(poolInstance, maxPoolSize, authenticatedMinAllowableIdleTimeMillis);
+      print ("auth actual allowed: $authenticatedActualAllowableIdleTime");
+      sleep(Duration(milliseconds: authenticatedActualAllowableIdleTime - elapsed + 1));
+      // now when we clear invalid connections, we're going to additionally see all of the unused AUTHENTICATED connections returned to pool
+      // Since we wrote to 3 authenticated connections, that means we will clean up an additional numAuthenticated - 3 connections
+      poolInstance.clearInvalidConnections();
+      expected -= (numAuthenticated - numAuthToWriteTo);
+      now = DateTime.now().millisecondsSinceEpoch;
+      elapsed = now-startTime;
+      print ('After $elapsed : expect pool size after AUTHenticated clean up to be $expected (pre-clear size was $desiredPoolSize)');
+      expect(poolInstance.getCurrentSize(), expected);
+
+    });
   });
+}
+
+int calcActualAllowableIdleTime(poolInstance, maxPoolSize, minAllowableIdleTime) {
+  int lowWaterMark = (maxPoolSize * serverContext.inboundConnectionLowWaterMarkRatio).floor();
+  int numConnectionsOverLwm = max(poolInstance.getCurrentSize() - lowWaterMark, 0);
+  double idleTimeReductionFactor = 1 - (numConnectionsOverLwm / (maxPoolSize - lowWaterMark));
+  return
+  (((serverContext.inboundIdleTimeMillis - minAllowableIdleTime) * idleTimeReductionFactor) +
+      minAllowableIdleTime)
+      .floor();
 }
 
 class MockInBoundConnectionImpl extends InboundConnectionImpl {
   MockInBoundConnectionImpl(Socket? socket, String sessionId)
-      : super(socket, sessionId);
+      : super(socket, sessionId, owningPool: InboundConnectionPool.getInstance());
 
   @override
   Future<void> close() async {
-    print('closing mock connection');
     getMetaData().isClosed = true;
   }
 
   @override
   void write(String data) {
-    print('writing to mock connection');
     getMetaData().lastAccessed = DateTime.now().toUtc();
   }
 }


### PR DESCRIPTION
**- What I did**
Made changes to inbound connection management as first wave of fixing problems described in https://github.com/atsign-foundation/at_server/issues/503

This PR should largely eliminate issues under normal operations. It will not prevent a determined DOS attacker; more changes are required for that, eg temporarily banning IP addresses of abusive connections, faster auth handshaking, and so on. 

**- How I did it**
* config.yaml : Added some more explanation on the inbound_idle_time_millis config parameter
* inbound_connection_impl.dart
  * added optional construction parameter, owningPool which, when provided, allows the inbound connection impl to do some fancier logic to do with idle time and thus allow the connection pool to do some fancier connection pool maintenance
  * added an override for the close() method, as previously done for (outbound connection impl), to destroy the underlying socket rather than just closing it
* inbound_connection_manager.dart
  * pass the owningPool parameter when constructing InboundConnectionImpls
  * some linting
* inbound_connection_pool.dart
  * log WARNING when reaches 85% full, SEVERE when reaches 95% full
  * log INFO when drops to < 95% full, INFO when drops to < 85% full
  * some linting
* at_secondary_impl.dart : one tiny code format change
* server_context.dart
  * bumped inboundConnectionLimit to same as latest in config.yaml (50)
  * bumped outboundConnectionLimit to same as latest in config.yaml (50)
  * added a few more global config parameters which we can later add to config.yaml if we need them to be tunable:
    * unauthenticatedMinAllowableIdleTimeMillis - the minimum amount of inactive time that needs to pass before a connection can be cleaned up as idle
    * inboundConnectionLowWaterMarkRatio - beyond this proportion of the inboundConnectionLimit, we get progressively more aggressive when determining acceptable idle times for connection cleanup
    * progressivelyReduceAllowableInboundIdleTime - a switch to disable all of this new logic if we want to
* inbound_connection_pool_test.dart : added some tests for the above changes

**- How to verify it**
Check that the added tests are sensible and that all the tests pass

**- Description for the changelog**
Reduce likelihood of server reaching capacity on inbound connections #503
