### PR TITLE
build(deps): rollup python v4 action and Dart 2.18.4

### DIFF
--- a/.github/workflows/refreshcerts.yaml
+++ b/.github/workflows/refreshcerts.yaml
@@ -9,7 +9,7 @@ jobs:
     name: SSL Renewal for vip.ve.atsign.zone
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9 #install the python needed
       - name: setup certinfo

--- a/packages/at_root_server/Dockerfile
+++ b/packages/at_root_server/Dockerfile
@@ -1,4 +1,4 @@
-FROM dart:2.18.3 AS buildimage
+FROM dart:2.18.4 AS buildimage
 ENV HOMEDIR=/atsign
 ENV BINARYDIR=/usr/local/at
 ENV USER_ID=1024

--- a/tools/build_secondary/Dockerfile
+++ b/tools/build_secondary/Dockerfile
@@ -1,4 +1,4 @@
-FROM dart:2.18.3 AS buildimage
+FROM dart:2.18.4 AS buildimage
 ENV HOMEDIR=/atsign
 ENV USER_ID=1024
 ENV GROUP_ID=1024

--- a/tools/build_secondary/Dockerfile.observe
+++ b/tools/build_secondary/Dockerfile.observe
@@ -1,4 +1,4 @@
-FROM dart:2.18.3 AS buildimage
+FROM dart:2.18.4 AS buildimage
 ENV HOMEDIR=/atsign
 ENV USER_ID=1024
 ENV GROUP_ID=1024

--- a/tools/build_virtual_environment/ve/Dockerfile.vip
+++ b/tools/build_virtual_environment/ve/Dockerfile.vip
@@ -1,4 +1,4 @@
-FROM dart:2.18.3 AS buildimage
+FROM dart:2.18.4 AS buildimage
 ENV USER_ID=1024
 ENV GROUP_ID=1024
 WORKDIR /app

--- a/tools/build_virtual_environment/ve_base/Dockerfile
+++ b/tools/build_virtual_environment/ve_base/Dockerfile
@@ -1,4 +1,4 @@
-FROM dart:2.18.3 AS buildimage
+FROM dart:2.18.4 AS buildimage
 ENV USER_ID=1024
 ENV GROUP_ID=1024
 WORKDIR /app


### PR DESCRIPTION
Rollup of #1030 #1031 #1032 #1033 #1034

**- What I did**

Merged dependabot branches

**- How I did it**

```
git checkout dependabot/github_actions/actions/setup-python-4
git checkout -b cpswan-rollup-python-v4-dart-2.18.4
git merge origin/dependabot/docker/packages/at_root_server/dart-2.18.4
git merge origin/dependabot/docker/tools/build_secondary/dart-2.18.4
git merge origin/dependabot/docker/tools/build_virtual_environment/ve_base/dart-2.18.4
git merge origin/dependabot/docker/tools/build_virtual_environment/ve/dart-2.18.4
```
**- How to verify it**

CI tests

Dart 2.18.4 has already passed through at_dockerfiles automation

**- Description for the changelog**

build(deps): rollup python v4 action and Dart 2.18.4