### PR TITLE
feat: remove malformed keys at server startup

### DIFF
--- a/at_secondary/at_secondary_server/config/config.yaml
+++ b/at_secondary/at_secondary_server/config/config.yaml
@@ -36,6 +36,8 @@ hive:
 
   # The frequent time interval(in minutes) to run job which removes the expired keys from secondary storage.
   expiringRunFrequencyMins: 10
+  # List of malformed keys that will be deleted on server startup
+  malformedKeys: 'public:publickey'
 
 # The @Protocol connection configurations.
 connection:

--- a/at_secondary/at_secondary_server/lib/src/server/at_secondary_config.dart
+++ b/at_secondary/at_secondary_server/lib/src/server/at_secondary_config.dart
@@ -84,6 +84,7 @@ class AtSecondaryConfig {
   //Sync Configurations
   static final int _syncBufferSize = 5242880;
   static final int _syncPageLimit = 100;
+  static final List<String> _malformedKeys = [];
 
   //version
   static final String? _secondaryServerVersion =
@@ -603,6 +604,18 @@ class AtSecondaryConfig {
       return getConfigFromYaml(['sync', 'pageLimit']);
     } on ElementNotFoundException {
       return _syncPageLimit;
+    }
+  }
+
+  static List<String> get malformedKeysList {
+    var result = _getStringEnvVar('hiveMalformedKeys');
+    if (result != null) {
+      return result.split(',');
+    }
+    try {
+      return getConfigFromYaml(['hive', 'malformedKeys']).split(',');
+    } on ElementNotFoundException {
+      return _malformedKeys;
     }
   }
 

--- a/at_secondary/at_secondary_server/lib/src/server/at_secondary_impl.dart
+++ b/at_secondary/at_secondary_server/lib/src/server/at_secondary_impl.dart
@@ -564,12 +564,13 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
       List<String> malformedKeys = AtSecondaryConfig.malformedKeysList;
       logger.finest('malformed keys from config: $malformedKeys');
       for (String key in malformedKeys) {
-        int? commitId = await _secondaryPersistenceStore
-            .getSecondaryKeyStore()!
-            .remove(key);
-        logger.finest('commitId for removed key $key: $commitId');
-        // do not sync back the deleted malformed key. remove from commit log
-        await _commitLog.commitLogKeyStore.remove(commitId);
+        final keyStore = _secondaryPersistenceStore.getSecondaryKeyStore()!;
+        if (keyStore.isKeyExists(key)) {
+          int? commitId = await keyStore.remove(key);
+          logger.warning('commitId for removed key $key: $commitId');
+          // do not sync back the deleted malformed key. remove from commit log
+          await _commitLog.commitLogKeyStore.remove(commitId);
+        }
       }
     } on Exception catch (e) {
       logger.severe('Exception in removing malformed key: ${e.toString()}');

--- a/at_secondary/at_secondary_server/lib/src/server/at_secondary_impl.dart
+++ b/at_secondary/at_secondary_server/lib/src/server/at_secondary_impl.dart
@@ -560,14 +560,19 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
   }
 
   Future<void> _removeMalformedKeys() async {
-    List<String> malformedKeys = AtSecondaryConfig.malformedKeysList;
-    logger.finest('malformed keys from config: $malformedKeys');
-    for (String key in malformedKeys) {
-      int? commitId =
-          await _secondaryPersistenceStore.getSecondaryKeyStore()!.remove(key);
-      logger.finest('commitId for removed key : $commitId');
-      // do not sync back the deleted malformed key. remove from commit log
-      await _commitLog.commitLogKeyStore.remove(commitId);
+    try {
+      List<String> malformedKeys = AtSecondaryConfig.malformedKeysList;
+      logger.finest('malformed keys from config: $malformedKeys');
+      for (String key in malformedKeys) {
+        int? commitId = await _secondaryPersistenceStore
+            .getSecondaryKeyStore()!
+            .remove(key);
+        logger.finest('commitId for removed key $key: $commitId');
+        // do not sync back the deleted malformed key. remove from commit log
+        await _commitLog.commitLogKeyStore.remove(commitId);
+      }
+    } on Exception catch (e) {
+      logger.severe('Exception in removing malformed key: ${e.toString()}');
     }
   }
 

--- a/at_secondary/at_secondary_server/pubspec.yaml
+++ b/at_secondary/at_secondary_server/pubspec.yaml
@@ -17,21 +17,21 @@ dependencies:
   crypton: 2.0.1
   collection: 1.15.0
   basic_utils: 3.0.2
-  at_persistence_secondary_server: 3.0.30
+#  at_persistence_secondary_server: 3.0.30
   at_lookup: 3.0.28
   at_server_spec: 3.0.9
 
-#dependency_overrides:
+dependency_overrides:
 #  at_commons:
 #    git:
 #      url: https://github.com/atsign-foundation/at_tools.git
 #      path: at_commons
 #      ref: new_set_verb
-#  at_persistence_secondary_server:
-#   git:
-#     url: https://github.com/atsign-foundation/at_server.git
-#     path: at_secondary/at_persistence_secondary_server
-#     ref: set_verb
+  at_persistence_secondary_server:
+   git:
+     url: https://github.com/atsign-foundation/at_server.git
+     path: at_secondary/at_persistence_secondary_server
+     ref: invalidate_commit_log_cache
 #  at_server_spec:
 #    git:
 #      url: https://github.com/atsign-foundation/at_server.git

--- a/at_secondary/at_secondary_server/pubspec.yaml
+++ b/at_secondary/at_secondary_server/pubspec.yaml
@@ -17,21 +17,21 @@ dependencies:
   crypton: 2.0.1
   collection: 1.15.0
   basic_utils: 3.0.2
-#  at_persistence_secondary_server: 3.0.30
+  at_persistence_secondary_server: 3.0.31
   at_lookup: 3.0.28
   at_server_spec: 3.0.9
 
-dependency_overrides:
+#dependency_overrides:
 #  at_commons:
 #    git:
 #      url: https://github.com/atsign-foundation/at_tools.git
 #      path: at_commons
 #      ref: new_set_verb
-  at_persistence_secondary_server:
-   git:
-     url: https://github.com/atsign-foundation/at_server.git
-     path: at_secondary/at_persistence_secondary_server
-     ref: invalidate_commit_log_cache
+#  at_persistence_secondary_server:
+#   git:
+#     url: https://github.com/atsign-foundation/at_server.git
+#     path: at_secondary/at_persistence_secondary_server
+#     ref: trunk
 #  at_server_spec:
 #    git:
 #      url: https://github.com/atsign-foundation/at_server.git


### PR DESCRIPTION
**- What I did**
- removed malformed keys on server startup
**- How I did it**
- configure list of malformed keys in config.yaml
- added a method _removeMalformedKeys in at_secondary_impl.dart. Read the malformed keys list from config and remove from keystore and commit log
**- How to verify it**
- start a secondary server without the changes. Run the below command in auth mode
update:public:publickey <some_random_value>
- restart the server with the changes
- public:publickey should not appear in scan and sync:from commands
