### PR TITLE
fix: use local context

### DIFF
--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -380,6 +380,7 @@ jobs:
         uses: docker/build-push-action@v3.2.0
         with:
           file: tools/build_virtual_environment/ve/Dockerfile.vip
+          context: .
           push: true
           tags: |
             atsigncompany/virtualenv:dev_env
@@ -433,6 +434,7 @@ jobs:
         with:
           push: true
           file: tools/build_secondary/Dockerfile
+          context: .
           tags: |
             atsigncompany/secondary:dev_env
             atsigncompany/secondary:dess_wtf
@@ -486,6 +488,7 @@ jobs:
         with:
           push: true
           file: tools/build_secondary/Dockerfile.observe
+          context: .
           tags: |
             atsigncompany/secondary:dev_obs
             atsigncompany/secondary:dev_obs-${{ env.BRANCH }}-gha${{ github.run_number }}
@@ -537,6 +540,7 @@ jobs:
         with:
           push: true
           file: tools/build_secondary/Dockerfile
+          context: .
           tags: |
             atsigncompany/secondary:canary
             atsigncompany/secondary:canary-${{ env.VERSION }}
@@ -625,6 +629,7 @@ jobs:
         with:
           push: true
           file: tools/build_secondary/Dockerfile
+          context: .
           tags: |
             atsigncompany/secondary:prod
             atsigncompany/secondary:prod-${{ env.VERSION }}
@@ -714,6 +719,7 @@ jobs:
         uses: docker/build-push-action@v3.2.0
         with:
           file: tools/build_virtual_environment/ve/Dockerfile.vip
+          context: .
           push: true
           tags: |
             atsigncompany/virtualenv:vip

--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -235,6 +235,7 @@ jobs:
         with:
           push: true
           file: tools/build_secondary/Dockerfile
+          context: .
           tags: |
             atsigncompany/secondary:dess_cicd
             atsigncompany/secondary:cicd-${{ env.BRANCH }}-gha${{ github.run_number }}


### PR DESCRIPTION
Fixes #1013

**- What I did**

Provide a local context to the Docker buildx action (to override default git context)

**- How to verify it**

Initially testing just cicd, but if that works then will amend other builds

**- Description for the changelog**

fix: use local context