### PR TITLE
Refactor certificate actions

### DIFF
--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -645,6 +645,46 @@ jobs:
             --amend atsigncompany/secondary:dess-x64
           docker manifest push atsigncompany/secondary:dess
       
+  push_prod_virtualenv_image:
+    needs: [ unit_tests, functional_tests, end2end_test_12, end2end_test_34, end2end_test_56 ]
+    if: ${{ github.repository == 'atsign-foundation/at_server' && github.event_name == 'push' && contains(github.ref, 'refs/tags/v') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1.6.0
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1.12.0 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2.10.0
+        with:
+          file: at_virtual_environment/ve/Dockerfile.vip
+          push: true
+          tags: |
+            atsigncompany/virtualenv:vip
+            atsigncompany/virtualenv:GHA${{ github.run_number }}
+          platforms: |
+            linux/amd64
+            linux/arm64/v8
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}
+
+      - name: Google Chat Notification
+        uses: Co-qn/google-chat-notification@releases/v1
+        with:
+          name: New Docker image for atsigncompany/virtualenv:vip
+          url: ${{ secrets.GOOGLE_CHAT_WEBHOOK }}
+          status: ${{ job.status }}
+ 
 #  # Deploy root server image to cluster
 #  deploy_root_sever:
 #    needs: [ unit_tests, functional_tests, end2end_tests ]

--- a/.github/workflows/refreshcerts.yml
+++ b/.github/workflows/refreshcerts.yml
@@ -2,7 +2,7 @@ name: Refreshcerts
 on:
   workflow_dispatch:
   schedule:
-    - cron: '39 7 15 1/2 *' # At 0739 on the 15th day of every odd month
+    - cron: '39 7 15 * *' # At 0739 on the 15th day of every month
     
 jobs:
   refresh-ACME-cert:
@@ -20,7 +20,7 @@ jobs:
       - name: setup certinfo
         uses: atsign-company/certinfo-action@v1
 
-      - name: execute acme_certs.py # sync action not fired by this push
+      - name: execute acme_certs.py
         run: |
           pip3 install dnspython requests
           CERTNAME="vip"
@@ -48,12 +48,8 @@ jobs:
           cp "$FQDN".fullchain.pem ./at_virtual_environment/ve_base/contents/atsign/root/certs/fullchain.pem
           cp ./at_virtual_environment/ve_base/contents/atsign/root/certs/*.pem \
             ./at_virtual_environment/ve_base/contents/atsign/secondary/base/certs/
-          git add ./at_virtual_environment/ve_base/contents/atsign/secondary/base/certs/*\
-            ./at_virtual_environment/ve_base/contents/atsign/root/certs/*
           git config --global user.name 'Getcert Action'
           git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git commit -m 'Automated certificate refresh'
-          git push
         env:
           GITHUB_API_TOKEN: ${{ secrets.MY_GITHUB_TOKEN }}
           DO_KEY: ${{ secrets.DO_KEY }}
@@ -65,50 +61,23 @@ jobs:
           name: cert-logs
           path: vip.ve.atsign.zone.*
 
-      - name: Google Chat Notification
-        if: always()
-        uses: Co-qn/google-chat-notification@releases/v1
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v4
         with:
-          name: New certificates for at_server virtual environment
-          url: ${{ secrets.GOOGLE_CHAT_WEBHOOK }}
-          status: ${{ job.status }}
-
-  docker:
-    runs-on: ubuntu-latest
-    needs: [ refresh-ACME-cert ]
-    steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1.6.0
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v1.12.0 
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Build and push
-        id: docker_build
-        uses: docker/build-push-action@v2.10.0
-        with:
-          file: at_virtual_environment/ve/Dockerfile.vip
-          push: true
-          tags: |
-            atsigncompany/virtualenv:vip
-            atsigncompany/virtualenv:GHA${{ github.run_number }}
-          platforms: |
-            linux/amd64
-            linux/arm64/v8
-
-      - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}
-
-      - name: Google Chat Notification
-        uses: Co-qn/google-chat-notification@releases/v1
-        with:
-          name: New Docker image for atsigncompany/virtualenv:vip
-          url: ${{ secrets.GOOGLE_CHAT_WEBHOOK }}
-          status: ${{ job.status }}
-          
+          token: ${{ secrets.MY_GITHUB_TOKEN }}
+          commit-message: New certificates for at_server
+          committer: library-action[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          author: library-action[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          signoff: false
+          add-paths: ./at_virtual_environment
+          branch: bot-new-certs
+          delete-branch: true
+          title: 'New certificates generated'
+          body: |
+            New descriptions for libraries have been scraped from pub.dev
+          labels: |
+            operations
+          assignees: cpswan
+          reviewers: cpswan
+          draft: false


### PR DESCRIPTION
Fixes #581 

**- What I did**

Refreshcerts action now raises a PR rather than committing directly to trunk (which doesn't work due to branch protection rules)

Build for virtualenv:vip moved to at_server action to run when we do a prod release 

**- How to verify it**

Will need to be merged before it can be properly tested :/

**- Description for the changelog**

Refactor certificate actions