### PR TITLE
Fix HandshakeException handling

### DIFF
--- a/at_secondary/at_secondary_server/lib/src/server/at_secondary_impl.dart
+++ b/at_secondary/at_secondary_server/lib/src/server/at_secondary_impl.dart
@@ -230,7 +230,7 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
         return;
       }
       var _sessionID = '_' + Uuid().v4();
-      var connection;
+      InboundConnection? connection;
       try {
         logger.finer(
             'In _listen - clientSocket.peerCertificate : ${clientSocket.peerCertificate}');
@@ -244,9 +244,8 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
             .handle(e, atConnection: connection, clientSocket: clientSocket);
       }
     }), onError: (error) {
-      logger.severe(error);
-      GlobalExceptionHandler.getInstance()
-          .handle(InternalServerError(error.toString()));
+      // We've got no action to take here, let's just log a warning
+      logger.warning("ServerSocket.listen called onError with '$error'");
     });
   }
 


### PR DESCRIPTION
**- What I did**
* Fixed issue where server would terminate upon a HandshakeException from ServerSocket.listen's onError handler

**- How I did it**
* GlobalExceptionHandler.handle(...) adjusted to match the new exception hierarchy
* Our onError() callback for ServerSocket.listen no longer throws an exception but just logs a warning, as there's no useful action to take
* Fixed the code in GlobalExceptionHandler so if we ever do need to terminate the secondary, then it shuts down cleanly by calling stop() on the secondary

**- How to verify it**
Tests should pass

**- Additional context**
* When this problem manifested after 3.0.16 was released, why was @cconstab's secondary crashing apparently on demand? Because he was running a version of a client app which had old code in it which would trigger a HandshakeException in the secondary every single time the app started up and connected to the secondary. So Colin's secondaries were crashing by far the most often. However HandshakeExceptions can and do happen for a whole bunch of reasons, hence a much lower but non-zero rate of server terminations in other secondaries.
* Bug was caused by change in at_commons which made AtServerException a super-class of multiple other server-side exceptions, including InternalServerError; ServerSocket.listen's onError handler was throwing InternalServerError - this was perfectly fine when InternalServerError was just a subclass of AtException but it's now a subclass of AtServerException; in turn, the GlobalExceptionHandler was treating AtServerExceptions, which are only directly created and thrown by unrecoverable exceptions during startup, as fatal, and terminating the secondary - even though there is no code path where an actual AtServerException can make its way to the GlobalExceptionHandler (although now that it's a superclass, its subclasses can)

**- Description for the changelog**
Fix HandshakeException handling