### PR TITLE
feat: add 'training' mode

### DIFF
--- a/at_secondary/at_secondary_server/bin/main.dart
+++ b/at_secondary/at_secondary_server/bin/main.dart
@@ -1,3 +1,6 @@
+import 'dart:io';
+
+import 'package:args/args.dart';
 import 'package:at_secondary/src/exception/global_exception_handler.dart';
 import 'package:at_secondary/src/server/at_secondary_config.dart';
 import 'package:at_secondary/src/server/bootstrapper.dart';
@@ -17,8 +20,11 @@ Future<void> main(List<String> arguments) async {
   try {
     var bootStrapper = SecondaryServerBootStrapper(arguments);
     await bootStrapper.run();
+  } on ArgParserException catch (e) {
+    logger.shout(e.message);
+    exit(1);
   } on Exception catch (e) {
-    logger.severe('Exception in starting secondary server: ${e.toString()}');
-    await GlobalExceptionHandler.getInstance().handle(e);
+    logger.shout('Unexpected exception while starting secondary server: ${e.toString()}');
+    exit(1);
   }
 }

--- a/at_secondary/at_secondary_server/lib/src/arg_utils.dart
+++ b/at_secondary/at_secondary_server/lib/src/arg_utils.dart
@@ -9,31 +9,33 @@ class CommandLineParser {
   /// Parses [arguments], a list of command-line arguments, matches them against the
   /// flags and options defined by this parser, and returns the result.
   ArgResults getParserResults(List<String>? arguments) {
-    var results;
+    ArgResults results;
     var parser = ArgParser();
     parser.addOption('at_sign',
         abbr: 'a',
-        //defaultsTo: 'localhost',
         help: 'AtSign handle');
     parser.addOption('server_port',
         abbr: 'p',
-        //defaultsTo: '64',
         help: 'Port of the secondary server');
     parser.addOption('shared_secret',
         abbr: 's', help: 'Shared secret of the AtSign');
+    parser.addFlag('training',
+      abbr: 't',
+      defaultsTo: false,
+      help: 'Training mode - will exit immediately after fully starting the server');
 
     try {
       if (arguments != null && arguments.isNotEmpty) {
         results = parser.parse(arguments);
         if (results.options.length != parser.options.length) {
-          throw ArgParserException('Invalid Arguments \n' + parser.usage);
+          throw ArgParserException('Invalid Arguments \n${parser.usage}');
         }
       } else {
-        throw ArgParserException('ArgParser Exception \n' + parser.usage);
+        throw ArgParserException('ArgParser Exception \n${parser.usage}');
       }
       return results;
     } on ArgParserException {
-      throw ArgParserException('ArgParserException\n' + parser.usage);
+      throw ArgParserException('ArgParserException\n${parser.usage}');
     }
   }
 }

--- a/at_secondary/at_secondary_server/lib/src/arg_utils.dart
+++ b/at_secondary/at_secondary_server/lib/src/arg_utils.dart
@@ -22,20 +22,21 @@ class CommandLineParser {
     parser.addFlag('training',
       abbr: 't',
       defaultsTo: false,
+      negatable: false,
       help: 'Training mode - will exit immediately after fully starting the server');
 
     try {
       if (arguments != null && arguments.isNotEmpty) {
         results = parser.parse(arguments);
         if (results.options.length != parser.options.length) {
-          throw ArgParserException('Invalid Arguments \n${parser.usage}');
+          throw ArgParserException('Invalid Arguments. Usage: \n${parser.usage}');
         }
       } else {
-        throw ArgParserException('ArgParser Exception \n${parser.usage}');
+        throw ArgParserException('Invalid Arguments. Usage: \n${parser.usage}');
       }
       return results;
     } on ArgParserException {
-      throw ArgParserException('ArgParserException\n${parser.usage}');
+      throw ArgParserException('Invalid Arguments. Usage: \n${parser.usage}');
     }
   }
 }

--- a/at_secondary/at_secondary_server/lib/src/exception/global_exception_handler.dart
+++ b/at_secondary/at_secondary_server/lib/src/exception/global_exception_handler.dart
@@ -68,14 +68,6 @@ class GlobalExceptionHandler {
       // TODO Not sure some of these are really worthy of WARNINGS, but let's leave as is for now
       logger.warning(exception.toString());
       await _sendResponseForException(exception, atConnection);
-    } else if (exception is ArgParserException) {
-      // TODO [gkc] I suspect this code block is not reachable. Verify and delete
-      logger.shout("Terminating secondary due to ${exception.toString()}");
-      try {
-        await AtSecondaryServerImpl.getInstance().stop();
-      } finally {
-        exit(1);
-      }
     } else if (exception is InternalServerError) {
       logger.severe(exception.toString());
       await _handleInternalException(exception, atConnection);

--- a/at_secondary/at_secondary_server/lib/src/server/at_secondary_impl.dart
+++ b/at_secondary/at_secondary_server/lib/src/server/at_secondary_impl.dart
@@ -236,6 +236,8 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
     if (serverContext!.trainingMode) {
       try {
         logger.warning('Training mode set - stopping server');
+        // waiting a few milliseconds to allow the server socket to finish its initialization
+        await Future.delayed(Duration(milliseconds: 100));
         await stop();
       } catch (e) {
         logger.severe('Caught exception $e in server stop()');

--- a/at_secondary/at_secondary_server/lib/src/server/at_secondary_impl.dart
+++ b/at_secondary/at_secondary_server/lib/src/server/at_secondary_impl.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: prefer_typing_uninitialized_variables
+
 import 'dart:io';
 import 'dart:math';
 
@@ -18,7 +20,6 @@ import 'package:at_secondary/src/server/server_context.dart';
 import 'package:at_secondary/src/utils/notification_util.dart';
 import 'package:at_secondary/src/utils/secondary_util.dart';
 import 'package:at_secondary/src/verb/handler/delete_verb_handler.dart';
-import 'package:at_secondary/src/verb/handler/update_meta_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/update_meta_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/update_verb_handler.dart';
 import 'package:at_secondary/src/verb/manager/verb_handler_manager.dart';
@@ -231,6 +232,18 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
       logger.severe(stacktrace);
       throw AtServerException(error.toString());
     }
+
+    if (serverContext!.trainingMode) {
+      try {
+        logger.warning('Training mode set - stopping server');
+        await stop();
+      } catch (e) {
+        logger.severe('Caught exception $e in server stop()');
+      }
+      logger.warning('Training mode set - exiting');
+      exit(0);
+    }
+
     resume();
   }
 
@@ -341,14 +354,14 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
         logger.info('Server cannot accept connections now.');
         return;
       }
-      var _sessionID = '_' + Uuid().v4();
+      var sessionID = '_${Uuid().v4()}';
       InboundConnection? connection;
       try {
         logger.finer(
             'In _listen - clientSocket.peerCertificate : ${clientSocket.peerCertificate}');
         var inBoundConnectionManager = InboundConnectionManager.getInstance();
         connection = inBoundConnectionManager.createConnection(clientSocket,
-            sessionId: _sessionID);
+            sessionId: sessionID);
         connection.acceptRequests(_executeVerbCallBack, _streamCallBack);
         connection.write('@');
       } on InboundConnectionLimitException catch (e) {

--- a/at_secondary/at_secondary_server/lib/src/server/bootstrapper.dart
+++ b/at_secondary/at_secondary_server/lib/src/server/bootstrapper.dart
@@ -45,6 +45,7 @@ class SecondaryServerBootStrapper {
       if (useSSL!) {
         secondaryContext.securityContext = AtSecurityContextImpl();
       }
+      secondaryContext.trainingMode = results['training'];
 
       // Start the secondary server
       secondaryServerInstance.setServerContext(secondaryContext);

--- a/at_secondary/at_secondary_server/lib/src/server/server_context.dart
+++ b/at_secondary/at_secondary_server/lib/src/server/server_context.dart
@@ -19,4 +19,7 @@ class AtSecondaryContext extends AtServerContext {
   AtSecurityContext? securityContext;
   SecondaryKeyStore? secondaryKeyStore;
   VerbExecutor? verbExecutor;
+  // When true, SecondaryServerImpl will gracefully shut down the service immediately
+  // after fully starting up.
+  bool trainingMode = false;
 }

--- a/at_secondary/at_secondary_server/test/secondary_argparser_test.dart
+++ b/at_secondary/at_secondary_server/test/secondary_argparser_test.dart
@@ -4,7 +4,7 @@ import 'package:test/test.dart';
 
 void main() {
   group('Commandline parser tests', () {
-    test('parse all the arguments', () {
+    test('parse all the arguments except for optional flags', () {
       var arguments = [
         '--at_sign',
         '@alice',
@@ -22,6 +22,32 @@ void main() {
       expect(results.arguments[3], '6400');
       expect(results.arguments[4], '--shared_secret');
       expect(results.arguments[5], 'cde445tsfg');
+
+      expect(results['training'], false);
+    });
+
+    test('parse all the arguments including optional flags', () {
+      var arguments = [
+        '--at_sign',
+        '@alice',
+        '--server_port',
+        '6400',
+        '--shared_secret',
+        'cde445tsfg',
+        '--training'
+      ];
+      var results = CommandLineParser().getParserResults(arguments);
+      expect(results.wasParsed('at_sign'), true);
+      expect(results.wasParsed('server_port'), true);
+      expect(results.arguments[0], '--at_sign');
+      expect(results.arguments[1], '@alice');
+      expect(results.arguments[2], '--server_port');
+      expect(results.arguments[3], '6400');
+      expect(results.arguments[4], '--shared_secret');
+      expect(results.arguments[5], 'cde445tsfg');
+      expect(results.arguments[6], '--training');
+
+      expect(results['training'], true);
     });
 
     test('parse arguments using abbreviation', () {
@@ -49,6 +75,12 @@ void main() {
 
     test('invalid argument name', () {
       var arguments = ['--at_signnn', 'alice', '--server_port', '6400'];
+      expect(() => CommandLineParser().getParserResults(arguments),
+          throwsA(predicate((dynamic e) => e is ArgParserException)));
+    });
+
+    test('invalid flag name', () {
+      var arguments = ['--at_sign', 'alice', '--server_port', '6400', '--ttraining'];
       expect(() => CommandLineParser().getParserResults(arguments),
           throwsA(predicate((dynamic e) => e is ArgParserException)));
     });


### PR DESCRIPTION
**- What I did**
* feat: add 'training' mode via command-line flag which, when set, will make the server exit immediately after fully starting
* resolves #845 

**- How I did it**
* Added new flag to the secondary's args
* Added tests for the new flag
* Added boolean 'trainingMode' instance variable to AtSecondaryContext
* Once secondary has completed startup, check the 'trainingMode' flag and, if set, gracefully stop the server and then exit
* Prettified and cleaned up the exception handling for invalid arguments

**- How to verify it**
* Tests pass
* Run a secondary server locally in training mode: `dart bin/main.dart -a @alice -p 12345 -s alice --training` - you should see a graceful startup followed immediately by a graceful shutdown

**- Description for the changelog**
* feat: add 'training' mode via command-line flag which, when set, will make the server exit immediately after fully starting
