### PR TITLE
feat: add encoding hive key store and update verb builder and refacto…

### DIFF
--- a/at_secondary/at_persistence_secondary_server/CHANGELOG.md
+++ b/at_secondary/at_persistence_secondary_server/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.32
+- Add 'encoding' to AtMetadata which represents the type of encoding
 ## 3.0.31
 - Invalidate commit log cache on removing entry from commit log
 ## 3.0.30

--- a/at_secondary/at_persistence_secondary_server/lib/src/compaction/at_compaction_job.dart
+++ b/at_secondary/at_persistence_secondary_server/lib/src/compaction/at_compaction_job.dart
@@ -22,12 +22,12 @@ class AtCompactionJob {
           atCompactionConfig, atLogType, _secondaryPersistenceStore);
     });
   }
-  
+
   //Method to cancel the current schedule. The Cron instance is not close and can be re-used
   Future<void> stopCompactionJob() async {
     await _schedule.cancel();
   }
-  
+
   //Method to stop compaction and also close the Cron instance.
   void close() {
     _cron.close();

--- a/at_secondary/at_persistence_secondary_server/lib/src/keystore/hive_keystore.dart
+++ b/at_secondary/at_persistence_secondary_server/lib/src/keystore/hive_keystore.dart
@@ -77,7 +77,8 @@ class HiveKeystore implements SecondaryKeyStore<String, AtData?, AtMetaData?> {
       bool? isEncrypted,
       String? dataSignature,
       String? sharedKeyEncrypted,
-      String? publicKeyChecksum}) async {
+      String? publicKeyChecksum,
+      String? encoding}) async {
     var result;
     // Default the commit op to just the value update
     CommitOp commitOp = CommitOp.UPDATE;
@@ -109,7 +110,8 @@ class HiveKeystore implements SecondaryKeyStore<String, AtData?, AtMetaData?> {
             isEncrypted: isEncrypted,
             dataSignature: dataSignature,
             sharedKeyEncrypted: sharedKeyEncrypted,
-            publicKeyChecksum: publicKeyChecksum);
+            publicKeyChecksum: publicKeyChecksum,
+            encoding: encoding);
       } else {
         AtData? existingData = await get(key);
         String hive_key = keyStoreHelper.prepareKey(key);
@@ -123,7 +125,8 @@ class HiveKeystore implements SecondaryKeyStore<String, AtData?, AtMetaData?> {
             isEncrypted: isEncrypted,
             dataSignature: dataSignature,
             sharedKeyEncrypted: sharedKeyEncrypted,
-            publicKeyChecksum: publicKeyChecksum);
+            publicKeyChecksum: publicKeyChecksum,
+            encoding: encoding);
         logger.finest('hive key:$hive_key');
         logger.finest('hive value:$hive_value');
         await persistenceManager.getBox().put(hive_key, hive_value);
@@ -154,7 +157,8 @@ class HiveKeystore implements SecondaryKeyStore<String, AtData?, AtMetaData?> {
       bool? isEncrypted,
       String? dataSignature,
       String? sharedKeyEncrypted,
-      String? publicKeyChecksum}) async {
+      String? publicKeyChecksum,
+      String? encoding}) async {
     var result;
     var commitOp;
     String hive_key = keyStoreHelper.prepareKey(key);
@@ -167,7 +171,8 @@ class HiveKeystore implements SecondaryKeyStore<String, AtData?, AtMetaData?> {
         isEncrypted: isEncrypted,
         dataSignature: dataSignature,
         sharedKeyEncrypted: sharedKeyEncrypted,
-        publicKeyChecksum: publicKeyChecksum);
+        publicKeyChecksum: publicKeyChecksum,
+        encoding: encoding);
     // Default commitOp to Update.
     commitOp = CommitOp.UPDATE;
 
@@ -182,6 +187,7 @@ class HiveKeystore implements SecondaryKeyStore<String, AtData?, AtMetaData?> {
       dataSignature ??= value.metaData!.dataSignature;
       sharedKeyEncrypted ??= value.metaData!.sharedKeyEnc;
       publicKeyChecksum ??= value.metaData!.pubKeyCS;
+      encoding ??= value.metaData!.encoding;
     }
 
     // If metadata is set, set commitOp to Update all

--- a/at_secondary/at_persistence_secondary_server/lib/src/keystore/hive_keystore_helper.dart
+++ b/at_secondary/at_persistence_secondary_server/lib/src/keystore/hive_keystore_helper.dart
@@ -28,10 +28,11 @@ class HiveKeyStoreHelper {
       bool? isEncrypted,
       String? dataSignature,
       String? sharedKeyEncrypted,
-      String? publicKeyChecksum}) {
-    var at_data = AtData();
-    at_data.data = newData.data;
-    at_data.metaData = AtMetadataBuilder(
+      String? publicKeyChecksum,
+      String? encoding}) {
+    var atData = AtData();
+    atData.data = newData.data;
+    atData.metaData = AtMetadataBuilder(
             newAtMetaData: newData.metaData,
             ttl: ttl,
             ttb: ttb,
@@ -41,10 +42,11 @@ class HiveKeyStoreHelper {
             isEncrypted: isEncrypted,
             dataSignature: dataSignature,
             sharedKeyEncrypted: sharedKeyEncrypted,
-            publicKeyChecksum: publicKeyChecksum)
+            publicKeyChecksum: publicKeyChecksum,
+            encoding: encoding)
         .build();
-    at_data.metaData!.version = 0;
-    return at_data;
+    atData.metaData!.version = 0;
+    return atData;
   }
 
   AtData prepareDataForUpdate(AtData existingData, AtData newData,
@@ -56,7 +58,8 @@ class HiveKeyStoreHelper {
       bool? isEncrypted,
       String? dataSignature,
       String? sharedKeyEncrypted,
-      String? publicKeyChecksum}) {
+      String? publicKeyChecksum,
+      String? encoding}) {
     existingData.metaData = AtMetadataBuilder(
             newAtMetaData: newData.metaData,
             existingMetaData: existingData.metaData,
@@ -68,7 +71,8 @@ class HiveKeyStoreHelper {
             isEncrypted: isEncrypted,
             dataSignature: dataSignature,
             sharedKeyEncrypted: sharedKeyEncrypted,
-            publicKeyChecksum: publicKeyChecksum)
+            publicKeyChecksum: publicKeyChecksum,
+            encoding: encoding)
         .build();
 //    (existingData.metaData!.version == null)
 //        ? existingData.metaData!.version = 0

--- a/at_secondary/at_persistence_secondary_server/lib/src/log/commitlog/commit_log_keystore.dart
+++ b/at_secondary/at_persistence_secondary_server/lib/src/log/commitlog/commit_log_keystore.dart
@@ -134,8 +134,7 @@ class CommitLogKeyStore
       // invalidate cache for the removed entry
       if (commitEntry != null) {
         _commitLogCacheMap.remove(commitEntry.atKey);
-        _logger.finest(
-            'removed key : ${commitEntry.atKey} from commit log.');
+        _logger.finest('removed key : ${commitEntry.atKey} from commit log.');
       }
     } on Exception catch (e) {
       throw DataStoreException('Exception deleting entry:${e.toString()}');

--- a/at_secondary/at_persistence_secondary_server/lib/src/model/at_meta_data.dart
+++ b/at_secondary/at_persistence_secondary_server/lib/src/model/at_meta_data.dart
@@ -1,5 +1,4 @@
 import 'package:at_commons/at_commons.dart';
-import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:at_persistence_secondary_server/src/utils/type_adapter_util.dart';
 import 'package:hive/hive.dart';
 
@@ -59,6 +58,9 @@ class AtMetaData extends HiveObject {
   @HiveField(17)
   String? pubKeyCS;
 
+  @HiveField(18)
+  String? encoding;
+
   @override
   String toString() {
     return toJson().toString();
@@ -85,6 +87,7 @@ class AtMetaData extends HiveObject {
     map[PUBLIC_DATA_SIGNATURE] = dataSignature;
     map[SHARED_KEY_ENCRYPTED] = sharedKeyEnc;
     map[SHARED_WITH_PUBLIC_KEY_CHECK_SUM] = pubKeyCS;
+    map[ENCODING] = encoding;
     return map;
   }
 
@@ -131,6 +134,7 @@ class AtMetaData extends HiveObject {
       dataSignature = json[PUBLIC_DATA_SIGNATURE];
       sharedKeyEnc = json[SHARED_KEY_ENCRYPTED];
       pubKeyCS = json[SHARED_WITH_PUBLIC_KEY_CHECK_SUM];
+      encoding = json[ENCODING];
     } catch (error) {
       print('AtMetaData.fromJson error: ' + error.toString());
     }
@@ -166,13 +170,14 @@ class AtMetaDataAdapter extends TypeAdapter<AtMetaData> {
       ..isEncrypted = fields[14]
       ..dataSignature = fields[15]
       ..sharedKeyEnc = fields[16]
-      ..pubKeyCS = fields[17];
+      ..pubKeyCS = fields[17]
+      ..encoding = fields[18];
   }
 
   @override
   void write(BinaryWriter writer, AtMetaData obj) {
     writer
-      ..writeByte(18)
+      ..writeByte(19)
       ..writeByte(0)
       ..write(obj.createdBy)
       ..writeByte(1)
@@ -208,6 +213,8 @@ class AtMetaDataAdapter extends TypeAdapter<AtMetaData> {
       ..writeByte(16)
       ..write(obj.sharedKeyEnc)
       ..writeByte(17)
-      ..write(obj.pubKeyCS);
+      ..write(obj.pubKeyCS)
+      ..writeByte(18)
+      ..write(obj.encoding);
   }
 }

--- a/at_secondary/at_persistence_secondary_server/lib/src/model/at_metadata_builder.dart
+++ b/at_secondary/at_persistence_secondary_server/lib/src/model/at_metadata_builder.dart
@@ -2,7 +2,7 @@ import 'package:at_persistence_secondary_server/at_persistence_secondary_server.
 
 /// Builder class to build [AtMetaData] object.
 class AtMetadataBuilder {
-  var atMetaData;
+  AtMetaData? atMetaData;
   var currentUtcTime = DateTime.now().toUtc();
 
   /// AtMetadata Object : Optional parameter, If atMetadata object is null a new AtMetadata object is created.
@@ -22,14 +22,15 @@ class AtMetadataBuilder {
       bool? isEncrypted,
       String? dataSignature,
       String? sharedKeyEncrypted,
-      String? publicKeyChecksum}) {
+      String? publicKeyChecksum,
+      String? encoding}) {
     newAtMetaData ??= AtMetaData();
     atMetaData = newAtMetaData;
-    atMetaData.createdAt ??= currentUtcTime;
-    atMetaData.createdBy ??= atSign;
-    atMetaData.updatedBy = atSign;
-    atMetaData.updatedAt = currentUtcTime;
-    atMetaData.status = 'active';
+    atMetaData!.createdAt ??= currentUtcTime;
+    atMetaData!.createdBy ??= atSign;
+    atMetaData!.updatedBy = atSign;
+    atMetaData!.updatedAt = currentUtcTime;
+    atMetaData!.status = 'active';
 
     //If new metadata is available, consider new metadata, else if existing metadata is available consider it.
     ttl ??= newAtMetaData.ttl;
@@ -50,6 +51,7 @@ class AtMetadataBuilder {
     dataSignature ??= newAtMetaData.dataSignature;
     sharedKeyEncrypted ??= newAtMetaData.sharedKeyEnc;
     publicKeyChecksum ??= newAtMetaData.pubKeyCS;
+    encoding ??= newAtMetaData.encoding;
 
     if (ttl != null && ttl >= 0) {
       setTTL(ttl, ttb: ttb);
@@ -69,62 +71,69 @@ class AtMetadataBuilder {
     setDataSignature(dataSignature);
     setSharedKeyEncrypted(sharedKeyEncrypted);
     setPublicKeyChecksum(publicKeyChecksum);
+    setEncoding(encoding);
   }
 
   void setTTL(int? ttl, {int? ttb}) {
     if (ttl != null) {
-      atMetaData.ttl = ttl;
-      atMetaData.expiresAt =
+      atMetaData!.ttl = ttl;
+      atMetaData!.expiresAt =
           _getExpiresAt(currentUtcTime.millisecondsSinceEpoch, ttl, ttb: ttb);
     }
   }
 
   void setTTB(int? ttb) {
     if (ttb != null) {
-      atMetaData.ttb = ttb;
-      atMetaData.availableAt =
+      atMetaData!.ttb = ttb;
+      atMetaData!.availableAt =
           _getAvailableAt(currentUtcTime.millisecondsSinceEpoch, ttb);
     }
   }
 
   void setTTR(int? ttr) {
     if (ttr != null) {
-      atMetaData.ttr = ttr;
-      atMetaData.refreshAt = _getRefreshAt(currentUtcTime, ttr);
+      atMetaData!.ttr = ttr;
+      atMetaData!.refreshAt = _getRefreshAt(currentUtcTime, ttr);
     }
   }
 
   void setCCD(bool ccd) {
-    atMetaData.isCascade = ccd;
+    atMetaData!.isCascade = ccd;
   }
 
   void setIsBinary(bool? isBinary) {
     if (isBinary != null) {
-      atMetaData.isBinary = isBinary;
+      atMetaData!.isBinary = isBinary;
     }
   }
 
   void setIsEncrypted(bool? isEncrypted) {
     if (isEncrypted != null) {
-      atMetaData.isEncrypted = isEncrypted;
+      atMetaData!.isEncrypted = isEncrypted;
     }
   }
 
   void setDataSignature(String? dataSignature) {
     if (dataSignature != null) {
-      atMetaData.dataSignature = dataSignature;
+      atMetaData!.dataSignature = dataSignature;
     }
   }
 
   void setSharedKeyEncrypted(String? sharedKeyEncrypted) {
     if (sharedKeyEncrypted != null) {
-      atMetaData.sharedKeyEnc = sharedKeyEncrypted;
+      atMetaData!.sharedKeyEnc = sharedKeyEncrypted;
     }
   }
 
   void setPublicKeyChecksum(String? publicKeyChecksum) {
     if (publicKeyChecksum != null) {
-      atMetaData.pubKeyCS = publicKeyChecksum;
+      atMetaData!.pubKeyCS = publicKeyChecksum;
+    }
+  }
+
+  void setEncoding(String? encoding) {
+    if (encoding != null && encoding.isNotEmpty) {
+      atMetaData!.encoding = encoding;
     }
   }
 
@@ -153,7 +162,7 @@ class AtMetadataBuilder {
     return today.add(Duration(seconds: ttr));
   }
 
-  AtMetaData? build() {
-    return atMetaData;
+  AtMetaData build() {
+    return atMetaData!;
   }
 }

--- a/at_secondary/at_persistence_secondary_server/lib/src/notification/at_notification_keystore.dart
+++ b/at_secondary/at_persistence_secondary_server/lib/src/notification/at_notification_keystore.dart
@@ -70,7 +70,8 @@ class AtNotificationKeystore
       bool? isEncrypted,
       String? dataSignature,
       String? sharedKeyEncrypted,
-      String? publicKeyChecksum}) async {
+      String? publicKeyChecksum,
+      String? encoding}) async {
     AtNotificationCallback.getInstance().invokeCallbacks(value);
     await _getBox().put(key, value);
   }
@@ -85,7 +86,8 @@ class AtNotificationKeystore
       bool? isEncrypted,
       String? dataSignature,
       String? sharedKeyEncrypted,
-      String? publicKeyChecksum}) async {
+      String? publicKeyChecksum,
+      String? encoding}) async {
     throw UnimplementedError();
   }
 

--- a/at_secondary/at_persistence_secondary_server/lib/src/utils/at_metadata_adapter.dart
+++ b/at_secondary/at_persistence_secondary_server/lib/src/utils/at_metadata_adapter.dart
@@ -12,7 +12,23 @@ AtMetaData? AtMetadataAdapter(Metadata metadata) {
     ..isEncrypted = metadata.isEncrypted
     ..dataSignature = metadata.dataSignature
     ..sharedKeyEnc = metadata.sharedKeyEnc
-    ..pubKeyCS = metadata.pubKeyCS;
+    ..pubKeyCS = metadata.pubKeyCS
+    ..encoding = metadata.encoding;
 
   return AtMetadataBuilder(newAtMetaData: atMetadata).build();
+}
+
+Metadata metadataAdapter(AtMetaData atMetaData) {
+  var metadata = Metadata()
+    ..ttl = atMetaData.ttl
+    ..ttb = atMetaData.ttb
+    ..ttr = atMetaData.ttr
+    ..ccd = atMetaData.isCascade
+    ..isBinary = atMetaData.isBinary
+    ..isEncrypted = atMetaData.isEncrypted
+    ..dataSignature = atMetaData.dataSignature
+    ..sharedKeyEnc = atMetaData.sharedKeyEnc
+    ..pubKeyCS = atMetaData.pubKeyCS
+    ..encoding = atMetaData.encoding;
+  return metadata;
 }

--- a/at_secondary/at_persistence_secondary_server/pubspec.yaml
+++ b/at_secondary/at_persistence_secondary_server/pubspec.yaml
@@ -13,23 +13,23 @@ dependencies:
   cron: ^0.3.0
   crypto: ^3.0.1
   uuid: ^3.0.4
-  at_persistence_spec: ^2.0.6
+  at_persistence_spec: ^2.0.7
   at_utils: ^3.0.10
-  at_commons: ^3.0.20
+  at_commons: ^3.0.22
   at_utf7: ^1.0.0
   meta: ^1.7.0
 
-dependency_overrides:
-  at_persistence_spec:
-    git:
-      url: https://github.com/atsign-foundation/at_server.git
-      path: at_persistence/at_persistence_spec
-      ref: at_persistence_encode_public_data
-  at_commons:
-    git:
-      url: https://github.com/atsign-foundation/at_tools.git
-      path: at_commons
-      ref: encode_public_data
+#dependency_overrides:
+#  at_persistence_spec:
+#    git:
+#      url: https://github.com/atsign-foundation/at_server.git
+#      path: at_persistence/at_persistence_spec
+#      ref: at_persistence_encode_public_data
+#  at_commons:
+#    git:
+#      url: https://github.com/atsign-foundation/at_tools.git
+#      path: at_commons
+#      ref: encode_public_data
 
 #  at_utils:
 #    git:

--- a/at_secondary/at_persistence_secondary_server/pubspec.yaml
+++ b/at_secondary/at_persistence_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_persistence_secondary_server
 description: A Dart library with the implementation classes for the persistence layer of the secondary server.
-version: 3.0.31
+version: 3.0.32
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://atsign.dev
 
@@ -19,21 +19,22 @@ dependencies:
   at_utf7: ^1.0.0
   meta: ^1.7.0
 
-# dependency_overrides:
-#   at_persistence_spec:
-#     git:
-#       url: https://github.com/atsign-foundation/at_server.git
-#       path: at_persistence/at_persistence_spec
-#       ref: trunk
+dependency_overrides:
+  at_persistence_spec:
+    git:
+      url: https://github.com/atsign-foundation/at_server.git
+      path: at_persistence/at_persistence_spec
+      ref: at_persistence_encode_public_data
+  at_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_tools.git
+      path: at_commons
+      ref: encode_public_data
+
 #  at_utils:
 #    git:
 #      url: https://github.com/atsign-foundation/at_tools.git
 #      path: at_utils
-#      ref: trunk
-#  at_commons:
-#    git:
-#      url: https://github.com/atsign-foundation/at_tools.git
-#      path: at_commons
 #      ref: trunk
 
 dev_dependencies:

--- a/at_secondary/at_secondary_server/lib/src/verb/handler/sync_progressive_verb_handler.dart
+++ b/at_secondary/at_secondary_server/lib/src/verb/handler/sync_progressive_verb_handler.dart
@@ -17,7 +17,7 @@ class SyncProgressiveVerbHandler extends AbstractVerbHandler {
 
   @override
   bool accept(String command) =>
-      command.startsWith(getName(VerbEnum.sync) + ':') &&
+      command.startsWith('${getName(VerbEnum.sync)}:') &&
       command.startsWith('sync:from');
 
   @override
@@ -79,49 +79,14 @@ class SyncProgressiveVerbHandler extends AbstractVerbHandler {
   Map _populateMetadata(value) {
     var metaDataMap = <String, dynamic>{};
     AtMetaData? metaData = value?.metaData;
-    if (metaData != null) {
-      if (metaData.ttl != null) {
-        metaDataMap.putIfAbsent(AT_TTL, () => metaData.ttl.toString());
-      }
-      if (metaData.ttb != null) {
-        metaDataMap.putIfAbsent(AT_TTB, () => metaData.ttb.toString());
-      }
-      if (metaData.ttr != null) {
-        metaDataMap.putIfAbsent(AT_TTR, () => metaData.ttr.toString());
-      }
-      if (metaData.isCascade != null) {
-        metaDataMap.putIfAbsent(CCD, () => metaData.isCascade.toString());
-      }
-
-      if (metaData.dataSignature != null) {
-        metaDataMap.putIfAbsent(
-            PUBLIC_DATA_SIGNATURE, () => metaData.dataSignature.toString());
-      }
-      if (metaData.isBinary != null) {
-        metaDataMap.putIfAbsent(IS_BINARY, () => metaData.isBinary.toString());
-      }
-      if (metaData.isEncrypted != null) {
-        metaDataMap.putIfAbsent(
-            IS_ENCRYPTED, () => metaData.isEncrypted.toString());
-      }
-
-      if (metaData.createdAt != null) {
-        metaDataMap.putIfAbsent(
-            CREATED_AT, () => metaData.createdAt.toString());
-      }
-      if (metaData.updatedAt != null) {
-        metaDataMap.putIfAbsent(
-            UPDATED_AT, () => metaData.updatedAt.toString());
-      }
-      if (metaData.sharedKeyEnc != null) {
-        metaDataMap.putIfAbsent(
-            SHARED_KEY_ENCRYPTED, () => metaData.sharedKeyEnc);
-      }
-      if (metaData.pubKeyCS != null) {
-        metaDataMap.putIfAbsent(
-            SHARED_WITH_PUBLIC_KEY_CHECK_SUM, () => metaData.pubKeyCS);
-      }
+    if (metaData == null) {
+      return metaDataMap;
     }
+    metaData.toJson().forEach((key, value) {
+      if (value != null) {
+        metaDataMap[key] = [value];
+      }
+    });
     return metaDataMap;
   }
 

--- a/at_secondary/at_secondary_server/lib/src/verb/handler/update_verb_handler.dart
+++ b/at_secondary/at_secondary_server/lib/src/verb/handler/update_verb_handler.dart
@@ -20,6 +20,7 @@ import 'package:at_utils/at_utils.dart';
 class UpdateVerbHandler extends ChangeVerbHandler {
   static bool? _autoNotify = AtSecondaryConfig.autoNotify;
   static Update update = Update();
+
   UpdateVerbHandler(SecondaryKeyStore? keyStore) : super(keyStore);
 
   //setter to set autoNotify value from dynamic server config "config:set".
@@ -34,7 +35,7 @@ class UpdateVerbHandler extends ChangeVerbHandler {
   // Input: command
   @override
   bool accept(String command) =>
-      command.startsWith(getName(VerbEnum.update) + ':') &&
+      command.startsWith('${getName(VerbEnum.update)}:') &&
       !command.startsWith('update:meta');
 
   // Method to return Instance of verb belongs to this VerbHandler
@@ -82,6 +83,8 @@ class UpdateVerbHandler extends ChangeVerbHandler {
       var ccd = updateParams.metadata!.ccd;
       String? sharedKeyEncrypted = updateParams.metadata!.sharedKeyEnc;
       String? publicKeyChecksum = updateParams.metadata!.pubKeyCS;
+      String? encoding = updateParams.metadata!.encoding;
+
       // Get the key using verbParams (forAtSign, key, atSign)
       if (forAtSign != null) {
         forAtSign = AtUtils.formatAtSign(forAtSign);
@@ -119,7 +122,8 @@ class UpdateVerbHandler extends ChangeVerbHandler {
         ..isEncrypted = isEncrypted
         ..dataSignature = dataSignature
         ..sharedKeyEnc = sharedKeyEncrypted
-        ..pubKeyCS = publicKeyChecksum;
+        ..pubKeyCS = publicKeyChecksum
+        ..encoding = encoding;
 
       if (_autoNotify!) {
         _notify(
@@ -141,7 +145,8 @@ class UpdateVerbHandler extends ChangeVerbHandler {
           isEncrypted: isEncrypted,
           dataSignature: dataSignature,
           sharedKeyEncrypted: sharedKeyEncrypted,
-          publicKeyChecksum: publicKeyChecksum);
+          publicKeyChecksum: publicKeyChecksum,
+          encoding: encoding);
       response.data = result?.toString();
     } on InvalidSyntaxException {
       rethrow;
@@ -204,9 +209,8 @@ class UpdateVerbHandler extends ChangeVerbHandler {
     metadata.isPublic = AtMetadataUtil.getBoolVerbParams(verbParams[IS_PUBLIC]);
     metadata.sharedKeyEnc = verbParams[SHARED_KEY_ENCRYPTED];
     metadata.pubKeyCS = verbParams[SHARED_WITH_PUBLIC_KEY_CHECK_SUM];
+    metadata.encoding = verbParams[ENCODING];
     updateParams.metadata = metadata;
     return updateParams;
   }
-
-  void _autoNotifyChange() {}
 }

--- a/at_secondary/at_secondary_server/pubspec.yaml
+++ b/at_secondary/at_secondary_server/pubspec.yaml
@@ -22,8 +22,22 @@ dependencies:
   at_server_spec: 3.0.9
   at_utils: 3.0.10
 
-#dependency_overrides:
-#  at_commons:
+dependency_overrides:
+  at_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_tools.git
+      path: at_commons
+      ref: encode_public_data
+  at_persistence_secondary_server:
+    git:
+      url: https://github.com/atsign-foundation/at_server.git
+      path: at_secondary/at_persistence_secondary_server
+      ref: at_secondary_encode_public_data
+  at_persistence_spec:
+    git:
+      url: https://github.com/atsign-foundation/at_server.git
+      path: at_persistence/at_persistence_spec
+      ref: at_persistence_encode_public_data
 #    git:
 #      url: https://github.com/atsign-foundation/at_tools.git
 #      path: at_commons


### PR DESCRIPTION
…r sync progressive verb handler

<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Add `encoding` to AtMetadata to support encoding new line character
- Add `encoding` to hive keystore methods - put and create
- Add `encoding` to update verb handler 
- Refactor code that add metadata in sync progressive verb handler. Iterate over the keys and add values that are not null instead of manually adding each key.

The changes related to encoding/decoding are in at_client repo: [PR-623](https://github.com/atsign-foundation/at_client_sdk/pull/623)

**- How I did it**
Use JSON version of update regex in when data is encoded. 

**- How to verify it**

When data contains new line character, the data is encoded with base64Encoder (as of today) and setting the encoding to type of encoding performed.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->