### PR TITLE
Remove last accessed check in stats_notification_service.dart

### DIFF
--- a/at_secondary/at_secondary_server/lib/src/notification/stats_notification_service.dart
+++ b/at_secondary/at_secondary_server/lib/src/notification/stats_notification_service.dart
@@ -41,7 +41,8 @@ class StatsNotificationService {
   final _logger = AtSignLogger('StatsNotificationService');
   final String _currentAtSign =
       AtSecondaryServerImpl.getInstance().currentAtSign;
-  var _atCommitLog;
+  AtCommitLog? _atCommitLog;
+  DateTime _lastSentTime = DateTime.now().toUtc();
 
   /// Starts the [StatsNotificationService] and notifies the latest commitID
   /// to the active monitor connections.
@@ -80,7 +81,10 @@ class StatsNotificationService {
       // Iterates on the list of active connections.
       await Future.forEach(connectionsList,
           (InboundConnection connection) async {
-        if (connection.isMonitor != null && connection.isMonitor!) {
+        if (connection.isMonitor != null &&
+            connection.isMonitor! &&
+            DateTime.now().toUtc().difference(_lastSentTime).inSeconds >
+                AtSecondaryConfig.statsNotificationJobTimeInterval) {
           //Construct a stats notification
           var atNotificationBuilder = AtNotificationBuilder()
             ..id = '-1'
@@ -93,6 +97,7 @@ class StatsNotificationService {
           var notification = Notification(atNotificationBuilder.build());
           connection.write(
               'notification: ' + jsonEncode(notification.toJson()) + '\n');
+          _lastSentTime = DateTime.now().toUtc();
         }
       });
     } on Exception catch (exception) {

--- a/at_secondary/at_secondary_server/lib/src/notification/stats_notification_service.dart
+++ b/at_secondary/at_secondary_server/lib/src/notification/stats_notification_service.dart
@@ -69,6 +69,7 @@ class StatsNotificationService {
     await writeStatsToMonitor();
   }
 
+  /// Writes the lastCommitID to the monitor connection for every [AtSecondaryConfig.statsNotificationJobTimeInterval] seconds. Defaulted to 15 seconds
   Future<void> writeStatsToMonitor(
       {String? latestCommitID, String? operationType}) async {
     try {
@@ -79,15 +80,7 @@ class StatsNotificationService {
       // Iterates on the list of active connections.
       await Future.forEach(connectionsList,
           (InboundConnection connection) async {
-        // If a monitor connection is stale for 15 seconds,
-        // Writes the lastCommitID to the monitor connection
-        if (connection.isMonitor != null &&
-            connection.isMonitor! &&
-            DateTime.now()
-                    .toUtc()
-                    .difference(connection.getMetaData().lastAccessed!)
-                    .inSeconds >=
-                AtSecondaryConfig.statsNotificationJobTimeInterval) {
+        if (connection.isMonitor != null && connection.isMonitor!) {
           //Construct a stats notification
           var atNotificationBuilder = AtNotificationBuilder()
             ..id = '-1'


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Remove the condition which check if lastAccessedTime duration on connection metadata is less than 15 seconds to enable write latest server commit id for every 15 seconds
**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->