### PR TITLE
fix: invalidate commit log cache

### DIFF
--- a/at_secondary/at_persistence_secondary_server/CHANGELOG.md
+++ b/at_secondary/at_persistence_secondary_server/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.31
+- Invalidate commit log cache on removing entry from commit log
 ## 3.0.30
 - Enhance KeyNotFoundException to chain into exception hierarchy.
 - Upgrade at_commons version to 3.0.20 to encrypt notify text

--- a/at_secondary/at_persistence_secondary_server/lib/src/log/commitlog/commit_log_keystore.dart
+++ b/at_secondary/at_persistence_secondary_server/lib/src/log/commitlog/commit_log_keystore.dart
@@ -135,7 +135,8 @@ class CommitLogKeyStore
       if (commitEntry != null) {
         final key = commitEntry.atKey;
         final value = _commitLogCacheMap.remove(key);
-        _logger.finest('removed value: $value');
+        _logger.finest(
+            'removed key : ${commitEntry.atKey} from commit log. value: $value');
       }
     } on Exception catch (e) {
       throw DataStoreException('Exception deleting entry:${e.toString()}');

--- a/at_secondary/at_persistence_secondary_server/lib/src/log/commitlog/commit_log_keystore.dart
+++ b/at_secondary/at_persistence_secondary_server/lib/src/log/commitlog/commit_log_keystore.dart
@@ -129,7 +129,14 @@ class CommitLogKeyStore
   @override
   Future<void> remove(int commitId) async {
     try {
+      final commitEntry = (await _getBox() as Box).get(commitId);
       await _getBox().delete(commitId);
+      // invalidate cache for the removed entry
+      if (commitEntry != null) {
+        final key = commitEntry.atKey;
+        final value = _commitLogCacheMap.remove(key);
+        _logger.finest('removed value: $value');
+      }
     } on Exception catch (e) {
       throw DataStoreException('Exception deleting entry:${e.toString()}');
     } on HiveError catch (e) {

--- a/at_secondary/at_persistence_secondary_server/lib/src/log/commitlog/commit_log_keystore.dart
+++ b/at_secondary/at_persistence_secondary_server/lib/src/log/commitlog/commit_log_keystore.dart
@@ -133,10 +133,9 @@ class CommitLogKeyStore
       await _getBox().delete(commitId);
       // invalidate cache for the removed entry
       if (commitEntry != null) {
-        final key = commitEntry.atKey;
-        final value = _commitLogCacheMap.remove(key);
+        _commitLogCacheMap.remove(commitEntry.atKey);
         _logger.finest(
-            'removed key : ${commitEntry.atKey} from commit log. value: $value');
+            'removed key : ${commitEntry.atKey} from commit log.');
       }
     } on Exception catch (e) {
       throw DataStoreException('Exception deleting entry:${e.toString()}');

--- a/at_secondary/at_persistence_secondary_server/pubspec.yaml
+++ b/at_secondary/at_persistence_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_persistence_secondary_server
 description: A Dart library with the implementation classes for the persistence layer of the secondary server.
-version: 3.0.30
+version: 3.0.31
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://atsign.dev
 


### PR DESCRIPTION
**- What I did**
- Invalidated commit log cache when an entry is removed from commit log
**- How I did it**
- modified implementation of commit log key store --> remove method. if commit entry of a passed commit id is not null, remove the key from cache
**- How to verify it**
- run the group of unit tests in commit log test -  A group of tests to verify commit log cache map
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->