### PR TITLE
fix: directory for secondary pubspec.yaml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,7 @@ updates:
     schedule:
       interval: "daily"
   - package-ecosystem: "pub"
-    directory: "/tools/build_secondary"
+    directory: "/packages/at_secondary_server"
     schedule:
       interval: "daily"
       


### PR DESCRIPTION
Dependabot hasn't been finding the secondary pubspec.yaml since the at_mono refactor

**- What I did**

Modified directory

**- How to verify it**

Dependabot tab in Insights > Dependency graph

**- Description for the changelog**

fix: directory for secondary pubspec.yaml