### PR TITLE
fix: only first occurrence of version in pubspec.yaml gets updated.

### DIFF
--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -350,7 +350,7 @@ jobs:
 
       - name: Place run number into version within pubspec.yaml
         working-directory: at_secondary/at_secondary_server
-        run: sed -i "s/version\:.*/&+gha${{ github.run_number }}/" pubspec.yaml
+        run: sed -i '0,/version/ s/version\:.*/&+gha${{ github.run_number }}/' pubspec.yaml
 
       # Extract branch for docker tag
       - name: Get branch name
@@ -402,7 +402,7 @@ jobs:
 
       - name: Place run number into version within pubspec.yaml
         working-directory: at_secondary/at_secondary_server
-        run: sed -i "s/version\:.*/&+gha${{ github.run_number }}/" pubspec.yaml
+        run: sed -i '0,/version/ s/version\:.*/&+gha${{ github.run_number }}/' pubspec.yaml
 
       # Extract branch for docker tag
       - name: Get branch name
@@ -455,7 +455,7 @@ jobs:
 
       - name: Place run number into version within pubspec.yaml
         working-directory: at_secondary/at_secondary_server
-        run: sed -i "s/version\:.*/&+gha${{ github.run_number }}/" pubspec.yaml
+        run: sed -i '0,/version/ s/version\:.*/&+gha${{ github.run_number }}/' pubspec.yaml
 
       # Extract branch for docker tag
       - name: Get branch name
@@ -530,7 +530,7 @@ jobs:
 
       - name: Place canary version into pubspec.yaml
         working-directory: at_secondary/at_secondary_server
-        run: sed -i "s/version\:.*/&+${GITHUB_REF#refs/tags/}/" pubspec.yaml
+        run: sed -i '0,/version/ s/version\:.*/&+${GITHUB_REF#refs/tags/}/" pubspec.yaml
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2.0.0


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- The github actions are failing because we have `version` as a dependent package. When appending the gha number to the at_secondary_server  'version' in  pubspec.yaml, the gha number is getting appended to the version package as well causing the github actions run to fail.

**- How I did it**
- Updated the at_server github workflow such that only the first occurrence of the version is updated in pubspec.yaml 

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->