### PR TITLE
fix: changing customizable values in config:set to lowercase

### DIFF
--- a/packages/at_secondary_server/lib/src/server/at_secondary_config.dart
+++ b/packages/at_secondary_server/lib/src/server/at_secondary_config.dart
@@ -685,17 +685,17 @@ class AtSecondaryConfig {
   //switch case that returns default value of modifiable configs
   static dynamic getDefaultValue(ModifiableConfigs configName) {
     switch (configName) {
-      case ModifiableConfigs.accessLogCompactionFrequencyMins:
+      case ModifiableConfigs.access_log_compaction_freq_mins:
         return accessLogCompactionFrequencyMins;
-      case ModifiableConfigs.commitLogCompactionFrequencyMins:
+      case ModifiableConfigs.commit_log_compaction_freq_mins:
         return commitLogCompactionFrequencyMins;
-      case ModifiableConfigs.notificationKeyStoreCompactionFrequencyMins:
+      case ModifiableConfigs.notification_keystore_compaction_freq_mins:
         return notificationKeyStoreCompactionFrequencyMins;
       case ModifiableConfigs.inbound_max_limit:
         return inbound_max_limit;
-      case ModifiableConfigs.autoNotify:
+      case ModifiableConfigs.auto_notify:
         return autoNotify;
-      case ModifiableConfigs.maxNotificationRetries:
+      case ModifiableConfigs.max_notification_retries:
         return maxNotificationRetries;
     }
   }
@@ -770,11 +770,11 @@ String? getStringValueFromYaml(List<String> keyParts) {
 
 enum ModifiableConfigs {
   inbound_max_limit,
-  commitLogCompactionFrequencyMins,
-  accessLogCompactionFrequencyMins,
-  notificationKeyStoreCompactionFrequencyMins,
-  autoNotify,
-  maxNotificationRetries
+  commit_log_compaction_freq_mins,
+  access_log_compaction_freq_mins,
+  notification_keystore_compaction_freq_mins,
+  auto_notify,
+  max_notification_retries
 }
 
 class ModifiableConfigurationEntry {

--- a/packages/at_secondary_server/lib/src/server/at_secondary_impl.dart
+++ b/packages/at_secondary_server/lib/src/server/at_secondary_impl.dart
@@ -283,9 +283,9 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
 
       //subscriber for notification keystore compaction freq change
       logger.finest(
-          'Subscribing to dynamic changes made to notificationKeystoreCompactionFreq');
+          'Subscribing to dynamic changes made to notification_keystore_compaction_freq_mins');
       AtSecondaryConfig.subscribe(
-              ModifiableConfigs.notificationKeyStoreCompactionFrequencyMins)
+              ModifiableConfigs.notification_keystore_compaction_freq_mins)
           ?.listen((newFrequency) async {
         restartCompaction(
             notificationKeyStoreCompactionJobInstance,
@@ -296,9 +296,9 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
 
       //subscriber for access log compaction frequency change
       logger.finest(
-          'Subscribing to dynamic changes made to accessLogCompactionFreq');
+          'Subscribing to dynamic changes made to access_log_compaction_freq_mins');
       AtSecondaryConfig.subscribe(
-              ModifiableConfigs.accessLogCompactionFrequencyMins)
+              ModifiableConfigs.access_log_compaction_freq_mins)
           ?.listen((newFrequency) async {
         restartCompaction(accessLogCompactionJobInstance,
             atAccessLogCompactionConfig, newFrequency, _accessLog);
@@ -306,18 +306,18 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
 
       //subscriber for commit log compaction frequency change
       logger.finest(
-          'Subscribing to dynamic changes made to commitLogCompactionFreq');
+          'Subscribing to dynamic changes made to commit_log_compaction_freq_mins');
       AtSecondaryConfig.subscribe(
-              ModifiableConfigs.commitLogCompactionFrequencyMins)
+              ModifiableConfigs.commit_log_compaction_freq_mins)
           ?.listen((newFrequency) async {
         restartCompaction(commitLogCompactionJobInstance,
             atCommitLogCompactionConfig, newFrequency, _commitLog);
       });
 
       //subscriber for autoNotify state change
-      logger.finest('Subscribing to dynamic changes made to autoNotify');
+      logger.finest('Subscribing to dynamic changes made to auto_notify');
       late bool autoNotifyState;
-      AtSecondaryConfig.subscribe(ModifiableConfigs.autoNotify)
+      AtSecondaryConfig.subscribe(ModifiableConfigs.auto_notify)
           ?.listen((newValue) {
         //parse bool from string
         if (newValue.toString() == 'true') {
@@ -326,18 +326,18 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
           autoNotifyState = false;
         }
         logger.finest(
-            'Received new value for config \'autoNotify\': $autoNotifyState');
+            'Received new value for config \'auto_notify\': $autoNotifyState');
         UpdateVerbHandler.setAutoNotify(autoNotifyState);
         DeleteVerbHandler.setAutoNotify(autoNotifyState);
         UpdateMetaVerbHandler.setAutoNotify(autoNotifyState);
       });
 
       //subscriber for maxNotificationRetries count change
-      logger.finest('Subscribing to dynamic changes made to max_retries');
-      AtSecondaryConfig.subscribe(ModifiableConfigs.maxNotificationRetries)
+      logger.finest('Subscribing to dynamic changes made to max_notification_retries');
+      AtSecondaryConfig.subscribe(ModifiableConfigs.max_notification_retries)
           ?.listen((newCount) {
         logger.finest(
-            'Received new value for config \'maxNotificationRetries\': $newCount');
+            'Received new value for config \'max_notification_retries\': $newCount');
         ResourceManager.getInstance().setMaxRetries(newCount);
         QueueManager.getInstance().setMaxRetries(newCount);
       });

--- a/tests/at_end2end_test/test/cached_key_test.dart
+++ b/tests/at_end2end_test/test/cached_key_test.dart
@@ -157,7 +157,7 @@ void main() {
       expect(response, contains('data: $oldValue'));
 
       // config set auto notify to false
-      await sh1.writeCommand('config:set:autoNotify=false');
+      await sh1.writeCommand('config:set:auto_notify=false');
       response = await sh1.read();
       print('config set verb response is $response');
       expect(response, contains('data:ok'));
@@ -189,7 +189,7 @@ void main() {
       print('lookup verb response : $response');
       expect(response, contains('data: $oldValue'));
     } finally {
-      await sh1.writeCommand('config:reset:autoNotify');
+      await sh1.writeCommand('config:reset:auto_notify');
       var response = await sh1.read();
       print('config set verb response is $response');
       expect(response, contains('data:ok'));

--- a/tests/at_functional_test/test/all_verbs_test.dart
+++ b/tests/at_functional_test/test/all_verbs_test.dart
@@ -107,14 +107,14 @@ void main() async {
   test('config verb test set-reset-print operation', () async {
       //the below block of code sets the commit log compaction freq to  4
       await socket_writer(
-          socketFirstAtsign!, 'config:set:commitLogCompactionFrequencyMins=4');
+          socketFirstAtsign!, 'config:set:commit_log_compaction_freq_mins=4');
       var response = await read();
       print('config verb response $response');
       expect(response, contains('data:ok'));
 
       //this resets the commit log compaction freq previously set to 4 to default value
       await socket_writer(
-          socketFirstAtsign!, 'config:reset:commitLogCompactionFrequencyMins');
+          socketFirstAtsign!, 'config:reset:commit_log_compaction_freq_mins');
       //await Future.delayed(Duration(seconds: 2));
       response = await read();
       print('config verb response $response');
@@ -122,30 +122,80 @@ void main() async {
 
       //this ensures that the reset actually works and the current value is 60(default value)
       await socket_writer(
-          socketFirstAtsign!, 'config:print:commitLogCompactionFrequencyMins');
+          socketFirstAtsign!, 'config:print:commit_log_compaction_freq_mins');
       //await Future.delayed(Duration(seconds: 2));
       response = await read();
       print('config verb response $response');
       expect(response, contains('data:30'));
   });
 
-  test('config verb test set-print', () async {
+  test('config verb test set-print for max_notification_retries', () async {
       //the block of code below sets max notification retries to 25
       await socket_writer(
-          socketFirstAtsign!, 'config:set:maxNotificationRetries=25');
+          socketFirstAtsign!, 'config:set:max_notification_retries=25');
       var response = await read();
       print('config verb response $response');
       expect(response, contains('data:ok'));
 
       //the block of code below verifies that the max notification retries is set to 25
       await socket_writer(
-          socketFirstAtsign!, 'config:print:maxNotificationRetries');
+          socketFirstAtsign!, 'config:print:max_notification_retries');
       await Future.delayed(Duration(seconds: 2));
       response = await read();
       print('config verb response $response');
       expect(response, contains('data:25'));
   });
 
+  test('config verb test set-print for auto_notify', () async {
+    //the block of code below sets max notification retries to 42
+    await socket_writer(
+        socketFirstAtsign!, 'config:set:auto_notify=42');
+    var response = await read();
+    print('config verb response $response');
+    expect(response, contains('data:ok'));
+
+    //the block of code below verifies that the max notification retries is set to 42
+    await socket_writer(
+        socketFirstAtsign!, 'config:print:auto_notify');
+    await Future.delayed(Duration(seconds: 2));
+    response = await read();
+    print('config verb response $response');
+    expect(response, contains('data:42'));
+  });
+
+  test('config verb test set-print for inbound_max_limit', () async {
+    //the block of code below sets max notification retries to 50
+    await socket_writer(
+        socketFirstAtsign!, 'config:set:inbound_max_limit=50');
+    var response = await read();
+    print('config verb response $response');
+    expect(response, contains('data:ok'));
+
+    //the block of code below verifies that the max notification retries is set to 50
+    await socket_writer(
+        socketFirstAtsign!, 'config:print:inbound_max_limit');
+    await Future.delayed(Duration(seconds: 2));
+    response = await read();
+    print('config verb response $response');
+    expect(response, contains('data:50'));
+  });
+
+  test('config verb test set-print for notification_keystore_compaction_freq_mins', () async {
+    //the block of code below sets max notification retries to 50
+    await socket_writer(
+        socketFirstAtsign!, 'config:set:notification_keystore_compaction_freq_mins=50');
+    var response = await read();
+    print('config verb response $response');
+    expect(response, contains('data:ok'));
+
+    //the block of code below verifies that the max notification retries is set to 50
+    await socket_writer(
+        socketFirstAtsign!, 'config:print:notification_keystore_compaction_freq_mins');
+    await Future.delayed(Duration(seconds: 2));
+    response = await read();
+    print('config verb response $response');
+    expect(response, contains('data:50'));
+  });
 
   tearDown(() {
     //Closing the socket connection


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- reformatted variable names that are part of the ModifiableConfigs enum
- carrying the abovementioned changes to all instances where the ModifiableConfigs enum was used
- making necessary changes in functional tests and e2e tests
- adding a couple of test cases in func_tests covering most of the values of ModifiableConfigs enum

**- enum value modifications list**

- older enum values
 
  - commitLogCompactionFrequencyMins,
  - accessLogCompactionFrequencyMins,
  - notificationKeyStoreCompactionFrequencyMins,
  - autoNotify,
  - maxNotificationRetries
  
- new enum values

  - commit_log_compaction_freq_mins,
  - access_log_compaction_freq_mins,
  - notification_keystore_compaction_freq_mins,
  - auto_notify,
  - max_notification_retries

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
fix: changing customizable values in config:set to lowercase