### PR TITLE
fix: pin Dockerfiles by SHA

### DIFF
--- a/packages/at_root_server/Dockerfile
+++ b/packages/at_root_server/Dockerfile
@@ -1,9 +1,12 @@
-FROM dart:2.18.4 AS buildimage
+FROM dart:2.18.4@sha256:f6ceb27c2b6d172020931d81a4f2721b341d718fdfd8fda508588d89c7bfae9d AS buildimage
 ENV HOMEDIR=/atsign
 ENV BINARYDIR=/usr/local/at
 ENV USER_ID=1024
 ENV GROUP_ID=1024
 WORKDIR /app
+# Context for this Dockerfile needs to be at_server repo packages/at_root_server
+# If building manually then (from packages/at_root_server):
+## sudo docker build -t atsigncompany/root .
 COPY . .
 RUN \
   mkdir -p $HOMEDIR/config ; \

--- a/tools/build_secondary/Dockerfile
+++ b/tools/build_secondary/Dockerfile
@@ -1,8 +1,12 @@
-FROM dart:2.18.4 AS buildimage
+FROM dart:2.18.4@sha256:f6ceb27c2b6d172020931d81a4f2721b341d718fdfd8fda508588d89c7bfae9d AS buildimage
 ENV HOMEDIR=/atsign
 ENV USER_ID=1024
 ENV GROUP_ID=1024
 WORKDIR /app
+# Context for this Dockerfile needs to be at_server repo root
+# If building manually then (from the repo root):
+## sudo docker build -t atsigncompany/secondary \
+## -f tools/build_secondary/Dockerfile .
 COPY ./packages/at_persistence_secondary_server/ ./at_persistence_secondary_server
 COPY ./packages/at_secondary_server/ ./at_secondary_server
 RUN \

--- a/tools/build_secondary/Dockerfile.canary_to_prod
+++ b/tools/build_secondary/Dockerfile.canary_to_prod
@@ -1,5 +1,9 @@
 FROM atsigncompany/secondary:canary
 ENV HOMEDIR=/atsign
+# Context for this Dockerfile needs to be at_server repo root
+# If building manually then (from the repo root):
+## sudo docker build -t atsigncompany/secondary \
+## -f tools/build_secondary/Dockerfile.canary_to_prod .
 COPY --chown=1024:1024 ./packages/at_secondary_server/pubspec.yaml $HOMEDIR/
 WORKDIR /atsign
 USER atsign

--- a/tools/build_secondary/Dockerfile.observe
+++ b/tools/build_secondary/Dockerfile.observe
@@ -1,4 +1,4 @@
-FROM dart:2.18.4 AS buildimage
+FROM dart:2.18.4@sha256:f6ceb27c2b6d172020931d81a4f2721b341d718fdfd8fda508588d89c7bfae9d AS buildimage
 ENV HOMEDIR=/atsign
 ENV USER_ID=1024
 ENV GROUP_ID=1024
@@ -6,7 +6,7 @@ WORKDIR /app
 # Context for this Dockerfile needs to be at_server repo root 
 # If building manually then (from the repo root):
 ## sudo docker build -t atsigncompany/secondary:dev_obs \
-##   -f tools/build_secondary/Dockerfile.observe .
+## -f tools/build_secondary/Dockerfile.observe .
 COPY ./packages/at_persistence_secondary_server/ ./at_persistence_secondary_server
 COPY ./packages/at_secondary_server/ ./at_secondary_server
 COPY ./tools/build_virtual_environment/ve_base/contents/atsign/secondary/base/ ./at_secondary_server

--- a/tools/build_virtual_environment/ve/Dockerfile
+++ b/tools/build_virtual_environment/ve/Dockerfile
@@ -3,7 +3,7 @@ USER root
 
 # Secondary binary will be put in place by GitHub Actions
 # Context for this Dockerfile is its local directory:
-# at_virtual_environment/ve
+# tools/build_virtual_environment/ve
 COPY ./contents /
 
 EXPOSE 64 6379 9001

--- a/tools/build_virtual_environment/ve/Dockerfile.canary_to_vip
+++ b/tools/build_virtual_environment/ve/Dockerfile.canary_to_vip
@@ -1,4 +1,8 @@
 FROM atsigncompany/virtualenv:canary
+# Context for this Dockerfile needs to be at_server repo root
+# If building manually then (from the repo root):
+## sudo docker build -t atsigncompany/virtualenv:vip \
+## -f tools/build_virtual_environment/ve/Dockerfile.canary_to_vip .
 COPY --chown=1024:1024 ./packages/at_secondary_server/pubspec.yaml /atsign/secondary/
 USER root
 EXPOSE 64 6379 9001

--- a/tools/build_virtual_environment/ve/Dockerfile.vip
+++ b/tools/build_virtual_environment/ve/Dockerfile.vip
@@ -1,11 +1,11 @@
-FROM dart:2.18.4 AS buildimage
+FROM dart:2.18.4@sha256:f6ceb27c2b6d172020931d81a4f2721b341d718fdfd8fda508588d89c7bfae9d AS buildimage
 ENV USER_ID=1024
 ENV GROUP_ID=1024
 WORKDIR /app
 # Context for this Dockerfile needs to be at_server repo root
 # If building manually then (from the repo root):
 ## sudo docker build -t atsigncompany/virtualenv:vip \
-##   -f tools/build_virtual_environment/ve/Dockerfile.vip .
+## -f tools/build_virtual_environment/ve/Dockerfile.vip .
 COPY . .
 RUN \
   cd /app/packages/at_persistence_secondary_server ; \

--- a/tools/build_virtual_environment/ve_base/Dockerfile
+++ b/tools/build_virtual_environment/ve_base/Dockerfile
@@ -1,4 +1,4 @@
-FROM dart:2.18.4 AS buildimage
+FROM dart:2.18.4@sha256:f6ceb27c2b6d172020931d81a4f2721b341d718fdfd8fda508588d89c7bfae9d AS buildimage
 ENV USER_ID=1024
 ENV GROUP_ID=1024
 WORKDIR /app
@@ -17,7 +17,8 @@ RUN \
   dart pub update ; \
   dart compile exe bin/install_PKAM_Keys.dart -o install_PKAM_Keys
 
-FROM debian:stable-20221114-slim
+FROM debian@sha256:3066ef83131c678999ce82e8473e8d017345a30f5573ad3e44f62e5c9c46442b
+# was debian:stable-20221114-slim
 USER root
 
 COPY ./tools/build_virtual_environment/ve_base/contents /


### PR DESCRIPTION
This addresses another bunch of Pinned-Dependencies issues raised by OSSF Scorecard.

**- What I did**

* FROM statements for upstream images pinned by SHA
* Context comment blocks added where missing
* CRLF files converted to LF

**- How I did it**

Recommendations from OSSF Scorecard report

**- How to verify it**

Scorecard issues should shrink when merged to trunk

**- Description for the changelog**

fix: pin Dockerfiles by SHA