### PR TITLE
build(deps): rollup Dependabot PRs for  Dart 2.18.3

### DIFF
--- a/packages/at_root_server/Dockerfile
+++ b/packages/at_root_server/Dockerfile
@@ -1,4 +1,4 @@
-FROM dart:2.18.2 AS buildimage
+FROM dart:2.18.3 AS buildimage
 ENV HOMEDIR=/atsign
 ENV BINARYDIR=/usr/local/at
 ENV USER_ID=1024

--- a/tools/build_secondary/Dockerfile
+++ b/tools/build_secondary/Dockerfile
@@ -1,4 +1,4 @@
-FROM dart:2.18.2 AS buildimage
+FROM dart:2.18.3 AS buildimage
 ENV HOMEDIR=/atsign
 ENV USER_ID=1024
 ENV GROUP_ID=1024

--- a/tools/build_secondary/Dockerfile.observe
+++ b/tools/build_secondary/Dockerfile.observe
@@ -1,4 +1,4 @@
-FROM dart:2.18.2 AS buildimage
+FROM dart:2.18.3 AS buildimage
 ENV HOMEDIR=/atsign
 ENV USER_ID=1024
 ENV GROUP_ID=1024

--- a/tools/build_virtual_environment/ve/Dockerfile.vip
+++ b/tools/build_virtual_environment/ve/Dockerfile.vip
@@ -1,4 +1,4 @@
-FROM dart:2.18.2 AS buildimage
+FROM dart:2.18.3 AS buildimage
 ENV USER_ID=1024
 ENV GROUP_ID=1024
 WORKDIR /app

--- a/tools/build_virtual_environment/ve_base/Dockerfile
+++ b/tools/build_virtual_environment/ve_base/Dockerfile
@@ -1,4 +1,4 @@
-FROM dart:2.18.2 AS buildimage
+FROM dart:2.18.3 AS buildimage
 ENV USER_ID=1024
 ENV GROUP_ID=1024
 WORKDIR /app


### PR DESCRIPTION
**- What I did**

Rollup of #996 #997 #998 #999

**- How to verify it**

at_dockerfiles has built successfully showing that Dart 2.18.3 is available across all needed ISAs

**- Description for the changelog**

build(deps): rollup Dependabot PRs for  Dart 2.18.3