### PR TITLE
feat: add OSSF scorecard badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 [![Build Status](https://github.com/atsign-foundation/at_server/actions/workflows/at_server.yaml/badge.svg?branch=trunk)](https://github.com/atsign-foundation/at_server/actions/workflows/at_server.yaml)
 [![GitHub License](https://img.shields.io/badge/license-BSD3-blue.svg)](./LICENSE)
+[![OpenSSF Scorecard]
+(https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_server/badge)]
+(https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_server)
 
 # at_server
 This repo contains the core software implementation of the atProtocol:

--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 [![Build Status](https://github.com/atsign-foundation/at_server/actions/workflows/at_server.yaml/badge.svg?branch=trunk)](https://github.com/atsign-foundation/at_server/actions/workflows/at_server.yaml)
 [![GitHub License](https://img.shields.io/badge/license-BSD3-blue.svg)](./LICENSE)
-[![OpenSSF Scorecard]
-(https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_server/badge)]
-(https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_server)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_server/badge)](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_server)
 
 # at_server
 This repo contains the core software implementation of the atProtocol:


### PR DESCRIPTION
Related to https://github.com/atsign-foundation/.github/issues/41

**- What I did**

Added OSSF badge to README

**- How to verify it**

Here's the badge: 

[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_server/badge)](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_server)

It can also be seen in the Rich Diff, on on the [branch view](https://github.com/atsign-foundation/at_server/blob/cpswan-ossf-badge/README.md)

**- Description for the changelog**

feat: add OSSF scorecard badge