### PR TITLE
Updated documentation on 'info' verb.

### DIFF
--- a/at_server_spec/CHANGELOG.md
+++ b/at_server_spec/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.7
+- Updated 'info' verb documentation to cover new functionality
 ## 3.0.6
 - Exported 'info' and 'noop' verbs in package export, redux
 ## 3.0.5

--- a/at_server_spec/lib/src/verb/info.dart
+++ b/at_server_spec/lib/src/verb/info.dart
@@ -8,17 +8,24 @@ import 'package:at_commons/at_commons.dart';
 ///   "uptime" : "uptime as string: D days, H hours, M minutes, S seconds",
 ///   "features" : [
 ///     {
-///       "name" : "name of feature 1",
+///       "name" : "ID of feature 1",
 ///       "status" : "One of Preview, Beta, GA",
-///       "description" : "optional description of feature"
+///       "description" : "Description of feature"
 ///     },
 ///     {
-///       "name" : "name of feature 2",
+///       "name" : "ID of feature 2",
 ///       "status" : "One of Preview, Beta, GA",
-///       "description" : "optional description of feature"
+///       "description" : "Description of feature"
 ///     },
 ///     ...
 ///   ]
+/// }
+/// ```
+/// `info:brief` will just return the version and uptime as milliseconds
+/// ```json
+/// {
+///   "version" : "the version being run",
+///   "uptime" : "uptime in milliseconds, as integer",
 /// }
 /// ```
 ///

--- a/at_server_spec/lib/src/verb/info.dart
+++ b/at_server_spec/lib/src/verb/info.dart
@@ -5,7 +5,7 @@ import 'package:at_commons/at_commons.dart';
 /// ```json
 /// {
 ///   "version" : "the version being run",
-///   "uptime" : "uptime as string: D days, H hours, M minutes, S seconds",
+///   "uptimeAsWords" : "uptime as string: D days, H hours, M minutes, S seconds",
 ///   "features" : [
 ///     {
 ///       "name" : "ID of feature 1",
@@ -25,7 +25,7 @@ import 'package:at_commons/at_commons.dart';
 /// ```json
 /// {
 ///   "version" : "the version being run",
-///   "uptime" : "uptime in milliseconds, as integer",
+///   "uptimeAsMillis" : "uptime in milliseconds, as integer",
 /// }
 /// ```
 ///

--- a/at_server_spec/pubspec.yaml
+++ b/at_server_spec/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  at_commons: 3.0.12
+  at_commons: ^3.0.12
 
 #dependency_overrides:
 # at_commons:

--- a/at_server_spec/pubspec.yaml
+++ b/at_server_spec/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_server_spec
 description: A Dart library containing abstract classes that defines what implementations of the root and secondary servers are responsible for.
-version: 3.0.6
+version: 3.0.7
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://atsign.dev
 documentation: https://atsign.dev/docs/
@@ -9,7 +9,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  at_commons: 3.0.11
+  at_commons: 3.0.12
 
 #dependency_overrides:
 # at_commons:


### PR DESCRIPTION
**- What I did**
Updated documentation on 'info' verb
Bumped at_server_spec dependency on at_commons from 3.0.11 to 3.0.12
Bumped at_server_spec version from 3.0.6 to 3.0.7
Updated changelog

**- Description for the changelog**
Updated 'info' verb documentation to cover new functionality