### PR TITLE
fix: Revert sync'ing of signing keys and latestNotificationId

### DIFF
--- a/at_secondary/at_persistence_secondary_server/CHANGELOG.md
+++ b/at_secondary/at_persistence_secondary_server/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.38
+- fix: Revert sync of signing keys and 'statsNotificationId'
 ## 3.0.37
 - fix: skip commit id for the 'statsNotificationId'
 ## 3.0.36

--- a/at_secondary/at_persistence_secondary_server/lib/src/log/commitlog/at_commit_log.dart
+++ b/at_secondary/at_persistence_secondary_server/lib/src/log/commitlog/at_commit_log.dart
@@ -1,4 +1,3 @@
-import 'package:at_commons/at_commons.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:at_persistence_secondary_server/src/event_listener/at_change_event.dart';
 import 'package:at_persistence_secondary_server/src/event_listener/at_change_event_listener.dart';
@@ -31,11 +30,7 @@ class AtCommitLog implements AtLogType {
     // So return -1.
     // The private: and privatekey: are not synced. so return -1.
     if (!key.startsWith('public:__') &&
-        (key.startsWith(RegExp(
-                'private:|privatekey:|public:_|public:signing_publickey|$statsNotificationId',
-                caseSensitive: false)) ||
-            key.startsWith(RegExp(
-                '@(?<sharedWith>.*):signing_privatekey@(?<sharedBy>.*)')))) {
+        (key.startsWith(RegExp('private:|privatekey:|public:_')))) {
       return -1;
     }
     int result;

--- a/at_secondary/at_persistence_secondary_server/pubspec.yaml
+++ b/at_secondary/at_persistence_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_persistence_secondary_server
 description: A Dart library with the implementation classes for the persistence layer of the secondary server.
-version: 3.0.37
+version: 3.0.38
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://atsign.dev
 

--- a/at_secondary/at_persistence_secondary_server/test/commit_log_test.dart
+++ b/at_secondary/at_persistence_secondary_server/test/commit_log_test.dart
@@ -108,7 +108,7 @@ void main() async {
           'public:signing_publickey@alice', CommitOp.UPDATE);
       expect(commitId, -1);
       expect(commitLogInstance?.lastCommittedSequenceNumber(), -1);
-    });
+    }, skip: 'Reverting the changes temporarily. Hence skipping the test');
 
     test('test to verify commitId does not increment for signing private key',
         () async {
@@ -118,7 +118,7 @@ void main() async {
           '@alice:signing_privatekey@alice', CommitOp.UPDATE);
       expect(commitId, -1);
       expect(commitLogInstance?.lastCommittedSequenceNumber(), -1);
-    });
+    }, skip: 'Reverting the changes temporarily. Hence skipping the test');
 
     test(
         'test to verify commitId does not increment for key starting with private:',


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Revert the syncing of signing private/public keys to the client.
- Revert the syncing of latestNotificationId key to the server

**- How I did it**
-  In at_commit_log.dart file, in IF condition removed the line that skips the entry into the commit log.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->