### PR TITLE
fix: use --require-hashes for Python deps

### DIFF
--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -42,7 +42,7 @@ jobs:
       # Install python packages
       - name: Install Python dependencies
         run: |
-          python3 -m pip install -r tools/requirements.txt
+          python3 -m pip install --require-hashes -r tools/requirements.txt
 
       # Runs dart lint rules and unit tests on at_persistence_root_server
       - name: Install dependencies in at_persistence_root_server
@@ -154,7 +154,7 @@ jobs:
       - name: Add dependency overrides on pull request
         if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' && contains(github.ref, 'trunk')}}
         run: |
-          python3 -m pip install -r tools/requirements.txt
+          python3 -m pip install --require-hashes -r tools/requirements.txt
           chmod +x ./tools/add_dependency_overrides.py
           python3 ./tools/add_dependency_overrides.py -p packages/at_secondary_server
 

--- a/.github/workflows/refreshcerts.yaml
+++ b/.github/workflows/refreshcerts.yaml
@@ -40,7 +40,7 @@ jobs:
       # Install Python Libraries
       - name: Install Python Libraries
         run: |-
-          python3 -m pip install -r tools/requirements.txt
+          python3 -m pip install --require-hashes -r tools/requirements.txt
       # Run Python ACME script
       - name: Run ACME script
         run: |-


### PR DESCRIPTION
This should squish the last 3 Pinned-Dependency (**MEDIUM**) findings for the OSSF Scorecard

**- What I did**

Added `--require-hashes` to pip command line

**- How to verify it**

Scorecard issues should be closed when merging to trunk

**- Description for the changelog**

fix: use --require-hashes for Python deps