### PR TITLE
Prevent concurrent list modification issue in InboundConnectionPool

### DIFF
--- a/at_secondary/at_secondary_server/lib/src/connection/inbound/inbound_connection_pool.dart
+++ b/at_secondary/at_secondary_server/lib/src/connection/inbound/inbound_connection_pool.dart
@@ -42,7 +42,7 @@ class InboundConnectionPool {
   void clearInvalidConnections() {
     var invalidConnections = [];
     //dart doesn't support iterator.remove(). So use forEach + removeWhere
-    for (var connection in _connections) {
+    for (var connection in _connections.toList()) {
       if (connection.isInValid()) {
         invalidConnections.add(connection);
         connection.close();
@@ -61,7 +61,7 @@ class InboundConnectionPool {
   }
 
   bool clearAllConnections() {
-    for (var connection in _connections) {
+    for (var connection in _connections.toList()) {
       connection.close();
     }
     _connections.clear();


### PR DESCRIPTION
**- What I did**
Removed opportunity for the concurrent modification issue to occur.

**- How I did it**
Make clearInvalidConnections and clearAllConnections take copies of the _connections list before iterating.

**- How to verify it**
The tests should all pass

**- Description for the changelog**
Prevent concurrent list modification issue in InboundConnectionPool

**- Additional context**
I think the (very tiny) increase in time taken to determine if a connection is idle or not (changes in #583) has led to an increased time to iterate the list in clearInvalidConnections and thus increased the likelihood of the list still being iterated while a new connection is being added, or one is being removed