### PR TITLE
fix: List.lastWhere does not return null and update regex

### DIFF
--- a/at_secondary/at_persistence_secondary_server/lib/src/log/commitlog/commit_log_keystore.dart
+++ b/at_secondary/at_persistence_secondary_server/lib/src/log/commitlog/commit_log_keystore.dart
@@ -113,7 +113,7 @@ class CommitLogKeyStore
       // Iterate through the regex's in the _lastSyncedEntryCacheMap.
       // Updates the commitEntry against the matching regexes.
       for (var regex in _lastSyncedEntryCacheMap.keys) {
-        if (RegExp(regex).hasMatch(commitEntry.atKey!)) {
+        if (_isRegexMatches(commitEntry.atKey!, regex)) {
           _lastSyncedEntryCacheMap[regex] = commitEntry;
         }
       }
@@ -150,7 +150,7 @@ class CommitLogKeyStore
     var values = await _getValues();
     var lastCommittedEntry = values.lastWhere(
         (entry) => (_isRegexMatches(entry.atKey, regex)),
-        orElse: () => null);
+        orElse: () => NullCommitEntry());
     var lastCommittedSequenceNum =
         (lastCommittedEntry != null) ? lastCommittedEntry.key : null;
     return lastCommittedSequenceNum;


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
1. In the latest Dart version, List.lastWhere clause throws error when returning null. Hence modified code to return `NullCommitEntry`

2. Modified code related lastSyncedEntryCacheMap to accept internal keys.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->