### PR TITLE
feat: enable dependabot beta ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,5 @@
 version: 2
+enable-beta-ecosystems: true
 updates:
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
pub packages are still in beta for dependabot, so we need to enable the beta ecosystem to get automated PRs for pubspec.yaml

**- What I did**

added line to enable beta ecosystem per guidance at https://github.blog/changelog/2022-04-05-pub-beta-support-for-dependabot-version-updates/

**- How to verify it**

Dependabot should start raising automated PRs (as we've updated some of our packages already).

**- Description for the changelog**

feat: enable dependabot beta ecosystem