### PR TITLE
fix: dess inc armv7 releases when canary promoted

### DIFF
--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -557,6 +557,47 @@ jobs:
           platforms: |
             linux/amd64
 
+      # Retag prod x64 and Arm64 images as canary
+      - name: Create canary-x64 label
+        run: |
+          docker pull atsigncompany/secondary:canary
+          docker tag atsigncompany/secondary:canary atsigncompany/secondary:canary-x64
+          docker push atsigncompany/secondary:canary-x64
+
+      - name: Create dess-arm64 label
+        uses: appleboy/ssh-action@v0.1.5
+        with:
+          host: "arm64cicd.atsign.wtf"
+          username: ubuntu
+          key: ${{ secrets.CICD_SSH_KEY }}
+          script: |
+            docker pull atsigncompany/secondary:canary
+            docker tag atsigncompany/secondary:canary atsigncompany/secondary:canary-arm64
+            docker push atsigncompany/secondary:canary-arm64
+
+      # Logs into Pi and builds Armv7 canary
+      - name: Create canary-arm image
+        uses: appleboy/ssh-action@v0.1.5
+        with:
+          host: "arm32cicd.atsign.wtf"
+          username: pi
+          key: ${{ secrets.CICD_SSH_KEY }}
+          command_timeout: 20m
+          script: |
+            cd /home/pi/git/github.com/atsign-foundation/at_server
+            git pull
+            cd at_secondary
+            docker build -t atsigncompany/secondary:canary-arm .
+            docker push atsigncompany/secondary:canary-arm
+
+      - name: Create and push multi-arch canary manifest
+        run: |
+          docker manifest create atsigncompany/secondary:canary \
+            --amend atsigncompany/secondary:canary-arm \
+            --amend atsigncompany/secondary:canary-arm64 \
+            --amend atsigncompany/secondary:canary-x64
+          docker manifest push atsigncompany/secondary:canary
+
   # The below jobs run's on completion of 'run_end2end_tests' job.
   # This job run's on trigger event 'push' and when a release is tagged.
   # The job builds the production version of secondary server docker image and pushes to docker hub.

--- a/.github/workflows/promote_canary.yaml
+++ b/.github/workflows/promote_canary.yaml
@@ -1,6 +1,9 @@
 name: promote_canary
 # Workflow to promote a canary release to production
 on:
+  push:
+    tags:
+      - 'p*.*.*'
   workflow_dispatch:
 
 jobs:
@@ -39,7 +42,9 @@ jobs:
           context: at_secondary
           tags: |
             atsigncompany/secondary:prod
+            atsigncompany/secondary:dess
             atsigncompany/secondary:prod-${{ env.VERSION }}
           platforms: |
             linux/amd64
-            linux/arm64/v8           
+            linux/arm64/v8
+            linux/arm/v7        


### PR DESCRIPTION
Fixes #945 

**- What I did**

Arm v7 and multi arch steps cloned from existing dess builds into canary so that any canary build will support all the architectures when they're promoted.

Workflow will also run for a release tagged with `p*.*.*` for **promote** and this should be our normal way of doing promotions going forward so that they're visible as releases.

**- How I did it**

Liberal reuse of existing steps with s/dess/canary/

**- How to verify it**

We will need to wait for a canary that's ready for promotion.

**- Description for the changelog**

fix: dess inc armv7 releases when canary promoted