### PR TITLE
Fix compaction when null commitId

### DIFF
--- a/at_secondary/at_persistence_secondary_server/lib/src/log/commitlog/commit_log_keystore.dart
+++ b/at_secondary/at_persistence_secondary_server/lib/src/log/commitlog/commit_log_keystore.dart
@@ -200,7 +200,6 @@ class CommitLogKeyStore
     commitLogMap.forEach((key, value) {
       if (value.commitId == null) {
         keysWithNullCommitIdsInValue.add(key);
-        commitLogMap.remove(key);
         _logger.severe('Commit ID is null for key $key with value $value');
       }
     });

--- a/at_secondary/at_persistence_secondary_server/lib/src/log/commitlog/commit_log_keystore.dart
+++ b/at_secondary/at_persistence_secondary_server/lib/src/log/commitlog/commit_log_keystore.dart
@@ -350,9 +350,7 @@ class CommitLogKeyStore
 
     await Future.forEach(keys, (key) async {
       var value = await getValue(key);
-      if (value != null && value.commitId != null) {
-        commitLogMap.putIfAbsent(key, () => value);
-      }
+      commitLogMap.putIfAbsent(key, () => value);
     });
     return commitLogMap;
   }


### PR DESCRIPTION
**- What I did**
Defensive code to fix #469
Also cleaned up lint warnings

**- How I did it**
* Changed getDuplicateEntries so while iterating over the map it keeps track of the entries where commitId is null by adding the keys to a set; then after the iteration is complete, it goes through that set and removes from the map.
* I considered changing the toMap() method so it didn't add values with null commitIds but decided that might have unexpected side-effects as toMap() is used by _getValues which is used a lot by other methods
* Many of the lint clean-ups were to do with style guide which recommends using a straight for loop rather than .forEach(...) in some situations

**- How to verify it**
* Tests should pass
* the `@the_bluebird` secondary should stop crash-looping once it is running a secondary server version which includes this change

**- Description for the changelog**
Defensive code to prevent commit log compaction crashing if it finds an entry with a null commitId
