### PR TITLE
fix: skip statsNotificationId to sync from client to secondary

### DIFF
--- a/at_secondary/at_persistence_secondary_server/CHANGELOG.md
+++ b/at_secondary/at_persistence_secondary_server/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.37
+- fix: skip commit id for the 'statsNotificationId'
 ## 3.0.36
 - fix: skip commit id and sync for signing keys
 - fix: dart analyzer issues

--- a/at_secondary/at_persistence_secondary_server/lib/src/log/commitlog/at_commit_log.dart
+++ b/at_secondary/at_persistence_secondary_server/lib/src/log/commitlog/at_commit_log.dart
@@ -1,3 +1,4 @@
+import 'package:at_commons/at_commons.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:at_persistence_secondary_server/src/event_listener/at_change_event.dart';
 import 'package:at_persistence_secondary_server/src/event_listener/at_change_event_listener.dart';
@@ -31,7 +32,7 @@ class AtCommitLog implements AtLogType {
     // The private: and privatekey: are not synced. so return -1.
     if (!key.startsWith('public:__') &&
         (key.startsWith(RegExp(
-                'private:|privatekey:|public:_|public:signing_publickey')) ||
+                'private:|privatekey:|public:_|public:signing_publickey|${statsNotificationId.toLowerCase()}')) ||
             key.startsWith(RegExp(
                 '@(?<sharedWith>.*):signing_privatekey@(?<sharedBy>.*)')))) {
       return -1;

--- a/at_secondary/at_persistence_secondary_server/lib/src/log/commitlog/at_commit_log.dart
+++ b/at_secondary/at_persistence_secondary_server/lib/src/log/commitlog/at_commit_log.dart
@@ -32,7 +32,8 @@ class AtCommitLog implements AtLogType {
     // The private: and privatekey: are not synced. so return -1.
     if (!key.startsWith('public:__') &&
         (key.startsWith(RegExp(
-                'private:|privatekey:|public:_|public:signing_publickey|${statsNotificationId.toLowerCase()}')) ||
+                'private:|privatekey:|public:_|public:signing_publickey|$statsNotificationId',
+                caseSensitive: false)) ||
             key.startsWith(RegExp(
                 '@(?<sharedWith>.*):signing_privatekey@(?<sharedBy>.*)')))) {
       return -1;

--- a/at_secondary/at_persistence_secondary_server/pubspec.yaml
+++ b/at_secondary/at_persistence_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_persistence_secondary_server
 description: A Dart library with the implementation classes for the persistence layer of the secondary server.
-version: 3.0.36
+version: 3.0.37
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://atsign.dev
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Skip 'statsNotificationId' to sync from client to cloud secondary

**- How I did it**
- Added 'skipNotificationId' to regex in 'commit' method to skip the from being added to commit log.
- The keys are being converted to lower case, hence in-order to satisfy the IF the condition set the `caseSentivity: false` in the Regex

**- How to verify it**
- The skipNotificationId should not be synced to the cloud secondary

**- Description for the changelog**
- Skip commit id for the 'statsNotificationId'
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->