### PR TITLE
fix: limit token permissions in workflows

### DIFF
--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -22,6 +22,9 @@ env:
   ftest-working-directory: ./tests/at_functional_test
   e2etest-working-directory: ./tests/at_end2end_test
 
+permissions:  # added using https://github.com/step-security/secure-workflows
+  contents: read
+
 jobs:
   unit_tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/at_server_dev_deploy.yaml
+++ b/.github/workflows/at_server_dev_deploy.yaml
@@ -5,6 +5,10 @@ on:
       - trunk
     paths:
       - packages/*_root_server/**
+
+permissions:  # added using https://github.com/step-security/secure-workflows
+  contents: read
+
 jobs:
   Docker_Build:
     runs-on: ubuntu-latest

--- a/.github/workflows/at_server_prod_deploy.yaml
+++ b/.github/workflows/at_server_prod_deploy.yaml
@@ -5,6 +5,10 @@ on:
       - 'r*.*.*'
     paths:
       - packages/*_root_server/**
+
+permissions:  # added using https://github.com/step-security/secure-workflows
+  contents: read
+
 jobs:
   Docker_Build:
     runs-on: ubuntu-latest

--- a/.github/workflows/autobug.yaml
+++ b/.github/workflows/autobug.yaml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [opened]
 
+permissions:  # added using https://github.com/step-security/secure-workflows
+  contents: read
+
 jobs:
   issue_opened:
     name: issue_opened

--- a/.github/workflows/refreshcerts.yaml
+++ b/.github/workflows/refreshcerts.yaml
@@ -3,6 +3,10 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '39 7 15 * *' # At 0739 on the 15th day of every odd month
+
+permissions:  # added using https://github.com/step-security/secure-workflows
+  contents: read
+
 jobs:
   refresh-ACME-cert:
     runs-on: ubuntu-latest

--- a/.github/workflows/ve_base.yaml
+++ b/.github/workflows/ve_base.yaml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '42 6 * * 1' # At 0642 each Monday
 
+permissions:  # added using https://github.com/step-security/secure-workflows
+  contents: read
+
 jobs:
   docker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This should close multiple *HIGH* Token-Permissions findings on out OSSF Scorecard.

**- What I did**

* Limited permissions to `read` as none of the actions we use need more.
* Converted ve_base from CRLF to LF

**- How I did it**

Using the [StepSecurity Secure Workflow tool](https://app.stepsecurity.io/secureworkflow)

Many of the actions we use aren't yet in the knowledge base, but I established that none of them need permissions, and commented out those steps so that the tool could evaluate the remaining actions.

**- How to verify it**

Security Scorecard should be updated on merge to trunk.

**- Description for the changelog**

fix: limit token permissions in workflows