### PR TITLE
build: upgrade persistence spec and persistence secondary version

### DIFF
--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -17,25 +17,25 @@ dependencies:
   crypton: 2.0.5
   collection: 1.16.0
   basic_utils: 4.5.2
-  at_persistence_spec: 2.0.8
-  at_persistence_secondary_server: 3.0.41
+  at_persistence_spec: 2.0.9
+  at_persistence_secondary_server: 3.0.42
   at_lookup: 3.0.32
   at_server_spec: 3.0.11
   at_utils: 3.0.11
   at_commons: 3.0.29
   version: 3.0.2
 
-dependency_overrides:
+#dependency_overrides:
 #  at_server_spec:
 #    git:
 #      url: https://github.com/atsign-foundation/at_server.git
 #      path: at_server_spec
 #      ref: trunk
-  at_persistence_secondary_server:
-    git:
-      url: https://github.com/atsign-foundation/at_server.git
-      path: packages/at_persistence_secondary_server
-      ref: rollback_delete_keynotfound
+#  at_persistence_secondary_server:
+#    git:
+#      url: https://github.com/atsign-foundation/at_server.git
+#      path: packages/at_persistence_secondary_server
+#      ref: rollback_delete_keynotfound
 #  at_persistence_spec:
 #    git:
 #      url: https://github.com/atsign-foundation/at_server.git


### PR DESCRIPTION
**- What I did**
- upgrade persistence spec and persistence secondary version
**- How I did it**
- modified pubspec.yaml to increment persistence spec version to 2.0.9 and persistence secondary version to 3.0.42
**- How to verify it**
- run dart pub get
- run the unit tests
