### PR TITLE
Listen for SIGKILL and SIGINT for graceful server shutdown

### DIFF
--- a/at_secondary/at_secondary_server/lib/src/server/bootstrapper.dart
+++ b/at_secondary/at_secondary_server/lib/src/server/bootstrapper.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:at_secondary/src/arg_utils.dart';
 import 'package:at_secondary/src/server/at_secondary_config.dart';
 import 'package:at_secondary/src/server/at_secondary_impl.dart';
@@ -5,51 +7,72 @@ import 'package:at_secondary/src/server/at_security_context_impl.dart';
 import 'package:at_secondary/src/server/server_context.dart';
 import 'package:at_secondary/src/verb/executor/default_verb_executor.dart';
 import 'package:at_secondary/src/verb/manager/verb_handler_manager.dart';
-import 'package:at_utils/at_logger.dart';
 import 'package:at_utils/at_utils.dart';
 
 /// The bootstrapper class for initializing the secondary server configuration parameters from [config.yaml]
 /// and call the start method to start the secondary server.
 class SecondaryServerBootStrapper {
-  var arguments;
+  List<String> arguments;
   static final bool? useSSL = AtSecondaryConfig.useSSL;
-  static final int inbound_max_limit = AtSecondaryConfig.inbound_max_limit;
-  static final int outbound_max_limit = AtSecondaryConfig.outbound_max_limit;
-  static final int inbound_idletime_millis =
-      AtSecondaryConfig.inbound_idletime_millis;
-  static final int outbound_idletime_millis =
-      AtSecondaryConfig.outbound_idletime_millis;
+  static final int inboundMaxLimit = AtSecondaryConfig.inbound_max_limit;
+  static final int outboundMaxLimit = AtSecondaryConfig.outbound_max_limit;
+  static final int inboundIdleTimeMillis = AtSecondaryConfig.inbound_idletime_millis;
+  static final int outboundIdleTimeMillis = AtSecondaryConfig.outbound_idletime_millis;
 
   SecondaryServerBootStrapper(this.arguments);
 
   var logger = AtSignLogger('SecondaryServerBootStrapper');
 
+  late AtSecondaryServerImpl secondaryServerInstance;
+
   /// Loads the default configurations from [config.yaml] and initiates a call to secondary server start method.
   /// Throws any exceptions back to the calling method.
   Future<void> run() async {
+    secondaryServerInstance = AtSecondaryServerImpl.getInstance();
     try {
       var results = CommandLineParser().getParserResults(arguments);
       var secondaryContext = AtSecondaryContext();
       secondaryContext.port = int.parse(results['server_port']);
       secondaryContext.currentAtSign = AtUtils.fixAtSign(results['at_sign']);
       secondaryContext.sharedSecret = results['shared_secret'];
-      secondaryContext.inboundConnectionLimit = inbound_max_limit;
-      secondaryContext.outboundConnectionLimit = outbound_max_limit;
-      secondaryContext.inboundIdleTimeMillis = inbound_idletime_millis;
-      secondaryContext.outboundIdleTimeMillis = outbound_idletime_millis;
+      secondaryContext.inboundConnectionLimit = inboundMaxLimit;
+      secondaryContext.outboundConnectionLimit = outboundMaxLimit;
+      secondaryContext.inboundIdleTimeMillis = inboundIdleTimeMillis;
+      secondaryContext.outboundIdleTimeMillis = outboundIdleTimeMillis;
       if (useSSL!) {
         secondaryContext.securityContext = AtSecurityContextImpl();
       }
 
       // Start the secondary server
-      var secondaryServerInstance = AtSecondaryServerImpl.getInstance();
       secondaryServerInstance.setServerContext(secondaryContext);
       secondaryServerInstance.setExecutor(DefaultVerbExecutor());
       secondaryServerInstance
           .setVerbHandlerManager(DefaultVerbHandlerManager());
       await secondaryServerInstance.start();
+      ProcessSignal.sigterm.watch().listen(handleTerminateSignal);
+      ProcessSignal.sigint.watch().listen(handleTerminateSignal);
     } on Exception {
       rethrow;
+    }
+  }
+
+  void handleTerminateSignal(event) async {
+    try {
+      logger.info("Caught $event - calling secondaryServerInstance.stop()");
+      await secondaryServerInstance.stop();
+      if (secondaryServerInstance.isRunning()) {
+        logger.warning("secondaryServerInstance.stop() completed but isRunning still true - exiting with status 1");
+        exit(1);
+      } else {
+        logger.info("secondaryServerInstance.stop() completed, and isRunning is false - exiting with status 0");
+        exit(0);
+      }
+    } on Exception catch (e, stacktrace) {
+      logger.warning("Caught $e from secondaryServerInstance.stop() sequence");
+      logger.warning(stacktrace.toString());
+    } finally {
+      logger.info("Somehow made it to the finally block - exiting with status 1");
+      exit(1);
     }
   }
 }


### PR DESCRIPTION
**- What I did**
Listen to SIGKILL and SIGINT and call AtSecondaryServer.stop() to gracefully shutdown the server, so that database connections can be closed etc.

Fixes #586 

**- How I did it**
* SecondaryServerBootStrapper:
  * some lint cleanup
  * via ProcessSignal, listen to SIGTERM and SIGINT and upon receipt, call secondaryServerInstance.stop()
* AtSecondaryServerImpl:
  * Added `await AtNotificationKeystore.getInstance().close();` to the stop() function
  * Added some logging to the stop() function

**- How to verify it**
* **What I'd like to do**: In GitHub workflow, add two more steps to the functional test job - (1) after starting the container, check that the 4 expected .lock files have been created (2) after stopping the container, check that there are no .lock files remaining 
* **What I'm currently doing**: Running locally, killing the process (via either `kill $pid` or Ctrl-C if running in foreground) and verifying the behaviour - and indeed, it works - here's some output:
```
gary$ dart bin/main.dart --server_port=3456 --at_sign=@gkc --shared_secret=abcdefg
INFO|2022-03-23 18:29:23.597964|AtSecondaryServer|currentAtSign : @gkc 
INFO|2022-03-23 18:29:23.675939|HiveBase|commit_log_666e6cffdbeaa5e9f0f6c5be2d874bdf7f91d3af37346cfac22fd5288d9c652c initialized successfully 
INFO|2022-03-23 18:29:23.699561|HiveBase|access_log_666e6cffdbeaa5e9f0f6c5be2d874bdf7f91d3af37346cfac22fd5288d9c652c initialized successfully 
INFO|2022-03-23 18:29:23.706920|HiveBase|notifications_666e6cffdbeaa5e9f0f6c5be2d874bdf7f91d3af37346cfac22fd5288d9c652c initialized successfully 
AtServer.getHiveSecretFromFile file found
INFO|2022-03-23 18:29:23.721218|HiveBase|666e6cffdbeaa5e9f0f6c5be2d874bdf7f91d3af37346cfac22fd5288d9c652c initialized successfully 
INFO|2022-03-23 18:29:23.800950|AtCertificationValidation|Certificates reload job scheduled to run at 10 hours and 22 hours 
INFO|2022-03-23 18:29:23.817757|StatsNotificationService|StatsNotificationService is enabled. Runs every 15 seconds 
INFO|2022-03-23 18:29:23.847187|AtSecondaryServer|Secondary server started on version : 3.0.13 on root server : root.atsign.org 
INFO|2022-03-23 18:29:23.847265|AtSecondaryServer|Secure Socket open for @gkc ! 
INFO|2022-03-23 18:29:45.326763|SecondaryServerBootStrapper|Caught SIGTERM - calling secondaryServerInstance.stop() 
INFO|2022-03-23 18:29:45.327454|AtSecondaryServer|Executing server stop() 
INFO|2022-03-23 18:29:45.327508|AtSecondaryServer|Closing ServerSocket 
INFO|2022-03-23 18:29:45.328292|AtSecondaryServer|Terminating all inbound connections 
INFO|2022-03-23 18:29:45.329254|AtSecondaryServer|Closing CommitLog HiveBox 
INFO|2022-03-23 18:29:45.339823|AtSecondaryServer|Closing AccessLog HiveBox 
INFO|2022-03-23 18:29:45.340934|AtSecondaryServer|Closing NotificationKeyStore HiveBox 
INFO|2022-03-23 18:29:45.342271|AtSecondaryServer|Closing Main key store HiveBox 
INFO|2022-03-23 18:29:45.343821|AtSecondaryServer|Stopping scheduled tasks 
INFO|2022-03-23 18:29:45.345445|SecondaryServerBootStrapper|secondaryServerInstance.stop() completed, and isRunning is false - exiting with status 0 
```

**- Description for the changelog**
Listen for SIGKILL and SIGINT for graceful server shutdown