### PR TITLE
fix: Fixed truncateForLogging function so it doesn't ignore characters after a newline.

### DIFF
--- a/at_secondary/at_secondary_server/lib/src/connection/base_connection.dart
+++ b/at_secondary/at_secondary_server/lib/src/connection/base_connection.dart
@@ -56,13 +56,9 @@ abstract class BaseConnection extends AtConnection {
     }
   }
 
-  static String truncateForLogging(String toLog, {int cutOffAfter = 1000}) {
+  static String truncateForLogging(String toLog, {int cutOffAfter = 2100}) {
     if (toLog.length > cutOffAfter) {
       toLog = '${toLog.substring(0, cutOffAfter)} [truncated, ${toLog.length - cutOffAfter} more chars]';
-    }
-    var lastNewLinePos = toLog.lastIndexOf("\n");
-    if (lastNewLinePos > -1) {
-      toLog = toLog.substring(0, lastNewLinePos);
     }
     return toLog;
   }


### PR DESCRIPTION
**- What I did**
Fixed truncateForLogging function so it doesn't ignore characters after a newline.

**- How I did it**
Removed code which was ignoring characters after a newline.

**- Description for the changelog**
fix: Fixed truncateForLogging function so it doesn't ignore characters after a newline.