### PR TITLE
Tweaked a timeout

### DIFF
--- a/at_end2end_test/test/e2e_test_utils.dart
+++ b/at_end2end_test/test/e2e_test_utils.dart
@@ -95,7 +95,7 @@ class SimpleOutboundSocketHandler {
   Future<void> sendFromAndPkam() async {
     // FROM VERB
     await writeCommand('from:$atSign');
-    var response = await read(timeoutMillis:2000);
+    var response = await read(timeoutMillis:4000);
     response = response.replaceAll('data:', '');
     var pkamDigest = generatePKAMDigest(atSign, response);
 
@@ -146,7 +146,7 @@ class SimpleOutboundSocketHandler {
   /// A message which is returned from [read] if throwTimeoutException is set to false
   static String readTimedOutMessage = 'E2E_SIMPLE_SOCKET_HANDLER_TIMED_OUT';
 
-  Future<String> read({bool log = true, int timeoutMillis = 2000, bool throwTimeoutException = true}) async {
+  Future<String> read({bool log = true, int timeoutMillis = 4000, bool throwTimeoutException = true}) async {
     String result;
 
     // Wait this many milliseconds between checks on the queue

--- a/at_end2end_test/test/lookup_verb_test.dart
+++ b/at_end2end_test/test/lookup_verb_test.dart
@@ -47,7 +47,7 @@ void main() {
 
     ///lookup verb alice  atsign
     await sh2.writeCommand('lookup:role$atSign_1');
-   response = await sh2.read();
+   response = await sh2.read(timeoutMillis: 4000);
     print('lookup verb response : $response');
     expect(response, contains('data:developer'));
   }, timeout: Timeout(Duration(minutes: 3)));


### PR DESCRIPTION
**- What I did**
Tweaked the default read timeout in e2e_test_utils from 2s to 4s. Why? Because 2s is currently too little. There will be work in the coming weeks to speed up all of the unit, functional and e2e tests. 

**- How to verify it**
E2E Tests should pass consistently

**- Additional context**
Looks like we're either hitting some new limit somewhere in the e2e test world which is making responses take a little bit longer to come through, or we've got multiple e2e tests running concurrently (from local environments) against the cicd* servers. Increasing timeouts in e2e_test_utils for now; speeding up tests will have more focus next sprint.