### PR TITLE
build: upgrade at_persistence_secondary_server version to 3.0.26

### DIFF
--- a/at_secondary/at_persistence_secondary_server/CHANGELOG.md
+++ b/at_secondary/at_persistence_secondary_server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.26
+- Replace null commitId's with hive internal key on secondary server startup
+- Return commit entry with highest commitId from lastSyncedEntry
+- Upgrade at_commons version for AtException hierarchy
 ## 3.0.25
 - To reduce latency on notifications, publish the event for the notification before persisting the notification 
 ## 3.0.24

--- a/at_secondary/at_persistence_secondary_server/pubspec.yaml
+++ b/at_secondary/at_persistence_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_persistence_secondary_server
 description: A Dart library with the implementation classes for the persistence layer of the secondary server.
-version: 3.0.25
+version: 3.0.26
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://atsign.dev
 
@@ -14,8 +14,8 @@ dependencies:
   crypto: ^3.0.1
   uuid: ^3.0.4
   at_persistence_spec: ^2.0.5
-  at_utils: ^3.0.8
-  at_commons: ^3.0.11
+  at_utils: ^3.0.10
+  at_commons: ^3.0.17
   at_utf7: ^1.0.0
 
 #dependency_overrides:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
1. Upgrade at_persistence_secondary_server version to 3.0.26
2. Upgrade dependencies in at_persistence_secondary_server to latest versions.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->