### PR TITLE
fix: refactor error messages and JSON encode the error responses.

### DIFF
--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -255,7 +255,7 @@ jobs:
 
       # Logs into CICD VMs and runs script to update to just pushed image
       - name: update image on cicd VMs
-        uses: appleboy/ssh-action@v0.1.4
+        uses: appleboy/ssh-action@v0.1.5
         with:
           host: "cicd1.atsign.wtf,cicd2.atsign.wtf"
           username: ubuntu
@@ -654,7 +654,7 @@ jobs:
           docker push atsigncompany/secondary:dess-x64
 
       - name: Create dess-arm64 label
-        uses: appleboy/ssh-action@v0.1.4
+        uses: appleboy/ssh-action@v0.1.5
         with:
           host: "arm64cicd.atsign.wtf"
           username: ubuntu
@@ -666,7 +666,7 @@ jobs:
 
       # Logs into Pi and builds Armv7 dess secondary
       - name: Create dess-arm image
-        uses: appleboy/ssh-action@v0.1.4
+        uses: appleboy/ssh-action@v0.1.5
         with:
           host: "arm32cicd.atsign.wtf"
           username: pi

--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -183,7 +183,7 @@ jobs:
           ls -laR at_virtual_environment/ve/*
 
       - name: Build docker image
-        uses: docker/build-push-action@v3.1.0
+        uses: docker/build-push-action@v3.1.1
         with:
           file: at_virtual_environment/ve/Dockerfile
           context: at_virtual_environment/ve
@@ -243,7 +243,7 @@ jobs:
       # Builds and pushes the secondary server image to docker hub.
       - name: Build and push secondary image for x64
         id: docker_build_secondary
-        uses: docker/build-push-action@v3.1.0
+        uses: docker/build-push-action@v3.1.1
         with:
           push: true
           context: at_secondary
@@ -388,7 +388,7 @@ jobs:
       # Builds and pushes the at_virtual_env to docker hub.
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v3.1.0
+        uses: docker/build-push-action@v3.1.1
         with:
           file: at_virtual_environment/ve/Dockerfile.vip
           push: true
@@ -440,7 +440,7 @@ jobs:
       # Builds and pushes the secondary server image to docker hub.
       - name: Build and push secondary image for amd64 and arm64
         id: docker_build_secondary
-        uses: docker/build-push-action@v3.1.0
+        uses: docker/build-push-action@v3.1.1
         with:
           push: true
           context: at_secondary
@@ -512,7 +512,7 @@ jobs:
       # Builds and pushes the secondary server image to docker hub.
       - name: Build and push secondary image for amd64 and arm64
         id: docker_build_observable_secondary
-        uses: docker/build-push-action@v3.1.0
+        uses: docker/build-push-action@v3.1.1
         with:
           push: true
           file: ./at_secondary/Dockerfile.observe
@@ -564,7 +564,7 @@ jobs:
       # Builds and pushes the secondary server image to docker hub.
       - name: Build and push secondary image for amd64 and arm64
         id: docker_build_secondary
-        uses: docker/build-push-action@v3.1.0
+        uses: docker/build-push-action@v3.1.1
         with:
           push: true
           context: at_secondary
@@ -614,7 +614,7 @@ jobs:
       # Builds and pushes the secondary server image to docker hub.
       - name: Build and push secondary image for amd64 and arm64
         id: docker_build_secondary
-        uses: docker/build-push-action@v3.1.0
+        uses: docker/build-push-action@v3.1.1
         with:
           push: true
           context: at_secondary
@@ -706,7 +706,7 @@ jobs:
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v3.1.0
+        uses: docker/build-push-action@v3.1.1
         with:
           file: at_virtual_environment/ve/Dockerfile.vip
           push: true
@@ -834,7 +834,7 @@ jobs:
       # Builds and pushes the secondary server image to docker hub.
       - name: Build and push secondary image for amd64 and arm64
         id: docker_build_canary_to_prod
-        uses: docker/build-push-action@v3.0.0
+        uses: docker/build-push-action@v3.1.1
         with:
           push: true 
           file: ./at_secondary/Dockerfile.canary_to_prod

--- a/.github/workflows/at_server_dev_deploy.yaml
+++ b/.github/workflows/at_server_dev_deploy.yaml
@@ -27,7 +27,7 @@ jobs:
 
       # Build the Docker image for Dev
       - name: Build and push
-        uses: docker/build-push-action@v3.1.0
+        uses: docker/build-push-action@v3.1.1
         with:
           file: at_root/at_root_server/Dockerfile
           context: at_root/at_root_server

--- a/.github/workflows/at_server_prod_deploy.yaml
+++ b/.github/workflows/at_server_prod_deploy.yaml
@@ -27,7 +27,7 @@ jobs:
 
       # Build the Docker image for Dev
       - name: Build and push
-        uses: docker/build-push-action@v3.1.0
+        uses: docker/build-push-action@v3.1.1
         with:
           file: at_root/at_root_server/Dockerfile
           context: at_root/at_root_server

--- a/.github/workflows/autobug.yaml
+++ b/.github/workflows/autobug.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Move issue to "Triage"'
-        uses: leonsteinhaeuser/project-beta-automations@v1.2.1
+        uses: leonsteinhaeuser/project-beta-automations@v1.3.0
         with:
           gh_token: ${{ secrets.MY_GITHUB_TOKEN }}
           organization: atsign-foundation

--- a/.github/workflows/ve_base.yaml
+++ b/.github/workflows/ve_base.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v3.1.0
+        uses: docker/build-push-action@v3.1.1
         with:
           file: at_virtual_environment/ve_base/Dockerfile
           push: true

--- a/at_end2end_test/pubspec.yaml
+++ b/at_end2end_test/pubspec.yaml
@@ -12,19 +12,19 @@ dependencies:
       url: https://github.com/atsign-foundation/at_demos.git
       path: at_demo_data
       ref: master
-  at_lookup: ^3.0.22
+  at_lookup: ^3.0.29
 
-dependency_overrides:
-  at_commons:
-    git:
-      url: https://github.com/atsign-foundation/at_tools.git
-      path: at_commons
-      ref: trunk
-  at_lookup:
-    git:
-      url: https://github.com/atsign-foundation/at_libraries.git
-      path: at_lookup
-      ref: json_decoding_response
+#dependency_overrides:
+#  at_commons:
+#    git:
+#      url: https://github.com/atsign-foundation/at_tools.git
+#      path: at_commons
+#      ref: trunk
+#  at_lookup:
+#    git:
+#      url: https://github.com/atsign-foundation/at_libraries.git
+#      path: at_lookup
+#      ref: json_decoding_response
 
 
 dev_dependencies:

--- a/at_end2end_test/pubspec.yaml
+++ b/at_end2end_test/pubspec.yaml
@@ -13,7 +13,18 @@ dependencies:
       path: at_demo_data
       ref: master
   at_lookup: ^3.0.22
-  at_client: ^3.0.20
+
+dependency_overrides:
+  at_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_tools.git
+      path: at_commons
+      ref: trunk
+  at_lookup:
+    git:
+      url: https://github.com/atsign-foundation/at_libraries.git
+      path: at_lookup
+      ref: json_decoding_response
 
 
 dev_dependencies:

--- a/at_end2end_test/test/cached_key_test.dart
+++ b/at_end2end_test/test/cached_key_test.dart
@@ -196,13 +196,6 @@ void main() {
     expect(response, contains('data:ok'));
   }, timeout: Timeout(Duration(minutes: 3)));
 
-
-  test('byPassCache with incorrect value', () async {
-    await sh2.writeCommand('lookup:bypass_Cache:true:fav-city$atSign_1');
-    var response = await sh2.read();
-    print('lookup verb response : $response');
-    expect(response, contains('data: Invalid Syntax'));
-  });
   // Will uncomment after validations are in place
   // test('update-llookup verb without ttr and with ccd', () async {
   //   /// UPDATE VERB

--- a/at_end2end_test/test/cached_key_test.dart
+++ b/at_end2end_test/test/cached_key_test.dart
@@ -175,17 +175,17 @@ void main() {
 
     /// lookup with bypass_cache set to true
     /// should return the newly updated value
-    await sh2.writeCommand('lookup:bypass_cache:true:username$atSign_1');
+    await sh2.writeCommand('lookup:bypassCache:true:username$atSign_1');
     response = await sh2.read();
     print('lookup verb response : $response');
     expect(response, contains('data:$newValue'));
 
     /// lookup with bypass_cache set to false
     /// should return the old value
-    await sh2.writeCommand('lookup:bypass_cache:true:username$atSign_1');
+    await sh2.writeCommand('lookup:bypassCache:false:username$atSign_1');
     response = await sh2.read();
     print('lookup verb response : $response');
-    expect(response, contains('data:$newValue'));
+    expect(response, contains('data:$value'));
   }, timeout: Timeout(Duration(minutes: 3)));
 
   // Will uncomment after validations are in place

--- a/at_end2end_test/test/cached_key_test.dart
+++ b/at_end2end_test/test/cached_key_test.dart
@@ -1,4 +1,3 @@
-import 'dart:math';
 
 import 'package:test/test.dart';
 import 'notify_verb_test.dart' as notification;
@@ -135,73 +134,67 @@ void main() {
   /// The purpose of this test verify the following:
   /// 1. Share a key from atsign_1 to atsign_2 with ttr, with autoNotify:true
   /// 2. lookup from atsign_2 returns the correct value
-  /// 3.  Set the autoNotify to false using the config verb 
-  /// 4. Update the existing key to a new value 
+  /// 3.  Set the autoNotify to false using the config verb
+  /// 4. Update the existing key to a new value
   /// 4. lookup with bypass_cache set to true should return the updated value
   /// 5. lookup with bypass_cache set to false should return the old value
   test('update-lookup verb passing bypasscache ', () async {
     ///Update verb on atsign_1
-    var oldValue = 'Hyderabad';
+    try {
+      var oldValue = 'Hyderabad';
 
-    await sh1
-        .writeCommand('update:ttr:100000:$atSign_2:fav-city$atSign_1  $oldValue');
-    String response = await sh1.read();
-    print('update verb response : $response');
-    assert(
-        (!response.contains('Invalid syntax')) && (!response.contains('null')));
+      await sh1.writeCommand(
+          'update:ttr:100000:$atSign_2:fav-city$atSign_1  $oldValue');
+      String response = await sh1.read();
+      print('update verb response : $response');
+      assert((!response.contains('Invalid syntax')) &&
+          (!response.contains('null')));
 
-    ///lookup verb alice  atsign_2
-    await sh2.writeCommand('lookup:fav-city$atSign_1');
-    response = await sh2.read();
-    print('lookup verb response : $response');
-    expect(response, contains('data: $oldValue'));
+      ///lookup verb alice  atsign_2
+      await sh2.writeCommand('lookup:fav-city$atSign_1');
+      response = await sh2.read();
+      print('lookup verb response : $response');
+      expect(response, contains('data: $oldValue'));
 
-    // config set auto notify to false
-    await sh1.writeCommand('config:set:autoNotify=false');
-    response = await sh1.read();
-    print('config set verb response is $response');
-    expect(response, contains('data:ok'));
+      // config set auto notify to false
+      await sh1.writeCommand('config:set:autoNotify=false');
+      response = await sh1.read();
+      print('config set verb response is $response');
+      expect(response, contains('data:ok'));
 
-    var newValue = 'Chennai';
-    await sh1.writeCommand('update:$atSign_2:fav-city$atSign_1  $newValue');
-    response = await sh1.read();
-    print('update verb response : $response');
-    assert(
-        (!response.contains('Invalid syntax')) && (!response.contains('null')));
+      var newValue = 'Chennai';
+      await sh1.writeCommand('update:$atSign_2:fav-city$atSign_1  $newValue');
+      response = await sh1.read();
+      print('update verb response : $response');
+      assert((!response.contains('Invalid syntax')) &&
+          (!response.contains('null')));
 
-    ///lookup should return the old value
-    await sh2.writeCommand('lookup:fav-city$atSign_1');
-    response = await sh2.read();
-    print('lookup verb response : $response');
-    expect(response, contains('data: $oldValue'));
+      ///lookup should return the old value
+      await sh2.writeCommand('lookup:fav-city$atSign_1');
+      response = await sh2.read();
+      print('lookup verb response : $response');
+      expect(response, contains('data: $oldValue'));
 
-    /// lookup with bypass_cache set to true
-    /// should return the newly updated value
-    await sh2.writeCommand('lookup:bypassCache:true:fav-city$atSign_1');
-    response = await sh2.read();
-    print('lookup verb response : $response');
-    expect(response, contains('data: $newValue'));
+      /// lookup with bypass_cache set to true
+      /// should return the newly updated value
+      await sh2.writeCommand('lookup:bypassCache:true:fav-city$atSign_1');
+      response = await sh2.read();
+      print('lookup verb response : $response');
+      expect(response, contains('data: $newValue'));
 
-    /// lookup with bypass_cache set to false
-    /// should return the old value
-    await sh2.writeCommand('lookup:bypassCache:false:fav-city$atSign_1');
-    response = await sh2.read();
-    print('lookup verb response : $response');
-    expect(response, contains('data: $oldValue'));
+      /// lookup with bypass_cache set to false
+      /// should return the old value
+      await sh2.writeCommand('lookup:bypassCache:false:fav-city$atSign_1');
+      response = await sh2.read();
+      print('lookup verb response : $response');
+      expect(response, contains('data: $oldValue'));
+    } finally {
+      await sh1.writeCommand('config:reset:autoNotify');
+      var response = await sh1.read();
+      print('config set verb response is $response');
+      expect(response, contains('data:ok'));
+    }
 
     // reset the autoNotify to default
-    await sh1.writeCommand('config:reset:autoNotify');
-    response = await sh1.read();
-    print('config set verb response is $response');
-    expect(response, contains('data:ok'));
   }, timeout: Timeout(Duration(minutes: 3)));
-
-  // Will uncomment after validations are in place
-  // test('update-llookup verb without ttr and with ccd', () async {
-  //   /// UPDATE VERB
-  //   await sh1.writeCommand('update:ccd:true:$atSign_2:sample$atSign_1 sams');
-  //   var response = await sh1.read();
-  //   print('update verb response : $response');
-  //   assert((response.contains('Invalid syntax')));
-  // });
 }

--- a/at_end2end_test/test/cached_key_test.dart
+++ b/at_end2end_test/test/cached_key_test.dart
@@ -152,7 +152,7 @@ void main() {
     await sh2.writeCommand('lookup:username$atSign_1');
     response = await sh2.read();
     print('lookup verb response : $response');
-    expect(response, contains('data:$value'));
+    expect(response, contains('data: $value'));
 
     // TODO
     // stop the atsign_2 server
@@ -167,6 +167,7 @@ void main() {
     // Start the atsign_2 server after the maximum retries for notification is reached
 
     ///lookup should return the old value
+    await Future.delayed(Duration(seconds: 10));
     await sh2.writeCommand('lookup:username$atSign_1');
     response = await sh2.read();
     print('lookup verb response : $response');

--- a/at_end2end_test/test/cached_key_test.dart
+++ b/at_end2end_test/test/cached_key_test.dart
@@ -132,6 +132,61 @@ void main() {
     expect(response, contains('data:$value'));
   }, timeout: Timeout(Duration(seconds: 100)));
 
+  /// The purpose of this test verify the following:
+  /// 1. Share a key from atsign_1 to atsign_2 with ttr
+  /// 2. lookup from atsign_2 returns the correct value
+  /// 3. Update the existing key to a new value
+  /// 4. lookup with bypass_cache set to true should return the updated value
+  /// 5. lookup with bypass_cache set to false should return the old value
+  test('update-lookup verb passing bypass_cache ', () async {
+    ///Update verb on atsign_1
+    var value = 'user_1';
+    await sh1
+        .writeCommand('update:ttr:1000:$atSign_2:username$atSign_1  $value');
+    String response = await sh1.read();
+    print('update verb response : $response');
+    assert(
+        (!response.contains('Invalid syntax')) && (!response.contains('null')));
+
+    ///lookup verb alice  atsign_2
+    await sh2.writeCommand('lookup:username$atSign_1');
+    response = await sh2.read();
+    print('lookup verb response : $response');
+    expect(response, contains('data:$value'));
+
+    // TODO
+    // stop the atsign_2 server
+    var newValue = 'a_user';
+    await sh1.writeCommand('update:$atSign_2:username$atSign_1  $newValue');
+    response = await sh1.read();
+    print('update verb response : $response');
+    assert(
+        (!response.contains('Invalid syntax')) && (!response.contains('null')));
+
+    // TODO
+    // Start the atsign_2 server after the maximum retries for notification is reached
+
+    ///lookup should return the old value
+    await sh2.writeCommand('lookup:username$atSign_1');
+    response = await sh2.read();
+    print('lookup verb response : $response');
+    expect(response, contains('data:$value'));
+
+    /// lookup with bypass_cache set to true
+    /// should return the newly updated value
+    await sh2.writeCommand('lookup:bypass_cache:true:username$atSign_1');
+    response = await sh2.read();
+    print('lookup verb response : $response');
+    expect(response, contains('data:$newValue'));
+
+    /// lookup with bypass_cache set to false
+    /// should return the old value
+    await sh2.writeCommand('lookup:bypass_cache:true:username$atSign_1');
+    response = await sh2.read();
+    print('lookup verb response : $response');
+    expect(response, contains('data:$newValue'));
+  }, timeout: Timeout(Duration(minutes: 3)));
+
   // Will uncomment after validations are in place
   // test('update-llookup verb without ttr and with ccd', () async {
   //   /// UPDATE VERB

--- a/at_end2end_test/test/e2e_test_utils.dart
+++ b/at_end2end_test/test/e2e_test_utils.dart
@@ -71,8 +71,7 @@ class SimpleOutboundSocketHandler {
         retryCount++;
       }
     }
-    throw Exception(
-        "Failed to connect to $host:$port after $retryCount attempts");
+    throw Exception("Failed to connect to $host:$port after $retryCount attempts");
   }
 
   void startListening() {
@@ -84,7 +83,7 @@ class SimpleOutboundSocketHandler {
     if (log) {
       print('command sent: $command');
     }
-    if (!command.endsWith('\n')) {
+    if (! command.endsWith('\n')) {
       command = command + '\n';
     }
     socket!.write(command);
@@ -94,14 +93,14 @@ class SimpleOutboundSocketHandler {
   Future<void> sendFromAndPkam() async {
     // FROM VERB
     await writeCommand('from:$atSign');
-    var response = await read(timeoutMillis: 4000);
+    var response = await read(timeoutMillis:4000);
     response = response.replaceAll('data:', '');
     var pkamDigest = generatePKAMDigest(atSign, response);
 
     // PKAM VERB
-    print("Sending pkam: command");
-    await writeCommand('pkam:$pkamDigest', log: false);
-    response = await read(timeoutMillis: 1000);
+    print ("Sending pkam: command");
+    await writeCommand('pkam:$pkamDigest', log:false);
+    response = await read(timeoutMillis:1000);
     print('pkam verb response $response');
     assert(response.contains('data:success'));
   }
@@ -145,14 +144,11 @@ class SimpleOutboundSocketHandler {
   /// A message which is returned from [read] if throwTimeoutException is set to false
   static String readTimedOutMessage = 'E2E_SIMPLE_SOCKET_HANDLER_TIMED_OUT';
 
-  Future<String> read(
-      {bool log = true,
-      int timeoutMillis = 4000,
-      bool throwTimeoutException = true}) async {
+  Future<String> read({bool log = true, int timeoutMillis = 4000, bool throwTimeoutException = true}) async {
     String result;
 
     // Wait this many milliseconds between checks on the queue
-    var loopDelay = 250;
+    var loopDelay=250;
 
     // Check every loopDelay milliseconds until we get a response or timeoutMillis have passed.
     var loopCount = (timeoutMillis / loopDelay).round();
@@ -170,15 +166,13 @@ class SimpleOutboundSocketHandler {
     }
     // No response - either throw a timeout exception or return the canned readTimedOutMessage
     if (throwTimeoutException) {
-      throw AtTimeoutException(
-          "No response from $host:$port ($atSign) after ${timeoutMillis / 1000} seconds");
+      throw AtTimeoutException ("No response from $host:$port ($atSign) after ${timeoutMillis/1000} seconds");
     } else {
-      print("read(): No response after $timeoutMillis milliseconds");
+      print ("read(): No response after $timeoutMillis milliseconds");
       return readTimedOutMessage;
     }
   }
 }
-
 /// Simple data-holding class which adds its instances into [atSignConfigMap]
 class _AtSignConfig {
   String atSign;
@@ -188,8 +182,7 @@ class _AtSignConfig {
   /// Creates and adds to [atSignConfigMap] or throws [_AtSignAlreadyAddedException] if we've already got it.
   _AtSignConfig(this.atSign, this.host, this.port) {
     if (atSignConfigMap.containsKey(atSign)) {
-      throw _AtSignAlreadyAddedException(
-          "AtSignConfig for $atSign has already been created");
+      throw _AtSignAlreadyAddedException("AtSignConfig for $atSign has already been created");
     }
     atSignConfigMap[atSign] = this;
   }

--- a/at_end2end_test/test/plookup_verb_test.dart
+++ b/at_end2end_test/test/plookup_verb_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:test/test.dart';
 
 import 'e2e_test_utils.dart' as e2e;
@@ -33,7 +35,8 @@ void main() {
     await sh1.writeCommand('update:public:phone$atSign_1 9982212143');
     String response = await sh1.read();
     print('update verb response $response');
-    assert((!response.contains('Invalid syntax')) && (!response.contains('null')));
+    assert(
+        (!response.contains('Invalid syntax')) && (!response.contains('null')));
 
     ///PLOOKUP VERB
     await sh2.writeCommand('plookup:phone$atSign_1');
@@ -47,7 +50,8 @@ void main() {
     await sh1.writeCommand('update:$atSign_2:mobile$atSign_1 9982212143');
     String response = await sh1.read();
     print('update verb response $response');
-    assert((!response.contains('Invalid syntax')) && (!response.contains('null')));
+    assert(
+        (!response.contains('Invalid syntax')) && (!response.contains('null')));
 
     ///PLOOKUP VERB
     await sh2.writeCommand('plookup:mobile$atSign_1$atSign_2');
@@ -64,7 +68,17 @@ void main() {
     await sh1.writeCommand('plookup:no-key$atSign_1');
     String response = await sh1.read();
     print('plookup verb response $response');
-    expect(response, contains('error:AT0015-key not found : public:no-key$atSign_1 does not exist in keystore'));
+    if (atSign_1 != '@cicd5') {
+      response = response.replaceFirst('error:', '');
+      var errorMap = jsonDecode(response);
+      expect(errorMap['errorCode'], 'AT0015');
+      assert(errorMap['errorDescription'].contains('key not found'));
+    } else {
+      expect(
+          response,
+          contains(
+              'error:AT0015-key not found : public:no-key$atSign_1 does not exist in keystore'));
+    }
   }, timeout: Timeout(Duration(seconds: 120)));
 
   test('plookup for an emoji key', () async {
@@ -72,7 +86,8 @@ void main() {
     await sh1.writeCommand('update:public:🦄🦄$atSign_1 2-unicorn-emojis');
     String response = await sh1.read();
     print('update verb response $response');
-    assert((!response.contains('data:null') && (!response.contains('Invalid syntax'))));
+    assert((!response.contains('data:null') &&
+        (!response.contains('Invalid syntax'))));
 
     ///PLOOKUP VERB
     await sh2.writeCommand('plookup:🦄🦄$atSign_1');
@@ -97,7 +112,8 @@ void main() {
     await sh1.writeCommand('update:public:key-1$atSign_1 9102');
     String response = await sh1.read();
     print('update verb response $response');
-    assert((!response.contains('Invalid syntax')) && (!response.contains('null')));
+    assert(
+        (!response.contains('Invalid syntax')) && (!response.contains('null')));
 
     ///PLOOKUP VERB
     await sh2.writeCommand('plookup:key-1$atSign_1');
@@ -112,12 +128,14 @@ void main() {
     assert(response.contains('cached:public:key-1$atSign_1'));
   }, timeout: Timeout(Duration(seconds: 120)));
 
-  test('plookup verb with public key -updating same key multiple times', () async {
+  test('plookup verb with public key -updating same key multiple times',
+      () async {
     /// UPDATE VERB
     await sh1.writeCommand('update:public:fav-series$atSign_1 Friends');
     String response = await sh1.read();
     print('update verb response $response');
-    assert((!response.contains('Invalid syntax')) && (!response.contains('null')));
+    assert(
+        (!response.contains('Invalid syntax')) && (!response.contains('null')));
 
     ///PLOOKUP VERB after updating same key multiple times
     await sh1.writeCommand('plookup:fav-series$atSign_1');
@@ -129,7 +147,8 @@ void main() {
     await sh1.writeCommand('update:public:fav-series$atSign_1 young sheldon');
     response = await sh1.read();
     print('update verb response $response');
-    assert((!response.contains('Invalid syntax')) && (!response.contains('null')));
+    assert(
+        (!response.contains('Invalid syntax')) && (!response.contains('null')));
 
     ///PLOOKUP VERB after updating same key second time
     await sh1.writeCommand('plookup:fav-series$atSign_1');
@@ -137,5 +156,4 @@ void main() {
     print('plookup verb response $response');
     expect(response, contains('data:young sheldon'));
   }, timeout: Timeout(Duration(seconds: 120)));
-
 }

--- a/at_end2end_test/test/plookup_verb_test.dart
+++ b/at_end2end_test/test/plookup_verb_test.dart
@@ -35,8 +35,7 @@ void main() {
     await sh1.writeCommand('update:public:phone$atSign_1 9982212143');
     String response = await sh1.read();
     print('update verb response $response');
-    assert(
-        (!response.contains('Invalid syntax')) && (!response.contains('null')));
+    assert((!response.contains('Invalid syntax')) && (!response.contains('null')));
 
     ///PLOOKUP VERB
     await sh2.writeCommand('plookup:phone$atSign_1');
@@ -50,8 +49,7 @@ void main() {
     await sh1.writeCommand('update:$atSign_2:mobile$atSign_1 9982212143');
     String response = await sh1.read();
     print('update verb response $response');
-    assert(
-        (!response.contains('Invalid syntax')) && (!response.contains('null')));
+    assert((!response.contains('Invalid syntax')) && (!response.contains('null')));
 
     ///PLOOKUP VERB
     await sh2.writeCommand('plookup:mobile$atSign_1$atSign_2');
@@ -86,8 +84,7 @@ void main() {
     await sh1.writeCommand('update:public:🦄🦄$atSign_1 2-unicorn-emojis');
     String response = await sh1.read();
     print('update verb response $response');
-    assert((!response.contains('data:null') &&
-        (!response.contains('Invalid syntax'))));
+    assert((!response.contains('data:null') && (!response.contains('Invalid syntax'))));
 
     ///PLOOKUP VERB
     await sh2.writeCommand('plookup:🦄🦄$atSign_1');
@@ -112,8 +109,7 @@ void main() {
     await sh1.writeCommand('update:public:key-1$atSign_1 9102');
     String response = await sh1.read();
     print('update verb response $response');
-    assert(
-        (!response.contains('Invalid syntax')) && (!response.contains('null')));
+    assert((!response.contains('Invalid syntax')) && (!response.contains('null')));
 
     ///PLOOKUP VERB
     await sh2.writeCommand('plookup:key-1$atSign_1');
@@ -128,14 +124,12 @@ void main() {
     assert(response.contains('cached:public:key-1$atSign_1'));
   }, timeout: Timeout(Duration(seconds: 120)));
 
-  test('plookup verb with public key -updating same key multiple times',
-      () async {
+  test('plookup verb with public key -updating same key multiple times', () async {
     /// UPDATE VERB
     await sh1.writeCommand('update:public:fav-series$atSign_1 Friends');
     String response = await sh1.read();
     print('update verb response $response');
-    assert(
-        (!response.contains('Invalid syntax')) && (!response.contains('null')));
+    assert((!response.contains('Invalid syntax')) && (!response.contains('null')));
 
     ///PLOOKUP VERB after updating same key multiple times
     await sh1.writeCommand('plookup:fav-series$atSign_1');
@@ -147,8 +141,7 @@ void main() {
     await sh1.writeCommand('update:public:fav-series$atSign_1 young sheldon');
     response = await sh1.read();
     print('update verb response $response');
-    assert(
-        (!response.contains('Invalid syntax')) && (!response.contains('null')));
+    assert((!response.contains('Invalid syntax')) && (!response.contains('null')));
 
     ///PLOOKUP VERB after updating same key second time
     await sh1.writeCommand('plookup:fav-series$atSign_1');
@@ -156,4 +149,5 @@ void main() {
     print('plookup verb response $response');
     expect(response, contains('data:young sheldon'));
   }, timeout: Timeout(Duration(seconds: 120)));
+
 }

--- a/at_end2end_test/test/update_verb_test.dart
+++ b/at_end2end_test/test/update_verb_test.dart
@@ -71,7 +71,7 @@ void main() {
     print(
         'llookup verb response without private key in llookup verb: $response');
     //TODO: remove else block in the next release -  when all servers json encode the error responses
-    if (atSign_1 != '@cicd5') {
+    if (await sh1.getVersion() >= 3021) {
       response = response.replaceFirst('error:', '');
       var errorMap = jsonDecode(response);
       expect(errorMap['errorCode'], 'AT0015');
@@ -89,8 +89,7 @@ void main() {
     await sh1.writeCommand('update:public:passcode$atSign_1 @!ice^&##');
     var response = await sh1.read();
     print('update verb response : $response');
-    assert(
-        (!response.contains('Invalid syntax')) && (!response.contains('null')));
+    assert((!response.contains('Invalid syntax')) && (!response.contains('null')));
 
     ///LLOOKUP VERB
     await sh1.writeCommand('llookup:public:passcode$atSign_1');
@@ -104,8 +103,7 @@ void main() {
     await sh1.writeCommand('update:public:unicode$atSign_1 U+0026');
     var response = await sh1.read();
     print('update verb response : $response');
-    assert(
-        (!response.contains('Invalid syntax')) && (!response.contains('null')));
+    assert((!response.contains('Invalid syntax')) && (!response.contains('null')));
 
     ///LLOOKUP VERB
     await sh1.writeCommand('llookup:public:unicode$atSign_1');
@@ -116,12 +114,10 @@ void main() {
 
   test('update verb with spaces ', () async {
     ///UPDATE VERB
-    await sh1.writeCommand(
-        'update:public:message$atSign_1 Hey Hello! welcome to the tests');
+    await sh1.writeCommand('update:public:message$atSign_1 Hey Hello! welcome to the tests');
     var response = await sh1.read();
     print('update verb response : $response');
-    assert(
-        (!response.contains('Invalid syntax')) && (!response.contains('null')));
+    assert((!response.contains('Invalid syntax')) && (!response.contains('null')));
 
     ///LLOOKUP VERB
     await sh1.writeCommand('llookup:public:message$atSign_1');
@@ -130,15 +126,12 @@ void main() {
     expect(response, contains('data:Hey Hello! welcome to the tests'));
   });
 
-  test('updating same key with different values and doing a llookup ',
-      () async {
+  test('updating same key with different values and doing a llookup ', () async {
     ///UPDATE VERB
-    await sh1.writeCommand(
-        'update:public:message$atSign_1 Hey Hello! welcome to the tests');
+    await sh1.writeCommand('update:public:message$atSign_1 Hey Hello! welcome to the tests');
     var response = await sh1.read();
     print('update verb response : $response');
-    assert(
-        (!response.contains('Invalid syntax')) && (!response.contains('null')));
+    assert((!response.contains('Invalid syntax')) && (!response.contains('null')));
 
     ///LLOOKUP VERB
     await sh1.writeCommand('llookup:public:message$atSign_1');
@@ -146,12 +139,10 @@ void main() {
     print('llookup verb response : $response');
     expect(response, contains('data:Hey Hello! welcome to the tests'));
 
-    await sh1
-        .writeCommand('update:public:message$atSign_1 Hope you are doing good');
+    await sh1.writeCommand('update:public:message$atSign_1 Hope you are doing good');
     response = await sh1.read();
     print('update verb response : $response');
-    assert(
-        (!response.contains('Invalid syntax')) && (!response.contains('null')));
+    assert((!response.contains('Invalid syntax')) && (!response.contains('null')));
 
     ///LLOOKUP VERB
     await sh1.writeCommand('llookup:public:message$atSign_1');
@@ -207,8 +198,7 @@ void main() {
   test('update verb by sharing a cached key ', () async {
     ///UPDATE VERB
     var value = 'joey$lastValue$lastValue';
-    await sh1
-        .writeCommand('update:ttr:-1:$atSign_2:youtube_id$atSign_1 $value');
+    await sh1.writeCommand('update:ttr:-1:$atSign_2:youtube_id$atSign_1 $value');
     var response = await sh1.read();
     print('update verb response : $response');
     assert(
@@ -275,7 +265,7 @@ void main() {
     response = await sh1.read();
     print('llookup verb response : $response');
     expect(response, contains('data:$value'));
-  });
+    });
 
   test('update-llookup for ttl ', () async {
     ///UPDATE VERB

--- a/at_end2end_test/test/update_verb_test.dart
+++ b/at_end2end_test/test/update_verb_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:math';
 
 import 'package:test/test.dart';
@@ -67,8 +68,20 @@ void main() {
     ///LLOOKUP VERB - with out @sign does not return value.
     await sh1.writeCommand('llookup:country$atSign_1');
     response = await sh1.read();
-    print('llookup verb response without private key in llookup verb: $response');
-    expect(response, contains('error:AT0015-key not found : country$atSign_1 does not exist in keystore'));
+    print(
+        'llookup verb response without private key in llookup verb: $response');
+    //TODO: remove else block in the next release -  when all servers json encode the error responses
+    if (atSign_1 != '@cicd5') {
+      response = response.replaceFirst('error:', '');
+      var errorMap = jsonDecode(response);
+      expect(errorMap['errorCode'], 'AT0015');
+      assert(errorMap['errorDescription'].contains('key not found'));
+    } else {
+      expect(
+          response,
+          contains(
+              'error:AT0015-key not found : country$atSign_1 does not exist in keystore'));
+    }
   });
 
   test('update verb with special characters', () async {
@@ -76,7 +89,8 @@ void main() {
     await sh1.writeCommand('update:public:passcode$atSign_1 @!ice^&##');
     var response = await sh1.read();
     print('update verb response : $response');
-    assert((!response.contains('Invalid syntax')) && (!response.contains('null')));
+    assert(
+        (!response.contains('Invalid syntax')) && (!response.contains('null')));
 
     ///LLOOKUP VERB
     await sh1.writeCommand('llookup:public:passcode$atSign_1');
@@ -90,7 +104,8 @@ void main() {
     await sh1.writeCommand('update:public:unicode$atSign_1 U+0026');
     var response = await sh1.read();
     print('update verb response : $response');
-    assert((!response.contains('Invalid syntax')) && (!response.contains('null')));
+    assert(
+        (!response.contains('Invalid syntax')) && (!response.contains('null')));
 
     ///LLOOKUP VERB
     await sh1.writeCommand('llookup:public:unicode$atSign_1');
@@ -101,10 +116,12 @@ void main() {
 
   test('update verb with spaces ', () async {
     ///UPDATE VERB
-    await sh1.writeCommand('update:public:message$atSign_1 Hey Hello! welcome to the tests');
+    await sh1.writeCommand(
+        'update:public:message$atSign_1 Hey Hello! welcome to the tests');
     var response = await sh1.read();
     print('update verb response : $response');
-    assert((!response.contains('Invalid syntax')) && (!response.contains('null')));
+    assert(
+        (!response.contains('Invalid syntax')) && (!response.contains('null')));
 
     ///LLOOKUP VERB
     await sh1.writeCommand('llookup:public:message$atSign_1');
@@ -113,12 +130,15 @@ void main() {
     expect(response, contains('data:Hey Hello! welcome to the tests'));
   });
 
-  test('updating same key with different values and doing a llookup ', () async {
+  test('updating same key with different values and doing a llookup ',
+      () async {
     ///UPDATE VERB
-    await sh1.writeCommand('update:public:message$atSign_1 Hey Hello! welcome to the tests');
+    await sh1.writeCommand(
+        'update:public:message$atSign_1 Hey Hello! welcome to the tests');
     var response = await sh1.read();
     print('update verb response : $response');
-    assert((!response.contains('Invalid syntax')) && (!response.contains('null')));
+    assert(
+        (!response.contains('Invalid syntax')) && (!response.contains('null')));
 
     ///LLOOKUP VERB
     await sh1.writeCommand('llookup:public:message$atSign_1');
@@ -126,10 +146,12 @@ void main() {
     print('llookup verb response : $response');
     expect(response, contains('data:Hey Hello! welcome to the tests'));
 
-    await sh1.writeCommand('update:public:message$atSign_1 Hope you are doing good');
+    await sh1
+        .writeCommand('update:public:message$atSign_1 Hope you are doing good');
     response = await sh1.read();
     print('update verb response : $response');
-    assert((!response.contains('Invalid syntax')) && (!response.contains('null')));
+    assert(
+        (!response.contains('Invalid syntax')) && (!response.contains('null')));
 
     ///LLOOKUP VERB
     await sh1.writeCommand('llookup:public:message$atSign_1');
@@ -185,7 +207,8 @@ void main() {
   test('update verb by sharing a cached key ', () async {
     ///UPDATE VERB
     var value = 'joey$lastValue$lastValue';
-    await sh1.writeCommand('update:ttr:-1:$atSign_2:youtube_id$atSign_1 $value');
+    await sh1
+        .writeCommand('update:ttr:-1:$atSign_2:youtube_id$atSign_1 $value');
     var response = await sh1.read();
     print('update verb response : $response');
     assert(
@@ -252,7 +275,7 @@ void main() {
     response = await sh1.read();
     print('llookup verb response : $response');
     expect(response, contains('data:$value'));
-    });
+  });
 
   test('update-llookup for ttl ', () async {
     ///UPDATE VERB

--- a/at_functional_test/pubspec.yaml
+++ b/at_functional_test/pubspec.yaml
@@ -14,8 +14,19 @@ dependencies:
       path: at_demo_data
       ref: master
   at_lookup: ^3.0.26
-  at_client: ^3.0.27
-  
+
+
+dependency_overrides:
+  at_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_tools.git
+      path: at_commons
+      ref: trunk
+  at_lookup:
+    git:
+      url: https://github.com/atsign-foundation/at_libraries.git
+      path: at_lookup
+      ref: json_decoding_response
 
 # dependency_overrides:
 #  at_client:

--- a/at_functional_test/pubspec.yaml
+++ b/at_functional_test/pubspec.yaml
@@ -13,20 +13,20 @@ dependencies:
       url: https://github.com/atsign-foundation/at_demos.git
       path: at_demo_data
       ref: master
-  at_lookup: ^3.0.26
+  at_lookup: ^3.0.29
 
 
-dependency_overrides:
-  at_commons:
-    git:
-      url: https://github.com/atsign-foundation/at_tools.git
-      path: at_commons
-      ref: trunk
-  at_lookup:
-    git:
-      url: https://github.com/atsign-foundation/at_libraries.git
-      path: at_lookup
-      ref: json_decoding_response
+#dependency_overrides:
+#  at_commons:
+#    git:
+#      url: https://github.com/atsign-foundation/at_tools.git
+#      path: at_commons
+#      ref: trunk
+#  at_lookup:
+#    git:
+#      url: https://github.com/atsign-foundation/at_libraries.git
+#      path: at_lookup
+#      ref: json_decoding_response
 
 # dependency_overrides:
 #  at_client:

--- a/at_functional_test/test/config_verb_test.dart
+++ b/at_functional_test/test/config_verb_test.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:test/test.dart';
@@ -16,8 +15,7 @@ void main() {
       ConfigUtil.getYaml()!['second_atsign_server']['second_atsign_name'];
 
   setUp(() async {
-    var firstAtsignServer =
-        ConfigUtil.getYaml()!['first_atsign_server']['first_atsign_url'];
+    var firstAtsignServer = ConfigUtil.getYaml()!['first_atsign_server']['first_atsign_url'];
     var firstAtsignPort =
         ConfigUtil.getYaml()!['first_atsign_server']['first_atsign_port'];
 
@@ -29,7 +27,8 @@ void main() {
 
   test('config verb for adding a atsign to blocklist', () async {
     /// CONFIG VERB
-    await socket_writer(socketFirstAtsign!, 'config:block:add:$secondAtsign');
+    await socket_writer(
+        socketFirstAtsign!, 'config:block:add:$secondAtsign');
     var response = await read();
     print('config verb response : $response');
     expect(response, contains('data:success'));
@@ -43,7 +42,8 @@ void main() {
 
   test('config verb for deleting a atsign from blocklist', () async {
     /// CONFIG VERB
-    await socket_writer(socketFirstAtsign!, 'config:block:add:$secondAtsign');
+    await socket_writer(
+        socketFirstAtsign!, 'config:block:add:$secondAtsign');
     var response = await read();
     print('config verb response : $response');
     expect(response, contains('data:success'));
@@ -68,11 +68,8 @@ void main() {
     /// CONFIG VERB
     await socket_writer(socketFirstAtsign!, 'config:block:add:');
     var response = await read();
-    response = response.replaceFirst('error:', '');
-    var errorMap = jsonDecode(response);
     print('config verb response : $response');
-    expect(errorMap['errorCode'], 'AT0003');
-    assert(errorMap['errorDescription'].contains('Invalid syntax'));
+    assert(response.contains('error:AT0003-Invalid syntax'));
   });
 
   test(
@@ -81,22 +78,16 @@ void main() {
     /// CONFIG VERB
     await socket_writer(socketFirstAtsign!, 'config:block:add:@@kevin');
     var response = await read();
-    response = response.replaceFirst('error:', '');
-    var errorMap = jsonDecode(response);
     print('config verb response : $response');
-    expect(errorMap['errorCode'], 'AT0003');
-    assert(errorMap['errorDescription'].contains('Invalid syntax'));
+    assert(response.contains('error:AT0003-Invalid syntax'));
   });
 
   test('config verb by giving list instead of show (Negative case)', () async {
     /// CONFIG VERB
     await socket_writer(socketFirstAtsign!, 'config:block:list');
     var response = await read();
-    response = response.replaceFirst('error:', '');
-    var errorMap = jsonDecode(response);
     print('config verb response : $response');
-    expect(errorMap['errorCode'], 'AT0003');
-    assert(errorMap['errorDescription'].contains('Invalid syntax'));
+    assert(response.contains('error:AT0003-Invalid syntax'));
   });
 
   tearDown(() {

--- a/at_functional_test/test/config_verb_test.dart
+++ b/at_functional_test/test/config_verb_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:test/test.dart';
@@ -15,7 +16,8 @@ void main() {
       ConfigUtil.getYaml()!['second_atsign_server']['second_atsign_name'];
 
   setUp(() async {
-    var firstAtsignServer = ConfigUtil.getYaml()!['first_atsign_server']['first_atsign_url'];
+    var firstAtsignServer =
+        ConfigUtil.getYaml()!['first_atsign_server']['first_atsign_url'];
     var firstAtsignPort =
         ConfigUtil.getYaml()!['first_atsign_server']['first_atsign_port'];
 
@@ -27,8 +29,7 @@ void main() {
 
   test('config verb for adding a atsign to blocklist', () async {
     /// CONFIG VERB
-    await socket_writer(
-        socketFirstAtsign!, 'config:block:add:$secondAtsign');
+    await socket_writer(socketFirstAtsign!, 'config:block:add:$secondAtsign');
     var response = await read();
     print('config verb response : $response');
     expect(response, contains('data:success'));
@@ -42,8 +43,7 @@ void main() {
 
   test('config verb for deleting a atsign from blocklist', () async {
     /// CONFIG VERB
-    await socket_writer(
-        socketFirstAtsign!, 'config:block:add:$secondAtsign');
+    await socket_writer(socketFirstAtsign!, 'config:block:add:$secondAtsign');
     var response = await read();
     print('config verb response : $response');
     expect(response, contains('data:success'));
@@ -68,8 +68,11 @@ void main() {
     /// CONFIG VERB
     await socket_writer(socketFirstAtsign!, 'config:block:add:');
     var response = await read();
+    response = response.replaceFirst('error:', '');
+    var errorMap = jsonDecode(response);
     print('config verb response : $response');
-    assert(response.contains('error:AT0003-Invalid syntax'));
+    expect(errorMap['errorCode'], 'AT0003');
+    assert(errorMap['errorDescription'].contains('Invalid syntax'));
   });
 
   test(
@@ -78,16 +81,22 @@ void main() {
     /// CONFIG VERB
     await socket_writer(socketFirstAtsign!, 'config:block:add:@@kevin');
     var response = await read();
+    response = response.replaceFirst('error:', '');
+    var errorMap = jsonDecode(response);
     print('config verb response : $response');
-    assert(response.contains('error:AT0003-Invalid syntax'));
+    expect(errorMap['errorCode'], 'AT0003');
+    assert(errorMap['errorDescription'].contains('Invalid syntax'));
   });
 
   test('config verb by giving list instead of show (Negative case)', () async {
     /// CONFIG VERB
     await socket_writer(socketFirstAtsign!, 'config:block:list');
     var response = await read();
+    response = response.replaceFirst('error:', '');
+    var errorMap = jsonDecode(response);
     print('config verb response : $response');
-    assert(response.contains('error:AT0003-Invalid syntax'));
+    expect(errorMap['errorCode'], 'AT0003');
+    assert(errorMap['errorDescription'].contains('Invalid syntax'));
   });
 
   tearDown(() {

--- a/at_persistence/at_persistence_spec/CHANGELOG.md
+++ b/at_persistence/at_persistence_spec/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.0.7
+- Add optional parameter 'encoding' to put and create method in keystore to support encoding of new line characters 
 ## 2.0.6
 - Added support for @server/@client annotation for separating server-specific/client-specific methods
 ## 2.0.5

--- a/at_persistence/at_persistence_spec/lib/src/keystore/keystore.dart
+++ b/at_persistence/at_persistence_spec/lib/src/keystore/keystore.dart
@@ -27,7 +27,8 @@ abstract class WritableKeystore<K, V> implements Keystore<K, V> {
       bool? isEncrypted,
       String? dataSignature,
       String? sharedKeyEncrypted,
-      String? publicKeyChecksum});
+      String? publicKeyChecksum,
+      String? encoding});
 
   /// If the specified key is not already associated with a value (or is mapped to null) associates it with the given value and returns null, else returns the current value.
   ///
@@ -46,7 +47,8 @@ abstract class WritableKeystore<K, V> implements Keystore<K, V> {
       bool? isEncrypted,
       String? dataSignature,
       String? sharedKeyEncrypted,
-      String? publicKeyChecksum});
+      String? publicKeyChecksum,
+      String? encoding});
 
   /// Removes the mapping for a key from this key store if it is present
   ///

--- a/at_persistence/at_persistence_spec/pubspec.yaml
+++ b/at_persistence/at_persistence_spec/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_persistence_spec
 description: A Dart library containing abstract classes that defines what an implementation of the persistence layer is responsible for. This can be used to guide implementation of other persistence solutions for servers or SDKs as desired.
-version: 2.0.6
+version: 2.0.7
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://atsign.dev
 documentation: https://atsign.dev/at_docs-dev_env/at_persistence_spec/index.html

--- a/at_secondary/at_persistence_secondary_server/CHANGELOG.md
+++ b/at_secondary/at_persistence_secondary_server/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.32
+- Add 'encoding' to AtMetadata which represents the type of encoding
 ## 3.0.31
 - Invalidate commit log cache on removing entry from commit log
 ## 3.0.30

--- a/at_secondary/at_persistence_secondary_server/lib/src/compaction/at_compaction_job.dart
+++ b/at_secondary/at_persistence_secondary_server/lib/src/compaction/at_compaction_job.dart
@@ -22,12 +22,12 @@ class AtCompactionJob {
           atCompactionConfig, atLogType, _secondaryPersistenceStore);
     });
   }
-  
+
   //Method to cancel the current schedule. The Cron instance is not close and can be re-used
   Future<void> stopCompactionJob() async {
     await _schedule.cancel();
   }
-  
+
   //Method to stop compaction and also close the Cron instance.
   void close() {
     _cron.close();

--- a/at_secondary/at_persistence_secondary_server/lib/src/keystore/hive_keystore.dart
+++ b/at_secondary/at_persistence_secondary_server/lib/src/keystore/hive_keystore.dart
@@ -77,7 +77,8 @@ class HiveKeystore implements SecondaryKeyStore<String, AtData?, AtMetaData?> {
       bool? isEncrypted,
       String? dataSignature,
       String? sharedKeyEncrypted,
-      String? publicKeyChecksum}) async {
+      String? publicKeyChecksum,
+      String? encoding}) async {
     var result;
     // Default the commit op to just the value update
     CommitOp commitOp = CommitOp.UPDATE;
@@ -109,7 +110,8 @@ class HiveKeystore implements SecondaryKeyStore<String, AtData?, AtMetaData?> {
             isEncrypted: isEncrypted,
             dataSignature: dataSignature,
             sharedKeyEncrypted: sharedKeyEncrypted,
-            publicKeyChecksum: publicKeyChecksum);
+            publicKeyChecksum: publicKeyChecksum,
+            encoding: encoding);
       } else {
         AtData? existingData = await get(key);
         String hive_key = keyStoreHelper.prepareKey(key);
@@ -123,7 +125,8 @@ class HiveKeystore implements SecondaryKeyStore<String, AtData?, AtMetaData?> {
             isEncrypted: isEncrypted,
             dataSignature: dataSignature,
             sharedKeyEncrypted: sharedKeyEncrypted,
-            publicKeyChecksum: publicKeyChecksum);
+            publicKeyChecksum: publicKeyChecksum,
+            encoding: encoding);
         logger.finest('hive key:$hive_key');
         logger.finest('hive value:$hive_value');
         await persistenceManager.getBox().put(hive_key, hive_value);
@@ -154,7 +157,8 @@ class HiveKeystore implements SecondaryKeyStore<String, AtData?, AtMetaData?> {
       bool? isEncrypted,
       String? dataSignature,
       String? sharedKeyEncrypted,
-      String? publicKeyChecksum}) async {
+      String? publicKeyChecksum,
+      String? encoding}) async {
     var result;
     var commitOp;
     String hive_key = keyStoreHelper.prepareKey(key);
@@ -167,7 +171,8 @@ class HiveKeystore implements SecondaryKeyStore<String, AtData?, AtMetaData?> {
         isEncrypted: isEncrypted,
         dataSignature: dataSignature,
         sharedKeyEncrypted: sharedKeyEncrypted,
-        publicKeyChecksum: publicKeyChecksum);
+        publicKeyChecksum: publicKeyChecksum,
+        encoding: encoding);
     // Default commitOp to Update.
     commitOp = CommitOp.UPDATE;
 
@@ -182,6 +187,7 @@ class HiveKeystore implements SecondaryKeyStore<String, AtData?, AtMetaData?> {
       dataSignature ??= value.metaData!.dataSignature;
       sharedKeyEncrypted ??= value.metaData!.sharedKeyEnc;
       publicKeyChecksum ??= value.metaData!.pubKeyCS;
+      encoding ??= value.metaData!.encoding;
     }
 
     // If metadata is set, set commitOp to Update all

--- a/at_secondary/at_persistence_secondary_server/lib/src/keystore/hive_keystore_helper.dart
+++ b/at_secondary/at_persistence_secondary_server/lib/src/keystore/hive_keystore_helper.dart
@@ -28,10 +28,11 @@ class HiveKeyStoreHelper {
       bool? isEncrypted,
       String? dataSignature,
       String? sharedKeyEncrypted,
-      String? publicKeyChecksum}) {
-    var at_data = AtData();
-    at_data.data = newData.data;
-    at_data.metaData = AtMetadataBuilder(
+      String? publicKeyChecksum,
+      String? encoding}) {
+    var atData = AtData();
+    atData.data = newData.data;
+    atData.metaData = AtMetadataBuilder(
             newAtMetaData: newData.metaData,
             ttl: ttl,
             ttb: ttb,
@@ -41,10 +42,11 @@ class HiveKeyStoreHelper {
             isEncrypted: isEncrypted,
             dataSignature: dataSignature,
             sharedKeyEncrypted: sharedKeyEncrypted,
-            publicKeyChecksum: publicKeyChecksum)
+            publicKeyChecksum: publicKeyChecksum,
+            encoding: encoding)
         .build();
-    at_data.metaData!.version = 0;
-    return at_data;
+    atData.metaData!.version = 0;
+    return atData;
   }
 
   AtData prepareDataForUpdate(AtData existingData, AtData newData,
@@ -56,7 +58,8 @@ class HiveKeyStoreHelper {
       bool? isEncrypted,
       String? dataSignature,
       String? sharedKeyEncrypted,
-      String? publicKeyChecksum}) {
+      String? publicKeyChecksum,
+      String? encoding}) {
     existingData.metaData = AtMetadataBuilder(
             newAtMetaData: newData.metaData,
             existingMetaData: existingData.metaData,
@@ -68,7 +71,8 @@ class HiveKeyStoreHelper {
             isEncrypted: isEncrypted,
             dataSignature: dataSignature,
             sharedKeyEncrypted: sharedKeyEncrypted,
-            publicKeyChecksum: publicKeyChecksum)
+            publicKeyChecksum: publicKeyChecksum,
+            encoding: encoding)
         .build();
 //    (existingData.metaData!.version == null)
 //        ? existingData.metaData!.version = 0

--- a/at_secondary/at_persistence_secondary_server/lib/src/log/commitlog/commit_log_keystore.dart
+++ b/at_secondary/at_persistence_secondary_server/lib/src/log/commitlog/commit_log_keystore.dart
@@ -134,8 +134,7 @@ class CommitLogKeyStore
       // invalidate cache for the removed entry
       if (commitEntry != null) {
         _commitLogCacheMap.remove(commitEntry.atKey);
-        _logger.finest(
-            'removed key : ${commitEntry.atKey} from commit log.');
+        _logger.finest('removed key : ${commitEntry.atKey} from commit log.');
       }
     } on Exception catch (e) {
       throw DataStoreException('Exception deleting entry:${e.toString()}');

--- a/at_secondary/at_persistence_secondary_server/lib/src/model/at_meta_data.dart
+++ b/at_secondary/at_persistence_secondary_server/lib/src/model/at_meta_data.dart
@@ -1,5 +1,4 @@
 import 'package:at_commons/at_commons.dart';
-import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:at_persistence_secondary_server/src/utils/type_adapter_util.dart';
 import 'package:hive/hive.dart';
 
@@ -59,6 +58,9 @@ class AtMetaData extends HiveObject {
   @HiveField(17)
   String? pubKeyCS;
 
+  @HiveField(18)
+  String? encoding;
+
   @override
   String toString() {
     return toJson().toString();
@@ -85,6 +87,7 @@ class AtMetaData extends HiveObject {
     map[PUBLIC_DATA_SIGNATURE] = dataSignature;
     map[SHARED_KEY_ENCRYPTED] = sharedKeyEnc;
     map[SHARED_WITH_PUBLIC_KEY_CHECK_SUM] = pubKeyCS;
+    map[ENCODING] = encoding;
     return map;
   }
 
@@ -131,6 +134,7 @@ class AtMetaData extends HiveObject {
       dataSignature = json[PUBLIC_DATA_SIGNATURE];
       sharedKeyEnc = json[SHARED_KEY_ENCRYPTED];
       pubKeyCS = json[SHARED_WITH_PUBLIC_KEY_CHECK_SUM];
+      encoding = json[ENCODING];
     } catch (error) {
       print('AtMetaData.fromJson error: ' + error.toString());
     }
@@ -166,13 +170,14 @@ class AtMetaDataAdapter extends TypeAdapter<AtMetaData> {
       ..isEncrypted = fields[14]
       ..dataSignature = fields[15]
       ..sharedKeyEnc = fields[16]
-      ..pubKeyCS = fields[17];
+      ..pubKeyCS = fields[17]
+      ..encoding = fields[18];
   }
 
   @override
   void write(BinaryWriter writer, AtMetaData obj) {
     writer
-      ..writeByte(18)
+      ..writeByte(19)
       ..writeByte(0)
       ..write(obj.createdBy)
       ..writeByte(1)
@@ -208,6 +213,8 @@ class AtMetaDataAdapter extends TypeAdapter<AtMetaData> {
       ..writeByte(16)
       ..write(obj.sharedKeyEnc)
       ..writeByte(17)
-      ..write(obj.pubKeyCS);
+      ..write(obj.pubKeyCS)
+      ..writeByte(18)
+      ..write(obj.encoding);
   }
 }

--- a/at_secondary/at_persistence_secondary_server/lib/src/model/at_metadata_builder.dart
+++ b/at_secondary/at_persistence_secondary_server/lib/src/model/at_metadata_builder.dart
@@ -2,7 +2,7 @@ import 'package:at_persistence_secondary_server/at_persistence_secondary_server.
 
 /// Builder class to build [AtMetaData] object.
 class AtMetadataBuilder {
-  var atMetaData;
+  AtMetaData? atMetaData;
   var currentUtcTime = DateTime.now().toUtc();
 
   /// AtMetadata Object : Optional parameter, If atMetadata object is null a new AtMetadata object is created.
@@ -22,14 +22,15 @@ class AtMetadataBuilder {
       bool? isEncrypted,
       String? dataSignature,
       String? sharedKeyEncrypted,
-      String? publicKeyChecksum}) {
+      String? publicKeyChecksum,
+      String? encoding}) {
     newAtMetaData ??= AtMetaData();
     atMetaData = newAtMetaData;
-    atMetaData.createdAt ??= currentUtcTime;
-    atMetaData.createdBy ??= atSign;
-    atMetaData.updatedBy = atSign;
-    atMetaData.updatedAt = currentUtcTime;
-    atMetaData.status = 'active';
+    atMetaData!.createdAt ??= currentUtcTime;
+    atMetaData!.createdBy ??= atSign;
+    atMetaData!.updatedBy = atSign;
+    atMetaData!.updatedAt = currentUtcTime;
+    atMetaData!.status = 'active';
 
     //If new metadata is available, consider new metadata, else if existing metadata is available consider it.
     ttl ??= newAtMetaData.ttl;
@@ -50,6 +51,7 @@ class AtMetadataBuilder {
     dataSignature ??= newAtMetaData.dataSignature;
     sharedKeyEncrypted ??= newAtMetaData.sharedKeyEnc;
     publicKeyChecksum ??= newAtMetaData.pubKeyCS;
+    encoding ??= newAtMetaData.encoding;
 
     if (ttl != null && ttl >= 0) {
       setTTL(ttl, ttb: ttb);
@@ -69,62 +71,69 @@ class AtMetadataBuilder {
     setDataSignature(dataSignature);
     setSharedKeyEncrypted(sharedKeyEncrypted);
     setPublicKeyChecksum(publicKeyChecksum);
+    setEncoding(encoding);
   }
 
   void setTTL(int? ttl, {int? ttb}) {
     if (ttl != null) {
-      atMetaData.ttl = ttl;
-      atMetaData.expiresAt =
+      atMetaData!.ttl = ttl;
+      atMetaData!.expiresAt =
           _getExpiresAt(currentUtcTime.millisecondsSinceEpoch, ttl, ttb: ttb);
     }
   }
 
   void setTTB(int? ttb) {
     if (ttb != null) {
-      atMetaData.ttb = ttb;
-      atMetaData.availableAt =
+      atMetaData!.ttb = ttb;
+      atMetaData!.availableAt =
           _getAvailableAt(currentUtcTime.millisecondsSinceEpoch, ttb);
     }
   }
 
   void setTTR(int? ttr) {
     if (ttr != null) {
-      atMetaData.ttr = ttr;
-      atMetaData.refreshAt = _getRefreshAt(currentUtcTime, ttr);
+      atMetaData!.ttr = ttr;
+      atMetaData!.refreshAt = _getRefreshAt(currentUtcTime, ttr);
     }
   }
 
   void setCCD(bool ccd) {
-    atMetaData.isCascade = ccd;
+    atMetaData!.isCascade = ccd;
   }
 
   void setIsBinary(bool? isBinary) {
     if (isBinary != null) {
-      atMetaData.isBinary = isBinary;
+      atMetaData!.isBinary = isBinary;
     }
   }
 
   void setIsEncrypted(bool? isEncrypted) {
     if (isEncrypted != null) {
-      atMetaData.isEncrypted = isEncrypted;
+      atMetaData!.isEncrypted = isEncrypted;
     }
   }
 
   void setDataSignature(String? dataSignature) {
     if (dataSignature != null) {
-      atMetaData.dataSignature = dataSignature;
+      atMetaData!.dataSignature = dataSignature;
     }
   }
 
   void setSharedKeyEncrypted(String? sharedKeyEncrypted) {
     if (sharedKeyEncrypted != null) {
-      atMetaData.sharedKeyEnc = sharedKeyEncrypted;
+      atMetaData!.sharedKeyEnc = sharedKeyEncrypted;
     }
   }
 
   void setPublicKeyChecksum(String? publicKeyChecksum) {
     if (publicKeyChecksum != null) {
-      atMetaData.pubKeyCS = publicKeyChecksum;
+      atMetaData!.pubKeyCS = publicKeyChecksum;
+    }
+  }
+
+  void setEncoding(String? encoding) {
+    if (encoding != null && encoding.isNotEmpty) {
+      atMetaData!.encoding = encoding;
     }
   }
 
@@ -153,7 +162,7 @@ class AtMetadataBuilder {
     return today.add(Duration(seconds: ttr));
   }
 
-  AtMetaData? build() {
-    return atMetaData;
+  AtMetaData build() {
+    return atMetaData!;
   }
 }

--- a/at_secondary/at_persistence_secondary_server/lib/src/notification/at_notification_keystore.dart
+++ b/at_secondary/at_persistence_secondary_server/lib/src/notification/at_notification_keystore.dart
@@ -70,7 +70,8 @@ class AtNotificationKeystore
       bool? isEncrypted,
       String? dataSignature,
       String? sharedKeyEncrypted,
-      String? publicKeyChecksum}) async {
+      String? publicKeyChecksum,
+      String? encoding}) async {
     AtNotificationCallback.getInstance().invokeCallbacks(value);
     await _getBox().put(key, value);
   }
@@ -85,7 +86,8 @@ class AtNotificationKeystore
       bool? isEncrypted,
       String? dataSignature,
       String? sharedKeyEncrypted,
-      String? publicKeyChecksum}) async {
+      String? publicKeyChecksum,
+      String? encoding}) async {
     throw UnimplementedError();
   }
 

--- a/at_secondary/at_persistence_secondary_server/lib/src/utils/at_metadata_adapter.dart
+++ b/at_secondary/at_persistence_secondary_server/lib/src/utils/at_metadata_adapter.dart
@@ -12,7 +12,23 @@ AtMetaData? AtMetadataAdapter(Metadata metadata) {
     ..isEncrypted = metadata.isEncrypted
     ..dataSignature = metadata.dataSignature
     ..sharedKeyEnc = metadata.sharedKeyEnc
-    ..pubKeyCS = metadata.pubKeyCS;
+    ..pubKeyCS = metadata.pubKeyCS
+    ..encoding = metadata.encoding;
 
   return AtMetadataBuilder(newAtMetaData: atMetadata).build();
+}
+
+Metadata metadataAdapter(AtMetaData atMetaData) {
+  var metadata = Metadata()
+    ..ttl = atMetaData.ttl
+    ..ttb = atMetaData.ttb
+    ..ttr = atMetaData.ttr
+    ..ccd = atMetaData.isCascade
+    ..isBinary = atMetaData.isBinary
+    ..isEncrypted = atMetaData.isEncrypted
+    ..dataSignature = atMetaData.dataSignature
+    ..sharedKeyEnc = atMetaData.sharedKeyEnc
+    ..pubKeyCS = atMetaData.pubKeyCS
+    ..encoding = atMetaData.encoding;
+  return metadata;
 }

--- a/at_secondary/at_persistence_secondary_server/pubspec.yaml
+++ b/at_secondary/at_persistence_secondary_server/pubspec.yaml
@@ -13,23 +13,23 @@ dependencies:
   cron: ^0.3.0
   crypto: ^3.0.1
   uuid: ^3.0.4
-  at_persistence_spec: ^2.0.6
+  at_persistence_spec: ^2.0.7
   at_utils: ^3.0.10
-  at_commons: ^3.0.20
+  at_commons: ^3.0.22
   at_utf7: ^1.0.0
   meta: ^1.7.0
 
-dependency_overrides:
-  at_persistence_spec:
-    git:
-      url: https://github.com/atsign-foundation/at_server.git
-      path: at_persistence/at_persistence_spec
-      ref: at_persistence_encode_public_data
-  at_commons:
-    git:
-      url: https://github.com/atsign-foundation/at_tools.git
-      path: at_commons
-      ref: encode_public_data
+#dependency_overrides:
+#  at_persistence_spec:
+#    git:
+#      url: https://github.com/atsign-foundation/at_server.git
+#      path: at_persistence/at_persistence_spec
+#      ref: at_persistence_encode_public_data
+#  at_commons:
+#    git:
+#      url: https://github.com/atsign-foundation/at_tools.git
+#      path: at_commons
+#      ref: encode_public_data
 
 #  at_utils:
 #    git:

--- a/at_secondary/at_persistence_secondary_server/pubspec.yaml
+++ b/at_secondary/at_persistence_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_persistence_secondary_server
 description: A Dart library with the implementation classes for the persistence layer of the secondary server.
-version: 3.0.31
+version: 3.0.32
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://atsign.dev
 
@@ -19,21 +19,22 @@ dependencies:
   at_utf7: ^1.0.0
   meta: ^1.7.0
 
-# dependency_overrides:
-#   at_persistence_spec:
-#     git:
-#       url: https://github.com/atsign-foundation/at_server.git
-#       path: at_persistence/at_persistence_spec
-#       ref: trunk
+dependency_overrides:
+  at_persistence_spec:
+    git:
+      url: https://github.com/atsign-foundation/at_server.git
+      path: at_persistence/at_persistence_spec
+      ref: at_persistence_encode_public_data
+  at_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_tools.git
+      path: at_commons
+      ref: encode_public_data
+
 #  at_utils:
 #    git:
 #      url: https://github.com/atsign-foundation/at_tools.git
 #      path: at_utils
-#      ref: trunk
-#  at_commons:
-#    git:
-#      url: https://github.com/atsign-foundation/at_tools.git
-#      path: at_commons
 #      ref: trunk
 
 dev_dependencies:

--- a/at_secondary/at_secondary_server/CHANGELOG.md
+++ b/at_secondary/at_secondary_server/CHANGELOG.md
@@ -2,6 +2,7 @@
 - fix: invalidate commit log cache on key deletion
 - feat: remove malformed keys on server startup
 - fix: inbound connection pool test flakiness
+- feat: encode the new line characters in the public key data
 ## 3.0.20
 - fix: Bypass cache rename fix
 - feat: Set isEncrypted to true when notify text message is encrypted.

--- a/at_secondary/at_secondary_server/config/config.yaml
+++ b/at_secondary/at_secondary_server/config/config.yaml
@@ -132,4 +132,4 @@ sync:
 #set to true in testing mode, false by default
 #IMPORTANT NOTE : please set testingMode to true only if you know what you're doing. Set to false when not testing
 testing:
-  testingMode: true
+  testingMode: false

--- a/at_secondary/at_secondary_server/config/config.yaml
+++ b/at_secondary/at_secondary_server/config/config.yaml
@@ -132,4 +132,4 @@ sync:
 #set to true in testing mode, false by default
 #IMPORTANT NOTE : please set testingMode to true only if you know what you're doing. Set to false when not testing
 testing:
-  testingMode: false
+  testingMode: true

--- a/at_secondary/at_secondary_server/lib/src/connection/outbound/outbound_message_listener.dart
+++ b/at_secondary/at_secondary_server/lib/src/connection/outbound/outbound_message_listener.dart
@@ -82,17 +82,29 @@ class OutboundMessageListener {
           // Right now, all callers of this method only expect there ever to be a 'data:' response.
           // So right now, the right thing to do here is to throw an exception.
           // We can leave the connection open since an 'error:' response indicates normal functioning on the other end
-          throw AtConnectException("Request to remote secondary ${outboundClient.toAtSign} at ${outboundClient.toHost}:${outboundClient.toPort} received error response '$result'");
+          try {
+            result = result.toString().replaceFirst('error:', '');
+            var errorMap = jsonDecode(result);
+            throw AtExceptionUtils.get(
+                errorMap['errorCode'], errorMap['errorDescription']);
+          } on FormatException {
+            // Catching the FormatException to preserve backward compatibility - responses without jsonEncoding.
+            // TODO: Can remove the catch block in the next release (once all the existing servers are migrated to new version).
+            throw AtConnectException(
+                "Request to remote secondary ${outboundClient.toAtSign} at ${outboundClient.toHost}:${outboundClient.toPort} received error response '$result'");
+          }
         } else {
           // any other response is unexpected and bad, so close the connection and throw an exception
           _closeOutboundClient();
-          throw AtConnectException("Unexpected response '$result' from remote secondary ${outboundClient.toAtSign} at ${outboundClient.toHost}:${outboundClient.toPort}");
+          throw AtConnectException(
+              "Unexpected response '$result' from remote secondary ${outboundClient.toAtSign} at ${outboundClient.toHost}:${outboundClient.toPort}");
         }
       }
     }
     // No response ... that's probably bad, so in addition to throwing an exception, let's also close the connection
     _closeOutboundClient();
-    throw AtTimeoutException("No response after $maxWaitMilliSeconds millis from remote secondary ${outboundClient.toAtSign} at ${outboundClient.toHost}:${outboundClient.toPort}");
+    throw AtTimeoutException(
+        "No response after $maxWaitMilliSeconds millis from remote secondary ${outboundClient.toAtSign} at ${outboundClient.toHost}:${outboundClient.toPort}");
   }
 
   /// Logs the error and closes the [OutboundClient]

--- a/at_secondary/at_secondary_server/lib/src/verb/handler/sync_progressive_verb_handler.dart
+++ b/at_secondary/at_secondary_server/lib/src/verb/handler/sync_progressive_verb_handler.dart
@@ -17,7 +17,7 @@ class SyncProgressiveVerbHandler extends AbstractVerbHandler {
 
   @override
   bool accept(String command) =>
-      command.startsWith(getName(VerbEnum.sync) + ':') &&
+      command.startsWith('${getName(VerbEnum.sync)}:') &&
       command.startsWith('sync:from');
 
   @override
@@ -79,49 +79,14 @@ class SyncProgressiveVerbHandler extends AbstractVerbHandler {
   Map _populateMetadata(value) {
     var metaDataMap = <String, dynamic>{};
     AtMetaData? metaData = value?.metaData;
-    if (metaData != null) {
-      if (metaData.ttl != null) {
-        metaDataMap.putIfAbsent(AT_TTL, () => metaData.ttl.toString());
-      }
-      if (metaData.ttb != null) {
-        metaDataMap.putIfAbsent(AT_TTB, () => metaData.ttb.toString());
-      }
-      if (metaData.ttr != null) {
-        metaDataMap.putIfAbsent(AT_TTR, () => metaData.ttr.toString());
-      }
-      if (metaData.isCascade != null) {
-        metaDataMap.putIfAbsent(CCD, () => metaData.isCascade.toString());
-      }
-
-      if (metaData.dataSignature != null) {
-        metaDataMap.putIfAbsent(
-            PUBLIC_DATA_SIGNATURE, () => metaData.dataSignature.toString());
-      }
-      if (metaData.isBinary != null) {
-        metaDataMap.putIfAbsent(IS_BINARY, () => metaData.isBinary.toString());
-      }
-      if (metaData.isEncrypted != null) {
-        metaDataMap.putIfAbsent(
-            IS_ENCRYPTED, () => metaData.isEncrypted.toString());
-      }
-
-      if (metaData.createdAt != null) {
-        metaDataMap.putIfAbsent(
-            CREATED_AT, () => metaData.createdAt.toString());
-      }
-      if (metaData.updatedAt != null) {
-        metaDataMap.putIfAbsent(
-            UPDATED_AT, () => metaData.updatedAt.toString());
-      }
-      if (metaData.sharedKeyEnc != null) {
-        metaDataMap.putIfAbsent(
-            SHARED_KEY_ENCRYPTED, () => metaData.sharedKeyEnc);
-      }
-      if (metaData.pubKeyCS != null) {
-        metaDataMap.putIfAbsent(
-            SHARED_WITH_PUBLIC_KEY_CHECK_SUM, () => metaData.pubKeyCS);
-      }
+    if (metaData == null) {
+      return metaDataMap;
     }
+    metaData.toJson().forEach((key, value) {
+      if (value != null) {
+        metaDataMap[key] = [value];
+      }
+    });
     return metaDataMap;
   }
 

--- a/at_secondary/at_secondary_server/lib/src/verb/handler/update_verb_handler.dart
+++ b/at_secondary/at_secondary_server/lib/src/verb/handler/update_verb_handler.dart
@@ -20,6 +20,7 @@ import 'package:at_utils/at_utils.dart';
 class UpdateVerbHandler extends ChangeVerbHandler {
   static bool? _autoNotify = AtSecondaryConfig.autoNotify;
   static Update update = Update();
+
   UpdateVerbHandler(SecondaryKeyStore? keyStore) : super(keyStore);
 
   //setter to set autoNotify value from dynamic server config "config:set".
@@ -34,7 +35,7 @@ class UpdateVerbHandler extends ChangeVerbHandler {
   // Input: command
   @override
   bool accept(String command) =>
-      command.startsWith(getName(VerbEnum.update) + ':') &&
+      command.startsWith('${getName(VerbEnum.update)}:') &&
       !command.startsWith('update:meta');
 
   // Method to return Instance of verb belongs to this VerbHandler
@@ -82,6 +83,8 @@ class UpdateVerbHandler extends ChangeVerbHandler {
       var ccd = updateParams.metadata!.ccd;
       String? sharedKeyEncrypted = updateParams.metadata!.sharedKeyEnc;
       String? publicKeyChecksum = updateParams.metadata!.pubKeyCS;
+      String? encoding = updateParams.metadata!.encoding;
+
       // Get the key using verbParams (forAtSign, key, atSign)
       if (forAtSign != null) {
         forAtSign = AtUtils.formatAtSign(forAtSign);
@@ -119,7 +122,8 @@ class UpdateVerbHandler extends ChangeVerbHandler {
         ..isEncrypted = isEncrypted
         ..dataSignature = dataSignature
         ..sharedKeyEnc = sharedKeyEncrypted
-        ..pubKeyCS = publicKeyChecksum;
+        ..pubKeyCS = publicKeyChecksum
+        ..encoding = encoding;
 
       if (_autoNotify!) {
         _notify(
@@ -141,7 +145,8 @@ class UpdateVerbHandler extends ChangeVerbHandler {
           isEncrypted: isEncrypted,
           dataSignature: dataSignature,
           sharedKeyEncrypted: sharedKeyEncrypted,
-          publicKeyChecksum: publicKeyChecksum);
+          publicKeyChecksum: publicKeyChecksum,
+          encoding: encoding);
       response.data = result?.toString();
     } on InvalidSyntaxException {
       rethrow;
@@ -204,9 +209,8 @@ class UpdateVerbHandler extends ChangeVerbHandler {
     metadata.isPublic = AtMetadataUtil.getBoolVerbParams(verbParams[IS_PUBLIC]);
     metadata.sharedKeyEnc = verbParams[SHARED_KEY_ENCRYPTED];
     metadata.pubKeyCS = verbParams[SHARED_WITH_PUBLIC_KEY_CHECK_SUM];
+    metadata.encoding = verbParams[ENCODING];
     updateParams.metadata = metadata;
     return updateParams;
   }
-
-  void _autoNotifyChange() {}
 }

--- a/at_secondary/at_secondary_server/pubspec.yaml
+++ b/at_secondary/at_secondary_server/pubspec.yaml
@@ -17,27 +17,22 @@ dependencies:
   crypton: 2.0.5
   collection: 1.16.0
   basic_utils: 4.4.3
-  at_persistence_secondary_server: 3.0.31
-  at_lookup: 3.0.28
+  at_persistence_secondary_server: 3.0.32
+  at_lookup: 3.0.29
   at_server_spec: 3.0.9
   at_utils: 3.0.10
 
-dependency_overrides:
-  at_commons:
-    git:
-      url: https://github.com/atsign-foundation/at_tools.git
-      path: at_commons
-      ref: trunk
-  at_lookup:
-    git:
-      url: https://github.com/atsign-foundation/at_libraries.git
-      path: at_lookup
-      ref: json_decoding_response
+#dependency_overrides:
+#  at_commons:
+#    git:
+#      url: https://github.com/atsign-foundation/at_tools.git
+#      path: at_commons
+#      ref: new_set_verb
 #  at_persistence_secondary_server:
 #   git:
 #     url: https://github.com/atsign-foundation/at_server.git
 #     path: at_secondary/at_persistence_secondary_server
-#     ref: trunk
+#     ref: set_verb
 #  at_server_spec:
 #    git:
 #      url: https://github.com/atsign-foundation/at_server.git

--- a/at_secondary/at_secondary_server/pubspec.yaml
+++ b/at_secondary/at_secondary_server/pubspec.yaml
@@ -22,12 +22,17 @@ dependencies:
   at_server_spec: 3.0.9
   at_utils: 3.0.10
 
-#dependency_overrides:
-#  at_commons:
-#    git:
-#      url: https://github.com/atsign-foundation/at_tools.git
-#      path: at_commons
-#      ref: new_set_verb
+dependency_overrides:
+  at_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_tools.git
+      path: at_commons
+      ref: trunk
+  at_lookup:
+    git:
+      url: https://github.com/atsign-foundation/at_libraries.git
+      path: at_lookup
+      ref: json_decoding_response
 #  at_persistence_secondary_server:
 #   git:
 #     url: https://github.com/atsign-foundation/at_server.git

--- a/at_secondary/at_secondary_server/pubspec.yaml
+++ b/at_secondary/at_secondary_server/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
 #   git:
 #     url: https://github.com/atsign-foundation/at_server.git
 #     path: at_secondary/at_persistence_secondary_server
-#     ref: set_verb
+#     ref: trunk
 #  at_server_spec:
 #    git:
 #      url: https://github.com/atsign-foundation/at_server.git

--- a/at_virtual_environment/ve_base/Dockerfile
+++ b/at_virtual_environment/ve_base/Dockerfile
@@ -17,7 +17,7 @@ RUN \
   dart pub update ; \
   dart compile exe bin/install_PKAM_Keys.dart -o install_PKAM_Keys
 
-FROM debian:stable-20220711-slim
+FROM debian:stable-20220801-slim
 USER root
 
 COPY ./at_virtual_environment/ve_base/contents /


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Return error codes and error description on exception.
- Generate the exception type from the error codes on the exception.

**- How I did it**
- When exception is raised, JSON encode the error codes and error descriptions.
- On receiving the exception, decode the JSON, and create the exception type from the error code and set the description.

**- How to verify it**
- Run the scenarios that trigger exception - look for a non existent key and verify the `KeyNotFoundException` type is returned along with error code and error description.

**- Description for the changelog** 
- Forward the error codes and error description.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**-Tests from at_server command line**

Look for a key when root server is not started.
@ sitaram@lookup:phone.wavi@murali
error:{"errorCode":"AT0011","errorDescription":"Internal server exception : Failed connecting to root server url vip.ve.atsign.zone on port 64"}

Look for a key when target secondary is not started.
@ sitaram@lookup:phone.wavi@murali
error:{"errorCode":"AT0007","errorDescription":"Secondary server not found : unable to connect to secondary"}

Look for a non existent key
@ sitaram@lookup:phone.wavi@murali
error:{"errorCode":"AT0015","errorDescription":"key not found : Exception: @ sitaram:phone.wavi@ murali does not exist in keystore"}
