### PR TITLE
fix: notificationDateTime has correct date

### DIFF
--- a/packages/at_secondary_server/lib/src/verb/handler/notify_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/notify_verb_handler.dart
@@ -14,6 +14,7 @@ import 'package:at_secondary/src/verb/verb_enum.dart';
 import 'package:at_server_spec/at_server_spec.dart';
 import 'package:at_server_spec/at_verb_spec.dart';
 import 'package:at_utils/at_utils.dart';
+import 'package:mutex/mutex.dart';
 
 enum Type { sent, received }
 
@@ -23,6 +24,8 @@ class NotifyVerbHandler extends AbstractVerbHandler {
   NotifyVerbHandler(SecondaryKeyStore? keyStore) : super(keyStore);
 
   AtNotificationBuilder atNotificationBuilder = AtNotificationBuilder();
+
+  Mutex processNotificationMutex = Mutex();
 
   /// A hashmap which holds the AtMetadata objects.
   /// The key represents if the notification text is encrypted or not
@@ -51,230 +54,234 @@ class NotifyVerbHandler extends AbstractVerbHandler {
       Response response,
       HashMap<String, String?> verbParams,
       InboundConnection atConnection) async {
-    int? cachedKeyCommitId;
-    var atConnectionMetadata =
-        atConnection.getMetaData() as InboundConnectionMetadata;
-    var currentAtSign = AtSecondaryServerImpl.getInstance().currentAtSign;
-    var fromAtSign = atConnectionMetadata.fromAtSign;
-    int? ttlMillis;
-    int? ttbMillis;
-    int? ttrMillis;
-    int ttlnMillis;
-    bool? isCascade;
-    // The notification id received from the SDK.
-    var id = verbParams['id'];
-    var forAtSign = verbParams[FOR_AT_SIGN];
-    var atSign = verbParams[AT_SIGN];
-    var atValue = verbParams[AT_VALUE];
-    atSign = AtUtils.formatAtSign(atSign);
-    var key = verbParams[AT_KEY];
-    String? sharedKeyEncrypted = verbParams[SHARED_KEY_ENCRYPTED];
-    String? pubKeyCS = verbParams[SHARED_WITH_PUBLIC_KEY_CHECK_SUM];
-    var messageType = SecondaryUtil.getMessageType(verbParams[MESSAGE_TYPE]);
-    var strategy = verbParams[STRATEGY];
-    // If strategy is null, default it to strategy all.
-    strategy ??= 'all';
-    var notifier = verbParams[NOTIFIER];
-    // If strategy latest, notifier is mandatory.
-    // If notifier is null, throws InvalidSyntaxException.
-    if (strategy == 'latest' && notifier == null) {
-      throw InvalidSyntaxException(
-          'For Strategy latest, notifier cannot be null');
-    }
-    // If strategy is ALL, default the notifier to system.
-    if (strategy == 'all') {
-      notifier ??= SYSTEM;
-    }
-    // If messageType is key, append the atSign to key. For messageType text,
-    // atSign is not appended to the key.
-    if (messageType == MessageType.key) {
-      key = '$key$atSign';
-    }
-    if (forAtSign != null) {
-      forAtSign = AtUtils.formatAtSign(forAtSign);
-      key = '$forAtSign:$key';
-    }
-    var operation = verbParams[AT_OPERATION];
-    OperationType? opType;
-    if (operation != null) {
-      opType = SecondaryUtil.getOperationType(operation);
-    }
     try {
-      if (AtMetadataUtil.validateTTL(verbParams[AT_TTL]) > 0) {
-        ttlMillis = AtMetadataUtil.validateTTL(verbParams[AT_TTL]);
+      processNotificationMutex.acquire();
+      atNotificationBuilder.reset();
+
+      int? cachedKeyCommitId;
+      var atConnectionMetadata =
+          atConnection.getMetaData() as InboundConnectionMetadata;
+      var currentAtSign = AtSecondaryServerImpl.getInstance().currentAtSign;
+      var fromAtSign = atConnectionMetadata.fromAtSign;
+      int? ttlMillis;
+      int? ttbMillis;
+      int? ttrMillis;
+      int ttlnMillis;
+      bool? isCascade;
+      // The notification id received from the SDK.
+      var id = verbParams['id'];
+      var forAtSign = verbParams[FOR_AT_SIGN];
+      var atSign = AtUtils.formatAtSign(verbParams[AT_SIGN]);
+      var atValue = verbParams[AT_VALUE];
+      var key = verbParams[AT_KEY];
+      String? sharedKeyEncrypted = verbParams[SHARED_KEY_ENCRYPTED];
+      String? pubKeyCS = verbParams[SHARED_WITH_PUBLIC_KEY_CHECK_SUM];
+      var messageType = SecondaryUtil.getMessageType(verbParams[MESSAGE_TYPE]);
+      // If strategy is null, default it to strategy all.
+      var strategy = verbParams[STRATEGY] ??= 'all';
+      var notifier = verbParams[NOTIFIER];
+      // If strategy latest, notifier is mandatory.
+      // If notifier is null, throws InvalidSyntaxException.
+      if (strategy == 'latest' && notifier == null) {
+        throw InvalidSyntaxException(
+            'For Strategy latest, notifier cannot be null');
       }
-      if (verbParams[AT_TTL_NOTIFICATION] == null ||
-          verbParams[AT_TTL_NOTIFICATION] == '0') {
-        ttlnMillis =
-            Duration(minutes: AtSecondaryConfig.notificationExpiryInMins)
-                .inMilliseconds;
-      } else {
-        ttlnMillis =
-            AtMetadataUtil.validateTTL(verbParams[AT_TTL_NOTIFICATION]);
+      // If strategy is ALL, default the notifier to system.
+      if (strategy == 'all') {
+        notifier ??= SYSTEM;
       }
-      if (AtMetadataUtil.validateTTB(verbParams[AT_TTB]) > 0) {
-        ttbMillis = AtMetadataUtil.validateTTB(verbParams[AT_TTB]);
+      // If messageType is key, append the atSign to key. For messageType text,
+      // atSign is not appended to the key.
+      if (messageType == MessageType.key) {
+        key = '$key$atSign';
       }
-      if (verbParams[AT_TTR] != null) {
-        ttrMillis = AtMetadataUtil.validateTTR(int.parse(verbParams[AT_TTR]!));
+      if (forAtSign != null) {
+        forAtSign = AtUtils.formatAtSign(forAtSign);
+        key = '$forAtSign:$key';
       }
-      isCascade = AtMetadataUtil.validateCascadeDelete(
-          ttrMillis, AtMetadataUtil.getBoolVerbParams(verbParams[CCD]));
-    } on InvalidSyntaxException {
-      rethrow;
-    }
-    logger.finer(
-        'fromAtSign : $fromAtSign \n atSign : ${atSign.toString()} \n key : $key');
-    // Connection is authenticated and the currentAtSign is not atSign
-    // notify secondary of atSign for the key
-    if (atConnectionMetadata.isAuthenticated) {
+      var operation = verbParams[AT_OPERATION];
+      OperationType? opType;
+      if (operation != null) {
+        opType = SecondaryUtil.getOperationType(operation);
+      }
+      try {
+        if (AtMetadataUtil.validateTTL(verbParams[AT_TTL]) > 0) {
+          ttlMillis = AtMetadataUtil.validateTTL(verbParams[AT_TTL]);
+        }
+        if (verbParams[AT_TTL_NOTIFICATION] == null ||
+            verbParams[AT_TTL_NOTIFICATION] == '0') {
+          ttlnMillis =
+              Duration(minutes: AtSecondaryConfig.notificationExpiryInMins)
+                  .inMilliseconds;
+        } else {
+          ttlnMillis =
+              AtMetadataUtil.validateTTL(verbParams[AT_TTL_NOTIFICATION]);
+        }
+        if (AtMetadataUtil.validateTTB(verbParams[AT_TTB]) > 0) {
+          ttbMillis = AtMetadataUtil.validateTTB(verbParams[AT_TTB]);
+        }
+        if (verbParams[AT_TTR] != null) {
+          ttrMillis =
+              AtMetadataUtil.validateTTR(int.parse(verbParams[AT_TTR]!));
+        }
+        isCascade = AtMetadataUtil.validateCascadeDelete(
+            ttrMillis, AtMetadataUtil.getBoolVerbParams(verbParams[CCD]));
+      } on InvalidSyntaxException {
+        rethrow;
+      }
       logger.finer(
-          'currentAtSign : $currentAtSign, forAtSign : $forAtSign, atSign : $atSign');
-      if (currentAtSign == forAtSign) {
-        var notificationId = await NotificationUtil.storeNotification(
-            forAtSign, atSign, key, NotificationType.received, opType,
-            value: atValue,
-            ttlMillis: ttlnMillis,
-            id: id,
-            atNotificationBuilder: atNotificationBuilder);
+          'fromAtSign : $fromAtSign \n atSign : ${atSign.toString()} \n key : $key');
+      // Connection is authenticated and the currentAtSign is not atSign
+      // notify secondary of atSign for the key
+      if (atConnectionMetadata.isAuthenticated) {
+        logger.finer(
+            'currentAtSign : $currentAtSign, forAtSign : $forAtSign, atSign : $atSign');
+        if (currentAtSign == forAtSign) {
+          var notificationId = await NotificationUtil.storeNotification(
+              forAtSign, atSign, key, NotificationType.received, opType,
+              value: atValue,
+              ttlMillis: ttlnMillis,
+              id: id,
+              atNotificationBuilder: atNotificationBuilder);
+          response.data = notificationId;
+          return;
+        }
+
+        var atMetadata = AtMetaData()
+          ..createdBy = AtSecondaryServerImpl.getInstance().currentAtSign;
+        // If operation type is update, set value and ttr to cache a key
+        // If operation type is delete, set ttr when not null to delete the cached key.
+        if ((opType == OperationType.update &&
+                ttrMillis != null &&
+                atValue != null) ||
+            (opType == OperationType.delete && ttrMillis != null)) {
+          atMetadata.ttr = ttrMillis;
+          atMetadata.isCascade = isCascade;
+        }
+        if (ttbMillis != null) {
+          atMetadata.ttb = ttbMillis;
+        }
+        if (ttlMillis != null) {
+          atMetadata.ttl = ttlMillis;
+        }
+        if (sharedKeyEncrypted != null) {
+          atMetadata.sharedKeyEnc = sharedKeyEncrypted;
+        }
+        if (pubKeyCS != null) {
+          atMetadata.pubKeyCS = pubKeyCS;
+        }
+        atMetadata.isEncrypted =
+            SecondaryUtil.getBoolFromString(verbParams[IS_ENCRYPTED]);
+        final notificationBuilder = atNotificationBuilder
+          ..fromAtSign = atSign
+          ..toAtSign = forAtSign
+          ..notification = key
+          ..opType = opType
+          ..priority =
+              SecondaryUtil.getNotificationPriority(verbParams[PRIORITY])
+          ..atValue = atValue
+          ..notifier = notifier
+          ..strategy = strategy
+          // For strategy latest, if depth is null, default it to 1. For strategy all, depth is not considered.
+          ..depth = (_getIntParam(verbParams[LATEST_N]) != null)
+              ? _getIntParam(verbParams[LATEST_N])
+              : 1
+          ..messageType = messageType
+          ..notificationStatus = NotificationStatus.queued
+          ..atMetaData = atMetadata
+          ..type = NotificationType.sent
+          ..ttl = ttlnMillis;
+        if (id != null && id.isNotEmpty) {
+          notificationBuilder.id = id;
+        }
+        var notificationId = await NotificationManager.getInstance()
+            .notify(notificationBuilder.build());
         response.data = notificationId;
-        atNotificationBuilder.reset();
         return;
       }
+      if (atConnectionMetadata.isPolAuthenticated) {
+        logger.info('Storing the notification $key');
+        // The atMetadata here represents if the notification text is encrypted or not.
+        // Hence to prevent creating AtMetadata instances for every notification,
+        // Creating AtMetadata instance on demand and adding it pool and reused.
+        _atMetadataPool.putIfAbsent(
+            SecondaryUtil.getBoolFromString(verbParams[IS_ENCRYPTED]),
+            () => AtMetaData()
+              ..isEncrypted =
+                  SecondaryUtil.getBoolFromString(verbParams[IS_ENCRYPTED])
+              ..createdBy = AtSecondaryServerImpl.getInstance().currentAtSign);
+        await NotificationUtil.storeNotification(
+            fromAtSign, forAtSign, key, NotificationType.received, opType,
+            ttlMillis: ttlnMillis,
+            value: atValue,
+            id: id,
+            messageType: messageType,
+            // Retrieving the atMetadata from the pool basing on if text is encrypted or not.
+            atMetaData: _atMetadataPool[
+                SecondaryUtil.getBoolFromString(verbParams[IS_ENCRYPTED])],
+            atNotificationBuilder: atNotificationBuilder);
+        // Setting isEncrypted variable to true. By default, value of all the keys are encrypted.
+        // except for the public keys. So, if key is public set isEncrypted to false.
+        var isEncrypted = true;
+        // If key is public, remove forAtSign from key.
+        if (key!.contains('public:')) {
+          var index = key.indexOf(':');
+          key = key.substring(index + 1);
+          isEncrypted = false;
+        }
+        var notifyKey = '$CACHED:$key';
+        if (operation == 'delete') {
+          cachedKeyCommitId = await _removeCachedKey(notifyKey);
+          //write the latest commit id to the StatsNotificationService
+          _writeStats(cachedKeyCommitId, operation);
+          response.data = 'data:success';
+          return;
+        }
 
-      var atMetadata = AtMetaData()
-        ..createdBy = AtSecondaryServerImpl.getInstance().currentAtSign;
-      // If operation type is update, set value and ttr to cache a key
-      // If operation type is delete, set ttr when not null to delete the cached key.
-      if ((opType == OperationType.update &&
-              ttrMillis != null &&
-              atValue != null) ||
-          (opType == OperationType.delete && ttrMillis != null)) {
-        atMetadata.ttr = ttrMillis;
-        atMetadata.isCascade = isCascade;
-      }
-      if (ttbMillis != null) {
-        atMetadata.ttb = ttbMillis;
-      }
-      if (ttlMillis != null) {
-        atMetadata.ttl = ttlMillis;
-      }
-      if (sharedKeyEncrypted != null) {
-        atMetadata.sharedKeyEnc = sharedKeyEncrypted;
-      }
-      if (pubKeyCS != null) {
-        atMetadata.pubKeyCS = pubKeyCS;
-      }
-      atMetadata.isEncrypted =
-          SecondaryUtil.getBoolFromString(verbParams[IS_ENCRYPTED]);
-      final notificationBuilder = atNotificationBuilder
-        ..fromAtSign = atSign
-        ..toAtSign = forAtSign
-        ..notification = key
-        ..opType = opType
-        ..priority = SecondaryUtil.getNotificationPriority(verbParams[PRIORITY])
-        ..atValue = atValue
-        ..notifier = notifier
-        ..strategy = strategy
-        // For strategy latest, if depth is null, default it to 1. For strategy all, depth is not considered.
-        ..depth = (_getIntParam(verbParams[LATEST_N]) != null)
-            ? _getIntParam(verbParams[LATEST_N])
-            : 1
-        ..messageType = messageType
-        ..notificationStatus = NotificationStatus.queued
-        ..atMetaData = atMetadata
-        ..type = NotificationType.sent
-        ..ttl = ttlnMillis;
-      if (id != null && id.isNotEmpty) {
-        notificationBuilder.id = id;
-      }
-      var notificationId = await NotificationManager.getInstance()
-          .notify(notificationBuilder.build());
-      response.data = notificationId;
-      atNotificationBuilder.reset();
-      return;
-    }
-    if (atConnectionMetadata.isPolAuthenticated) {
-      logger.info('Storing the notification $key');
-      // The atMetadata here represents if the notification text is encrypted or not.
-      // Hence to prevent creating AtMetadata instances for every notification,
-      // Creating AtMetadata instance on demand and adding it pool and reused.
-      _atMetadataPool.putIfAbsent(
-          SecondaryUtil.getBoolFromString(verbParams[IS_ENCRYPTED]),
-          () => AtMetaData()
-            ..isEncrypted =
-                SecondaryUtil.getBoolFromString(verbParams[IS_ENCRYPTED])
-            ..createdBy = AtSecondaryServerImpl.getInstance().currentAtSign);
-      await NotificationUtil.storeNotification(
-          fromAtSign, forAtSign, key, NotificationType.received, opType,
-          ttlMillis: ttlnMillis,
-          value: atValue,
-          id: id,
-          messageType: messageType,
-          // Retrieving the atMetadata from the pool basing on if text is encrypted or not.
-          atMetaData: _atMetadataPool[
-              SecondaryUtil.getBoolFromString(verbParams[IS_ENCRYPTED])],
-          atNotificationBuilder: atNotificationBuilder);
-      atNotificationBuilder.reset();
-      // Setting isEncrypted variable to true. By default, value of all the keys are encrypted.
-      // except for the public keys. So, if key is public set isEncrypted to false.
-      var isEncrypted = true;
-      // If key is public, remove forAtSign from key.
-      if (key!.contains('public:')) {
-        var index = key.indexOf(':');
-        key = key.substring(index + 1);
-        isEncrypted = false;
-      }
-      var notifyKey = '$CACHED:$key';
-      if (operation == 'delete') {
-        cachedKeyCommitId = await _removeCachedKey(notifyKey);
-        //write the latest commit id to the StatsNotificationService
-        _writeStats(cachedKeyCommitId, operation);
-        response.data = 'data:success';
-        return;
-      }
+        var isKeyPresent = keyStore!.isKeyExists(notifyKey);
+        AtMetaData? atMetadata;
+        if (isKeyPresent) {
+          atMetadata = await keyStore!.getMeta(notifyKey);
+        }
+        if (atValue != null && ttrMillis != null) {
+          var metadata = AtMetadataBuilder(
+                  newAtMetaData: atMetadata,
+                  ttl: ttlMillis,
+                  ttb: ttbMillis,
+                  ttr: ttrMillis,
+                  ccd: isCascade,
+                  isEncrypted: isEncrypted,
+                  sharedKeyEncrypted: sharedKeyEncrypted,
+                  publicKeyChecksum: pubKeyCS)
+              .build();
+          cachedKeyCommitId =
+              await _storeCachedKeys(key, metadata, atValue: atValue);
+          //write the latest commit id to the StatsNotificationService
+          _writeStats(cachedKeyCommitId, operation);
+          response.data = 'data:success';
+          return;
+        }
 
-      var isKeyPresent = keyStore!.isKeyExists(notifyKey);
-      AtMetaData? atMetadata;
-      if (isKeyPresent) {
-        atMetadata = await keyStore!.getMeta(notifyKey);
-      }
-      if (atValue != null && ttrMillis != null) {
-        var metadata = AtMetadataBuilder(
-                newAtMetaData: atMetadata,
-                ttl: ttlMillis,
-                ttb: ttbMillis,
-                ttr: ttrMillis,
-                ccd: isCascade,
-                isEncrypted: isEncrypted,
-                sharedKeyEncrypted: sharedKeyEncrypted,
-                publicKeyChecksum: pubKeyCS)
-            .build();
-        cachedKeyCommitId =
-            await _storeCachedKeys(key, metadata, atValue: atValue);
-        //write the latest commit id to the StatsNotificationService
-        _writeStats(cachedKeyCommitId, operation);
+        // Update metadata only if key is cached.
+        if (isKeyPresent) {
+          var atMetaData = AtMetadataBuilder(
+                  newAtMetaData: atMetadata,
+                  ttl: ttlMillis,
+                  ttb: ttbMillis,
+                  ttr: ttrMillis,
+                  ccd: isCascade,
+                  isEncrypted: isEncrypted)
+              .build();
+          cachedKeyCommitId = await _updateMetadata(notifyKey, atMetaData);
+          //write the latest commit id to the StatsNotificationService
+          _writeStats(cachedKeyCommitId, operation);
+          response.data = 'data:success';
+          return;
+        }
         response.data = 'data:success';
-        return;
       }
-
-      // Update metadata only if key is cached.
-      if (isKeyPresent) {
-        var atMetaData = AtMetadataBuilder(
-                newAtMetaData: atMetadata,
-                ttl: ttlMillis,
-                ttb: ttbMillis,
-                ttr: ttrMillis,
-                ccd: isCascade,
-                isEncrypted: isEncrypted)
-            .build();
-        cachedKeyCommitId = await _updateMetadata(notifyKey, atMetaData);
-        //write the latest commit id to the StatsNotificationService
-        _writeStats(cachedKeyCommitId, operation);
-        response.data = 'data:success';
-        return;
-      }
-      response.data = 'data:success';
+    } finally {
+      processNotificationMutex.release();
     }
   }
 

--- a/tests/at_end2end_test/test/notify_verb_test.dart
+++ b/tests/at_end2end_test/test/notify_verb_test.dart
@@ -507,6 +507,29 @@ void main() {
     print('time difference is $timeDifferenceValue');
     expect(timeDifferenceValue.inMilliseconds <= 10000, true);
   });
+
+  /// The purpose of this test is verify the date time of second notification is correct
+  /// not picked from the earlier notification.
+  test('A test to verify subsequent notifications has correct date', () async {
+    // Sending first notification
+    await sh1.writeCommand('notify:$atSign_2:firstNotification$atSign_1');
+    var response = await sh1.read();
+
+    var currentDateTime = DateTime.now().toUtc();
+    // Sending second notification
+    await sh1.writeCommand('notify:$atSign_2:secondNotification$atSign_1');
+    response = await sh1.read();
+    response = response.replaceAll('data:', '');
+    await sh2.writeCommand('notify:fetch:$response');
+    response = await sh2.read();
+    response = response.replaceAll('data:', '');
+    var atNotificationMap = jsonDecode(response);
+    expect(
+        DateTime.parse(atNotificationMap['notificationDateTime'])
+                .microsecondsSinceEpoch >
+            currentDateTime.microsecondsSinceEpoch,
+        true);
+  });
 // commenting till server code is released to prod
 //  test('notify verb for notifying a key update with shared key metadata',
 //      () async {

--- a/tests/at_end2end_test/test/notify_verb_test.dart
+++ b/tests/at_end2end_test/test/notify_verb_test.dart
@@ -514,8 +514,7 @@ void main() {
     // Sending first notification
     await sh1.writeCommand('notify:$atSign_2:firstNotification$atSign_1');
     var response = await sh1.read();
-
-    var currentDateTime = DateTime.now().toUtc();
+    var currentDateTime = DateTime.now();
     // Sending second notification
     await sh1.writeCommand('notify:$atSign_2:secondNotification$atSign_1');
     response = await sh1.read();
@@ -529,7 +528,9 @@ void main() {
                 .microsecondsSinceEpoch >
             currentDateTime.microsecondsSinceEpoch,
         true);
-  });
+  },
+      skip:
+          'skipping the end-2-end tests untill changes are merged to trunk branch');
 // commenting till server code is released to prod
 //  test('notify verb for notifying a key update with shared key metadata',
 //      () async {

--- a/tests/at_functional_test/test/notify_verb_test.dart
+++ b/tests/at_functional_test/test/notify_verb_test.dart
@@ -70,7 +70,7 @@ void main() {
       await socket_writer(
           socketFirstAtsign!, 'notify:$firstAtsign:phone.me$firstAtsign');
       var response = await read();
-      var currentDateTime = DateTime.now().toUtc();
+      var currentDateTime = DateTime.now();
       // Sending second notification
       await socket_writer(
           socketFirstAtsign!, 'notify:$firstAtsign:about.me$firstAtsign');

--- a/tests/at_functional_test/test/notify_verb_test.dart
+++ b/tests/at_functional_test/test/notify_verb_test.dart
@@ -44,6 +44,10 @@ void main() {
       expect(atNotificationMap['fromAtSign'], firstAtsign);
       expect(atNotificationMap['toAtSign'], firstAtsign);
       expect(atNotificationMap['type'], 'NotificationType.received');
+      expect(atNotificationMap['messageType'], "MessageType.key");
+      expect(atNotificationMap['priority'], "NotificationPriority.low");
+      expect(atNotificationMap['retryCount'], "1");
+      expect(atNotificationMap['strategy'], "all");
     });
 
     test('A test to verify fetching notification that is deleted', () async {
@@ -56,6 +60,33 @@ void main() {
       expect(atNotificationMap['id'], notificationId.trim());
       expect(atNotificationMap['notificationStatus'],
           'NotificationStatus.expired');
+    });
+  });
+
+  group('A group of tests to verify notification date time', () {
+    test('A test to verify two notification to self has correct date time',
+        () async {
+      // Sending first notification
+      await socket_writer(
+          socketFirstAtsign!, 'notify:$firstAtsign:phone.me$firstAtsign');
+      var response = await read();
+      var currentDateTime = DateTime.now().toUtc();
+      // Sending second notification
+      await socket_writer(
+          socketFirstAtsign!, 'notify:$firstAtsign:about.me$firstAtsign');
+      var notificationId = await read();
+      notificationId = notificationId.replaceFirst('data:', '');
+      await socket_writer(socketFirstAtsign!, 'notify:fetch:$notificationId');
+      response = await read();
+      response = response.replaceFirst('data:', '');
+      var atNotificationMap = jsonDecode(response);
+      expect(atNotificationMap['id'], notificationId.trim());
+      // the date time of the second notification should be greater than the current Date Time
+      expect(
+          DateTime.parse(atNotificationMap['notificationDateTime'])
+                  .microsecondsSinceEpoch >
+              currentDateTime.microsecondsSinceEpoch,
+          true);
     });
   });
 }


### PR DESCRIPTION
Fixes #1003 

**- What I did**
1. Add mutex to the the NotifyVerbHandler.processVerb to prevent race conditions as we now have long-lived state (the NotificationBuilder which we are now reusing rather than creating a new one for every notification)
2. Move the reset method to the start of the NotifyVerbHandler.processVerb. So that it gets called before the start of every notification.
3. Added unit test, functional test and end-to-end test to assert that the second notification has a correct date and time.

**- How I did it**
1. Moved the reset method to the start of the NotifyVerbHandler.processVerb in NotifyVerbHandler to fix the issue of subsequent notifications having incorrect date-time.

**- How to verify it**
1. The subsequent notification should have the correct date and time.
2. The unit tests, functional tests and end-to-end tests assert the functionality,

**- Description for the changelog**
1. fix: Subsequent notifications have the incorrect date-time.
