### PR TITLE
chore: failed dependabot pub changes for major change to basic_utils

### DIFF
--- a/at_secondary/at_secondary_server/pubspec.yaml
+++ b/at_secondary/at_secondary_server/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   crypto: 3.0.1
   crypton: 2.0.1
   collection: 1.15.0
-  basic_utils: 3.0.2
+  basic_utils: 4.4.2
   at_persistence_secondary_server: 3.0.30
   at_lookup: 3.0.28
   at_server_spec: 3.0.9


### PR DESCRIPTION
Failed dependabot run for pub identified that basic_utils can be upgraded to a new major version

**- What I did**

Standalone PR rather than a rollup due to the potential for breakage.

**- How to verify it**

Automated tests.

**- Description for the changelog**

chore: failed dependabot pub changes for major change to basic_utils