### PR TITLE
Fixes #621

### DIFF
--- a/at_secondary/at_secondary_server/lib/src/notification/resource_manager.dart
+++ b/at_secondary/at_secondary_server/lib/src/notification/resource_manager.dart
@@ -106,6 +106,9 @@ class ResourceManager {
       logger.severe(
           'Exception in processing the notification ${atNotification.id} : ${e.toString()}');
       errorList.add(atNotification);
+      while (iterator.moveNext()) {
+        errorList.add(iterator.current);
+      }
     } finally {
       //1. Adds errored notifications back to queue.
       await _enqueueErrorList(errorList);


### PR DESCRIPTION
In the _sendNotifications method, which is called for a single atSign:
* if an exception happens while sending a notification
* and the iterator has other notifications not yet processed
* then those other notifications are not added to the errorList
* and therefore they are not re-enqueued

What we want:
* The 'other notifications' mentioned above should be re-enqueued.

<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->