### PR TITLE
build: upgrade peristence spec version

### DIFF
--- a/packages/at_persistence_secondary_server/pubspec.yaml
+++ b/packages/at_persistence_secondary_server/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   cron: ^0.5.0
   crypto: ^3.0.2
   uuid: ^3.0.6
-  at_persistence_spec: ^2.0.8
+  at_persistence_spec: ^2.0.9
   at_utils: ^3.0.11
   at_commons: ^3.0.29
   at_utf7: ^1.0.0


### PR DESCRIPTION
**- What I did**
- upgdate persistence spec version in persistence secondary repo
**- How I did it**
- modified pub get to upgrade dependency from 2.0.8 to 2.0.9
**- How to verify it**
- run dart pub get
- run unit tests
