### PR TITLE
Straight through notify

### DIFF
--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Convert coverage to LCOV format
         working-directory: ${{ env.secondary-working-directory }}
-        run: pub run coverage:format_coverage --lcov --in=coverage --out=coverage.lcov --packages=.packages --report-on=lib
+        run: dart pub run coverage:format_coverage --lcov --in=coverage --out=coverage.lcov --packages=.packages --report-on=lib
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3.1.0

--- a/at_end2end_test/config/config12.yaml
+++ b/at_end2end_test/config/config12.yaml
@@ -19,18 +19,3 @@ second_atsign_server:
   second_atsign_port: 6464
   # # The url to connect to second atsign server
   second_atsign_url: cicd2.atsign.wtf
-
-notification:
-  ### Setting configuration more amenable to the end-to-end tests
-  autoNotify: true
-  # The maximum number of retries for a notification.
-  max_retries: 3
-  # The quarantine duration of an atsign. Notifications will be retried max_retries times, every quarantineDuration seconds approximately.
-  quarantineDuration: 3
-  # The notifications queue will be processed every jobFrequency seconds. However, the notifications queue will always be processed
-  # *immediately* when a new notification is queued. When that happens, the queue processing will not run again until jobFrequency
-  # seconds have passed since the last queue-processing run completed.
-  jobFrequency: 2
-  # The time interval(in seconds) to notify latest commitID to monitor connections
-  # To disable to the feature, set to -1.
-  statsNotificationJobTimeInterval: 15

--- a/at_end2end_test/config/config12.yaml
+++ b/at_end2end_test/config/config12.yaml
@@ -19,3 +19,18 @@ second_atsign_server:
   second_atsign_port: 6464
   # # The url to connect to second atsign server
   second_atsign_url: cicd2.atsign.wtf
+
+notification:
+  ### Setting configuration more amenable to the end-to-end tests
+  autoNotify: true
+  # The maximum number of retries for a notification.
+  max_retries: 3
+  # The quarantine duration of an atsign. Notifications will be retried max_retries times, every quarantineDuration seconds approximately.
+  quarantineDuration: 3
+  # The notifications queue will be processed every jobFrequency seconds. However, the notifications queue will always be processed
+  # *immediately* when a new notification is queued. When that happens, the queue processing will not run again until jobFrequency
+  # seconds have passed since the last queue-processing run completed.
+  jobFrequency: 2
+  # The time interval(in seconds) to notify latest commitID to monitor connections
+  # To disable to the feature, set to -1.
+  statsNotificationJobTimeInterval: 15

--- a/at_end2end_test/config/config34.yaml
+++ b/at_end2end_test/config/config34.yaml
@@ -19,3 +19,18 @@ second_atsign_server:
   second_atsign_port: 6465
   # # The url to connect to second atsign server
   second_atsign_url: cicd4.atsign.wtf
+
+notification:
+  ### Setting configuration more amenable to the end-to-end tests
+  autoNotify: true
+  # The maximum number of retries for a notification.
+  max_retries: 3
+  # The quarantine duration of an atsign. Notifications will be retried max_retries times, every quarantineDuration seconds approximately.
+  quarantineDuration: 3
+  # The notifications queue will be processed every jobFrequency seconds. However, the notifications queue will always be processed
+  # *immediately* when a new notification is queued. When that happens, the queue processing will not run again until jobFrequency
+  # seconds have passed since the last queue-processing run completed.
+  jobFrequency: 2
+  # The time interval(in seconds) to notify latest commitID to monitor connections
+  # To disable to the feature, set to -1.
+  statsNotificationJobTimeInterval: 15

--- a/at_end2end_test/config/config34.yaml
+++ b/at_end2end_test/config/config34.yaml
@@ -19,18 +19,3 @@ second_atsign_server:
   second_atsign_port: 6465
   # # The url to connect to second atsign server
   second_atsign_url: cicd4.atsign.wtf
-
-notification:
-  ### Setting configuration more amenable to the end-to-end tests
-  autoNotify: true
-  # The maximum number of retries for a notification.
-  max_retries: 3
-  # The quarantine duration of an atsign. Notifications will be retried max_retries times, every quarantineDuration seconds approximately.
-  quarantineDuration: 3
-  # The notifications queue will be processed every jobFrequency seconds. However, the notifications queue will always be processed
-  # *immediately* when a new notification is queued. When that happens, the queue processing will not run again until jobFrequency
-  # seconds have passed since the last queue-processing run completed.
-  jobFrequency: 2
-  # The time interval(in seconds) to notify latest commitID to monitor connections
-  # To disable to the feature, set to -1.
-  statsNotificationJobTimeInterval: 15

--- a/at_end2end_test/config/config56.yaml
+++ b/at_end2end_test/config/config56.yaml
@@ -19,3 +19,18 @@ second_atsign_server:
   second_atsign_port: 6466
   # # The url to connect to second atsign server
   second_atsign_url: cicd6.atsign.wtf
+
+notification:
+  ### Setting configuration more amenable to the end-to-end tests
+  autoNotify: true
+  # The maximum number of retries for a notification.
+  max_retries: 3
+  # The quarantine duration of an atsign. Notifications will be retried max_retries times, every quarantineDuration seconds approximately.
+  quarantineDuration: 3
+  # The notifications queue will be processed every jobFrequency seconds. However, the notifications queue will always be processed
+  # *immediately* when a new notification is queued. When that happens, the queue processing will not run again until jobFrequency
+  # seconds have passed since the last queue-processing run completed.
+  jobFrequency: 2
+  # The time interval(in seconds) to notify latest commitID to monitor connections
+  # To disable to the feature, set to -1.
+  statsNotificationJobTimeInterval: 15

--- a/at_end2end_test/config/config56.yaml
+++ b/at_end2end_test/config/config56.yaml
@@ -19,18 +19,3 @@ second_atsign_server:
   second_atsign_port: 6466
   # # The url to connect to second atsign server
   second_atsign_url: cicd6.atsign.wtf
-
-notification:
-  ### Setting configuration more amenable to the end-to-end tests
-  autoNotify: true
-  # The maximum number of retries for a notification.
-  max_retries: 3
-  # The quarantine duration of an atsign. Notifications will be retried max_retries times, every quarantineDuration seconds approximately.
-  quarantineDuration: 3
-  # The notifications queue will be processed every jobFrequency seconds. However, the notifications queue will always be processed
-  # *immediately* when a new notification is queued. When that happens, the queue processing will not run again until jobFrequency
-  # seconds have passed since the last queue-processing run completed.
-  jobFrequency: 2
-  # The time interval(in seconds) to notify latest commitID to monitor connections
-  # To disable to the feature, set to -1.
-  statsNotificationJobTimeInterval: 15

--- a/at_end2end_test/test/cached_key_test.dart
+++ b/at_end2end_test/test/cached_key_test.dart
@@ -43,7 +43,7 @@ void main() {
         (!response.contains('Invalid syntax')) && (!response.contains('null')));
     String notificationId = response.replaceAll('data:', '');
     await notification.getNotifyStatus(sh1, notificationId,
-        returnWhenStatusIn: ['delivered'], timeOutMillis: 30000);
+        returnWhenStatusIn: ['delivered'], timeOutMillis: 60000);
 
     ///LLOOKUP VERB in the receiving atsign
     await Future.delayed(Duration(seconds: 2));

--- a/at_end2end_test/test/cached_key_test.dart
+++ b/at_end2end_test/test/cached_key_test.dart
@@ -33,6 +33,12 @@ void main() {
   });
 
   test('update-llookup verb with ttr:-1', () async {
+    // TODO Remove this when https://github.com/atsign-foundation/at_server/pull/664 has been included in a production release
+    if ('@cicd5' == atSign_1) {
+      expect(true, true);
+      return;
+    }
+
     /// UPDATE VERB
     var value = 'val-ttr--1-$lastValue';
     await sh1.writeCommand(

--- a/at_end2end_test/test/notify_verb_test.dart
+++ b/at_end2end_test/test/notify_verb_test.dart
@@ -376,7 +376,7 @@ void main() {
         returnWhenStatusIn: ['expired'], timeOutMillis: 1000);
     print('notify status response : $response');
     expect(response, contains('data:expired'));
-  },skip: 'Non existent atSign. Skipping the test for now to avoid connection issue');
+  });
 
   test('notify verb with notification expiry with messageType text', () async {
     //   /// NOTIFY VERB

--- a/at_end2end_test/test/stats_verb_test.dart
+++ b/at_end2end_test/test/stats_verb_test.dart
@@ -218,7 +218,7 @@ void main() {
         (!notifyResponse.contains('null')));
     String notificationId = notifyResponse.replaceAll('data:', '');
     await notification
-        .getNotifyStatus(sh1, notificationId, returnWhenStatusIn: ['errored']);
+        .getNotifyStatus(sh1, notificationId, returnWhenStatusIn: ['errored'], timeOutMillis: 15000);
     var afterUpdate = await notificationStats(sh1);
     var sentCountAfterUpdate = await afterUpdate['type']['sent'];
     var statusAfterUpdate = await afterUpdate['status']['failed'];

--- a/at_end2end_test/test/update_verb_test.dart
+++ b/at_end2end_test/test/update_verb_test.dart
@@ -252,7 +252,7 @@ void main() {
     response = await sh1.read();
     print('llookup verb response : $response');
     expect(response, contains('data:$value'));
-    }, skip: 'Non existent atSign, skipping the test to avoid connection issue');
+    });
 
   test('update-llookup for ttl ', () async {
     ///UPDATE VERB

--- a/at_secondary/at_persistence_secondary_server/CHANGELOG.md
+++ b/at_secondary/at_persistence_secondary_server/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.25
+- To reduce latency on notifications, publish the event for the notification before persisting the notification 
 ## 3.0.24
 - Introduced a cache to speed up metaData retrieval.
 - Removed unnecessary print statements

--- a/at_secondary/at_persistence_secondary_server/lib/src/notification/at_notification.dart
+++ b/at_secondary/at_persistence_secondary_server/lib/src/notification/at_notification.dart
@@ -133,10 +133,12 @@ class AtNotification {
 
   @override
   String toString() {
-    return 'AtNotification{id: $_id,fromAtSign: $_fromAtSign, '
-        'notificationDateTime: $_notificationDateTime, '
-        'toAtSign:$_toAtSign, notification:$_notification, '
-        'type:$_type, opType:$_opType, ttl: $_ttl, expiresAt:$_expiresAt : priority:$priority : notificationStatus:$notificationStatus : atValue:$atValue';
+    return 'AtNotification{id: $_id, notificationStatus:$notificationStatus, '
+        'fromAtSign: $_fromAtSign, toAtSign:$_toAtSign, '
+        'strategy:$_strategy, notificationDateTime: $_notificationDateTime, '
+        'notification:$_notification, type:$_type, opType:$_opType, '
+        'ttl: $_ttl, expiresAt:$_expiresAt, priority:$priority, '
+        'atValue:$atValue';
   }
 
   bool isExpired() {

--- a/at_secondary/at_persistence_secondary_server/lib/src/notification/at_notification_keystore.dart
+++ b/at_secondary/at_persistence_secondary_server/lib/src/notification/at_notification_keystore.dart
@@ -73,8 +73,8 @@ class AtNotificationKeystore
       String? dataSignature,
       String? sharedKeyEncrypted,
       String? publicKeyChecksum}) async {
-    await _getBox().put(key, value);
     AtNotificationCallback.getInstance().invokeCallbacks(value);
+    await _getBox().put(key, value);
   }
 
   @override

--- a/at_secondary/at_persistence_secondary_server/pubspec.yaml
+++ b/at_secondary/at_persistence_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_persistence_secondary_server
 description: A Dart library with the implementation classes for the persistence layer of the secondary server.
-version: 3.0.24
+version: 3.0.25
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://atsign.dev
 

--- a/at_secondary/at_secondary_server/CHANGELOG.md
+++ b/at_secondary/at_secondary_server/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.16
+- Significant decreases in inter-at-sign notification latency from 1 to 6 seconds to 5 to 100 milliseconds
 ## 3.0.15
 - Info verb now supports 'info:brief' usage
 ## 3.0.14

--- a/at_secondary/at_secondary_server/config/config.yaml
+++ b/at_secondary/at_secondary_server/config/config.yaml
@@ -98,9 +98,9 @@ stats:
 notification:
   autoNotify: true
   # The maximum number of retries for a notification.
-  max_retries: 60
+  max_retries: 30
   # The quarantine duration of an atsign. Notifications will be retried max_retries times, every quarantineDuration seconds approximately.
-  quarantineDuration: 5
+  quarantineDuration: 10
   # The notifications queue will be processed every jobFrequency seconds. However, the notifications queue will always be processed
   # *immediately* when a new notification is queued. When that happens, the queue processing will not run again until jobFrequency
   # seconds have passed since the last queue-processing run completed.

--- a/at_secondary/at_secondary_server/config/config.yaml
+++ b/at_secondary/at_secondary_server/config/config.yaml
@@ -97,13 +97,14 @@ stats:
 
 notification:
   autoNotify: true
-  max_entries: 5
   # The maximum number of retries for a notification.
-  max_retries: 5
-  # The quarantine duration of an atsign.
+  max_retries: 30
+  # The quarantine duration of an atsign. Notifications will be retried max_retries times, every quarantineDuration seconds approximately.
   quarantineDuration: 10
-  # The job frequency
-  jobFrequency: 5
+  # The notifications queue will be processed every jobFrequency seconds. However, the notifications queue will always be processed
+  # *immediately* when a new notification is queued. When that happens, the queue processing will not run again until jobFrequency
+  # seconds have passed since the last queue-processing run completed.
+  jobFrequency: 11
   # The time interval(in seconds) to notify latest commitID to monitor connections
   # To disable to the feature, set to -1.
   statsNotificationJobTimeInterval: 15

--- a/at_secondary/at_secondary_server/config/config.yaml
+++ b/at_secondary/at_secondary_server/config/config.yaml
@@ -98,13 +98,13 @@ stats:
 notification:
   autoNotify: true
   # The maximum number of retries for a notification.
-  max_retries: 30
+  max_retries: 60
   # The quarantine duration of an atsign. Notifications will be retried max_retries times, every quarantineDuration seconds approximately.
-  quarantineDuration: 10
+  quarantineDuration: 5
   # The notifications queue will be processed every jobFrequency seconds. However, the notifications queue will always be processed
   # *immediately* when a new notification is queued. When that happens, the queue processing will not run again until jobFrequency
   # seconds have passed since the last queue-processing run completed.
-  jobFrequency: 11
+  jobFrequency: 5
   # The time interval(in seconds) to notify latest commitID to monitor connections
   # To disable to the feature, set to -1.
   statsNotificationJobTimeInterval: 15

--- a/at_secondary/at_secondary_server/lib/src/connection/base_connection.dart
+++ b/at_secondary/at_secondary_server/lib/src/connection/base_connection.dart
@@ -47,11 +47,23 @@ abstract class BaseConnection extends AtConnection {
       throw ConnectionInvalidException('Connection is invalid');
     }
     try {
+      logger.info('SENT: [${getMetaData().sessionID}] ${BaseConnection.truncateForLogging(data)}');
       getSocket().write(data);
       getMetaData().lastAccessed = DateTime.now().toUtc();
     } on Exception catch (e) {
       getMetaData().isStale = true;
       throw AtIOException(e.toString());
     }
+  }
+
+  static String truncateForLogging(String toLog, {int cutOffAfter = 1000}) {
+    if (toLog.length > cutOffAfter) {
+      toLog = '${toLog.substring(0, cutOffAfter)} [truncated, ${toLog.length - cutOffAfter} more chars]';
+    }
+    var lastNewLinePos = toLog.lastIndexOf("\n");
+    if (lastNewLinePos > -1) {
+      toLog = toLog.substring(0, lastNewLinePos);
+    }
+    return toLog;
   }
 }

--- a/at_secondary/at_secondary_server/lib/src/connection/inbound/inbound_message_listener.dart
+++ b/at_secondary/at_secondary_server/lib/src/connection/inbound/inbound_message_listener.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:at_commons/at_commons.dart';
 import 'package:at_commons/at_commons.dart' as at_commons;
+import 'package:at_secondary/src/connection/base_connection.dart';
 import 'package:at_secondary/src/connection/inbound/inbound_connection_pool.dart';
 import 'package:at_secondary/src/exception/global_exception_handler.dart';
 import 'package:at_server_spec/at_server_spec.dart';
@@ -66,8 +67,7 @@ class InboundMessageListener {
         //decode only when end of buffer is reached
         var command = utf8.decode(_buffer.getData());
         command = command.trim();
-        logger.finer(
-            'command received: $command sessionID:${connection.getMetaData().sessionID}');
+        logger.info('RCVD: [${connection.getMetaData().sessionID}] ${BaseConnection.truncateForLogging(command)}');
         // if command is '@exit', close the connection.
         if (command == '@exit') {
           await _finishedHandler();

--- a/at_secondary/at_secondary_server/lib/src/connection/outbound/outbound_client.dart
+++ b/at_secondary/at_secondary_server/lib/src/connection/outbound/outbound_client.dart
@@ -32,6 +32,8 @@ class OutboundClient {
 
   bool isHandShakeDone = false;
 
+  DateTime lastUsed = DateTime.now();
+
 
   @override
   String toString() {
@@ -86,6 +88,7 @@ class OutboundClient {
       logger.severe('HandShakeException connecting to secondary $toAtSign: ${e.toString()}');
       rethrow;
     }
+    lastUsed = DateTime.now();
     return result;
   }
 
@@ -195,6 +198,7 @@ class OutboundClient {
     if (lookupResult != null) {
       lookupResult = lookupResult.replaceFirst(RegExp(r'\n\S+'), '');
     }
+    lastUsed = DateTime.now();
     return lookupResult;
   }
 
@@ -221,6 +225,7 @@ class OutboundClient {
     if (scanResult != null) {
       scanResult = scanResult.replaceFirst(RegExp(r'\n\S+'), '');
     }
+    lastUsed = DateTime.now();
     return scanResult;
   }
 
@@ -231,6 +236,7 @@ class OutboundClient {
   /// Throws a [LookupException] if there is exception during lookup
   Future<String?> plookUp(String key) async {
     var result = await lookUp(key, handshake: false);
+    lastUsed = DateTime.now();
     return result;
   }
 
@@ -245,13 +251,13 @@ class OutboundClient {
         (outboundConnection != null && outboundConnection!.isInValid());
   }
 
-  Future<String?> notify(String key, {bool handshake = true}) async {
+  Future<String?> notify(String notifyCommandBody, {bool handshake = true}) async {
     if (handshake && !isHandShakeDone) {
       throw UnAuthorizedException(
           'Handshake did not succeed. Cannot perform a lookup');
     }
     try {
-      var notificationRequest = 'notify:$key\n';
+      var notificationRequest = 'notify:$notifyCommandBody\n';
       outboundConnection!.write(notificationRequest);
     } on AtIOException catch (e) {
       await outboundConnection!.close();
@@ -264,6 +270,7 @@ class OutboundClient {
     // response.
     var notifyResult = await messageListener.read(maxWaitMilliSeconds: 30000);
     //notifyResult = notifyResult.replaceFirst(RegExp(r'\n\S+'), '');
+    lastUsed = DateTime.now();
     return notifyResult;
   }
 
@@ -290,6 +297,7 @@ class OutboundClient {
       throw OutBoundConnectionInvalidException('Outbound connection invalid');
     }
 
+    lastUsed = DateTime.now();
     return notifyResult.sentNotifications;
   }
 }

--- a/at_secondary/at_secondary_server/lib/src/connection/outbound/outbound_client.dart
+++ b/at_secondary/at_secondary_server/lib/src/connection/outbound/outbound_client.dart
@@ -32,6 +32,13 @@ class OutboundClient {
 
   bool isHandShakeDone = false;
 
+
+  @override
+  String toString() {
+    return 'OutboundClient{toAtSign: $toAtSign, toHost: $toHost, toPort: $toPort, '
+        'isConnectionCreated: $isConnectionCreated, isHandShakeDone: $isHandShakeDone}';
+  }
+
   late OutboundMessageListener messageListener;
 
   OutboundClient(this.inboundConnection, this.toAtSign);
@@ -76,7 +83,7 @@ class OutboundClient {
           'socket exception connecting to secondary $toAtSign: ${e.toString()}');
       rethrow;
     } on HandShakeException catch (e) {
-      logger.severe('HandShakeException for $toAtSign: ${e.toString()}');
+      logger.severe('HandShakeException connecting to secondary $toAtSign: ${e.toString()}');
       rethrow;
     }
     return result;
@@ -122,7 +129,6 @@ class OutboundClient {
 
       //2. Receive proof
       var fromResult = await messageListener.read();
-      logger.info('fromResult : $fromResult');
       if (fromResult == null || fromResult == '') {
         throw HandShakeException(
             'no response received for From:$toAtSign command');
@@ -142,7 +148,6 @@ class OutboundClient {
 
       // 5. wait for handshake result - @<current_atsign>@
       var handShakeResult = await messageListener.read();
-      logger.finer('handShakeResult: $handShakeResult');
       if (handShakeResult == null) {
         await outboundConnection!.close();
         throw HandShakeException('no response received for pol command');
@@ -175,7 +180,6 @@ class OutboundClient {
     }
     var lookUpRequest = AtRequestFormatter.createLookUpRequest(key);
     try {
-      logger.finer('writing to outbound connection: $lookUpRequest');
       outboundConnection!.write(lookUpRequest);
     } on AtIOException catch (e) {
       await outboundConnection!.close();
@@ -191,7 +195,6 @@ class OutboundClient {
     if (lookupResult != null) {
       lookupResult = lookupResult.replaceFirst(RegExp(r'\n\S+'), '');
     }
-    logger.finer('lookup result after format: $lookupResult');
     return lookupResult;
   }
 
@@ -206,7 +209,6 @@ class OutboundClient {
       scanRequest = 'scan $regex\n';
     }
     try {
-      logger.finer('writing to outbound connection: $scanRequest');
       outboundConnection!.write(scanRequest);
     } on AtIOException catch (e) {
       await outboundConnection!.close();
@@ -219,7 +221,6 @@ class OutboundClient {
     if (scanResult != null) {
       scanResult = scanResult.replaceFirst(RegExp(r'\n\S+'), '');
     }
-    logger.finer('scan result after format: $scanResult');
     return scanResult;
   }
 
@@ -251,7 +252,6 @@ class OutboundClient {
     }
     try {
       var notificationRequest = 'notify:$key\n';
-      logger.info('notificationRequest : $notificationRequest');
       outboundConnection!.write(notificationRequest);
     } on AtIOException catch (e) {
       await outboundConnection!.close();
@@ -260,12 +260,10 @@ class OutboundClient {
     } on ConnectionInvalidException {
       throw OutBoundConnectionInvalidException('Outbound connection invalid');
     }
-    logger.info('waiting for response from outbound connection');
     // Setting maxWaitMilliSeconds to 30000 to wait 30 seconds for notification
     // response.
     var notifyResult = await messageListener.read(maxWaitMilliSeconds: 30000);
     //notifyResult = notifyResult.replaceFirst(RegExp(r'\n\S+'), '');
-    logger.info('notifyResult result after format: $notifyResult');
     return notifyResult;
   }
 

--- a/at_secondary/at_secondary_server/lib/src/connection/outbound/outbound_client_pool.dart
+++ b/at_secondary/at_secondary_server/lib/src/connection/outbound/outbound_client_pool.dart
@@ -5,11 +5,10 @@ import 'package:at_server_spec/at_server_spec.dart';
 class OutboundClientPool {
   late int _size;
 
-  late List<OutboundClient> _clients;
+  final List<OutboundClient> _clients = [];
 
   void init(int size) {
     _size = size;
-    _clients = [];
   }
 
   bool hasCapacity() {
@@ -25,6 +24,12 @@ class OutboundClientPool {
       _clients.sort((a, b) => a.lastUsed.compareTo(b.lastUsed));
       return _clients.removeAt(0);
     }
+  }
+
+  // Returns a copy of the list of clients in this pool, sorted by lastUsed, ascending
+  List<OutboundClient> clients() {
+    _clients.sort((a, b) => a.lastUsed.compareTo(b.lastUsed));
+    return [..._clients];
   }
 
   void add(OutboundClient outBoundClient) => _clients.add(outBoundClient);

--- a/at_secondary/at_secondary_server/lib/src/connection/outbound/outbound_client_pool.dart
+++ b/at_secondary/at_secondary_server/lib/src/connection/outbound/outbound_client_pool.dart
@@ -3,17 +3,28 @@ import 'package:at_server_spec/at_server_spec.dart';
 
 /// Pool to hold [OutboundClient]
 class OutboundClientPool {
-  int? _size;
+  late int _size;
 
   late List<OutboundClient> _clients;
 
-  void init(int? size) {
+  void init(int size) {
     _size = size;
     _clients = [];
   }
 
   bool hasCapacity() {
-    return _clients.length < _size!;
+    return _clients.length < _size;
+  }
+
+  /// Removes the least recently used OutboundClient from the pool. Returns the removed client,
+  /// or returns null if there are fewer than 2 items currently in the pool.
+  OutboundClient? removeLeastRecentlyUsed() {
+    if (_clients.length < 2) {
+      return null;
+    } else {
+      _clients.sort((a, b) => a.lastUsed.compareTo(b.lastUsed));
+      return _clients.removeAt(0);
+    }
   }
 
   void add(OutboundClient outBoundClient) => _clients.add(outBoundClient);
@@ -35,12 +46,12 @@ class OutboundClientPool {
 
   void clearInvalidClients() {
     var invalidClients = [];
-    _clients.forEach((client) {
+    for (var client in _clients) {
       if (client.isInValid()) {
         invalidClients.add(client);
         client.close();
       }
-    });
+    }
     _clients.removeWhere((client) => invalidClients.contains(client));
   }
 
@@ -50,11 +61,11 @@ class OutboundClientPool {
 
   int getActiveConnectionSize() {
     var count = 0;
-    _clients.forEach((client) {
+    for (var client in _clients) {
       if (!client.isInValid()) {
         count++;
       }
-    });
+    }
     return count;
   }
 
@@ -63,9 +74,9 @@ class OutboundClientPool {
   }
 
   bool clearAllClients() {
-    _clients.forEach((client) {
+    for (var client in _clients) {
       client.close();
-    });
+    }
     _clients.clear();
     return true;
   }

--- a/at_secondary/at_secondary_server/lib/src/connection/outbound/outbound_connection_impl.dart
+++ b/at_secondary/at_secondary_server/lib/src/connection/outbound/outbound_connection_impl.dart
@@ -4,7 +4,7 @@ import 'package:at_secondary/src/server/at_secondary_impl.dart';
 import 'package:uuid/uuid.dart';
 
 class OutboundConnectionImpl extends OutboundConnection {
-  static int? outbound_idle_time =
+  static int? outboundIdleTime =
       AtSecondaryServerImpl.getInstance().serverContext!.outboundIdleTimeMillis;
 
   OutboundConnectionImpl(Socket? socket, String? toAtSign) : super(socket) {
@@ -24,7 +24,7 @@ class OutboundConnectionImpl extends OutboundConnection {
   }
 
   bool _isIdle() {
-    return _getIdleTimeMillis() > outbound_idle_time!;
+    return _getIdleTimeMillis() > outboundIdleTime!;
   }
 
   @override

--- a/at_secondary/at_secondary_server/lib/src/connection/outbound/outbound_message_listener.dart
+++ b/at_secondary/at_secondary_server/lib/src/connection/outbound/outbound_message_listener.dart
@@ -1,6 +1,7 @@
 import 'dart:collection';
 import 'dart:convert';
 import 'package:at_commons/at_commons.dart';
+import 'package:at_secondary/src/connection/base_connection.dart';
 import 'package:at_secondary/src/connection/outbound/outbound_client.dart';
 import 'package:at_utils/at_logger.dart';
 
@@ -51,6 +52,7 @@ class OutboundMessageListener {
       result = utf8.decode(_buffer.getData());
       result = result.trim();
       _buffer.clear();
+      logger.info('RCVD: [${outboundClient.outboundConnection!.metaData.sessionID}] ${BaseConnection.truncateForLogging(result)}');
       _queue.add(result);
     }
   }

--- a/at_secondary/at_secondary_server/lib/src/notification/at_notification_map.dart
+++ b/at_secondary/at_secondary_server/lib/src/notification/at_notification_map.dart
@@ -32,12 +32,12 @@ class AtNotificationMap {
     // If map is empty, or map doesn't contain the atSign, return an iterator for an empty list
     if (_notificationMap.isEmpty || !_notificationMap.containsKey(atSign)) {
       return 0;
-    } else {
-      Map<String, NotificationStrategy>? tempMap = _notificationMap[atSign]!; // can't be null, we've just checked containsKey
-      LatestNotifications latestList = tempMap['latest'] as LatestNotifications;
-      AllNotifications allList = tempMap['all'] as AllNotifications;
-      return latestList.length + allList.length;
     }
+
+    Map<String, NotificationStrategy>? tempMap = _notificationMap[atSign]!; // can't be null, we've just checked containsKey
+    LatestNotifications latestList = tempMap['latest'] as LatestNotifications;
+    AllNotifications allList = tempMap['all'] as AllNotifications;
+    return latestList.length + allList.length;
   }
 
   /// Returns the map of first N entries.

--- a/at_secondary/at_secondary_server/lib/src/notification/at_notification_map.dart
+++ b/at_secondary/at_secondary_server/lib/src/notification/at_notification_map.dart
@@ -13,15 +13,11 @@ class AtNotificationMap {
     return _singleton;
   }
 
-  final _notificationMap = <String?, Map<String, NotificationStrategy>>{};
-  final _waitTimeMap = <String?, NotificationWaitTime>{};
-  var _quarantineMap = <String?, DateTime>{};
+  final Map<String?, Map<String, NotificationStrategy>> _notificationMap = <String?, Map<String, NotificationStrategy>>{};
+  final Map<String?, NotificationWaitTime> _waitTimeMap = <String?, NotificationWaitTime>{};
+  final Map<String?, DateTime> _quarantineMap = <String?, DateTime>{};
 
   Map<String?, DateTime> get quarantineMap => _quarantineMap;
-
-  set quarantineMap(value) {
-    _quarantineMap = value;
-  }
 
   /// Adds the notifications to map where key is [AtNotification.toAtSign] and value is classes implementing [NotificationStrategy]
   void add(AtNotification atNotification) {
@@ -30,6 +26,18 @@ class AtNotificationMap {
     var notificationsMap = _notificationMap[atNotification.toAtSign]!;
     notificationsMap[atNotification.strategy!]!.add(atNotification);
     _computeWaitTime(atNotification);
+  }
+
+  int numQueued(String atSign) {
+    // If map is empty, or map doesn't contain the atSign, return an iterator for an empty list
+    if (_notificationMap.isEmpty || !_notificationMap.containsKey(atSign)) {
+      return 0;
+    } else {
+      Map<String, NotificationStrategy>? tempMap = _notificationMap[atSign]!; // can't be null, we've just checked containsKey
+      LatestNotifications latestList = tempMap['latest'] as LatestNotifications;
+      AllNotifications allList = tempMap['all'] as AllNotifications;
+      return latestList.length + allList.length;
+    }
   }
 
   /// Returns the map of first N entries.

--- a/at_secondary/at_secondary_server/lib/src/notification/at_notification_map.dart
+++ b/at_secondary/at_secondary_server/lib/src/notification/at_notification_map.dart
@@ -33,21 +33,19 @@ class AtNotificationMap {
   }
 
   /// Returns the map of first N entries.
-  Iterator<AtNotification> remove(String? atsign) {
-    // If map is empty, return empty map
-    if (_notificationMap.isEmpty) {
-      return [].iterator as Iterator<AtNotification>;
+  Iterator<AtNotification> remove(String? atSign) {
+    List<AtNotification> returnList;
+    // If map is empty, or map doesn't contain the atSign, return an iterator for an empty list
+    if (_notificationMap.isEmpty || !_notificationMap.containsKey(atSign)) {
+      returnList = [];
+    } else {
+      Map<String, NotificationStrategy> tempMap = _notificationMap.remove(atSign)!;
+      var latestList = tempMap['latest'] as LatestNotifications;
+      var list = tempMap['all'] as AllNotifications;
+      returnList = List<AtNotification>.from(latestList.toList())
+        ..addAll(list.toList()!);
+      tempMap.clear();
     }
-    // If map does not contain the atsign, return empty map.
-    if (!_notificationMap.containsKey(atsign)) {
-      return [].iterator as Iterator<AtNotification>;
-    }
-    var tempMap = _notificationMap.remove(atsign)!;
-    var latestList = tempMap['latest'] as LatestNotifications;
-    var list = tempMap['all'] as AllNotifications;
-    var returnList = List<AtNotification>.from(latestList.toList())
-      ..addAll(list.toList()!);
-    tempMap.clear();
     return returnList.iterator;
   }
 
@@ -78,7 +76,7 @@ class AtNotificationMap {
     var notificationWaitTime = _waitTimeMap[atNotification.toAtSign]!;
     notificationWaitTime.prioritiesSum = atNotification.priority!.index;
     notificationWaitTime.totalPriorities += 1;
-    var date;
+    DateTime? date;
     if (notificationWaitTime.totalPriorities == 1) {
       date = atNotification.notificationDateTime;
     }

--- a/at_secondary/at_secondary_server/lib/src/notification/at_notification_map.dart
+++ b/at_secondary/at_secondary_server/lib/src/notification/at_notification_map.dart
@@ -3,9 +3,11 @@ import 'package:at_secondary/src/notification/notification_wait_time.dart';
 import 'package:at_secondary/src/notification/strategy/all_notifications.dart';
 import 'package:at_secondary/src/notification/strategy/latest_notifications.dart';
 import 'package:at_secondary/src/server/at_secondary_impl.dart';
+import 'package:at_utils/at_logger.dart';
 
 class AtNotificationMap {
   static final AtNotificationMap _singleton = AtNotificationMap._internal();
+  final logger = AtSignLogger('AtNotificationMap');
 
   AtNotificationMap._internal();
 
@@ -49,11 +51,25 @@ class AtNotificationMap {
     } else {
       Map<String, NotificationStrategy> tempMap = _notificationMap.remove(atSign)!;
       var latestList = tempMap['latest'] as LatestNotifications;
-      var list = tempMap['all'] as AllNotifications;
+      var allList = tempMap['all'] as AllNotifications;
       returnList = List<AtNotification>.from(latestList.toList())
-        ..addAll(list.toList()!);
+        ..addAll(allList.toList()!);
       tempMap.clear();
     }
+    returnList.sort((a, b) {
+      if(a.notificationDateTime == null && b.notificationDateTime == null) {
+        return 0;
+      }
+      if(a.notificationDateTime == null) {
+        return 1;
+      }
+      if(b.notificationDateTime == null) {
+        return -1;
+      }
+
+      return a.notificationDateTime!.compareTo(b.notificationDateTime!);
+    });
+
     return returnList.iterator;
   }
 

--- a/at_secondary/at_secondary_server/lib/src/notification/notification_manager_impl.dart
+++ b/at_secondary/at_secondary_server/lib/src/notification/notification_manager_impl.dart
@@ -1,7 +1,7 @@
 import 'package:at_commons/at_commons.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
-import 'package:at_persistence_secondary_server/src/notification/at_notification_manager.dart';
 import 'package:at_secondary/src/notification/queue_manager.dart';
+import 'package:at_secondary/src/notification/resource_manager.dart';
 
 /// Class implementing [NotificationManagerSpec].
 class NotificationManager implements NotificationManagerSpec {
@@ -28,17 +28,18 @@ class NotificationManager implements NotificationManagerSpec {
 
   ///Stores the AtNotification Object to Queue.
   ///Returns the AtNotification id.
-  Future<String?> _storeNotificationInQueue(
-      AtNotification atNotification) async {
+  Future<String?> _storeNotificationInQueue(AtNotification atNotification) async {
+    // Queueing notification for sending
+    if (atNotification.type == NotificationType.sent) {
+      var queueManager = QueueManager.getInstance();
+      queueManager.enqueue(atNotification);
+      ResourceManager.getInstance().nudge();
+    }
+
     // Adding notification to hive key-store.
     await AtNotificationKeystore.getInstance()
         .put(atNotification.id, atNotification);
 
-    // Adding sent notification to queue.
-    if (atNotification.type == NotificationType.sent) {
-      var queueManager = QueueManager.getInstance();
-      queueManager.enqueue(atNotification);
-    }
     return atNotification.id;
   }
 

--- a/at_secondary/at_secondary_server/lib/src/notification/notification_wait_time.dart
+++ b/at_secondary/at_secondary_server/lib/src/notification/notification_wait_time.dart
@@ -59,4 +59,9 @@ class NotificationWaitTime {
     waitTime = prioritiesSum + meanValue;
     return waitTime;
   }
+
+  @override
+  String toString() {
+    return 'NotificationWaitTime{_totalPriorities: $_totalPriorities, _prioritiesSum: $_prioritiesSum, _lastComputedAt: $_lastComputedAt, _waitTime: $_waitTime}';
+  }
 }

--- a/at_secondary/at_secondary_server/lib/src/notification/notify_connection_pool.dart
+++ b/at_secondary/at_secondary_server/lib/src/notification/notify_connection_pool.dart
@@ -3,6 +3,7 @@ import 'package:at_secondary/src/connection/inbound/dummy_inbound_connection.dar
 import 'package:at_secondary/src/connection/outbound/outbound_client.dart';
 import 'package:at_secondary/src/connection/outbound/outbound_client_pool.dart';
 import 'package:at_utils/at_logger.dart';
+import 'package:meta/meta.dart';
 
 /// Class to maintains the pool of outbound connections for notifying.
 class NotifyConnectionsPool {
@@ -12,6 +13,8 @@ class NotifyConnectionsPool {
   var logger = AtSignLogger('NotifyConnectionPool');
 
   late OutboundClientPool _pool;
+  OutboundClientPool get pool => _pool;
+
   static const int defaultPoolSize = 50;
 
   bool isInitialised = false;
@@ -28,7 +31,13 @@ class NotifyConnectionsPool {
   void init(int size) {
     if (isInitialised) {
       return;
+    } else {
+      privateInit(size);
     }
+  }
+
+  @visibleForTesting
+  void privateInit(int size) {
     _size = size;
     isInitialised = true;
     _pool = OutboundClientPool();

--- a/at_secondary/at_secondary_server/lib/src/notification/notify_connection_pool.dart
+++ b/at_secondary/at_secondary_server/lib/src/notification/notify_connection_pool.dart
@@ -25,13 +25,11 @@ class NotifyConnectionsPool {
     return _singleton;
   }
 
-  void init(int? size) {
+  void init(int size) {
     if (isInitialised) {
       return;
     }
-    if (size != null) {
-      _size = size;
-    }
+    _size = size;
     isInitialised = true;
     _pool = OutboundClientPool();
     _pool.init(_size);
@@ -60,7 +58,11 @@ class NotifyConnectionsPool {
     }
 
     if (!_pool.hasCapacity()) {
-      throw OutboundConnectionLimitException('max limit $_size reached on outbound pool');
+      OutboundClient? evictedClient = _pool.removeLeastRecentlyUsed();
+      logger.info("Evicted LRU client from pool : $evictedClient");
+      if (!_pool.hasCapacity()) {
+        throw OutboundConnectionLimitException('max limit $_size reached on outbound pool');
+      }
     }
 
     // If client is null and pool has capacity, create a new OutboundClient and add it to the pool

--- a/at_secondary/at_secondary_server/lib/src/notification/priority_queue_impl.dart
+++ b/at_secondary/at_secondary_server/lib/src/notification/priority_queue_impl.dart
@@ -3,11 +3,10 @@ import 'package:collection/src/priority_queue.dart';
 
 /// Class implementing the priority queue.
 class AtNotificationPriorityQueue {
-  final _priorityQueue;
+  final PriorityQueue<AtNotification> _priorityQueue;
 
   AtNotificationPriorityQueue({priorityQueue, comparison})
-      : _priorityQueue =
-            PriorityQueue<AtNotification>(comparison ??= _comparePriority);
+      : _priorityQueue = PriorityQueue<AtNotification>(comparison ??= _comparePriority);
 
   /// Adds [AtNotification] to the priority queue.
   /// Accepts [AtNotification] as input param.
@@ -27,7 +26,7 @@ class AtNotificationPriorityQueue {
   }
 
   /// Returns the size of the priority queue
-  int? size() {
+  int size() {
     return _priorityQueue.length;
   }
 

--- a/at_secondary/at_secondary_server/lib/src/notification/queue_manager.dart
+++ b/at_secondary/at_secondary_server/lib/src/notification/queue_manager.dart
@@ -35,4 +35,8 @@ class QueueManager {
     var mapInstance = AtNotificationMap.getInstance();
     return mapInstance.remove(atsign);
   }
+
+  int numQueued(String atSign) {
+    return AtNotificationMap.getInstance().numQueued(atSign);
+  }
 }

--- a/at_secondary/at_secondary_server/lib/src/notification/queue_manager.dart
+++ b/at_secondary/at_secondary_server/lib/src/notification/queue_manager.dart
@@ -1,4 +1,4 @@
-import 'package:at_persistence_secondary_server/src/notification/at_notification.dart';
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:at_secondary/src/notification/at_notification_map.dart';
 import 'package:at_secondary/src/server/at_secondary_config.dart';
 

--- a/at_secondary/at_secondary_server/lib/src/notification/resource_manager.dart
+++ b/at_secondary/at_secondary_server/lib/src/notification/resource_manager.dart
@@ -45,7 +45,6 @@ class ResourceManager {
 
   ///Runs for every configured number of seconds(5).
   Future<void> _schedule() async {
-    logger.info("schedule() calling _processNotificationQueue()");
     await _processNotificationQueue();
     var millisBetweenRuns = notificationJobFrequency * 1000;
     Future.delayed(Duration(milliseconds: millisBetweenRuns)).then((value) => _schedule());
@@ -126,7 +125,6 @@ class ResourceManager {
         atNotification = iterator.current;
         var key = _prepareNotificationKey(atNotification);
         notifyResponse = await outBoundClient.notify(key);
-        logger.info('notifyResult : $notifyResponse');
         await _notifyResponseProcessor(
             notifyResponse, atNotification, errorList);
       }
@@ -224,8 +222,9 @@ class ResourceManager {
             'Failed to notify ${atNotification.id} from ${atNotification.fromAtSign} to ${atNotification.toAtSign}. Maximum retries ($maxRetries) reached');
         continue;
       }
-      logger.info(
-          'Retrying to notify: ${atNotification.id} from ${atNotification.fromAtSign} to ${atNotification.toAtSign}. Retry count: ${atNotification.retryCount}');
+      logger.info('Retrying to notify: ${atNotification.id}'
+          ' from ${atNotification.fromAtSign} to ${atNotification.toAtSign}.'
+          ' Retry count: ${atNotification.retryCount}');
       QueueManager.getInstance().enqueue(atNotification);
     }
   }

--- a/at_secondary/at_secondary_server/lib/src/notification/resource_manager.dart
+++ b/at_secondary/at_secondary_server/lib/src/notification/resource_manager.dart
@@ -25,7 +25,7 @@ class ResourceManager {
     return _singleton;
   }
 
-  void init(int? outboundConnectionLimit) {
+  void init(int outboundConnectionLimit) {
     NotifyConnectionsPool.getInstance().init(outboundConnectionLimit);
     _isStarted = true;
     Future.delayed(Duration(milliseconds: 0)).then((value) {
@@ -122,8 +122,8 @@ class ResourceManager {
     try {
       while (iterator.moveNext()) {
         atNotification = iterator.current;
-        var key = _prepareNotificationKey(atNotification);
-        notifyResponse = await outBoundClient.notify(key);
+        var notifyCommandBody = _prepareNotifyCommandBody(atNotification);
+        notifyResponse = await outBoundClient.notify(notifyCommandBody);
         await _notifyResponseProcessor(
             notifyResponse, atNotification, errorList);
       }
@@ -162,43 +162,43 @@ class ResourceManager {
   /// Prepares the notification key.
   /// Accepts [AtNotification]
   /// Returns the key of notification key.
-  String _prepareNotificationKey(AtNotification atNotification) {
-    String key;
-    key = '${atNotification.notification}';
+  String _prepareNotifyCommandBody(AtNotification atNotification) {
+    String commandBody;
+    commandBody = '${atNotification.notification}';
     var atMetaData = atNotification.atMetadata;
     if (atMetaData != null) {
       if (atNotification.atMetadata!.pubKeyCS != null) {
-        key =
-            '$SHARED_WITH_PUBLIC_KEY_CHECK_SUM:${atNotification.atMetadata!.pubKeyCS}:$key';
+        commandBody =
+            '$SHARED_WITH_PUBLIC_KEY_CHECK_SUM:${atNotification.atMetadata!.pubKeyCS}:$commandBody';
       }
       if (atNotification.atMetadata!.sharedKeyEnc != null) {
-        key =
-            '$SHARED_KEY_ENCRYPTED:${atNotification.atMetadata!.sharedKeyEnc}:$key';
+        commandBody =
+            '$SHARED_KEY_ENCRYPTED:${atNotification.atMetadata!.sharedKeyEnc}:$commandBody';
       }
       if (atMetaData.ttr != null) {
-        key =
-            'ttr:${atMetaData.ttr}:ccd:${atMetaData.isCascade}:$key:${atNotification.atValue}';
+        commandBody =
+            'ttr:${atMetaData.ttr}:ccd:${atMetaData.isCascade}:$commandBody:${atNotification.atValue}';
       }
       if (atMetaData.ttb != null) {
-        key = 'ttb:${atMetaData.ttb}:$key';
+        commandBody = 'ttb:${atMetaData.ttb}:$commandBody';
       }
       if (atMetaData.ttl != null) {
-        key = 'ttl:${atMetaData.ttl}:$key';
+        commandBody = 'ttl:${atMetaData.ttl}:$commandBody';
       }
     }
     if (atNotification.ttl != null) {
-      key = 'ttln:${atNotification.ttl}:$key';
+      commandBody = 'ttln:${atNotification.ttl}:$commandBody';
     }
 
-    key = 'notifier:${atNotification.notifier}:$key';
-    key =
-        'messageType:${atNotification.messageType.toString().split('.').last}:$key';
+    commandBody = 'notifier:${atNotification.notifier}:$commandBody';
+    commandBody =
+        'messageType:${atNotification.messageType.toString().split('.').last}:$commandBody';
     if (atNotification.opType != null) {
-      key = '${atNotification.opType.toString().split('.').last}:$key';
+      commandBody = '${atNotification.opType.toString().split('.').last}:$commandBody';
     }
     // appending id to the notify command.
-    key = 'id:${atNotification.id}:$key';
-    return key;
+    commandBody = 'id:${atNotification.id}:$commandBody';
+    return commandBody;
   }
 
   ///Adds the errored notifications back to queue.

--- a/at_secondary/at_secondary_server/lib/src/notification/resource_manager.dart
+++ b/at_secondary/at_secondary_server/lib/src/notification/resource_manager.dart
@@ -71,7 +71,7 @@ class ResourceManager {
         //3. Connect to the atSign and send the notifications
         var outboundClient = await _connect(atSign);
         if (outboundClient != null) {
-          _sendNotifications(atSign!, outboundClient, notificationIterator);
+          await _sendNotifications(atSign!, outboundClient, notificationIterator);
         }
       }
     } on ConnectionInvalidException catch (e) {
@@ -114,7 +114,7 @@ class ResourceManager {
   }
 
   /// Send the Notification to [atNotificationList.toAtSign]
-  void _sendNotifications(String atSign, OutboundClient outBoundClient, Iterator iterator) async {
+  Future<void> _sendNotifications(String atSign, OutboundClient outBoundClient, Iterator iterator) async {
     // ignore: prefer_typing_uninitialized_variables
     var notifyResponse, atNotification;
     var errorList = [];

--- a/at_secondary/at_secondary_server/lib/src/notification/strategy/all_notifications.dart
+++ b/at_secondary/at_secondary_server/lib/src/notification/strategy/all_notifications.dart
@@ -7,6 +7,8 @@ import 'package:at_secondary/src/notification/priority_queue_impl.dart';
 class AllNotifications implements NotificationStrategy {
   final _priorityQueue = AtNotificationPriorityQueue();
 
+  int get length => _priorityQueue.size();
+
   @override
   void add(AtNotification atNotification) {
     _priorityQueue.addNotification(atNotification);

--- a/at_secondary/at_secondary_server/lib/src/notification/strategy/latest_notifications.dart
+++ b/at_secondary/at_secondary_server/lib/src/notification/strategy/latest_notifications.dart
@@ -7,6 +7,8 @@ import 'package:at_secondary/src/notification/priority_queue_impl.dart';
 class LatestNotifications implements NotificationStrategy {
   final _latestNotificationsMap = <String?, AtNotificationPriorityQueue>{};
 
+  int get length => _latestNotificationsMap.length;
+
   @override
   void add(AtNotification atNotification) {
     if (!_latestNotificationsMap.containsKey(atNotification.notifier)) {
@@ -14,8 +16,8 @@ class LatestNotifications implements NotificationStrategy {
           () => AtNotificationPriorityQueue(comparison: _comparePriorityDates));
     }
     var list = _latestNotificationsMap[atNotification.notifier]!;
-    if (atNotification.depth! <= list.size()!) {
-      var n = atNotification.depth! - list.size()!;
+    if (atNotification.depth! <= list.size()) {
+      var n = atNotification.depth! - list.size();
       while (n == 0) {
         list.removeNotification();
         n--;
@@ -28,9 +30,9 @@ class LatestNotifications implements NotificationStrategy {
   /// Returns a List of AtNotifications.
   List<AtNotification> toList() {
     var tempList = <AtNotification>[];
-    _latestNotificationsMap.keys.forEach((element) {
+    for (var element in _latestNotificationsMap.keys) {
       tempList.addAll(_latestNotificationsMap[element]!.toList()!);
-    });
+    }
     return tempList;
   }
 

--- a/at_secondary/at_secondary_server/lib/src/server/at_secondary_config.dart
+++ b/at_secondary/at_secondary_server/lib/src/server/at_secondary_config.dart
@@ -33,11 +33,19 @@ class AtSecondaryConfig {
   static final int? _accessLogSizeInKB = 2;
 
   //Notification
-  static final int _maxNotificationRetries = 5;
-  static final int? _maxNotificationEntries = 5;
   static final bool? _autoNotify = true;
+  // The maximum number of retries for a notification.
+  static final int _maxNotificationRetries = 30;
+  // The quarantine duration of an atsign. Notifications will be retried max_retries times, every quarantineDuration seconds approximately.
   static final int _notificationQuarantineDuration = 10;
-  static final int _notificationJobFrequency = 5;
+  // The notifications queue will be processed every jobFrequency seconds. However, the notifications queue will always be processed
+  // *immediately* when a new notification is queued. When that happens, the queue processing will not run again until jobFrequency
+  // seconds have passed since the last queue-processing run completed.
+  static final int _notificationJobFrequency = 11;
+  // The time interval(in seconds) to notify latest commitID to monitor connections
+  // To disable to the feature, set to -1.
+  static final int _statsNotificationJobTimeInterval = 15;
+
   static final int? _notificationKeyStoreCompactionFrequencyMins = 5;
   static final int? _notificationKeyStoreCompactionPercentage = 30;
   static final int? _notificationKeyStoreExpiryInDays = 1;
@@ -68,9 +76,6 @@ class AtSecondaryConfig {
 
   //force restart
   static final bool _isForceRestart = false;
-
-  //StatsNotificationService
-  static final int _statsNotificationJobTimeInterval = 15;
 
   //Sync Configurations
   static final int _syncBufferSize = 5242880;
@@ -130,18 +135,6 @@ class AtSecondaryConfig {
       return getConfigFromYaml(['refreshJob', 'runJobHour']);
     } on ElementNotFoundException {
       return _runRefreshJobHour;
-    }
-  }
-
-  static int? get maxNotificationEntries {
-    var result = _getIntEnvVar('maxNotificationEntries');
-    if (result != null) {
-      return result;
-    }
-    try {
-      return getConfigFromYaml(['notification', 'max_entries']);
-    } on ElementNotFoundException {
-      return _maxNotificationEntries;
     }
   }
 
@@ -548,10 +541,10 @@ class AtSecondaryConfig {
     }
   }
 
-  static int? get notificationJobFrequency {
+  static int get notificationJobFrequency {
     var result = _getIntEnvVar('notificationJobFrequency');
     if (result != null) {
-      return _getIntEnvVar('notificationJobFrequency');
+      return result;
     }
     try {
       return getConfigFromYaml(['notification', 'jobFrequency']);

--- a/at_secondary/at_secondary_server/lib/src/server/at_secondary_config.dart
+++ b/at_secondary/at_secondary_server/lib/src/server/at_secondary_config.dart
@@ -52,20 +52,20 @@ class AtSecondaryConfig {
   static final int? _notificationKeyStoreSizeInKB = -1;
 
   //Refresh Job
-  static int? _runRefreshJobHour = 3;
+  static final int _runRefreshJobHour = 3;
 
   //Connection
-  static final int _inbound_max_limit = 10;
-  static final int _outbound_max_limit = 10;
-  static final int _inbound_idletime_millis = 600000;
-  static final int _outbound_idletime_millis = 600000;
+  static final int _inboundMaxLimit = 10;
+  static final int _outboundMaxLimit = 10;
+  static final int _inboundIdleTimeMillis = 600000;
+  static final int _outboundIdleTimeMillis = 600000;
 
   //Lookup
-  static final int? _lookup_depth_of_resolution = 3;
+  static final int _lookupDepthOfResolution = 3;
 
   //Stats
-  static final int? _stats_top_keys = 5;
-  static final int? _stats_top_visits = 5;
+  static final int _statsTopKeys = 5;
+  static final int _statsTopVisits = 5;
 
   //log level configuration. Value should match the name of one of dart logging package's Level.LEVELS
   static final String _defaultLogLevel = 'INFO';
@@ -355,7 +355,7 @@ class AtSecondaryConfig {
     try {
       return getConfigFromYaml(['connection', 'outbound_idle_time_millis']);
     } on ElementNotFoundException {
-      return _outbound_idletime_millis;
+      return _outboundIdleTimeMillis;
     }
   }
 
@@ -368,7 +368,7 @@ class AtSecondaryConfig {
     try {
       return getConfigFromYaml(['connection', 'inbound_idle_time_millis']);
     } on ElementNotFoundException {
-      return _inbound_idletime_millis;
+      return _inboundIdleTimeMillis;
     }
   }
 
@@ -381,7 +381,7 @@ class AtSecondaryConfig {
     try {
       return getConfigFromYaml(['connection', 'outbound_max_limit']);
     } on ElementNotFoundException {
-      return _outbound_max_limit;
+      return _outboundMaxLimit;
     }
   }
 
@@ -394,7 +394,7 @@ class AtSecondaryConfig {
     try {
       return getConfigFromYaml(['connection', 'inbound_max_limit']);
     } on ElementNotFoundException {
-      return _inbound_max_limit;
+      return _inboundMaxLimit;
     }
   }
 
@@ -407,7 +407,7 @@ class AtSecondaryConfig {
     try {
       return getConfigFromYaml(['lookup', 'depth_of_resolution']);
     } on ElementNotFoundException {
-      return _lookup_depth_of_resolution;
+      return _lookupDepthOfResolution;
     }
   }
 
@@ -420,7 +420,7 @@ class AtSecondaryConfig {
     try {
       return getConfigFromYaml(['stats', 'top_visits']);
     } on ElementNotFoundException {
-      return _stats_top_visits;
+      return _statsTopVisits;
     }
   }
 
@@ -433,7 +433,7 @@ class AtSecondaryConfig {
     try {
       return getConfigFromYaml(['stats', 'top_keys']);
     } on ElementNotFoundException {
-      return _stats_top_keys;
+      return _statsTopKeys;
     }
   }
 

--- a/at_secondary/at_secondary_server/lib/src/server/at_secondary_impl.dart
+++ b/at_secondary/at_secondary_server/lib/src/server/at_secondary_impl.dart
@@ -51,8 +51,6 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
   static final int? accessLogExpiryInDays =
       AtSecondaryConfig.accessLogExpiryInDays;
   static final int? accessLogSizeInKB = AtSecondaryConfig.accessLogSizeInKB;
-  static final int? maxNotificationEntries =
-      AtSecondaryConfig.maxNotificationEntries;
   static final bool? clientCertificateRequired =
       AtSecondaryConfig.clientCertificateRequired;
   late bool _isPaused;
@@ -187,16 +185,13 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
     var certificateReload = AtCertificateValidationJob.getInstance();
     await certificateReload.runCertificateExpiryCheckJob();
 
-    // Notification job
-    var resourceManager = ResourceManager.getInstance();
-    if (!resourceManager.isRunning) {
-      resourceManager.schedule();
-    }
-
     // Initialize inbound factory and outbound manager
     inboundConnectionFactory.init(serverContext!.inboundConnectionLimit);
     OutboundClientManager.getInstance()
         .init(serverContext!.outboundConnectionLimit);
+
+    // Notification job
+    ResourceManager.getInstance().init(serverContext!.outboundConnectionLimit);
 
     // Starts StatsNotificationService to keep monitor connections alive
     StatsNotificationService.getInstance().schedule();

--- a/at_secondary/at_secondary_server/lib/src/utils/handler_util.dart
+++ b/at_secondary/at_secondary_server/lib/src/utils/handler_util.dart
@@ -16,33 +16,33 @@ HashMap<String, String?> getVerbParam(String regex, String command) {
 
 /// Validates the TTR and CCD metadata.
 Map<String, dynamic> validateCacheMetadata(
-    AtMetaData? metadata, int? ttr_ms, bool? ccd) {
+    AtMetaData? metadata, int? ttrMillis, bool? ccd) {
   // If metadata is null, key is new.
   // When key is new, If TTR is populated and CCD is not populated, CCD defaults to false.
   // If TTR is not populated and CCD is populated, Throw InvalidSyntaxException.
   if (metadata == null) {
-    ccd = AtMetadataUtil.validateCascadeDelete(ttr_ms, ccd);
+    ccd = AtMetadataUtil.validateCascadeDelete(ttrMillis, ccd);
   }
   // If metadata is not null, key is existing.
   if (metadata != null) {
     // On existing key, when TTR and CCD are set, update TTR and CCD values.
-    if (ttr_ms != null && ccd != null) {
-      ccd = AtMetadataUtil.validateCascadeDelete(ttr_ms, ccd);
+    if (ttrMillis != null && ccd != null) {
+      ccd = AtMetadataUtil.validateCascadeDelete(ttrMillis, ccd);
     }
     // On existing key, if TTR is null and CCD is populated, get existing TTR value.
-    if (ttr_ms == null && ccd != null) {
+    if (ttrMillis == null && ccd != null) {
       if (metadata.ttr != null) {
-        ttr_ms = metadata.ttr;
-        ccd = AtMetadataUtil.validateCascadeDelete(ttr_ms, ccd);
+        ttrMillis = metadata.ttr;
+        ccd = AtMetadataUtil.validateCascadeDelete(ttrMillis, ccd);
       }
     }
     // On existing key, if CCD is null and TTR is populated, get existing CCD value.
-    if (ccd == null && ttr_ms != null) {
+    if (ccd == null && ttrMillis != null) {
       ccd = metadata.isCascade;
       ccd ??= false;
-      ttr_ms = AtMetadataUtil.validateTTR(ttr_ms);
+      ttrMillis = AtMetadataUtil.validateTTR(ttrMillis);
     }
   }
-  var valueMap = {AT_TTR: ttr_ms, CCD: ccd};
+  var valueMap = {AT_TTR: ttrMillis, CCD: ccd};
   return valueMap;
 }

--- a/at_secondary/at_secondary_server/lib/src/utils/notification_util.dart
+++ b/at_secondary/at_secondary_server/lib/src/utils/notification_util.dart
@@ -7,7 +7,7 @@ import 'package:at_utils/at_utils.dart';
 /// Util class for Notifications
 class NotificationUtil {
   static var logger = AtSignLogger('NotificationUtil');
-  static final AUTO_NOTIFY = AtSecondaryConfig.autoNotify;
+  static final autoNotify = AtSecondaryConfig.autoNotify;
 
   /// Method to store notification in data store
   /// Accepts fromAtSign, forAtSign, key, Notification and Operation type,

--- a/at_secondary/at_secondary_server/lib/src/utils/notification_util.dart
+++ b/at_secondary/at_secondary_server/lib/src/utils/notification_util.dart
@@ -1,7 +1,6 @@
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:at_secondary/src/notification/queue_manager.dart';
 import 'package:at_secondary/src/server/at_secondary_config.dart';
-import 'package:at_utils/at_logger.dart';
 import 'package:at_utils/at_utils.dart';
 
 /// Util class for Notifications
@@ -19,7 +18,7 @@ class NotificationUtil {
       NotificationType notificationType,
       OperationType? operationType,
       {MessageType messageType = MessageType.key,
-      int? ttl_ms,
+      int? ttlMillis,
       String? value,
       NotificationStatus? notificationStatus,
       String? id}) async {
@@ -39,10 +38,10 @@ class NotificationUtil {
         ..atValue = value
         ..notificationStatus = notificationStatus;
       //setting ttl only when it has a valid value
-      if (ttl_ms != null && ttl_ms > 0) {
-        notificationBuilder.ttl = ttl_ms;
+      if (ttlMillis != null && ttlMillis > 0) {
+        notificationBuilder.ttl = ttlMillis;
         notificationBuilder.expiresAt =
-            DateTime.now().toUtc().add(Duration(milliseconds: ttl_ms));
+            DateTime.now().toUtc().add(Duration(milliseconds: ttlMillis));
       }
       if(id != null && id.isNotEmpty){
         notificationBuilder.id = id;
@@ -65,12 +64,12 @@ class NotificationUtil {
       return;
     }
     var values = await _notificationLog.getValues();
-    values.forEach((element) {
+    for (var element in values) {
       //_notificationLog.getValues().forEach((element) {
       // If notifications are sent and not delivered, add to notificationQueue.
       if (element.type == NotificationType.sent) {
         QueueManager.getInstance().enqueue(element);
       }
-    });
+    }
   }
 }

--- a/at_secondary/at_secondary_server/lib/src/utils/secondary_util.dart
+++ b/at_secondary/at_secondary_server/lib/src/utils/secondary_util.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
-import 'package:at_persistence_spec/at_persistence_spec.dart';
 import 'package:at_utils/at_logger.dart';
 import 'package:crypton/crypton.dart';
 
@@ -69,14 +68,14 @@ class SecondaryUtil {
       var ttl = atData.metaData!.expiresAt;
       if (ttb == null && ttl == null) return true;
       if (ttb != null) {
-        var ttb_ms = ttb.toUtc().millisecondsSinceEpoch;
-        if (ttb_ms > now) {
+        var ttbMillis = ttb.toUtc().millisecondsSinceEpoch;
+        if (ttbMillis > now) {
           return false;
         }
       }
       if (ttl != null) {
-        var ttl_ms = ttl.toUtc().millisecondsSinceEpoch;
-        if (ttl_ms < now) {
+        var ttlMillis = ttl.toUtc().millisecondsSinceEpoch;
+        if (ttlMillis < now) {
           return false;
         }
       }
@@ -95,7 +94,7 @@ class SecondaryUtil {
   }
 
   static String? prepareResponseData(String? operation, AtData? atData) {
-    var result;
+    String? result;
     if (atData == null) {
       return result;
     }

--- a/at_secondary/at_secondary_server/lib/src/verb/handler/abstract_verb_handler.dart
+++ b/at_secondary/at_secondary_server/lib/src/verb/handler/abstract_verb_handler.dart
@@ -15,7 +15,7 @@ final String paramFullCommandAsReceived = 'FullCommandAsReceived';
 abstract class AbstractVerbHandler implements VerbHandler {
   SecondaryKeyStore? keyStore;
 
-  late var logger;
+  late AtSignLogger logger;
   ResponseHandlerManager responseManager = DefaultResponseHandlerManager();
 
   AbstractVerbHandler(this.keyStore) {

--- a/at_secondary/at_secondary_server/lib/src/verb/handler/delete_verb_handler.dart
+++ b/at_secondary/at_secondary_server/lib/src/verb/handler/delete_verb_handler.dart
@@ -2,7 +2,6 @@ import 'dart:collection';
 
 import 'package:at_commons/at_commons.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
-import 'package:at_persistence_secondary_server/src/notification/at_notification.dart';
 import 'package:at_secondary/src/notification/notification_manager_impl.dart';
 import 'package:at_secondary/src/server/at_secondary_config.dart';
 import 'package:at_secondary/src/utils/secondary_util.dart';
@@ -14,7 +13,7 @@ import 'package:at_utils/at_utils.dart';
 
 class DeleteVerbHandler extends ChangeVerbHandler {
   static Delete delete = Delete();
-  static final AUTO_NOTIFY = AtSecondaryConfig.autoNotify;
+  static final autoNotify = AtSecondaryConfig.autoNotify;
 
   DeleteVerbHandler(SecondaryKeyStore? keyStore) : super(keyStore);
 
@@ -46,6 +45,7 @@ class DeleteVerbHandler extends ChangeVerbHandler {
       InboundConnection atConnection) async {
     // Sets Response bean to the response bean in ChangeVerbHandler
     await super.processVerb(response, verbParams, atConnection);
+    // ignore: prefer_typing_uninitialized_variables
     var deleteKey;
     var atSign = AtUtils.formatAtSign(verbParams[AT_SIGN]);
     deleteKey = verbParams[AT_KEY];
@@ -80,8 +80,8 @@ class DeleteVerbHandler extends ChangeVerbHandler {
       forAtSign = AtUtils.formatAtSign(forAtSign);
       atSign = AtUtils.formatAtSign(atSign);
 
-      // send notification to other secondary is AUTO_NOTIFY is enabled
-      if (AUTO_NOTIFY! && (forAtSign != atSign)) {
+      // send notification to other secondary if [AtSecondaryConfig.autoNotify] is true
+      if (autoNotify! && (forAtSign != atSign)) {
         try {
           _notify(forAtSign, atSign, key,
               SecondaryUtil().getNotificationPriority(verbParams[PRIORITY]));
@@ -98,7 +98,7 @@ class DeleteVerbHandler extends ChangeVerbHandler {
 
   void _notify(forAtSign, atSign, key, priority) {
     if (forAtSign == null) {
-      return null;
+      return;
     }
     key = '$forAtSign:$key$atSign';
     var atNotification = (AtNotificationBuilder()

--- a/at_secondary/at_secondary_server/lib/src/verb/handler/local_lookup_verb_handler.dart
+++ b/at_secondary/at_secondary_server/lib/src/verb/handler/local_lookup_verb_handler.dart
@@ -60,7 +60,7 @@ class LocalLookupVerbHandler extends AbstractVerbHandler {
     var isActive = false;
     isActive = SecondaryUtil.isActiveKey(lookup_data);
     if (isActive) {
-      logger.info('isActiveKey : $isActive');
+      logger.finer('isActiveKey($key) : $isActive');
       response.data = SecondaryUtil.prepareResponseData(operation, lookup_data);
     }
   }

--- a/at_secondary/at_secondary_server/lib/src/verb/handler/notify_all_verb_handler.dart
+++ b/at_secondary/at_secondary_server/lib/src/verb/handler/notify_all_verb_handler.dart
@@ -3,13 +3,11 @@ import 'dart:convert';
 
 import 'package:at_commons/at_commons.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
-import 'package:at_persistence_spec/src/keystore/secondary_keystore.dart';
 import 'package:at_secondary/src/notification/notification_manager_impl.dart';
 import 'package:at_secondary/src/server/at_secondary_impl.dart';
 import 'package:at_secondary/src/utils/secondary_util.dart';
-import 'package:at_server_spec/src/connection/inbound_connection.dart';
-import 'package:at_server_spec/src/verb/notify_all.dart';
-import 'package:at_server_spec/src/verb/verb.dart';
+import 'package:at_server_spec/at_server_spec.dart';
+import 'package:at_server_spec/at_verb_spec.dart';
 import 'package:at_utils/at_utils.dart';
 
 import '../verb_enum.dart';
@@ -35,10 +33,10 @@ class NotifyAllVerbHandler extends AbstractVerbHandler {
       Response response,
       HashMap<String, String?> verbParams,
       InboundConnection atConnection) async {
-    var ttl_ms;
-    var ttb_ms;
-    var ttr_ms;
-    var isCascade;
+    int ttlMillis;
+    int ttbMillis;
+    int? ttrMillis;
+    bool? isCascade;
     var forAtSignList = verbParams[FOR_AT_SIGN];
     var atSign = verbParams[AT_SIGN];
     atSign = AtUtils.formatAtSign(atSign);
@@ -54,13 +52,13 @@ class NotifyAllVerbHandler extends AbstractVerbHandler {
     }
 
     try {
-      ttl_ms = AtMetadataUtil.validateTTL(verbParams[AT_TTL]);
-      ttb_ms = AtMetadataUtil.validateTTB(verbParams[AT_TTB]);
+      ttlMillis = AtMetadataUtil.validateTTL(verbParams[AT_TTL]);
+      ttbMillis = AtMetadataUtil.validateTTB(verbParams[AT_TTB]);
       if (verbParams[AT_TTR] != null) {
-        ttr_ms = AtMetadataUtil.validateTTR(int.parse(verbParams[AT_TTR]!));
+        ttrMillis = AtMetadataUtil.validateTTR(int.parse(verbParams[AT_TTR]!));
       }
       isCascade = AtMetadataUtil.validateCascadeDelete(
-          ttr_ms, AtMetadataUtil.getBoolVerbParams(verbParams[CCD]));
+          ttrMillis, AtMetadataUtil.getBoolVerbParams(verbParams[CCD]));
     } on InvalidSyntaxException {
       rethrow;
     }
@@ -72,18 +70,18 @@ class NotifyAllVerbHandler extends AbstractVerbHandler {
       var forAtSigns = forAtSignList.split(',');
       var forAtSignsSet = forAtSigns.toSet();
       for (var forAtSign in forAtSignsSet) {
-        var updated_key = '$forAtSign:$key';
+        var updatedKey = '$forAtSign:$key';
         var atMetadata = AtMetaData()
-          ..ttl = ttl_ms
-          ..ttb = ttb_ms
-          ..ttr = ttr_ms
+          ..ttl = ttlMillis
+          ..ttb = ttbMillis
+          ..ttr = ttrMillis
           ..isCascade = isCascade
           ..dataSignature = dataSignature;
         var atNotification = (AtNotificationBuilder()
               ..type = NotificationType.sent
               ..fromAtSign = atSign
               ..toAtSign = forAtSign
-              ..notification = updated_key
+              ..notification = updatedKey
               ..opType = operation
               ..messageType = messageType
               ..atValue = value

--- a/at_secondary/at_secondary_server/lib/src/verb/handler/update_meta_verb_handler.dart
+++ b/at_secondary/at_secondary_server/lib/src/verb/handler/update_meta_verb_handler.dart
@@ -12,7 +12,7 @@ import 'package:at_server_spec/at_server_spec.dart';
 import 'package:at_utils/at_utils.dart';
 
 class UpdateMetaVerbHandler extends AbstractVerbHandler {
-  static final AUTO_NOTIFY = AtSecondaryConfig.autoNotify;
+  static final autoNotify = AtSecondaryConfig.autoNotify;
   static UpdateMeta updateMeta = UpdateMeta();
 
   UpdateMetaVerbHandler(SecondaryKeyStore? keyStore) : super(keyStore);
@@ -45,13 +45,13 @@ class UpdateMetaVerbHandler extends AbstractVerbHandler {
     atSign = AtUtils.formatAtSign(atSign);
 
     var key = verbParams[AT_KEY];
-    var ttl_ms;
-    var ttb_ms;
-    var ttr_ms;
-    var ccd;
-    var isBinary;
-    var isEncrypted;
-    var metadata;
+    int ttlMillis;
+    int ttbMillis;
+    int? ttrMillis;
+    bool ccd;
+    bool isBinary;
+    bool isEncrypted;
+    AtMetaData? metadata;
     String? sharedKeyEncrypted, sharedWithPublicKeyChecksum;
 
     key = _constructKey(key, forAtSign, atSign);
@@ -59,10 +59,10 @@ class UpdateMetaVerbHandler extends AbstractVerbHandler {
       key = 'public:$key';
     }
     try {
-      ttl_ms = AtMetadataUtil.validateTTL(verbParams[AT_TTL]);
-      ttb_ms = AtMetadataUtil.validateTTB(verbParams[AT_TTB]);
-      if (ttr_ms != null) {
-        ttr_ms = AtMetadataUtil.validateTTR(int.parse(verbParams[AT_TTR]!));
+      ttlMillis = AtMetadataUtil.validateTTL(verbParams[AT_TTL]);
+      ttbMillis = AtMetadataUtil.validateTTB(verbParams[AT_TTB]);
+      if (ttrMillis != null) {
+        ttrMillis = AtMetadataUtil.validateTTR(int.parse(verbParams[AT_TTR]!));
       }
       isBinary = AtMetadataUtil.getBoolVerbParams(verbParams[IS_BINARY]);
       isEncrypted = AtMetadataUtil.getBoolVerbParams(verbParams[IS_ENCRYPTED]);
@@ -71,17 +71,17 @@ class UpdateMetaVerbHandler extends AbstractVerbHandler {
           verbParams[SHARED_WITH_PUBLIC_KEY_CHECK_SUM];
       ccd = AtMetadataUtil.getBoolVerbParams(verbParams[CCD]);
       metadata = await keyStore!.getMeta(key);
-      var cacheRefreshMetaMap = validateCacheMetadata(metadata, ttr_ms, ccd);
-      ttr_ms = cacheRefreshMetaMap[AT_TTR];
+      var cacheRefreshMetaMap = validateCacheMetadata(metadata, ttrMillis, ccd);
+      ttrMillis = cacheRefreshMetaMap[AT_TTR];
       ccd = cacheRefreshMetaMap[CCD];
     } on InvalidSyntaxException {
       rethrow;
     }
     var atMetaData = AtMetadataBuilder(
             newAtMetaData: metadata,
-            ttl: ttl_ms,
-            ttb: ttb_ms,
-            ttr: ttr_ms,
+            ttl: ttlMillis,
+            ttb: ttbMillis,
+            ttr: ttrMillis,
             ccd: ccd,
             isBinary: isBinary,
             isEncrypted: isEncrypted,
@@ -94,7 +94,7 @@ class UpdateMetaVerbHandler extends AbstractVerbHandler {
     if (forAtSign == null || forAtSign.isEmpty) {
       return;
     }
-    if (AUTO_NOTIFY! && (atSign != forAtSign)) {
+    if (autoNotify! && (atSign != forAtSign)) {
       _notify(
           forAtSign,
           atSign,

--- a/at_secondary/at_secondary_server/lib/src/verb/handler/update_verb_handler.dart
+++ b/at_secondary/at_secondary_server/lib/src/verb/handler/update_verb_handler.dart
@@ -18,7 +18,7 @@ import 'package:at_utils/at_utils.dart';
 // update can be used to update the public/private keys
 // Ex: update:public:email@alice alice@atsign.com \n
 class UpdateVerbHandler extends ChangeVerbHandler {
-  static final AUTO_NOTIFY = AtSecondaryConfig.autoNotify;
+  static final autoNotify = AtSecondaryConfig.autoNotify;
   static Update update = Update();
 
   UpdateVerbHandler(SecondaryKeyStore? keyStore) : super(keyStore);
@@ -66,9 +66,9 @@ class UpdateVerbHandler extends ChangeVerbHandler {
       var atData = AtData();
       atData.data = value;
       atData.metaData = AtMetaData();
-      var ttl_ms = updateParams.metadata!.ttl;
-      var ttb_ms = updateParams.metadata!.ttb;
-      var ttr_ms = updateParams.metadata!.ttr;
+      var ttlMillis = updateParams.metadata!.ttl;
+      var ttbMillis = updateParams.metadata!.ttb;
+      var ttrMillis = updateParams.metadata!.ttr;
       var isBinary = updateParams.metadata!.isBinary;
       var isEncrypted = updateParams.metadata!.isEncrypted;
       var dataSignature = updateParams.metadata!.dataSignature;
@@ -90,23 +90,23 @@ class UpdateVerbHandler extends ChangeVerbHandler {
         key = 'public:$key';
       }
       var metadata = await keyStore!.getMeta(key);
-      var cacheRefreshMetaMap = validateCacheMetadata(metadata, ttr_ms, ccd);
-      ttr_ms = cacheRefreshMetaMap[AT_TTR];
+      var cacheRefreshMetaMap = validateCacheMetadata(metadata, ttrMillis, ccd);
+      ttrMillis = cacheRefreshMetaMap[AT_TTR];
       ccd = cacheRefreshMetaMap[CCD];
 
       //If ttr is set and atsign is not equal to currentAtSign, the key is
       //cached key.
-      if (ttr_ms != null &&
-          ttr_ms > 0 &&
+      if (ttrMillis != null &&
+          ttrMillis > 0 &&
           atSign != null &&
           atSign != AtSecondaryServerImpl.getInstance().currentAtSign) {
         key = 'cached:$key';
       }
 
       var atMetadata = AtMetaData()
-        ..ttl = ttl_ms
-        ..ttb = ttb_ms
-        ..ttr = ttr_ms
+        ..ttl = ttlMillis
+        ..ttb = ttbMillis
+        ..ttr = ttrMillis
         ..isCascade = ccd
         ..isBinary = isBinary
         ..isEncrypted = isEncrypted
@@ -114,19 +114,7 @@ class UpdateVerbHandler extends ChangeVerbHandler {
         ..sharedKeyEnc = sharedKeyEncrypted
         ..pubKeyCS = publicKeyChecksum;
 
-      // update the key in data store
-      var result = await keyStore!.put(key, atData,
-          time_to_live: ttl_ms,
-          time_to_born: ttb_ms,
-          time_to_refresh: ttr_ms,
-          isCascade: ccd,
-          isBinary: isBinary,
-          isEncrypted: isEncrypted,
-          dataSignature: dataSignature,
-          sharedKeyEncrypted: sharedKeyEncrypted,
-          publicKeyChecksum: publicKeyChecksum);
-      response.data = result?.toString();
-      if (AUTO_NOTIFY!) {
+      if (autoNotify!) {
         _notify(
             atSign,
             forAtSign,
@@ -135,6 +123,19 @@ class UpdateVerbHandler extends ChangeVerbHandler {
             SecondaryUtil().getNotificationPriority(verbParams[PRIORITY]),
             atMetadata);
       }
+
+      // update the key in data store
+      var result = await keyStore!.put(key, atData,
+          time_to_live: ttlMillis,
+          time_to_born: ttbMillis,
+          time_to_refresh: ttrMillis,
+          isCascade: ccd,
+          isBinary: isBinary,
+          isEncrypted: isEncrypted,
+          dataSignature: dataSignature,
+          sharedKeyEncrypted: sharedKeyEncrypted,
+          publicKeyChecksum: publicKeyChecksum);
+      response.data = result?.toString();
     } on InvalidSyntaxException {
       rethrow;
     } catch (exception) {
@@ -147,10 +148,10 @@ class UpdateVerbHandler extends ChangeVerbHandler {
   void _notify(String? atSign, String? forAtSign, String? key, String? value,
       NotificationPriority priority, AtMetaData atMetaData) {
     if (forAtSign == null) {
-      return null;
+      return;
     }
     key = '$forAtSign:$key$atSign';
-    var expiresAt;
+    DateTime? expiresAt;
     if (atMetaData.ttl != null) {
       expiresAt = DateTime.now().add(Duration(seconds: atMetaData.ttl!));
     }

--- a/at_secondary/at_secondary_server/pubspec.yaml
+++ b/at_secondary/at_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_secondary
 description: Implementation of secondary server.
-version: 3.0.15
+version: 3.0.16
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://www.example.com
 publish_to: none
@@ -20,7 +20,12 @@ dependencies:
   at_lookup: ^3.0.22
   at_server_spec: ^3.0.7
 
-#dependency_overrides:
+dependency_overrides:
+  at_persistence_secondary_server:
+    git:
+      url: https://github.com/atsign-foundation/at_server.git
+      path: at_secondary/at_persistence_secondary_server
+      ref: straight_through_notify
 #  at_commons:
 #    git:
 #      url: https://github.com/atsign-foundation/at_tools.git
@@ -36,11 +41,6 @@ dependencies:
 #      url: https://github.com/atsign-foundation/at_tools.git
 #      path: at_utils
 #      ref: trunk
-#   at_persistence_secondary_server:
-#     git:
-#       url: https://github.com/atsign-foundation/at_server.git
-#       path: at_secondary/at_persistence_secondary_server
-#       ref: meta_data_cache
 #   at_server_spec:
 #     git:
 #       url: https://github.com/atsign-foundation/at_server.git

--- a/at_secondary/at_secondary_server/test/outbound_client_pool_test.dart
+++ b/at_secondary/at_secondary_server/test/outbound_client_pool_test.dart
@@ -9,84 +9,135 @@ import 'package:at_secondary/src/server/server_context.dart';
 import 'package:test/test.dart';
 
 void main() async {
-  late var outboundClient;
+  // ignore: prefer_typing_uninitialized_variables
+  late OutboundClientPool outboundClientPool;
+  final int outboundIdleTimeMillis = 2000;
   setUp(() {
     var serverContext = AtSecondaryContext();
-    serverContext.outboundIdleTimeMillis = 2000;
+    serverContext.outboundIdleTimeMillis = outboundIdleTimeMillis;
     AtSecondaryServerImpl.getInstance().serverContext = serverContext;
-    outboundClient = OutboundClientPool();
+    outboundClientPool = OutboundClientPool();
   });
+
   tearDown(() {
-    outboundClient.clearAllClients();
+    outboundClientPool.clearAllClients();
   });
+
   group('A group of outbound client pool test', () {
     test('test outbound client pool init', () {
-      outboundClient.init((5));
-      expect(outboundClient.getCapacity(), 5);
-      expect(outboundClient.getCurrentSize(), 0);
+      outboundClientPool.init((5));
+      expect(outboundClientPool.getCapacity(), 5);
+      expect(outboundClientPool.getCurrentSize(), 0);
     });
 
+    Socket? dummySocket;
+    OutboundClient newOutboundClient(String toAtSign) {
+      var inboundConnection = InboundConnectionImpl(dummySocket, toAtSign);
+      OutboundClient outboundClient = OutboundClient(inboundConnection, toAtSign);
+      outboundClient.outboundConnection = OutboundConnectionImpl(dummySocket, toAtSign);
+
+      return outboundClient;
+    }
+
     test('test connection pool add clients', () {
-      var poolInstance = outboundClient;
+      var poolInstance = outboundClientPool;
       poolInstance.init(5);
-      var dummySocket_1, dummySocket_2;
-      var inboundConnection_1 = InboundConnectionImpl(dummySocket_1, 'aaa');
-      var client_1 = OutboundClient(inboundConnection_1, 'alice');
-      client_1.outboundConnection =
-          OutboundConnectionImpl(dummySocket_2, 'alice');
-      var inboundConnection_2 = InboundConnectionImpl(dummySocket_2, 'bbb');
-      var client_2 = OutboundClient(inboundConnection_2, 'bob');
-      client_2.outboundConnection =
-          OutboundConnectionImpl(dummySocket_1, 'bob');
+
+      var client_1 = newOutboundClient('alice');
       poolInstance.add(client_1);
+      var client_2 = newOutboundClient('bob');
       poolInstance.add(client_2);
+
       expect(poolInstance.getCapacity(), 5);
       expect(poolInstance.getCurrentSize(), 2);
     });
-    test('test client pool - invalid clients', () {
-      var poolInstance = outboundClient;
+
+    test('test client pool - invalid clients', () async {
+      var poolInstance = outboundClientPool;
       poolInstance.init(5);
-      var dummySocket_1, dummySocket_2, dummySocket_3;
-      var inboundConnection_1 = InboundConnectionImpl(dummySocket_1, 'aaa');
-      var client_1 = OutboundClient(inboundConnection_1, 'alice');
-      client_1.outboundConnection =
-          OutboundConnectionImpl(dummySocket_2, 'alice');
-      var inboundConnection_2 = InboundConnectionImpl(dummySocket_2, 'bbb');
-      var client_2 = OutboundClient(inboundConnection_2, 'bob');
-      client_2.outboundConnection =
-          OutboundConnectionImpl(dummySocket_1, 'bob');
+
+      var client_1 = newOutboundClient('alice');
       poolInstance.add(client_1);
+      var client_2 = newOutboundClient('bob');
       poolInstance.add(client_2);
+
       expect(poolInstance.getCapacity(), 5);
       expect(poolInstance.getCurrentSize(), 2);
-      sleep(Duration(seconds: 3));
-      var inboundConnection_3 = InboundConnectionImpl(dummySocket_3, 'ccc');
-      var client_3 = OutboundClient(inboundConnection_3, 'charlie');
-      client_3.outboundConnection =
-          OutboundConnectionImpl(dummySocket_2, 'charlie');
+
+      await Future.delayed(Duration(milliseconds: outboundIdleTimeMillis + 100));
+
+      var client_3 = newOutboundClient('charlie');
       poolInstance.add(client_3);
+
       poolInstance.clearInvalidClients();
       expect(poolInstance.getCurrentSize(), 1);
     });
 
     test('test connection pool remove all clients', () {
-      var poolInstance = outboundClient;
+      var poolInstance = outboundClientPool;
       poolInstance.init(5);
-      var dummySocket_1, dummySocket_2;
-      var inboundConnection_1 = InboundConnectionImpl(dummySocket_1, 'aaa');
-      var client_1 = OutboundClient(inboundConnection_1, 'alice');
-      client_1.outboundConnection =
-          OutboundConnectionImpl(dummySocket_2, 'alice');
-      var inboundConnection_2 = InboundConnectionImpl(dummySocket_2, 'bbb');
-      var client_2 = OutboundClient(inboundConnection_2, 'bob');
-      client_2.outboundConnection =
-          OutboundConnectionImpl(dummySocket_1, 'bob');
+
+      var client_1 = newOutboundClient('alice');
       poolInstance.add(client_1);
+      var client_2 = newOutboundClient('bob');
       poolInstance.add(client_2);
+
       expect(poolInstance.getCapacity(), 5);
       expect(poolInstance.getCurrentSize(), 2);
+
       poolInstance.clearAllClients();
       expect(poolInstance.getCurrentSize(), 0);
+    });
+
+    test('test connection pool remove least recently used when pool size >= 2', () async {
+      var poolInstance = outboundClientPool;
+      poolInstance.init(5);
+
+      var client_1 = newOutboundClient('alice');
+      poolInstance.add(client_1);
+
+      await Future.delayed(Duration(milliseconds: 1));
+      var client_2 = newOutboundClient('bob');
+      poolInstance.add(client_2);
+
+      expect(poolInstance.getCapacity(), 5);
+      expect(poolInstance.getCurrentSize(), 2);
+      expect(poolInstance.hasCapacity(), true);
+
+      await Future.delayed(Duration(milliseconds: 1));
+
+      client_1.lastUsed = DateTime.now();
+
+      expect(poolInstance.removeLeastRecentlyUsed(), client_2);
+      expect (poolInstance.getCurrentSize(), 1);
+
+      poolInstance.clearAllClients();
+    });
+
+    test('test connection pool remove least recently used when pool size <= 1', () async {
+      var poolInstance = outboundClientPool;
+      poolInstance.init(5);
+
+      expect(poolInstance.getCurrentSize(), 0);
+      expect(poolInstance.removeLeastRecentlyUsed(), null);
+      expect(poolInstance.getCurrentSize(), 0);
+
+      var client_1 = newOutboundClient('alice');
+      poolInstance.add(client_1);
+
+      expect(poolInstance.getCurrentSize(), 1);
+      expect(poolInstance.removeLeastRecentlyUsed(), null);
+      expect(poolInstance.getCurrentSize(), 1);
+
+      await Future.delayed(Duration(milliseconds: 1));
+      var client_2 = newOutboundClient('bob');
+      poolInstance.add(client_2);
+
+      expect(poolInstance.getCurrentSize(), 2);
+      expect(poolInstance.removeLeastRecentlyUsed(), client_1);
+      expect(poolInstance.getCurrentSize(), 1);
+
+      poolInstance.clearAllClients();
     });
   });
 }

--- a/at_secondary/at_secondary_server/test/update_meta_verb_test.dart
+++ b/at_secondary/at_secondary_server/test/update_meta_verb_test.dart
@@ -86,6 +86,7 @@ void main() {
           atConnection.getMetaData() as InboundConnectionMetadata;
       expect(connectionMetadata.isAuthenticated, true);
       expect(cramResponse.data, 'success');
+
       //Update Verb
       var updateVerbHandler = UpdateVerbHandler(keyStore);
       var updateResponse = Response();
@@ -95,6 +96,8 @@ void main() {
       updateVerbParams.putIfAbsent('value', () => '99899');
       await updateVerbHandler.processVerb(
           updateResponse, updateVerbParams, atConnection);
+
+      int ttb = 1000; // ttb, in milliseconds
       //Update Meta
       var updateMetaVerbHandler =
           UpdateMetaVerbHandler(keyStoreManager.getKeyStore());
@@ -102,9 +105,10 @@ void main() {
       var updateMetaVerbParam = HashMap<String, String>();
       updateMetaVerbParam.putIfAbsent('atSign', () => '@sitaram');
       updateMetaVerbParam.putIfAbsent('atKey', () => 'phone');
-      updateMetaVerbParam.putIfAbsent('ttb', () => '10000');
+      updateMetaVerbParam.putIfAbsent('ttb', () => ttb.toString());
       await updateMetaVerbHandler.processVerb(
           updateMetaResponse, updateMetaVerbParam, atConnection);
+
       // Look Up verb
       var localLookUpResponse = Response();
       var localLookupVerbHandler = LocalLookupVerbHandler(keyStore);
@@ -113,8 +117,9 @@ void main() {
       localLookVerbParam.putIfAbsent('atKey', () => 'phone');
       await localLookupVerbHandler.processVerb(
           localLookUpResponse, localLookVerbParam, atConnection);
-      expect(localLookUpResponse.data, null);
-      await Future.delayed(Duration(seconds: 12));
+      expect(localLookUpResponse.data, null); // should be null, as we have not yet reached ttb
+
+      await Future.delayed(Duration(milliseconds: ttb));
       await localLookupVerbHandler.processVerb(
           localLookUpResponse, localLookVerbParam, atConnection);
       expect(localLookUpResponse.data, '99899');
@@ -148,6 +153,7 @@ void main() {
           atConnection.getMetaData() as InboundConnectionMetadata;
       expect(connectionMetadata.isAuthenticated, true);
       expect(cramResponse.data, 'success');
+
       //Update Verb
       var updateVerbHandler = UpdateVerbHandler(keyStore);
       var updateResponse = Response();
@@ -157,6 +163,9 @@ void main() {
       updateVerbParams.putIfAbsent('value', () => 'hyderabad');
       await updateVerbHandler.processVerb(
           updateResponse, updateVerbParams, atConnection);
+
+      int ttl = 1000; // in milliseconds
+
       //Update Meta
       var updateMetaVerbHandler =
           UpdateMetaVerbHandler(keyStoreManager.getKeyStore());
@@ -164,9 +173,10 @@ void main() {
       var updateMetaVerbParam = HashMap<String, String>();
       updateMetaVerbParam.putIfAbsent('atSign', () => '@sitaram');
       updateMetaVerbParam.putIfAbsent('atKey', () => 'location');
-      updateMetaVerbParam.putIfAbsent('ttl', () => '10000');
+      updateMetaVerbParam.putIfAbsent('ttl', () => ttl.toString());
       await updateMetaVerbHandler.processVerb(
           updateMetaResponse, updateMetaVerbParam, atConnection);
+
       // Look Up verb
       var localLookUpResponse = Response();
       var localLookupVerbHandler = LocalLookupVerbHandler(keyStore);
@@ -175,12 +185,13 @@ void main() {
       localLookVerbParam.putIfAbsent('atKey', () => 'location');
       await localLookupVerbHandler.processVerb(
           localLookUpResponse, localLookVerbParam, atConnection);
-      expect(localLookUpResponse.data, 'hyderabad');
-      await Future.delayed(Duration(seconds: 10));
+      expect(localLookUpResponse.data, 'hyderabad'); // ttl not yet reached, value will be live
+
+      await Future.delayed(Duration(milliseconds: ttl));
       var localLookUpResponse1 = Response();
       await localLookupVerbHandler.processVerb(
           localLookUpResponse1, localLookVerbParam, atConnection);
-      expect(localLookUpResponse1.data, null);
+      expect(localLookUpResponse1.data, null); // ttl has passed, value should no longer be live
     });
     tearDown(() async => await tearDownFunc());
   });

--- a/at_secondary/at_secondary_server/test/update_verb_test.dart
+++ b/at_secondary/at_secondary_server/test/update_verb_test.dart
@@ -594,38 +594,46 @@ void main() {
       var updateVerbHandler = UpdateVerbHandler(keyStore);
       var updateResponse = Response();
       var updateVerbParams = HashMap<String, String>();
+
+      int ttl = 1000; // in milliseconds
+      int ttb = 1000; // in milliseconds
+
       updateVerbParams.putIfAbsent(AT_SIGN, () => '@sitaram');
       updateVerbParams.putIfAbsent(AT_KEY, () => 'location');
-      updateVerbParams.putIfAbsent(AT_TTL, () => '10000');
-      updateVerbParams.putIfAbsent(AT_TTB, () => '10000');
+      updateVerbParams.putIfAbsent(AT_TTL, () => ttl.toString());
+      updateVerbParams.putIfAbsent(AT_TTB, () => ttb.toString());
       updateVerbParams.putIfAbsent(AT_VALUE, () => 'hyderabad');
+
       await updateVerbHandler.processVerb(
           updateResponse, updateVerbParams, atConnection);
-      //LLOOKUP Verb - TTB
-      var localLookUpResponse_ttb = Response();
+
+      //LLOOKUP Verb - Before TTB
+      var localLookUpResponseBeforeTtb = Response();
       var localLookupVerbHandler = LocalLookupVerbHandler(keyStore);
       var localLookVerbParam = HashMap<String, String>();
       localLookVerbParam.putIfAbsent(AT_SIGN, () => '@sitaram');
       localLookVerbParam.putIfAbsent(AT_KEY, () => 'location');
       await localLookupVerbHandler.processVerb(
-          localLookUpResponse_ttb, localLookVerbParam, atConnection);
-      expect(localLookUpResponse_ttb.data, null);
-      await Future.delayed(Duration(seconds: 10));
+          localLookUpResponseBeforeTtb, localLookVerbParam, atConnection);
+      expect(localLookUpResponseBeforeTtb.data, null); // should be null, value has not passed ttb
+
       //LLOOKUP Verb - After TTB
-      var localLookUpResponse_ttb1 = Response();
+      await Future.delayed(Duration(milliseconds: ttb));
+      var localLookUpResponseAfterTtb = Response();
       localLookVerbParam.putIfAbsent(AT_SIGN, () => '@sitaram');
       localLookVerbParam.putIfAbsent(AT_KEY, () => 'location');
       await localLookupVerbHandler.processVerb(
-          localLookUpResponse_ttb1, localLookVerbParam, atConnection);
-      expect(localLookUpResponse_ttb1.data, 'hyderabad');
-      await Future.delayed(Duration(seconds: 10));
+          localLookUpResponseAfterTtb, localLookVerbParam, atConnection);
+      expect(localLookUpResponseAfterTtb.data, 'hyderabad'); // after ttb has passed, the value should exist
+
       //LLOOKUP Verb - After TTL
-      var localLookUpResponse_ttl = Response();
+      await Future.delayed(Duration(milliseconds: ttl));
+      var localLookUpResponseAfterTtl = Response();
       localLookVerbParam.putIfAbsent(AT_SIGN, () => '@sitaram');
       localLookVerbParam.putIfAbsent(AT_KEY, () => 'location');
       await localLookupVerbHandler.processVerb(
-          localLookUpResponse_ttl, localLookVerbParam, atConnection);
-      expect(localLookUpResponse_ttl.data, null);
+          localLookUpResponseAfterTtl, localLookVerbParam, atConnection);
+      expect(localLookUpResponseAfterTtl.data, null); // after ttl has passed, the value should no longer be live
     });
 
     test('Test to verify reset of TTB', () async {


### PR DESCRIPTION
### NOTE!
This branch includes changes to at_persistence_secondary_server, so at_secondary_server's pubspec.yaml in this branch has a dependency override to get at_persistence_secondary_server from this same branch rather than from pub.dev.

**When this PR is merged**, it should immediately be followed by
- [x] Publish new version of at_persistence_secondary_server (its pupspec.yaml and CHANGELOG.md are ready to go)
- [x] Create a new PR which removes the dependency override for at_persistence_secondary_server from at_secondary_server's pubspec.yaml

### Update, May 12
This is why automated test packs are among the most valuable, if not **_the_** most valuable, of a platform's assets
* I un-skipped the e2e tests for notifications to non-existent destination atSigns, which had previously been marked 'skip' because the tests after them were flaking at the time (for a problem which was subsequently fixed)
* However the un-skipping now caused some flakiness (a different flakiness, caused because I have significantly changed various server config settings - number of retries, quarantine interval, etc)
* Stared at the cicd1 secondary logs on the cicd1 VM and eventually figured out that when connect failed for a given atSign, _processNotificationQueue would not process any other atSign in its current run
* Fixed this so that when connect fails during _processNotificationQueue, then the notifications are re-enqueued for that atSign but the while loop moves on to processing the notifications for the next atSign, if any.

### Main PR description follows
**- What I did**
Removed all avoidable server-side latency under normal conditions when delivering notifications from one atSign to another. (Normal conditions means that both secondary servers are available, connectable and functioning normally)
Lower bound of latency inside the sending secondary server is now approximately 2.5 milliseconds. With regards to total end-to-end latency, for short encrypted messages, the combination of Client-1 encryption time, client-1-to-server-1 communication time, server-2-to-client-2 communication time and client-2 decryption ( excluding other network latency caused by e.g. speed-of-light), adds about another 2.5 milliseconds, giving an overall lower bound for end-to-end latency of approximately 5 milliseconds. 

**- How I did it**
_(All of the 'how I did it' info here comes from this PR's commits' messages. As this PR also contains some logging and de-linting changes, reviewers will likely find it easier to review the changed files one commit at a time)_

In the _at_persistence_secondary_server_ package:
  * in AtNotificationKeystore, publish the new notification event before persisting

In the _at_secondary_server_ package:
* notify_connection_pool.dart
  * added pool.init(size) method. init(size) is called by AtSecondaryImpl when it is starting.
  * pool.get(atSign): Removed redundant second call to _hasCapacity() on the underlying OutboundClientPool
* at_secondary_impl.dart
  * Removed some dead code
  * Moved initialization of the notifications ResourceManager to _after_ the initialization of the OutboundClientManager
  * Uses new init(size) method on the ResourceManager, which in turn calls the new init(size) method on NotifyConnectionPool
* notification_manager_impl.dart
  * NotificationManager_storeNotificationInQueue (called by the public NotificationManager.notify method) now
    1. calls queueManager.enqueue(notification) before persisting it
    2. nudges the notifications ResourceManager to let it know there is a new notification ready to send
* update_verb_handler.dart
  * queues the notification for delivery (via NotificationManager.notify()) before persisting it
  * de-linted
* resource_manager.dart
  * Enhanced the queue processing so that it still periodically runs on a timer, but also can be 'nudged' into action at any time (e.g. NotificationManager and UpdateVerbHandler as described above)
  * Added boolean guard _isProcessingQueue to ensure that the main queue processing loop, in the _processNotificationQueue() function, is not re-entrant
  * Added boolean _nudged so that when _processNotificationQueue() completes, it knows that it should immediately run again
  * Added new init(outboundConnectionsLimit) method (called by AtSecondaryImpl while **it** is starting) which in turns initializes the NotifyConnectionsPool with size _outboundConnectionsLimit
  * Removed this line of code from the main processing for a given atSign within _processNotificationQueue() : `AtNotificationMap.getInstance().removeWaitTimeEntry(atSign);` and moved it into _sendNotifications in order to fix a race-condition bug where
      * if a new notification for a given atSign was enqueued by the NotificationManager at the same time as _processNotificationQueue() was processing previously-queued notifications for **that same atSign** (the window for this to occur is provided by `var outboundClient = await _connect(atSign);` which can be very long)
      * then the next time _processNotificationQueue() would run, with no other notification having been enqueued for that atSign in the interim, it would find nothing to process because the atSign had been removed from the waitTimeMap
  * Changed _sendNotifications so it no longer closes the outbound connection after delivering all of the notifications for a given atSign. Keeping the connection open means that we avoid the (significant) latency added by creating and authenticating a new connection each time.
* at_notification_map.dart : Bug-fix: Made the empty list strongly typed in AtNotificationMap.remove() which was previously untyped and therefore being returned as a ListIterator\<dynamic\>, which was in turn causing problems elsewhere when casting to Iterator\<AtNotification\>
* Made OutboundClientPool usable as an LRU pool
  * Added lastUsed DateTime field to OutboundClient class; field is updated to DateTime.now() every time a method is called
  * Added removeLeastRecentlyUsed() method to OutboundClientPool. Sorts the clients in the pool by lastUsed, ascending
  * Modified NotifyConnectionPool to call removeLeastRecentlyUsed() on its OutboundClientPool if it is at capacity
  * Modified OutboundClientManager to call removeLeastRecentlyUsed() on its OutboundClientPool if it is at capacity
  * Added some tests for direct use of removeLeastRecentlyUsed() method
  * Added some tests on NotifyConnectionsPool to verify LRU behaviour of its underlying OutboundClientPool

**- How to verify it**
All existing and new (in this PR) tests should pass.

**- Description for the changelog**
Removed all avoidable server-side latency under normal conditions when delivering notifications from one atSign to another. 