### PR TITLE
fix: pin Python dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,4 +26,8 @@ updates:
     directory: "/packages/at_secondary_server"
     schedule:
       interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/tools" # Location of package manifests
+    schedule:
+      interval: "daily"
       

--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -39,7 +39,7 @@ jobs:
       # Install python packages
       - name: Install Python dependencies
         run: |
-          python3 -m pip install -r requirements.txt
+          python3 -m pip install -r tools/requirements.txt
 
       # Runs dart lint rules and unit tests on at_persistence_root_server
       - name: Install dependencies in at_persistence_root_server

--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -39,8 +39,7 @@ jobs:
       # Install python packages
       - name: Install Python dependencies
         run: |
-          python3 -m pip install --upgrade pip
-          pip3 install ruamel.yaml
+          python3 -m pip install -r requirements.txt
 
       # Runs dart lint rules and unit tests on at_persistence_root_server
       - name: Install dependencies in at_persistence_root_server
@@ -152,8 +151,7 @@ jobs:
       - name: Add dependency overrides on pull request
         if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' && contains(github.ref, 'trunk')}}
         run: |
-          python3 -m pip install --upgrade pip
-          pip3 install ruamel.yaml
+          python3 -m pip install -r requirements.txt
           chmod +x ./tools/add_dependency_overrides.py
           python3 ./tools/add_dependency_overrides.py -p packages/at_secondary_server
 

--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -151,7 +151,7 @@ jobs:
       - name: Add dependency overrides on pull request
         if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' && contains(github.ref, 'trunk')}}
         run: |
-          python3 -m pip install -r requirements.txt
+          python3 -m pip install -r tools/requirements.txt
           chmod +x ./tools/add_dependency_overrides.py
           python3 ./tools/add_dependency_overrides.py -p packages/at_secondary_server
 

--- a/.github/workflows/refreshcerts.yaml
+++ b/.github/workflows/refreshcerts.yaml
@@ -36,7 +36,7 @@ jobs:
       # Install Python Libraries
       - name: Install Python Libraries
         run: |-
-          python3 -m pip install requests dnspython
+          python3 -m pip install -r requirements.txt
       # Run Python ACME script
       - name: Run ACME script
         run: |-

--- a/.github/workflows/refreshcerts.yaml
+++ b/.github/workflows/refreshcerts.yaml
@@ -36,7 +36,7 @@ jobs:
       # Install Python Libraries
       - name: Install Python Libraries
         run: |-
-          python3 -m pip install -r requirements.txt
+          python3 -m pip install -r tools/requirements.txt
       # Run Python ACME script
       - name: Run ACME script
         run: |-

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,0 +1,3 @@
+dnspython==2.2.1
+requests==2.22.0
+ruamel.base==1.0.0

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,3 +1,3 @@
 dnspython==2.2.1
 requests==2.22.0
-ruamel.base==1.0.0
+ruamel.yaml==0.17.4


### PR DESCRIPTION
Fixes OSSF Scorecard findings related to Python Pinned-Dependencies

**- What I did**

* Created a requirements.txt file
* Configured Dependabot to keep requirements.txt up to date
* Modified workflows with Python dependencies to use requirements.txt

**- How I did it**

Based on earlier work with dump_cards

**- How to verify it**

Python dependency related issues will be closed by OSSF Scorecard action when merged to trunk

**- Description for the changelog**

fix: pin Python dependencies