### PR TITLE
fix: ve_base mods to track at_mono refactor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,23 +7,23 @@ updates:
     schedule:
       interval: "daily"
   - package-ecosystem: "docker"
-    directory: "/at_secondary"
+    directory: "/tools/build_secondary"
     schedule:
       interval: "daily"
   - package-ecosystem: "docker"
-    directory: "/at_virtual_environment/ve"
+    directory: "/tools/build_virtual_environment/ve"
     schedule:
       interval: "daily"
   - package-ecosystem: "docker"
-    directory: "/at_virtual_environment/ve_base"
+    directory: "/tools/build_virtual_environment/ve_base"
     schedule:
       interval: "daily"     
   - package-ecosystem: "docker"
-    directory: "/at_root/at_root_server"
+    directory: "/packages/at_root_server"
     schedule:
       interval: "daily"
   - package-ecosystem: "pub"
-    directory: "/at_secondary/at_secondary_server"
+    directory: "/tools/build_secondary"
     schedule:
       interval: "daily"
       

--- a/tools/build_virtual_environment/ve/Dockerfile.vip
+++ b/tools/build_virtual_environment/ve/Dockerfile.vip
@@ -8,10 +8,10 @@ WORKDIR /app
 ##   -f at_virtual_environment/ve/Dockerfile.vip .
 COPY . .
 RUN \
-  cd /app/at_secondary/at_persistence_secondary_server ; \
+  cd /app/packages/at_secondary/at_persistence_secondary_server ; \
   dart pub get ; \
   dart pub update ; \
-  cd /app/at_secondary/at_secondary_server ; \
+  cd /app/packages/at_secondary/at_secondary_server ; \
   dart pub get ; \
   dart pub update ; \
   dart compile exe bin/main.dart -o secondary
@@ -21,9 +21,9 @@ USER root
 
 # Secondary binary and pubspec.yaml from first stage
 COPY --from=buildimage --chown=atsign:atsign \
-  /app/at_secondary/at_secondary_server/secondary /atsign/secondary/
+  /app/packages/at_secondary/at_secondary_server/secondary /atsign/secondary/
 COPY --from=buildimage --chown=atsign:atsign \
-  /app/at_secondary/at_secondary_server/pubspec.yaml /atsign/secondary/
+  /app/packages/at_secondary/at_secondary_server/pubspec.yaml /atsign/secondary/
 
 EXPOSE 64 6379 9001
 

--- a/tools/build_virtual_environment/ve_base/Dockerfile
+++ b/tools/build_virtual_environment/ve_base/Dockerfile
@@ -5,14 +5,14 @@ WORKDIR /app
 # Context for this Dockerfile needs to be at_server repo root
 # If building manually then (from the repo root):
 ## sudo docker build -t atsigncompany/vebase \
-## -f at_virtual_environment/ve_base/Dockerfile .
+## -f tools/build_virtual_environment/ve_base/Dockerfile .
 COPY . .
 RUN \
-  cd /app/at_root/at_root_server ; \
+  cd /app/packages/at_root/at_root_server ; \
   dart pub get ; \
   dart pub update ; \
   dart compile exe bin/main.dart -o root ; \
-  cd /app/at_virtual_environment/install_PKAM_Keys ; \
+  cd /app/tools/build_virtual_environment/install_PKAM_Keys ; \
   dart pub get ; \
   dart pub update ; \
   dart compile exe bin/install_PKAM_Keys.dart -o install_PKAM_Keys
@@ -33,8 +33,8 @@ RUN chmod 777 /tmp && \
     /tmp/setup/create_demo_accounts.sh
 
 COPY --from=buildimage --chown=atsign:atsign \
-  /app/at_root/at_root_server/root /atsign/root/
+  /app/packages/at_root/at_root_server/root /atsign/root/
 COPY --from=buildimage --chown=atsign:atsign \
-  /app/at_virtual_environment/install_PKAM_Keys/install_PKAM_Keys \
+  /app/tools/build_virtual_environment/install_PKAM_Keys/install_PKAM_Keys \
   /usr/local/bin/
   


### PR DESCRIPTION
**- What I did**

ve_base Dockerfile needed to be remapped to new directory structure

Similar changes also required for dependabot.yml

**- How to verify it**

Re-run ve_base action

**- Description for the changelog**

fix: ve_base mods to track at_mono refactor