### PR TITLE
fix: add `await` when calling acquire() on the processNotificationMutex

### DIFF
--- a/packages/at_secondary_server/lib/src/verb/handler/notify_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/notify_verb_handler.dart
@@ -55,7 +55,7 @@ class NotifyVerbHandler extends AbstractVerbHandler {
       HashMap<String, String?> verbParams,
       InboundConnection atConnection) async {
     try {
-      processNotificationMutex.acquire();
+      await processNotificationMutex.acquire();
       atNotificationBuilder.reset();
 
       int? cachedKeyCommitId;


### PR DESCRIPTION
**- What I did**
fix: add `await` when calling acquire() on the processNotificationMutex

**- How to verify it**
tests pass

**- Description for the changelog**
fix: add `await` when calling acquire() on the processNotificationMutex
