### PR TITLE
fix: Rollback keystore delete keynotfoundexception changes

### DIFF
--- a/packages/at_persistence_secondary_server/CHANGELOG.md
+++ b/packages/at_persistence_secondary_server/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.42
+- fix: rollback keystore delete KeyNotFoundException
 ## 3.0.41
 - fix: store actual keys in hive keystore metadata cache instead of encoded keys
 - feat: throw KeyNotFoundException if key to be removed is not present in keystore

--- a/packages/at_persistence_secondary_server/pubspec.yaml
+++ b/packages/at_persistence_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_persistence_secondary_server
 description: A Dart library with the implementation classes for the persistence layer of the secondary server.
-version: 3.0.41
+version: 3.0.42
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://atsign.dev
 

--- a/packages/at_persistence_secondary_server/test/hive_keystore_impl_test.dart
+++ b/packages/at_persistence_secondary_server/test/hive_keystore_impl_test.dart
@@ -8,7 +8,6 @@ import 'package:at_persistence_secondary_server/src/keystore/hive_keystore.dart'
 import 'package:crypto/crypto.dart';
 import 'package:hive/hive.dart';
 import 'package:test/test.dart';
-import 'package:at_utf7/at_utf7.dart';
 
 void main() async {
   var storageDir = '${Directory.current.path}/test/hive';
@@ -82,7 +81,7 @@ void main() async {
       await keyStore.remove('last_name.wavi@test_user_1');
       expectLater(keyStore.remove('last_name.wavi@test_user_1'),
           throwsA(predicate((dynamic e) => e is KeyNotFoundException)));
-    });
+    }, skip: 'Reverting the changes temporarily. Hence skipping the test');
 
     test('get keys', () async {
       var keyStoreManager = SecondaryPersistenceStoreFactory.getInstance()
@@ -428,14 +427,13 @@ void main() async {
           .getCommitLog('@test_user_1'));
       int? lastCommittedSequenceBeforeRemove =
           commitLogInstance?.lastCommittedSequenceNumber();
+      await keystore?.remove(nonExistentKey);
       int? lastCommittedSequenceAfterRemove =
           commitLogInstance?.lastCommittedSequenceNumber();
-      final metaDataCache = keystore?.getMetaDataCache();
-      expectLater(keystore?.remove(nonExistentKey),
-          throwsA(predicate((dynamic e) => e is KeyNotFoundException)));
-      expect(metaDataCache!.length, cacheEntriesCountBeforeRemove!);
-      expect(lastCommittedSequenceBeforeRemove,
-          equals(lastCommittedSequenceAfterRemove));
+      int? cacheEntriesCountAfterRemove = keystore?.getMetaDataCache().length;
+      expect(cacheEntriesCountAfterRemove, cacheEntriesCountBeforeRemove!);
+      expect(lastCommittedSequenceAfterRemove,
+          equals(lastCommittedSequenceBeforeRemove! + 1));
     });
     test('test to verify put and remove', () async {
       SecondaryPersistenceStore? keyStoreManager =

--- a/packages/at_persistence_spec/CHANGELOG.md
+++ b/packages/at_persistence_spec/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.0.9
+- fix: rollback keystore delete KeyNotFoundException
 ## 2.0.8
 - fix dart analyzer issue
 - documentation changes

--- a/packages/at_persistence_spec/lib/src/keystore/keystore.dart
+++ b/packages/at_persistence_spec/lib/src/keystore/keystore.dart
@@ -57,7 +57,6 @@ abstract class WritableKeystore<K, V> implements Keystore<K, V> {
   /// @param key - Key associated with a value.
   /// @return - sequence number from commit log if remove is success. null otherwise
   /// Throws a [DataStoreException] if the operation fails due to some issue with the data store.
-  /// Throws a [KeyNotFoundException] if the key to be removed doesn't exist in the keystore.
   Future<dynamic> remove(K key);
 }
 

--- a/packages/at_persistence_spec/pubspec.yaml
+++ b/packages/at_persistence_spec/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_persistence_spec
 description: A Dart library containing abstract classes that defines what an implementation of the persistence layer is responsible for. This can be used to guide implementation of other persistence solutions for servers or SDKs as desired.
-version: 2.0.8
+version: 2.0.9
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://atsign.dev
 documentation: https://docs.atsign.com/

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -25,17 +25,17 @@ dependencies:
   at_commons: 3.0.29
   version: 3.0.2
 
-#dependency_overrides:
+dependency_overrides:
 #  at_server_spec:
 #    git:
 #      url: https://github.com/atsign-foundation/at_server.git
 #      path: at_server_spec
 #      ref: trunk
-#  at_persistence_secondary_server:
-#    git:
-#      url: https://github.com/atsign-foundation/at_server.git
-#      path: packages/at_persistence_secondary_server
-#      ref: trunk
+  at_persistence_secondary_server:
+    git:
+      url: https://github.com/atsign-foundation/at_server.git
+      path: packages/at_persistence_secondary_server
+      ref: rollback_delete_keynotfound
 #  at_persistence_spec:
 #    git:
 #      url: https://github.com/atsign-foundation/at_server.git

--- a/tests/at_functional_test/test/delete_verb_test.dart
+++ b/tests/at_functional_test/test/delete_verb_test.dart
@@ -149,10 +149,8 @@ void main() {
     await socket_writer(socketFirstAtsign!, 'delete:location$firstAtsign');
     response = await read();
     print('delete verb response : $response');
-    assert(response.startsWith('error:'));
-    assert(response.contains('AT0015'));
-    assert(response
-        .contains('location$firstAtsign does not exist in the keystore'));
+    assert(
+        (!response.contains('Invalid syntax')) && (!response.contains('null')));
   }, timeout: Timeout(Duration(seconds: 50)));
 
   tearDown(() {


### PR DESCRIPTION
**- What I did**
- rollback keystore delete keynotfoundexception since it is causing issues in certain sync scenarios
**- How I did it**
- reverted code in hive_keystore.dart --> remove method
**- How to verify it**
- run the units tests in persistence
- end to end and functional tests in server pointing to the current branch should pass 
