### PR TITLE
chore: failed dependabot pub changes for major change to lints

### DIFF
--- a/at_secondary/at_secondary_server/pubspec.yaml
+++ b/at_secondary/at_secondary_server/pubspec.yaml
@@ -59,4 +59,4 @@ dev_dependencies:
   test: ^1.17.3
   coverage: ^1.0.3
   mockito: ^5.0.7
-  lints: ^1.0.1
+  lints: ^2.0.0


### PR DESCRIPTION
Failed dependabot run identified that lints could be bumped to new major version

**- What I did**

Standalone PR for this rather than a rollup as it's a (potentially) breaking change.

**- How to verify it**

Do our tests still work?

**- Description for the changelog**

chore: failed dependabot pub changes for major change to lints