### PR TITLE
build: remove dependency override for at_server_spec

### DIFF
--- a/at_secondary/at_secondary_server/pubspec.yaml
+++ b/at_secondary/at_secondary_server/pubspec.yaml
@@ -20,16 +20,16 @@ dependencies:
   at_persistence_spec: 2.0.7
   at_persistence_secondary_server: 3.0.33
   at_lookup: 3.0.29
-  at_server_spec: 3.0.9
+  at_server_spec: 3.0.10
   at_utils: 3.0.10
   at_commons: 3.0.25
 
-dependency_overrides:
-  at_server_spec:
-    git:
-      url: https://github.com/atsign-foundation/at_server.git
-      path: at_server_spec
-      ref: trunk
+#dependency_overrides:
+#  at_server_spec:
+#    git:
+#      url: https://github.com/atsign-foundation/at_server.git
+#      path: at_server_spec
+#      ref: trunk
 #  at_commons:
 #    git:
 #      url: https://github.com/atsign-foundation/at_tools.git

--- a/at_server_spec/lib/src/verb/config.dart
+++ b/at_server_spec/lib/src/verb/config.dart
@@ -1,4 +1,3 @@
-import 'package:at_server_spec/src/verb/verb.dart';
 import 'package:at_commons/at_commons.dart';
 import 'verb.dart';
 


### PR DESCRIPTION
**- What I did**
* build: remove dependency override for at_server_spec (now using newly-published version 3.0.10)
* chore: fixed a lint warning in at_server_spec/lib/src/verb/config.dart

**- How to verify it**
Checks succeed

**- Description for the changelog**
* build: remove dependency override for at_server_spec (now using newly-published version 3.0.10)
* chore: fixed a lint warning in at_server_spec/lib/src/verb/config.dart
