### PR TITLE
fix: add toString to the value in metadata

### DIFF
--- a/at_secondary/at_secondary_server/lib/src/verb/handler/sync_progressive_verb_handler.dart
+++ b/at_secondary/at_secondary_server/lib/src/verb/handler/sync_progressive_verb_handler.dart
@@ -84,7 +84,7 @@ class SyncProgressiveVerbHandler extends AbstractVerbHandler {
     }
     metaData.toJson().forEach((key, value) {
       if (value != null) {
-        metaDataMap[key] = [value];
+        metaDataMap[key] = [value].toString();
       }
     });
     return metaDataMap;


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
1. Add toString the value in the sync_progressive_verb_handler.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->