### PR TITLE
fix: update command validate sharedBy is same as currentAtSign

### DIFF
--- a/at_secondary/at_secondary_server/lib/src/verb/handler/update_verb_handler.dart
+++ b/at_secondary/at_secondary_server/lib/src/verb/handler/update_verb_handler.dart
@@ -64,11 +64,19 @@ class UpdateVerbHandler extends ChangeVerbHandler {
     // Sets Response bean to the response bean in ChangeVerbHandler
     await super.processVerb(response, verbParams, atConnection);
     var updateParams = _getUpdateParams(verbParams);
-
+    if (updateParams.sharedBy != null &&
+        updateParams.sharedBy!.isNotEmpty &&
+        AtUtils.formatAtSign(updateParams.sharedBy) !=
+            AtSecondaryServerImpl.getInstance().currentAtSign) {
+      logger.warning(
+          'Invalid update command sharedBy atsign ${AtUtils.formatAtSign(updateParams.sharedBy)} should be same as current atsign ${AtSecondaryServerImpl.getInstance().currentAtSign} ');
+      throw InvalidAtKeyException(
+          'SharedBy atsign should be the same as current atsign');
+    }
     try {
       // Get the key and update the value
-      var forAtSign = updateParams.sharedBy;
-      var atSign = updateParams.sharedWith;
+      var forAtSign = updateParams.sharedWith;
+      var atSign = updateParams.sharedBy;
       var key = updateParams.atKey;
       var value = updateParams.value;
       var atData = AtData();
@@ -187,14 +195,13 @@ class UpdateVerbHandler extends ChangeVerbHandler {
 
   UpdateParams _getUpdateParams(HashMap<String, String?> verbParams) {
     if (verbParams['json'] != null) {
-      print('update json');
       var jsonString = verbParams['json']!;
       Map jsonMap = jsonDecode(jsonString);
       return UpdateParams.fromJson(jsonMap);
     }
     var updateParams = UpdateParams();
-    updateParams.sharedBy = verbParams[FOR_AT_SIGN];
-    updateParams.sharedWith = verbParams[AT_SIGN];
+    updateParams.sharedBy = verbParams[AT_SIGN];
+    updateParams.sharedWith = verbParams[FOR_AT_SIGN];
     updateParams.atKey = verbParams[AT_KEY];
     updateParams.value = verbParams[AT_VALUE];
     var metadata = Metadata();

--- a/at_secondary/at_secondary_server/lib/src/verb/handler/update_verb_handler.dart
+++ b/at_secondary/at_secondary_server/lib/src/verb/handler/update_verb_handler.dart
@@ -69,9 +69,9 @@ class UpdateVerbHandler extends ChangeVerbHandler {
         AtUtils.formatAtSign(updateParams.sharedBy) !=
             AtSecondaryServerImpl.getInstance().currentAtSign) {
       logger.warning(
-          'Invalid update command sharedBy atsign ${AtUtils.formatAtSign(updateParams.sharedBy)} should be same as current atsign ${AtSecondaryServerImpl.getInstance().currentAtSign} ');
+          'Invalid update command sharedBy atsign ${AtUtils.formatAtSign(updateParams.sharedBy)} should be same as current atsign ${AtSecondaryServerImpl.getInstance().currentAtSign}');
       throw InvalidAtKeyException(
-          'SharedBy atsign should be the same as current atsign');
+          'Invalid update command sharedBy atsign ${AtUtils.formatAtSign(updateParams.sharedBy)} should be same as current atsign ${AtSecondaryServerImpl.getInstance().currentAtSign}');
     }
     try {
       // Get the key and update the value

--- a/at_secondary/at_secondary_server/test/update_meta_verb_test.dart
+++ b/at_secondary/at_secondary_server/test/update_meta_verb_test.dart
@@ -91,7 +91,7 @@ void main() {
       var updateVerbHandler = UpdateVerbHandler(keyStore);
       var updateResponse = Response();
       var updateVerbParams = HashMap<String, String>();
-      updateVerbParams.putIfAbsent('atSign', () => '@sitaram');
+      updateVerbParams.putIfAbsent('atSign', () => '@kevin');
       updateVerbParams.putIfAbsent('atKey', () => 'phone');
       updateVerbParams.putIfAbsent('value', () => '99899');
       await updateVerbHandler.processVerb(
@@ -103,7 +103,7 @@ void main() {
           UpdateMetaVerbHandler(keyStoreManager.getKeyStore());
       var updateMetaResponse = Response();
       var updateMetaVerbParam = HashMap<String, String>();
-      updateMetaVerbParam.putIfAbsent('atSign', () => '@sitaram');
+      updateMetaVerbParam.putIfAbsent('atSign', () => '@kevin');
       updateMetaVerbParam.putIfAbsent('atKey', () => 'phone');
       updateMetaVerbParam.putIfAbsent('ttb', () => ttb.toString());
       await updateMetaVerbHandler.processVerb(
@@ -113,11 +113,12 @@ void main() {
       var localLookUpResponse = Response();
       var localLookupVerbHandler = LocalLookupVerbHandler(keyStore);
       var localLookVerbParam = HashMap<String, String>();
-      localLookVerbParam.putIfAbsent('atSign', () => '@sitaram');
+      localLookVerbParam.putIfAbsent('atSign', () => '@kevin');
       localLookVerbParam.putIfAbsent('atKey', () => 'phone');
       await localLookupVerbHandler.processVerb(
           localLookUpResponse, localLookVerbParam, atConnection);
-      expect(localLookUpResponse.data, null); // should be null, as we have not yet reached ttb
+      expect(localLookUpResponse.data,
+          null); // should be null, as we have not yet reached ttb
 
       await Future.delayed(Duration(milliseconds: ttb));
       await localLookupVerbHandler.processVerb(
@@ -158,7 +159,7 @@ void main() {
       var updateVerbHandler = UpdateVerbHandler(keyStore);
       var updateResponse = Response();
       var updateVerbParams = HashMap<String, String>();
-      updateVerbParams.putIfAbsent('atSign', () => '@sitaram');
+      updateVerbParams.putIfAbsent('atSign', () => '@kevin');
       updateVerbParams.putIfAbsent('atKey', () => 'location');
       updateVerbParams.putIfAbsent('value', () => 'hyderabad');
       await updateVerbHandler.processVerb(
@@ -171,7 +172,7 @@ void main() {
           UpdateMetaVerbHandler(keyStoreManager.getKeyStore());
       var updateMetaResponse = Response();
       var updateMetaVerbParam = HashMap<String, String>();
-      updateMetaVerbParam.putIfAbsent('atSign', () => '@sitaram');
+      updateMetaVerbParam.putIfAbsent('atSign', () => '@kevin');
       updateMetaVerbParam.putIfAbsent('atKey', () => 'location');
       updateMetaVerbParam.putIfAbsent('ttl', () => ttl.toString());
       await updateMetaVerbHandler.processVerb(
@@ -181,17 +182,19 @@ void main() {
       var localLookUpResponse = Response();
       var localLookupVerbHandler = LocalLookupVerbHandler(keyStore);
       var localLookVerbParam = HashMap<String, String>();
-      localLookVerbParam.putIfAbsent('atSign', () => '@sitaram');
+      localLookVerbParam.putIfAbsent('atSign', () => '@kevin');
       localLookVerbParam.putIfAbsent('atKey', () => 'location');
       await localLookupVerbHandler.processVerb(
           localLookUpResponse, localLookVerbParam, atConnection);
-      expect(localLookUpResponse.data, 'hyderabad'); // ttl not yet reached, value will be live
+      expect(localLookUpResponse.data,
+          'hyderabad'); // ttl not yet reached, value will be live
 
       await Future.delayed(Duration(milliseconds: ttl));
       var localLookUpResponse1 = Response();
       await localLookupVerbHandler.processVerb(
           localLookUpResponse1, localLookVerbParam, atConnection);
-      expect(localLookUpResponse1.data, null); // ttl has passed, value should no longer be live
+      expect(localLookUpResponse1.data,
+          null); // ttl has passed, value should no longer be live
     });
     tearDown(() async => await tearDownFunc());
   });

--- a/at_secondary/at_secondary_server/test/update_verb_test.dart
+++ b/at_secondary/at_secondary_server/test/update_verb_test.dart
@@ -547,7 +547,7 @@ void main() {
       var updateVerbHandler = UpdateVerbHandler(keyStore);
       var updateResponse = Response();
       var updateVerbParams = HashMap<String, String>();
-      updateVerbParams.putIfAbsent('atSign', () => '@sitaram');
+      updateVerbParams.putIfAbsent('atSign', () => '@alice');
       updateVerbParams.putIfAbsent('atKey', () => 'location');
       updateVerbParams.putIfAbsent('value', () => 'hyderabad');
       await updateVerbHandler.processVerb(
@@ -555,7 +555,7 @@ void main() {
       var localLookUpResponse = Response();
       var localLookupVerbHandler = LocalLookupVerbHandler(keyStore);
       var localLookVerbParam = HashMap<String, String>();
-      localLookVerbParam.putIfAbsent('atSign', () => '@sitaram');
+      localLookVerbParam.putIfAbsent('atSign', () => '@alice');
       localLookVerbParam.putIfAbsent('atKey', () => 'location');
       await localLookupVerbHandler.processVerb(
           localLookUpResponse, localLookVerbParam, atConnection);
@@ -598,7 +598,7 @@ void main() {
       int ttl = 1000; // in milliseconds
       int ttb = 1000; // in milliseconds
 
-      updateVerbParams.putIfAbsent(AT_SIGN, () => '@sitaram');
+      updateVerbParams.putIfAbsent(AT_SIGN, () => '@alice');
       updateVerbParams.putIfAbsent(AT_KEY, () => 'location');
       updateVerbParams.putIfAbsent(AT_TTL, () => ttl.toString());
       updateVerbParams.putIfAbsent(AT_TTB, () => ttb.toString());
@@ -611,29 +611,32 @@ void main() {
       var localLookUpResponseBeforeTtb = Response();
       var localLookupVerbHandler = LocalLookupVerbHandler(keyStore);
       var localLookVerbParam = HashMap<String, String>();
-      localLookVerbParam.putIfAbsent(AT_SIGN, () => '@sitaram');
+      localLookVerbParam.putIfAbsent(AT_SIGN, () => '@alice');
       localLookVerbParam.putIfAbsent(AT_KEY, () => 'location');
       await localLookupVerbHandler.processVerb(
           localLookUpResponseBeforeTtb, localLookVerbParam, atConnection);
-      expect(localLookUpResponseBeforeTtb.data, null); // should be null, value has not passed ttb
+      expect(localLookUpResponseBeforeTtb.data,
+          null); // should be null, value has not passed ttb
 
       //LLOOKUP Verb - After TTB
       await Future.delayed(Duration(milliseconds: ttb));
       var localLookUpResponseAfterTtb = Response();
-      localLookVerbParam.putIfAbsent(AT_SIGN, () => '@sitaram');
+      localLookVerbParam.putIfAbsent(AT_SIGN, () => '@alice');
       localLookVerbParam.putIfAbsent(AT_KEY, () => 'location');
       await localLookupVerbHandler.processVerb(
           localLookUpResponseAfterTtb, localLookVerbParam, atConnection);
-      expect(localLookUpResponseAfterTtb.data, 'hyderabad'); // after ttb has passed, the value should exist
+      expect(localLookUpResponseAfterTtb.data,
+          'hyderabad'); // after ttb has passed, the value should exist
 
       //LLOOKUP Verb - After TTL
       await Future.delayed(Duration(milliseconds: ttl));
       var localLookUpResponseAfterTtl = Response();
-      localLookVerbParam.putIfAbsent(AT_SIGN, () => '@sitaram');
+      localLookVerbParam.putIfAbsent(AT_SIGN, () => '@alice');
       localLookVerbParam.putIfAbsent(AT_KEY, () => 'location');
       await localLookupVerbHandler.processVerb(
           localLookUpResponseAfterTtl, localLookVerbParam, atConnection);
-      expect(localLookUpResponseAfterTtl.data, null); // after ttl has passed, the value should no longer be live
+      expect(localLookUpResponseAfterTtl.data,
+          null); // after ttl has passed, the value should no longer be live
     });
 
     test('Test to verify reset of TTB', () async {
@@ -668,7 +671,7 @@ void main() {
       var updateVerbHandler = UpdateVerbHandler(keyStore);
       var updateResponse = Response();
       var updateVerbParams = HashMap<String, String>();
-      updateVerbParams.putIfAbsent(AT_SIGN, () => '@sitaram');
+      updateVerbParams.putIfAbsent(AT_SIGN, () => '@alice');
       updateVerbParams.putIfAbsent(AT_KEY, () => 'location');
       updateVerbParams.putIfAbsent(AT_TTB, () => '60000');
       updateVerbParams.putIfAbsent(AT_VALUE, () => 'hyderabad');
@@ -678,25 +681,67 @@ void main() {
       var localLookUpResponse = Response();
       var localLookupVerbHandler = LocalLookupVerbHandler(keyStore);
       var localLookVerbParam = HashMap<String, String>();
-      localLookVerbParam.putIfAbsent(AT_SIGN, () => '@sitaram');
+      localLookVerbParam.putIfAbsent(AT_SIGN, () => '@alice');
       localLookVerbParam.putIfAbsent(AT_KEY, () => 'location');
       await localLookupVerbHandler.processVerb(
           localLookUpResponse, localLookVerbParam, atConnection);
       expect(localLookUpResponse.data, null);
       //Reset TTB
       updateVerbParams = HashMap<String, String>();
-      updateVerbParams.putIfAbsent(AT_SIGN, () => '@sitaram');
+      updateVerbParams.putIfAbsent(AT_SIGN, () => '@alice');
       updateVerbParams.putIfAbsent(AT_KEY, () => 'location');
       updateVerbParams.putIfAbsent(AT_TTB, () => '0');
       updateVerbParams.putIfAbsent(AT_VALUE, () => 'hyderabad');
       await updateVerbHandler.processVerb(
           updateResponse, updateVerbParams, atConnection);
       //LLOOKUP Verb - After TTB
-      localLookVerbParam.putIfAbsent(AT_SIGN, () => '@sitaram');
+      localLookVerbParam.putIfAbsent(AT_SIGN, () => '@alice');
       localLookVerbParam.putIfAbsent(AT_KEY, () => 'location');
       await localLookupVerbHandler.processVerb(
           localLookUpResponse, localLookVerbParam, atConnection);
       expect(localLookUpResponse.data, 'hyderabad');
+    });
+  });
+  group('A group of tests to validate sharedBy atsign', () {
+    test('sharedBy atsign is not equal to current atsign', () async {
+      var command = 'update:phone@bob +12345';
+      command = SecondaryUtil.convertCommand(command);
+      AbstractVerbHandler handler = UpdateVerbHandler(null);
+      AtSecondaryServerImpl.getInstance().currentAtSign = '@alice';
+      var secondaryPersistenceStore =
+          SecondaryPersistenceStoreFactory.getInstance()
+              .getSecondaryPersistenceStore(
+                  AtSecondaryServerImpl.getInstance().currentAtSign)!;
+      handler.keyStore = secondaryPersistenceStore
+          .getSecondaryKeyStoreManager()!
+          .getKeyStore();
+      var response = Response();
+      var verbParams = handler.parse(command);
+      var atConnection = InboundConnectionImpl(null, null);
+      expect(
+          () => handler.processVerb(response, verbParams, atConnection),
+          throwsA(predicate((dynamic e) =>
+              e is InvalidAtKeyException &&
+              e.message ==
+                  'SharedBy atsign should be same as current atsign')));
+    });
+    test('sharedBy atsign same as current atsign', () async {
+      var command = 'update:phone@alice +12345';
+      command = SecondaryUtil.convertCommand(command);
+      AbstractVerbHandler handler = UpdateVerbHandler(null);
+      AtSecondaryServerImpl.getInstance().currentAtSign = '@alice';
+      var secondaryPersistenceStore =
+          SecondaryPersistenceStoreFactory.getInstance()
+              .getSecondaryPersistenceStore(
+                  AtSecondaryServerImpl.getInstance().currentAtSign)!;
+      handler.keyStore = secondaryPersistenceStore
+          .getSecondaryKeyStoreManager()!
+          .getKeyStore();
+      var response = Response();
+      var verbParams = handler.parse(command);
+      var atConnection = InboundConnectionImpl(null, null);
+      await handler.processVerb(response, verbParams, atConnection);
+      expect(response.isError, false);
     });
   });
   tearDown(() async => await tearDownFunc());

--- a/at_secondary/at_secondary_server/test/update_verb_test.dart
+++ b/at_secondary/at_secondary_server/test/update_verb_test.dart
@@ -718,12 +718,13 @@ void main() {
       var response = Response();
       var verbParams = handler.parse(command);
       var atConnection = InboundConnectionImpl(null, null);
-      expect(
-          () => handler.processVerb(response, verbParams, atConnection),
+      expectLater(
+          () async =>
+              await handler.processVerb(response, verbParams, atConnection),
           throwsA(predicate((dynamic e) =>
               e is InvalidAtKeyException &&
               e.message ==
-                  'SharedBy atsign should be the same as current atsign')));
+                  'Invalid update command sharedBy atsign @bob should be same as current atsign @alice')));
     });
     test('sharedBy atsign same as current atsign', () async {
       var command = 'update:phone@alice +12345';

--- a/at_secondary/at_secondary_server/test/update_verb_test.dart
+++ b/at_secondary/at_secondary_server/test/update_verb_test.dart
@@ -723,7 +723,7 @@ void main() {
           throwsA(predicate((dynamic e) =>
               e is InvalidAtKeyException &&
               e.message ==
-                  'SharedBy atsign should be same as current atsign')));
+                  'SharedBy atsign should be the same as current atsign')));
     });
     test('sharedBy atsign same as current atsign', () async {
       var command = 'update:phone@alice +12345';


### PR DESCRIPTION
**- What I did**
- added a validation check for update command
**- How I did it**
- in update_verb_handler, if sharedBy atsign is set and if it is not same as current atsign then return InvalidAtKeyException
- fixed a code bug in two places where sharedBy and sharedWith were set incorrectly. No impact due to this bug since it was incorrect in couple of places, eventually key was constructed in the correct format.
- added unit tests to "A group of tests to validate sharedBy atsign" in update_verb_test
- fixed few tests which were failing due to new validation
**- How to verify it**
- run the unit tests in secondary server