### PR TITLE
Info verb now supports info:brief usage

### DIFF
--- a/at_secondary/at_persistence_secondary_server/pubspec.yaml
+++ b/at_secondary/at_persistence_secondary_server/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   cron: ^0.3.0
   crypto: ^3.0.1
   uuid: ^3.0.4
-  at_persistence_spec: 2.0.5
+  at_persistence_spec: ^2.0.5
   at_utils: ^3.0.8
   at_commons: ^3.0.11
   at_utf7: ^1.0.0

--- a/at_secondary/at_secondary_server/CHANGELOG.md
+++ b/at_secondary/at_secondary_server/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.15
+- Info verb now supports 'info:brief' usage
 ## 3.0.14
 - Notify verb handler changes for shared key and public key checksum in metadata
 - Inbound connection management improvements

--- a/at_secondary/at_secondary_server/lib/src/verb/handler/abstract_verb_handler.dart
+++ b/at_secondary/at_secondary_server/lib/src/verb/handler/abstract_verb_handler.dart
@@ -10,6 +10,8 @@ import 'package:at_server_spec/at_server_spec.dart';
 import 'package:at_server_spec/at_verb_spec.dart';
 import 'package:at_utils/at_logger.dart';
 
+final String paramFullCommandAsReceived = 'FullCommandAsReceived';
+
 abstract class AbstractVerbHandler implements VerbHandler {
   SecondaryKeyStore? keyStore;
 
@@ -47,6 +49,8 @@ abstract class AbstractVerbHandler implements VerbHandler {
     try {
       // Parse the command
       var verbParams = parse(command);
+      // TODO This is not ideal. Would be better to make it so that processVerb takes command as an argument also.
+      verbParams[paramFullCommandAsReceived] = command;
       // Syntax is valid. Process the verb now.
       await processVerb(response, verbParams, atConnection);
       if (this is SyncVerbHandler || this is SyncFromVerbHandler) {

--- a/at_secondary/at_secondary_server/pubspec.yaml
+++ b/at_secondary/at_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_secondary
 description: Implementation of secondary server.
-version: 3.0.14
+version: 3.0.15
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://www.example.com
 publish_to: none
@@ -16,16 +16,13 @@ dependencies:
   crypton: ^2.0.1
   collection: ^1.15.0
   basic_utils: ^3.0.2
-  at_persistence_secondary_server: 3.0.21
-  at_lookup: 3.0.16
-  at_server_spec: 3.0.6
+  at_persistence_secondary_server: ^3.0.22
+  at_lookup: ^3.0.16
+  at_server_spec: ^3.0.7
 
 #dependency_overrides:
-#  at_commons:
-#    git:
-#      url: https://github.com/atsign-foundation/at_tools.git
-#      path: at_commons
-#      ref: trunk
+#  at_persistence_secondary_server:
+#    path: ../../at_secondary/at_persistence_secondary_server
 #  at_persistence_spec:
 #    git:
 #      url: https://github.com/atsign-foundation/at_server.git


### PR DESCRIPTION
**- What I did**
Info verb now supports info:brief usage

**- How I did it**
* Modified abstract_verb_handler.dart so that it also adds the actual command as received into the verbParams map.
* Modified info_verb_handler.dart to handle either 'info' or 'info:brief'. Usage of info verb is documented in at_server_spec/lib/src/verb/info.dart
* Bumped version to 3.0.15 and updated CHANGELOG.md
* Updated dependencies. Specifically this required changes in at_commons (verb syntax) and at_server_spec (Info Verb). In turn this required changes in other packages to loosen strict dependencies e.g. changing at_commons: 3.0.11 to at_commons: ^3.0.11

**- Description for the changelog**
Info verb now supports info:brief usage
