### PR TITLE
fix: build canary virtualenv images so that they can be promoted to prod

### DIFF
--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -592,6 +592,9 @@ jobs:
     if: ${{ github.repository == 'atsign-foundation/at_server' && github.event_name == 'push' && contains(github.ref, 'refs/tags/c') }}
     runs-on: ubuntu-latest
     steps:
+      - name: Get version
+        run: echo "VERSION=${GITHUB_REF##*/}" >> $GITHUB_ENV
+
       - name: Place canary version into pubspec.yaml
         working-directory: ${{ env.secondary-working-directory }}
         run: |
@@ -619,7 +622,7 @@ jobs:
           push: true
           tags: |
             atsigncompany/virtualenv:canary
-            atsigncompany/virtualenv:GHA${{ github.run_number }}
+            atsigncompany/virtualenv:canary-${{ env.VERSION }}
           platforms: |
             linux/amd64
             linux/arm64/v8

--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -587,6 +587,40 @@ jobs:
             --amend atsigncompany/secondary:canary-x64
           docker manifest push atsigncompany/secondary:canary
 
+  push_canary_virtualenv_image:
+    needs: [ unit_tests, functional_tests, end2end_test_12, end2end_test_34, end2end_test_56 ]
+    if: ${{ github.repository == 'atsign-foundation/at_server' && github.event_name == 'push' && contains(github.ref, 'refs/tags/c') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2.1.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2.2.1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v3.2.0
+        with:
+          file: tools/build_virtual_environment/ve/Dockerfile.vip
+          context: .
+          push: true
+          tags: |
+            atsigncompany/virtualenv:canary
+            atsigncompany/virtualenv:GHA${{ github.run_number }}
+          platforms: |
+            linux/amd64
+            linux/arm64/v8
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}
+
   # The below jobs run's on completion of 'run_end2end_tests' job.
   # This job run's on trigger event 'push' and when a release is tagged.
   # The job builds the production version of secondary server docker image and pushes to docker hub.

--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -592,6 +592,12 @@ jobs:
     if: ${{ github.repository == 'atsign-foundation/at_server' && github.event_name == 'push' && contains(github.ref, 'refs/tags/c') }}
     runs-on: ubuntu-latest
     steps:
+      - name: Place canary version into pubspec.yaml
+        working-directory: ${{ env.secondary-working-directory }}
+        run: |
+          sed -i "0,/version/ s/version\:.*/&+${GITHUB_REF#refs/tags/}/" pubspec.yaml
+          grep version pubspec.yaml | head -1
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2.1.0
 

--- a/.github/workflows/promote_canary.yaml
+++ b/.github/workflows/promote_canary.yaml
@@ -47,7 +47,7 @@ jobs:
             linux/arm64/v8
             linux/arm/v7
 
-  # Retag virtualenv canary image to vip
+  # Add layer to canary virtualenv image with prod pubspec.yaml
   deploy_canary_virtualenv_to_prod_image:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/promote_canary.yaml
+++ b/.github/workflows/promote_canary.yaml
@@ -7,10 +7,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  # Deploy canary image to secondary image
-  deploy_canary_image_to_prod_secondary_image:
-    env:
-      working-directory: at_server
+  # Add layer to canary secondary image with prod pubspec.yaml
+  deploy_canary_secondary_to_prod_image:
     runs-on: ubuntu-latest
 
     steps:
@@ -39,7 +37,7 @@ jobs:
         with:
           push: true
           file: tools/build_secondary/Dockerfile.canary_to_prod
-          context: packages
+          context: .
           tags: |
             atsigncompany/secondary:prod
             atsigncompany/secondary:dess
@@ -48,3 +46,41 @@ jobs:
             linux/amd64
             linux/arm64/v8
             linux/arm/v7
+
+  # Retag virtualenv canary image to vip
+  deploy_canary_virtualenv_to_prod_image:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3.1.0
+
+      # Extract version for docker tag
+      - name: Get version
+        run: echo "VERSION=${GITHUB_REF##*/}" >> $GITHUB_ENV
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2.1.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2.2.1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Builds and pushes the secondary server image to docker hub.
+      - name: Build and push virtualenv image for amd64 and arm64
+        id: docker_build_canary_to_vip
+        uses: docker/build-push-action@v3.2.0
+        with:
+          push: true
+          file: tools/build_virtual_environment/ve/Dockerfile.canary_to_vip
+          context: .
+          tags: |
+            atsigncompany/virtualenv:vip
+            atsigncompany/virtualenv:vip-${{ env.VERSION }}
+          platforms: |
+            linux/amd64
+            linux/arm64/v8

--- a/tools/build_secondary/Dockerfile.canary_to_prod
+++ b/tools/build_secondary/Dockerfile.canary_to_prod
@@ -1,6 +1,6 @@
 FROM atsigncompany/secondary:canary
 ENV HOMEDIR=/atsign
-COPY --chown=atsign:atsign ./at_secondary_server/pubspec.yaml $HOMEDIR/
+COPY --chown=atsign:atsign ./packages/at_secondary_server/pubspec.yaml $HOMEDIR/
 WORKDIR /atsign
 USER atsign
 ENTRYPOINT ["/usr/local/at/secondary"]

--- a/tools/build_secondary/Dockerfile.canary_to_prod
+++ b/tools/build_secondary/Dockerfile.canary_to_prod
@@ -1,6 +1,6 @@
 FROM atsigncompany/secondary:canary
 ENV HOMEDIR=/atsign
-COPY --chown=atsign:atsign ./packages/at_secondary_server/pubspec.yaml $HOMEDIR/
+COPY --chown=1024:1024 ./packages/at_secondary_server/pubspec.yaml $HOMEDIR/
 WORKDIR /atsign
 USER atsign
 ENTRYPOINT ["/usr/local/at/secondary"]

--- a/tools/build_virtual_environment/ve/Dockerfile.canary_to_vip
+++ b/tools/build_virtual_environment/ve/Dockerfile.canary_to_vip
@@ -1,5 +1,5 @@
 FROM atsigncompany/virtualenv:canary
-COPY --chown=atsign:atsign ./packages/at_secondary_server/pubspec.yaml /atsign/secondary/
+COPY --chown=1024:1024 ./packages/at_secondary_server/pubspec.yaml /atsign/secondary/
 USER root
 EXPOSE 64 6379 9001
 # Run supervisor configuration file on container startup

--- a/tools/build_virtual_environment/ve/Dockerfile.canary_to_vip
+++ b/tools/build_virtual_environment/ve/Dockerfile.canary_to_vip
@@ -1,0 +1,6 @@
+FROM atsigncompany/virtualenv:canary
+COPY --chown=atsign:atsign ./packages/at_secondary_server/pubspec.yaml /atsign/secondary/
+USER root
+EXPOSE 64 6379 9001
+# Run supervisor configuration file on container startup
+CMD ["supervisord", "-n"]


### PR DESCRIPTION
Fixes #1014

**- What I did**

at_server workflow will now build a `virtualenv:canary` image alongside `secondary:canary`

That image can then be promoted to `virtualenv:vip` at the same time we promote a `secondary:canary` to `:prod`

**- How to verify it**

I have manually run the following to build and push `virtualenv:canary` and `virtualenv:vip`:

```
sudo docker buildx build --file tools/build_virtual_environment/ve/Dockerfile.vip \
--platform linux/amd64,linux/arm64/v8 --tag atsigncompany/virtualenv:canary --push .
```

```
sudo docker buildx build --file tools/build_virtual_environment/ve/Dockerfile.canary_to_vip \
--platform linux/amd64,linux/arm64/v8 --tag atsigncompany/virtualenv:vip --push .
```

**- Description for the changelog**

fix: build canary virtualenv images so that they can be promoted to prod