### PR TITLE
fix: Change duration of ttln in notify_verb_handler.dart

### DIFF
--- a/at_secondary/at_secondary_server/lib/src/verb/handler/notify_verb_handler.dart
+++ b/at_secondary/at_secondary_server/lib/src/verb/handler/notify_verb_handler.dart
@@ -108,8 +108,10 @@ class NotifyVerbHandler extends AbstractVerbHandler {
             Duration(minutes: AtSecondaryConfig.notificationExpiryInMins)
                 .inMilliseconds;
       } else {
-        ttlnMillis =
-            AtMetadataUtil.validateTTL(verbParams[AT_TTL_NOTIFICATION]);
+        ttlnMillis = Duration(
+                minutes:
+                    AtMetadataUtil.validateTTL(verbParams[AT_TTL_NOTIFICATION]))
+            .inMilliseconds;
       }
       if (AtMetadataUtil.validateTTB(verbParams[AT_TTB]) > 0) {
         ttbMillis = AtMetadataUtil.validateTTB(verbParams[AT_TTB]);


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Change the notification expiry time from milliseconds to minutes.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->