### PR TITLE
fix: ensure certs in place for building observable secondary

### DIFF
--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -233,7 +233,6 @@ jobs:
         with:
           push: true
           file: tools/build_secondary/Dockerfile
-          context: packages
           tags: |
             atsigncompany/secondary:dess_cicd
             atsigncompany/secondary:cicd-${{ env.BRANCH }}-gha${{ github.run_number }}
@@ -431,7 +430,6 @@ jobs:
         with:
           push: true
           file: tools/build_secondary/Dockerfile
-          context: packages
           tags: |
             atsigncompany/secondary:dev_env
             atsigncompany/secondary:dess_wtf
@@ -478,25 +476,6 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # Setup python
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.8'
-
-      # Install python packages
-      - name: Install dependencies
-        run: |
-          python3 -m pip install --upgrade pip
-          pip3 install jproperties ruamel.yaml argparse
-
-      # Gets the secondary server binary generated from the above "secondary" job.
-      - name: Get secondary server
-        uses: actions/download-artifact@v3
-        with:
-          name: secondary-server
-          path: ${{ env.secondary-working-directory }}
-
       # Builds and pushes the secondary server image to docker hub.
       - name: Build and push secondary image for amd64 and arm64
         id: docker_build_observable_secondary
@@ -504,7 +483,6 @@ jobs:
         with:
           push: true
           file: tools/build_secondary/Dockerfile.observe
-          context: packages
           tags: |
             atsigncompany/secondary:dev_obs
             atsigncompany/secondary:dev_obs-${{ env.BRANCH }}-gha${{ github.run_number }}
@@ -556,7 +534,6 @@ jobs:
         with:
           push: true
           file: tools/build_secondary/Dockerfile
-          context: packages
           tags: |
             atsigncompany/secondary:canary
             atsigncompany/secondary:canary-${{ env.VERSION }}
@@ -647,7 +624,6 @@ jobs:
         with:
           push: true
           file: tools/build_secondary/Dockerfile
-          context: packages
           tags: |
             atsigncompany/secondary:prod
             atsigncompany/secondary:prod-${{ env.VERSION }}

--- a/tools/build_secondary/Dockerfile
+++ b/tools/build_secondary/Dockerfile
@@ -3,8 +3,8 @@ ENV HOMEDIR=/atsign
 ENV USER_ID=1024
 ENV GROUP_ID=1024
 WORKDIR /app
-COPY ./at_persistence_secondary_server ./at_persistence_secondary_server
-COPY ./at_secondary_server ./at_secondary_server
+COPY ./packages/at_persistence_secondary_server/ ./at_persistence_secondary_server
+COPY ./packages/at_secondary_server/ ./at_secondary_server
 RUN \
   mkdir -p $HOMEDIR/storage ; \
   mkdir -p $HOMEDIR/config ; \

--- a/tools/build_secondary/Dockerfile.observe
+++ b/tools/build_secondary/Dockerfile.observe
@@ -3,8 +3,13 @@ ENV HOMEDIR=/atsign
 ENV USER_ID=1024
 ENV GROUP_ID=1024
 WORKDIR /app
-COPY ./at_persistence_secondary_server ./at_persistence_secondary_server
-COPY ./at_secondary_server ./at_secondary_server
+# Context for this Dockerfile needs to be at_server repo root 
+# If building manually then (from the repo root):
+## sudo docker build -t atsigncompany/secondary:dev_obs \
+##   -f tools/build_secondary/Dockerfile.observe .
+COPY ./packages/at_persistence_secondary_server/ ./at_persistence_secondary_server
+COPY ./packages/at_secondary_server/ ./at_secondary_server
+COPY ./tools/build_virtual_environment/ve_base/contents/atsign/secondary/base/ ./at_secondary_server
 RUN \
   cd at_persistence_secondary_server ; \
   dart pub get ; \


### PR DESCRIPTION
Observable secondary was starting in training mode without any certs, causing the compiler to take ages to time out

**- What I did**

Dockerfile modified to copy certs into place
Docker build context had to be moved up a directory
Build context for regular secondary aligned

Also cut away some cruft from the at_server workflow

**- How to verify it**

The new Dockerfile is building locally from the new (root) context

**- Description for the changelog**

fix: ensure certs in place for building observable secondary