### PR TITLE
build: remove dependency overrides for persistence

### DIFF
--- a/at_secondary/at_secondary_server/pubspec.yaml
+++ b/at_secondary/at_secondary_server/pubspec.yaml
@@ -18,23 +18,23 @@ dependencies:
   collection: 1.16.0
   basic_utils: 4.5.2
   at_persistence_spec: 2.0.7
-  at_persistence_secondary_server: 3.0.32
+  at_persistence_secondary_server: 3.0.33
   at_lookup: 3.0.29
   at_server_spec: 3.0.9
   at_utils: 3.0.10
   at_commons: 3.0.24
 
-dependency_overrides:
+#dependency_overrides:
 #  at_commons:
 #    git:
 #      url: https://github.com/atsign-foundation/at_tools.git
 #      path: at_commons
 #      ref: encode_public_data
-  at_persistence_secondary_server:
-    git:
-      url: https://github.com/atsign-foundation/at_server.git
-      path: at_secondary/at_persistence_secondary_server
-      ref: trunk
+#  at_persistence_secondary_server:
+#    git:
+#      url: https://github.com/atsign-foundation/at_server.git
+#      path: at_secondary/at_persistence_secondary_server
+#      ref: trunk
 #  at_persistence_spec:
 #    git:
 #      url: https://github.com/atsign-foundation/at_server.git


### PR DESCRIPTION
**- What I did**
- commented dependency overrides for persistence secondary server
**- How I did it**
- commented dependency overrides section in pubspec.yaml
- upgraded persistence secondary server version from 3.0.32 to 3.0.33
**- How to verify it**
- tests should pass