### PR TITLE
fix: refactor commit log

### DIFF
--- a/packages/at_persistence_secondary_server/lib/src/log/commitlog/client/at_client_commit_log.dart
+++ b/packages/at_persistence_secondary_server/lib/src/log/commitlog/client/at_client_commit_log.dart
@@ -1,0 +1,51 @@
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:hive/hive.dart';
+import 'at_client_commit_log_keystore.dart';
+
+/// The class implementing the [AtCommitLog].
+///
+/// When an [AtKey] is created/updated or deleted, a [CommitEntry] is created
+/// with commitId set to null.
+///
+/// The [CommitEntry] with commitId's set null are termed as "Uncommitted entries" which indicates the
+/// [CommitEntry.atKey] needs to be synced to cloud secondary.
+///
+/// A batch process will look for "Uncommitted entries" at a frequent intervals and syncs the keys to
+/// the cloud secondary and updates the key's [CommitEntry.commitId] with the commitId returned by the
+/// secondary server
+class AtClientCommitLog extends AtCommitLog {
+  final AtClientCommitLogKeyStore _atClientCommitLogKeyStore;
+
+  AtClientCommitLog(this._atClientCommitLogKeyStore)
+      : super(_atClientCommitLogKeyStore);
+
+  /// Returns the list of commit entries greater than [sequenceNumber]
+  /// throws [DataStoreException] if there is an exception getting the commit entries
+  @override
+  Future<List<CommitEntry>> getChanges(int? sequenceNumber, String? regex,
+      {int? limit}) async {
+    Future<List<CommitEntry>> changes;
+    try {
+      changes = _atClientCommitLogKeyStore.getChanges(sequenceNumber!,
+          regex: regex, limit: limit);
+    } on Exception catch (e) {
+      throw DataStoreException('Exception getting changes:${e.toString()}');
+    } on HiveError catch (e) {
+      throw DataStoreException(
+          'Hive error adding to commit log:${e.toString()}');
+    }
+    // ignore: unnecessary_null_comparison
+    if (changes == null) {
+      return [];
+    }
+    return changes;
+  }
+
+  /// Return the latest [CommitEntry] for the given key.
+  ///
+  /// If CommitEntry does not exist for the given key, [NullCommitEntry] is returned.
+  @override
+  Future<CommitEntry> getLatestCommitEntry(String key) async {
+    return await _atClientCommitLogKeyStore.getLatestCommitEntry(key);
+  }
+}

--- a/packages/at_persistence_secondary_server/lib/src/log/commitlog/client/at_client_commit_log_keystore.dart
+++ b/packages/at_persistence_secondary_server/lib/src/log/commitlog/client/at_client_commit_log_keystore.dart
@@ -1,0 +1,169 @@
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_utils/at_logger.dart';
+import 'package:hive/hive.dart';
+
+/// Class extending the [CommitLogKeyStore]
+///
+/// This class is specific to the Client SDK.
+class AtClientCommitLogKeyStore extends CommitLogKeyStore {
+  AtClientCommitLogKeyStore(String currentAtSign) : super(currentAtSign);
+
+  final _logger = AtSignLogger('AtClientCommitLogKeyStore');
+
+  /// Contains the entries that are last synced by the client SDK.
+  /// The key represents the regex and value represents the [CommitEntry]
+  final _lastSyncedEntryCacheMap = <String, CommitEntry>{};
+
+  /// Updates the [commitEntry.commitId] with the given [commitId].
+  ///
+  /// This method is only called by the client(s) because when a key is created on the
+  /// client side, a record is created in the [CommitLogKeyStore] with a null commitId.
+  /// At the time of sync, a key is created/updated in cloud secondary server and generates
+  /// the commitId; sends it back to client which the gets updated against the commitEntry
+  /// of the key synced.
+  ///
+  @override
+  Future<void> update(int commitId, CommitEntry? commitEntry) async {
+    try {
+      // Updates the commitId for the given commit entry
+      await super.update(commitId, commitEntry);
+
+      if (_lastSyncedEntryCacheMap.isEmpty) {
+        return;
+      }
+      // Iterate through the regex's in the _lastSyncedEntryCacheMap.
+      // Updates the commitEntry against the matching regexes.
+      for (var regex in _lastSyncedEntryCacheMap.keys) {
+        if (acceptKey(commitEntry!.atKey!, regex)) {
+          _lastSyncedEntryCacheMap[regex] = commitEntry;
+        }
+      }
+    } on Exception catch (e) {
+      throw DataStoreException('Exception updating entry:${e.toString()}');
+    } on HiveError catch (e) {
+      throw DataStoreException(
+          'Hive error updating entry to commit log:${e.toString()}');
+    }
+  }
+
+  /// Returns the list of commit entries greater than [sequenceNumber]
+  /// throws [DataStoreException] if there is an exception getting the commit entries
+  Future<List<CommitEntry>> getChanges(int sequenceNumber,
+      {String? regex, int? limit}) async {
+    var changes = <CommitEntry>[];
+    var regexString = (regex != null) ? regex : '';
+    var values = (await toMap()).values.toList();
+    try {
+      var keys = super.getBox().keys;
+      if (keys.isEmpty) {
+        return changes;
+      }
+      var startKey = sequenceNumber + 1;
+      _logger.finer('startKey: $startKey all commit log entries: $values');
+      limit ??= values.length + 1;
+      for (CommitEntry element in values) {
+        if (element.key >= startKey &&
+            acceptKey(element.atKey!, regexString) &&
+            changes.length <= limit) {
+          if (element.commitId == null) {
+            changes.add(element);
+          }
+        }
+      }
+      return changes;
+    } on Exception catch (e) {
+      throw DataStoreException('Exception getting changes:${e.toString()}');
+    } on HiveError catch (e) {
+      throw DataStoreException(
+          'Hive error adding to commit log:${e.toString()}');
+    }
+  }
+
+  /// Returns the lastSyncedEntry to the local secondary commitLog keystore by the clients.
+  ///
+  /// Optionally accepts the regex. Matches the regex against the [CommitEntry.AtKey] and returns the
+  /// matching [CommitEntry]. Defaulted to accept all patterns.
+  ///
+  /// This is used by the clients which have local secondary keystore. Not used by the secondary server.
+  Future<CommitEntry?> lastSyncedEntry({String regex = '.*'}) async {
+    CommitEntry? lastSyncedEntry;
+    if (_lastSyncedEntryCacheMap.containsKey(regex)) {
+      lastSyncedEntry = _lastSyncedEntryCacheMap[regex];
+      _logger.finer(
+          'Returning the lastSyncedEntry matching regex $regex from cache. lastSyncedKey : ${lastSyncedEntry!.atKey} with commitId ${lastSyncedEntry.commitId}');
+      return lastSyncedEntry;
+    }
+
+    var commitLogMap = await toMap();
+    var values = (commitLogMap.values.toList())..sort(_sortByCommitId);
+    if (values.isEmpty) {
+      return null;
+    }
+
+    // Returns the commitEntry with maximum commitId matching the given regex.
+    // otherwise returns NullCommitEntry
+    lastSyncedEntry = values.lastWhere(
+        (entry) => (acceptKey(entry.atKey!, regex) && (entry.commitId != null)),
+        orElse: () => NullCommitEntry());
+
+    if (lastSyncedEntry is NullCommitEntry) {
+      _logger.finer('Unable to fetch lastSyncedEntry. Returning null');
+      return null;
+    }
+
+    _logger.finer(
+        'Updating the lastSyncedEntry matching regex $regex to the cache. Returning lastSyncedEntry with key : ${lastSyncedEntry.atKey} and commitId ${lastSyncedEntry.commitId}');
+    _lastSyncedEntryCacheMap.putIfAbsent(regex, () => lastSyncedEntry!);
+    return lastSyncedEntry;
+  }
+
+  int _sortByCommitId(dynamic c1, dynamic c2) {
+    if (c1.commitId == null && c2.commitId == null) {
+      return 0;
+    }
+    if (c1.commitId != null && c2.commitId == null) {
+      return 1;
+    }
+    if (c1.commitId == null && c2.commitId != null) {
+      return -1;
+    }
+    return c1.commitId.compareTo(c2.commitId);
+  }
+
+  Future<CommitEntry> getLatestCommitEntry(String key) async {
+    var values = (await toMap()).values.toList()..sort(compareCommitId);
+    for (CommitEntry commitEntry in values) {
+      if (commitEntry.atKey == key) {
+        return commitEntry;
+      }
+    }
+    return NullCommitEntry();
+  }
+
+  /// Sorts the commit entries in descending order.
+  ///
+  /// The CommitEntries with commitId 'null' comes before the commit entries with commitId
+  int compareCommitId(commitEntry1, commitEntry2) {
+    if (commitEntry1.commitId == null && commitEntry2.commitId == null) {
+      return 0;
+    }
+    if (commitEntry1.commitId == null && commitEntry2.commitId != null) {
+      return -1;
+    }
+    if (commitEntry1.commitId != null && commitEntry2.commitId == null) {
+      return 1;
+    }
+    return commitEntry2.commitId!.compareTo(commitEntry1.commitId!);
+  }
+
+  ///Not a part of API. Exposed for Unit test
+  List<CommitEntry> getLastSyncedEntryCacheMapValues() {
+    return _lastSyncedEntryCacheMap.values.toList();
+  }
+
+  @override
+  Future<List> getExpired(int expiryInDays) {
+    throw UnimplementedError(
+        'This not applicable for client. Applicable only on server');
+  }
+}

--- a/packages/at_persistence_secondary_server/lib/src/log/commitlog/commit_log_keystore.dart
+++ b/packages/at_persistence_secondary_server/lib/src/log/commitlog/commit_log_keystore.dart
@@ -1,29 +1,22 @@
-import 'dart:collection';
-import 'dart:math';
-
 import 'package:at_commons/at_commons.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:at_persistence_secondary_server/src/keystore/hive_base.dart';
 import 'package:at_utils/at_utils.dart';
 import 'package:hive/hive.dart';
-import 'package:meta/meta.dart';
 
-class CommitLogKeyStore
+/// An In-Memory data store backed by [Hive] to maintain the [AtCommitLog]
+///
+/// An abstract class that is responsible to initialize the KeyStore.
+///
+/// Contains the methods to perform CRUD operations on the CommitLog and methods
+/// that are common between the Client and Server.
+abstract class CommitLogKeyStore
     with HiveBase<CommitEntry?>
     implements LogKeyStore<int, CommitEntry?> {
   final _logger = AtSignLogger('CommitLogKeyStore');
   bool enableCommitId = true;
   final String _currentAtSign;
   late String _boxName;
-  final _commitLogCacheMap = <String, CommitEntry>{};
-
-  /// Contains the entries that are last synced by the client SDK.
-  /// The key represents the regex and value represents the [CommitEntry]
-  final _lastSyncedEntryCacheMap = <String, CommitEntry>{};
-
-  int _latestCommitId = -1;
-
-  int get latestCommitId => _latestCommitId;
 
   CommitLogKeyStore(this._currentAtSign);
 
@@ -39,19 +32,6 @@ class CommitLogKeyStore
     await super.openBox(_boxName);
     var lastCommittedSequenceNum = lastCommittedSequenceNumber();
     _logger.finer('last committed sequence: $lastCommittedSequenceNum');
-
-    // Ensures the below code runs only when initialized from secondary server.
-    // enableCommitId is set to true in secondary server and to false in client SDK.
-    if (enableCommitId) {
-      // Repairs the commit log.
-      // If null commit id's exist in commitEntry, replaces the commitId with
-      // respective hive internal key
-      await repairCommitLog(await toMap());
-      // Cache the latest commitId of each key.
-      // Add entries to commitLogCacheMap when initialized from at_secondary_server
-      // and refrain for at_client_sdk.
-      _commitLogCacheMap.addAll(await _getCommitIdMap());
-    }
   }
 
   @override
@@ -71,19 +51,7 @@ class CommitLogKeyStore
   Future<int> add(CommitEntry? commitEntry) async {
     int internalKey;
     try {
-      internalKey = await _getBox().add(commitEntry);
-      //set the hive generated key as commit id
-      if (enableCommitId) {
-        commitEntry!.commitId = internalKey;
-        // update entry with commitId
-        await _getBox().put(internalKey, commitEntry);
-        // update the commitId in cache commitMap.
-        _updateCacheLog(commitEntry.atKey!, commitEntry);
-        if (commitEntry.commitId != null &&
-            commitEntry.commitId! > _latestCommitId) {
-          _latestCommitId = commitEntry.commitId!;
-        }
-      }
+      internalKey = await super.getBox().add(commitEntry);
     } on Exception catch (e) {
       throw DataStoreException('Exception updating entry:${e.toString()}');
     } on HiveError catch (e) {
@@ -93,30 +61,11 @@ class CommitLogKeyStore
     return internalKey;
   }
 
-  /// Updates the [commitEntry.commitId] with the given [commitId].
-  ///
-  /// This method is only called by the client(s) because when a key is created on the
-  /// client side, a record is created in the [CommitLogKeyStore] with a null commitId.
-  /// At the time sync, a key is created/updated in cloud secondary server and generates
-  /// the commitId sends it back to client which the gets updated against the commitEntry
-  /// of the key synced.
-  ///
   @override
   Future<void> update(int commitId, CommitEntry? commitEntry) async {
     try {
-      commitEntry!.commitId = commitId;
-      await _getBox().put(commitEntry.key, commitEntry);
-
-      if (_lastSyncedEntryCacheMap.isEmpty) {
-        return;
-      }
-      // Iterate through the regex's in the _lastSyncedEntryCacheMap.
-      // Updates the commitEntry against the matching regexes.
-      for (var regex in _lastSyncedEntryCacheMap.keys) {
-        if (_acceptKey(commitEntry.atKey!, regex)) {
-          _lastSyncedEntryCacheMap[regex] = commitEntry;
-        }
-      }
+      commitEntry?.commitId = commitId;
+      await super.getBox().put(commitEntry?.key, commitEntry);
     } on Exception catch (e) {
       throw DataStoreException('Exception updating entry:${e.toString()}');
     } on HiveError catch (e) {
@@ -129,13 +78,7 @@ class CommitLogKeyStore
   @override
   Future<void> remove(int commitId) async {
     try {
-      final commitEntry = (_getBox() as Box).get(commitId);
-      await _getBox().delete(commitId);
-      // invalidate cache for the removed entry
-      if (commitEntry != null) {
-        _commitLogCacheMap.remove(commitEntry.atKey);
-        _logger.finest('removed key : ${commitEntry.atKey} from commit log.');
-      }
+      await super.getBox().delete(commitId);
     } on Exception catch (e) {
       throw DataStoreException('Exception deleting entry:${e.toString()}');
     } on HiveError catch (e) {
@@ -147,85 +90,24 @@ class CommitLogKeyStore
   /// Returns the latest committed sequence number
   int? lastCommittedSequenceNumber() {
     var lastCommittedSequenceNum =
-        _getBox().keys.isNotEmpty ? _getBox().keys.last : null;
+        super.getBox().keys.isNotEmpty ? super.getBox().keys.last : null;
     return lastCommittedSequenceNum;
-  }
-
-  /// Returns the latest committed sequence number with regex
-  Future<int?> lastCommittedSequenceNumberWithRegex(String regex) async {
-    var values = await _getValues();
-    var lastCommittedEntry = values.lastWhere(
-        (entry) => (_acceptKey(entry.atKey, regex)),
-        orElse: () => NullCommitEntry());
-    var lastCommittedSequenceNum =
-        (lastCommittedEntry != null) ? lastCommittedEntry.key : null;
-    return lastCommittedSequenceNum;
-  }
-
-  /// Returns the lastSyncedEntry to the local secondary commitLog keystore by the clients.
-  ///
-  /// Optionally accepts the regex. Matches the regex against the [CommitEntry.AtKey] and returns the
-  /// matching [CommitEntry]. Defaulted to accept all patterns.
-  ///
-  /// This is used by the clients which have local secondary keystore. Not used by the secondary server.
-  Future<CommitEntry?> lastSyncedEntry({String regex = '.*'}) async {
-    CommitEntry? lastSyncedEntry;
-    if (_lastSyncedEntryCacheMap.containsKey(regex)) {
-      lastSyncedEntry = _lastSyncedEntryCacheMap[regex];
-      _logger.finer(
-          'Returning the lastSyncedEntry matching regex $regex from cache. lastSyncedKey : ${lastSyncedEntry!.atKey} with commitId ${lastSyncedEntry.commitId}');
-      return lastSyncedEntry;
-    }
-
-    var values = (await _getValues())..sort(_sortByCommitId);
-    if (values.isEmpty) {
-      return null;
-    }
-
-    // Returns the commitEntry with maximum commitId matching the given regex.
-    // otherwise returns NullCommitEntry
-    lastSyncedEntry = values.lastWhere(
-        (entry) =>
-            (_acceptKey(entry!.atKey!, regex) && (entry.commitId != null)),
-        orElse: () => NullCommitEntry());
-
-    if (lastSyncedEntry == null || lastSyncedEntry is NullCommitEntry) {
-      _logger.finer('Unable to fetch lastSyncedEntry. Returning null');
-      return null;
-    }
-
-    _logger.finer(
-        'Updating the lastSyncedEntry matching regex $regex to the cache. Returning lastSyncedEntry with key : ${lastSyncedEntry.atKey} and commitId ${lastSyncedEntry.commitId}');
-    _lastSyncedEntryCacheMap.putIfAbsent(regex, () => lastSyncedEntry!);
-    return lastSyncedEntry;
-  }
-
-  int _sortByCommitId(dynamic c1, dynamic c2) {
-    if (c1.commitId == null && c2.commitId == null) {
-      return 0;
-    }
-    if (c1.commitId != null && c2.commitId == null) {
-      return 1;
-    }
-    if (c1.commitId == null && c2.commitId != null) {
-      return -1;
-    }
-    return c1.commitId.compareTo(c2.commitId);
   }
 
   /// Returns the first committed sequence number
-  int? firstCommittedSequenceNumber() {
-    var firstCommittedSequenceNum =
-        _getBox().keys.isNotEmpty ? _getBox().keys.first : null;
-    return firstCommittedSequenceNum;
-  }
+  /// ToDo Not in use. Can remove code?
+  // int? firstCommittedSequenceNumber() {
+  //   var firstCommittedSequenceNum =
+  //       super.getBox().keys.isNotEmpty ? super.getBox().keys.first : null;
+  //   return firstCommittedSequenceNum;
+  // }
 
   /// Returns the total number of keys
   /// @return - int : Returns number of keys in access log
   @override
   int entriesCount() {
     int? totalKeys = 0;
-    totalKeys = _getBox().keys.length;
+    totalKeys = super.getBox().keys.length;
     return totalKeys;
   }
 
@@ -236,7 +118,7 @@ class CommitLogKeyStore
   List getFirstNEntries(int N) {
     var entries = [];
     try {
-      entries = _getBox().keys.toList().take(N).toList();
+      entries = super.getBox().keys.toList().take(N).toList();
     } on Exception catch (e) {
       throw DataStoreException(
           'Exception getting first N entries:${e.toString()}');
@@ -252,89 +134,11 @@ class CommitLogKeyStore
   @override
   Future<void> delete(dynamic expiredKeys) async {
     if (expiredKeys.isNotEmpty) {
-      await _getBox().deleteAll(expiredKeys);
+      await super.getBox().deleteAll(expiredKeys);
     }
   }
 
-  @override
-  Future<List<dynamic>> getExpired(int expiryInDays) async {
-    final dupEntries = await getDuplicateEntries();
-
-    _logger.finer('commit log entries to delete: $dupEntries');
-
-    return dupEntries;
-  }
-
-  Future<List> getDuplicateEntries() async {
-    var commitLogMap = await toMap();
-    //defensive fix for commit entries with commitId equal to null
-    Set keysWithNullCommitIdsInValue = {};
-    commitLogMap.forEach((key, value) {
-      if (value.commitId == null) {
-        keysWithNullCommitIdsInValue.add(key);
-        _logger.severe('Commit ID is null for key $key with value $value');
-      }
-    });
-    for (var key in keysWithNullCommitIdsInValue) {
-      commitLogMap.remove(key);
-    }
-    var sortedKeys = commitLogMap.keys.toList(growable: false)
-      ..sort((k1, k2) =>
-          commitLogMap[k2]!.commitId!.compareTo(commitLogMap[k1]!.commitId!));
-    var tempSet = <String>{};
-    var expiredKeys = [];
-    for (var entry in sortedKeys) {
-      _processEntry(entry, tempSet, expiredKeys, commitLogMap);
-    }
-    return expiredKeys;
-  }
-
-  void _processEntry(entry, tempSet, expiredKeys, commitLogMap) {
-    var isKeyLatest = tempSet.add(commitLogMap[entry].atKey);
-    if (!isKeyLatest) {
-      expiredKeys.add(entry);
-    }
-  }
-
-  /// Returns the list of commit entries greater than [sequenceNumber]
-  /// throws [DataStoreException] if there is an exception getting the commit entries
-  Future<List<CommitEntry>> getChanges(int sequenceNumber,
-      {String? regex, int? limit}) async {
-    var changes = <CommitEntry>[];
-    var regexString = (regex != null) ? regex : '';
-    var values = await _getValues();
-    try {
-      var keys = _getBox().keys;
-      if (keys.isEmpty) {
-        return changes;
-      }
-      var startKey = sequenceNumber + 1;
-      _logger.finer('startKey: $startKey all commit log entries: $values');
-      limit ??= values.length + 1;
-        for (CommitEntry element in values) {
-          if (element.key >= startKey &&
-              _acceptKey(element.atKey!, regexString) &&
-              changes.length <= limit) {
-            if (enableCommitId == false){
-              if(element.commitId == null){
-                changes.add(element);
-              }
-            } else {
-                changes.add(element);
-            }
-          }
-        }
-        return changes;
-
-    } on Exception catch (e) {
-      throw DataStoreException('Exception getting changes:${e.toString()}');
-    } on HiveError catch (e) {
-      throw DataStoreException(
-          'Hive error adding to commit log:${e.toString()}');
-    }
-  }
-
-  bool _acceptKey(String atKey, String regex) {
+  bool acceptKey(String atKey, String regex) {
     return _isRegexMatches(atKey, regex) || _isSpecialKey(atKey);
   }
 
@@ -349,76 +153,11 @@ class CommitLogKeyStore
         atKey.contains(AT_SIGNING_PRIVATE_KEY);
   }
 
-  /// Returns a map of all the keys in the commitLog and latest [CommitEntry] of the key.
-  /// Called in init method of commitLog to initialize on server start-up.
-  Future<Map<String, CommitEntry>> _getCommitIdMap() async {
-    var keyMap = <String, CommitEntry>{};
-    var values = await _getValues();
-    for (var value in values) {
-      if (value.commitId == null) {
-        _logger.severe(
-            'CommitID is null for ${value.atKey}. Skipping to update entry into commitLogCacheMap');
-        continue;
-      }
-      // If keyMap contains the key, update the commitId in the map with greater commitId.
-      if (keyMap.containsKey(value.atKey)) {
-        keyMap[value.atKey]!.commitId =
-            max(keyMap[value.atKey]!.commitId!, value.commitId);
-      } else {
-        keyMap[value.atKey] = value;
-      }
-      // update the latest commit id
-      if (value.commitId > _latestCommitId) {
-        _latestCommitId = value.commitId;
-      }
-    }
-    return keyMap;
-  }
-
-  /// Updates the commitId of the key.
-  void _updateCacheLog(String key, CommitEntry commitEntry) {
-    _commitLogCacheMap[key] = commitEntry;
-  }
-
-  /// Returns the latest commitEntry of the key.
-  CommitEntry? getLatestCommitEntry(String key) {
-    if (_commitLogCacheMap.containsKey(key)) {
-      return _commitLogCacheMap[key]!;
-    }
-    return null;
-  }
-
-  /// Returns the Iterator of [_commitLogCacheMap] from the commitId specified.
-  Iterator getEntries(int commitId, {String regex = '.*'}) {
-    // Sorts the keys by commitId in ascending order.
-    var sortedKeys = _commitLogCacheMap.keys.toList()
-      ..sort((k1, k2) => _commitLogCacheMap[k1]!
-          .commitId!
-          .compareTo(_commitLogCacheMap[k2]!.commitId!));
-
-    var sortedMap = LinkedHashMap.fromIterable(sortedKeys,
-        key: (k) => k, value: (k) => _commitLogCacheMap[k]);
-    // Remove the keys that does not match regex or commitId of the key
-    // less than the commitId specified in the argument.
-    sortedMap.removeWhere(
-        (key, value) => !_acceptKey(key, regex) || value!.commitId! < commitId);
-    return sortedMap.entries.iterator;
-  }
-
-  Future<List> _getValues() async {
-    var commitLogMap = await toMap();
-    return commitLogMap.values.toList();
-  }
-
-  BoxBase _getBox() {
-    return super.getBox();
-  }
-
   ///Returns the key-value pair of commit-log where key is hive internal key and
   ///value is [CommitEntry]
   Future<Map<int, CommitEntry>> toMap() async {
     var commitLogMap = <int, CommitEntry>{};
-    var keys = _getBox().keys;
+    var keys = super.getBox().keys;
 
     await Future.forEach(keys, (key) async {
       var value = await getValue(key) as CommitEntry;
@@ -429,22 +168,6 @@ class CommitLogKeyStore
 
   ///Returns the total number of keys in commit log keystore.
   int getEntriesCount() {
-    return _getBox().length;
-  }
-
-  ///Not a part of API. Exposed for Unit test
-  List<CommitEntry> getLastSyncedEntryCacheMapValues() {
-    return _lastSyncedEntryCacheMap.values.toList();
-  }
-
-  /// Replaces the null commit id's with hive internal key's
-  @visibleForTesting
-  Future<void> repairCommitLog(Map<int, CommitEntry> commitLogMap) async {
-    await Future.forEach(commitLogMap.keys, (key) async {
-      CommitEntry? commitEntry = commitLogMap[key];
-      if (commitEntry?.commitId == null) {
-        await update(key as int, commitEntry);
-      }
-    });
+    return super.getBox().length;
   }
 }

--- a/packages/at_persistence_secondary_server/lib/src/log/commitlog/server/at_server_commit_log.dart
+++ b/packages/at_persistence_secondary_server/lib/src/log/commitlog/server/at_server_commit_log.dart
@@ -1,0 +1,47 @@
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:hive/hive.dart';
+import 'at_server_commit_log_keystore.dart';
+
+/// The class implementing the [AtCommitLog].
+///
+/// When an [AtKey] is created/updated or deleted, a [CommitEntry] is created
+/// with commitId set to auto-incremented integer.
+class AtServerCommitLog extends AtCommitLog {
+  final AtServerCommitLogKeyStore _atServerCommitLogKeyStore;
+
+  AtServerCommitLog(this._atServerCommitLogKeyStore)
+      : super(_atServerCommitLogKeyStore);
+
+  /// Returns the list of commit entries greater than [sequenceNumber]
+  /// throws [DataStoreException] if there is an exception getting the commit entries
+  @override
+  Future<List<CommitEntry>> getChanges(int? sequenceNumber, String? regex,
+      {int? limit}) async {
+    Future<List<CommitEntry>> changes;
+    try {
+      changes = _atServerCommitLogKeyStore.getChanges(sequenceNumber!,
+          regex: regex, limit: limit);
+    } on Exception catch (e) {
+      throw DataStoreException('Exception getting changes:${e.toString()}');
+    } on HiveError catch (e) {
+      throw DataStoreException(
+          'Hive error adding to commit log:${e.toString()}');
+    }
+    // ignore: unnecessary_null_comparison
+    if (changes == null) {
+      return [];
+    }
+    return changes;
+  }
+
+  @override
+  Future<void> update(CommitEntry commitEntry, int commitId) {
+    // TODO: implement update
+    throw UnimplementedError();
+  }
+
+  @override
+  CommitEntry getLatestCommitEntry(String key) {
+    return _atServerCommitLogKeyStore.getLatestCommitEntry(key);
+  }
+}

--- a/packages/at_persistence_secondary_server/lib/src/log/commitlog/server/at_server_commit_log_keystore.dart
+++ b/packages/at_persistence_secondary_server/lib/src/log/commitlog/server/at_server_commit_log_keystore.dart
@@ -1,0 +1,213 @@
+import 'dart:collection';
+import 'dart:math';
+
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_utils/at_logger.dart';
+import 'package:hive/hive.dart';
+import 'package:meta/meta.dart';
+
+/// Class extending the [CommitLogKeyStore].
+///
+/// This class is specific to the AtSecondaryServer
+class AtServerCommitLogKeyStore extends CommitLogKeyStore {
+  AtServerCommitLogKeyStore(String currentAtSign) : super(currentAtSign);
+
+  final _commitLogCacheMap = <String, CommitEntry>{};
+
+  int _latestCommitId = -1;
+
+  int get latestCommitId => _latestCommitId;
+
+  final _logger = AtSignLogger('AtServerCommitLogKeyStore');
+
+  @override
+  Future<void> initialize() async {
+    await super.initialize();
+    // Repairs the commit log.
+    // If null commit id's exist in commitEntry, replaces the commitId with
+    // respective hive internal key
+    await repairCommitLog(await toMap());
+    // Cache the latest commitId of each key.
+    // Add entries to commitLogCacheMap when initialized from at_secondary_server
+    // and refrain for at_client_sdk.
+    _commitLogCacheMap.addAll(await _getCommitIdMap());
+  }
+
+  @override
+  Future<int> add(CommitEntry? commitEntry) async {
+    var internalKey = await super.add(commitEntry);
+    //set the hive generated key as commit id
+    commitEntry!.commitId = internalKey;
+    // update entry with commitId
+    await super.getBox().put(internalKey, commitEntry);
+    // update the commitId in cache commitMap.
+    _updateCacheLog(commitEntry.atKey!, commitEntry);
+    if (commitEntry.commitId != null &&
+        commitEntry.commitId! > _latestCommitId) {
+      _latestCommitId = commitEntry.commitId!;
+    }
+    return internalKey;
+  }
+
+  Future<int?> lastCommittedSequenceNumberWithRegex(String regex) async {
+    var values = await _getValues();
+    var lastCommittedEntry = values.lastWhere(
+        (entry) => (acceptKey(entry.atKey, regex)),
+        orElse: () => NullCommitEntry());
+    var lastCommittedSequenceNum =
+        (lastCommittedEntry != null) ? lastCommittedEntry.key : null;
+    return lastCommittedSequenceNum;
+  }
+
+  @override
+  Future<List<dynamic>> getExpired(int expiryInDays) async {
+    final dupEntries = await getDuplicateEntries();
+    _logger.finer('commit log entries to delete: $dupEntries');
+    return dupEntries;
+  }
+
+  Future<List> getDuplicateEntries() async {
+    var commitLogMap = await toMap();
+    //defensive fix for commit entries with commitId equal to null
+    Set keysWithNullCommitIdsInValue = {};
+    commitLogMap.forEach((key, value) {
+      if (value.commitId == null) {
+        keysWithNullCommitIdsInValue.add(key);
+        _logger.severe('Commit ID is null for key $key with value $value');
+      }
+    });
+    for (var key in keysWithNullCommitIdsInValue) {
+      commitLogMap.remove(key);
+    }
+    var sortedKeys = commitLogMap.keys.toList(growable: false)
+      ..sort((k1, k2) =>
+          commitLogMap[k2]!.commitId!.compareTo(commitLogMap[k1]!.commitId!));
+    var tempSet = <String>{};
+    var expiredKeys = [];
+    for (var entry in sortedKeys) {
+      _processEntry(entry, tempSet, expiredKeys, commitLogMap);
+    }
+    return expiredKeys;
+  }
+
+  void _processEntry(entry, tempSet, expiredKeys, commitLogMap) {
+    var isKeyLatest = tempSet.add(commitLogMap[entry].atKey);
+    if (!isKeyLatest) {
+      expiredKeys.add(entry);
+    }
+  }
+
+  /// Returns the list of commit entries greater than [sequenceNumber]
+  /// throws [DataStoreException] if there is an exception getting the commit entries
+  Future<List<CommitEntry>> getChanges(int sequenceNumber,
+      {String? regex, int? limit}) async {
+    var changes = <CommitEntry>[];
+    var regexString = (regex != null) ? regex : '';
+    var values = await _getValues();
+    try {
+      var keys = super.getBox().keys;
+      if (keys.isEmpty) {
+        return changes;
+      }
+      var startKey = sequenceNumber + 1;
+      _logger.finer('startKey: $startKey all commit log entries: $values');
+      limit ??= values.length + 1;
+      for (CommitEntry element in values) {
+        if (element.key >= startKey &&
+            acceptKey(element.atKey!, regexString) &&
+            changes.length <= limit) {
+          changes.add(element);
+        }
+      }
+      return changes;
+    } on Exception catch (e) {
+      throw DataStoreException('Exception getting changes:${e.toString()}');
+    } on HiveError catch (e) {
+      throw DataStoreException(
+          'Hive error adding to commit log:${e.toString()}');
+    }
+  }
+
+  /// Returns a map of all the keys in the commitLog and latest [CommitEntry] of the key.
+  /// Called in init method of commitLog to initialize on server start-up.
+  Future<Map<String, CommitEntry>> _getCommitIdMap() async {
+    var keyMap = <String, CommitEntry>{};
+    var values = await _getValues();
+    for (var value in values) {
+      if (value.commitId == null) {
+        _logger.severe(
+            'CommitID is null for ${value.atKey}. Skipping to update entry into commitLogCacheMap');
+        continue;
+      }
+      // If keyMap contains the key, update the commitId in the map with greater commitId.
+      if (keyMap.containsKey(value.atKey)) {
+        keyMap[value.atKey]!.commitId =
+            max(keyMap[value.atKey]!.commitId!, value.commitId);
+      } else {
+        keyMap[value.atKey] = value;
+      }
+      // update the latest commit id
+      if (value.commitId > _latestCommitId) {
+        _latestCommitId = value.commitId;
+      }
+    }
+    return keyMap;
+  }
+
+  /// Updates the commitId of the key.
+  void _updateCacheLog(String key, CommitEntry commitEntry) {
+    _commitLogCacheMap[key] = commitEntry;
+  }
+
+  /// Returns the latest commitEntry of the key.
+  CommitEntry getLatestCommitEntry(String key) {
+    if (_commitLogCacheMap.containsKey(key)) {
+      return _commitLogCacheMap[key]!;
+    }
+    return NullCommitEntry();
+  }
+
+  /// Returns the Iterator of [_commitLogCacheMap] from the commitId specified.
+  Iterator getEntries(int commitId, {String regex = '.*'}) {
+    // Sorts the keys by commitId in ascending order.
+    var sortedKeys = _commitLogCacheMap.keys.toList()
+      ..sort((k1, k2) => _commitLogCacheMap[k1]!
+          .commitId!
+          .compareTo(_commitLogCacheMap[k2]!.commitId!));
+
+    var sortedMap = LinkedHashMap.fromIterable(sortedKeys,
+        key: (k) => k, value: (k) => _commitLogCacheMap[k]);
+    // Remove the keys that does not match regex or commitId of the key
+    // less than the commitId specified in the argument.
+    sortedMap.removeWhere(
+        (key, value) => !acceptKey(key, regex) || value!.commitId! < commitId);
+    return sortedMap.entries.iterator;
+  }
+
+  Future<List> _getValues() async {
+    var commitLogMap = await toMap();
+    return commitLogMap.values.toList();
+  }
+
+  @override
+  Future<void> remove(int commitId) async {
+    final commitEntry = (super.getBox() as Box).get(commitId);
+    await super.remove(commitId);
+    // invalidate cache for the removed entry
+    if (commitEntry != null) {
+      _commitLogCacheMap.remove(commitEntry.atKey);
+      _logger.finest('removed key : ${commitEntry.atKey} from commit log.');
+    }
+  }
+
+  /// Replaces the null commit id's with hive internal key's
+  @visibleForTesting
+  Future<void> repairCommitLog(Map<int, CommitEntry> commitLogMap) async {
+    await Future.forEach(commitLogMap.keys, (key) async {
+      CommitEntry? commitEntry = commitLogMap[key];
+      if (commitEntry?.commitId == null) {
+        await update(key as int, commitEntry);
+      }
+    });
+  }
+}

--- a/packages/at_persistence_secondary_server/test/at_client_commit_log_test.dart
+++ b/packages/at_persistence_secondary_server/test/at_client_commit_log_test.dart
@@ -1,0 +1,156 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:at_commons/at_commons.dart';
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_persistence_secondary_server/src/log/commitlog/client/at_client_commit_log_keystore.dart';
+import 'package:test/test.dart';
+
+void main() async {
+  var storageDir = '${Directory.current.path}/test/hive';
+
+  group('A group of tests to verify lastSynced commit entry', () {
+    setUp(() async => await setUpFunc(storageDir, enableCommitId: false));
+    test(
+        'test to verify the last synced entry returns entry with highest commit id',
+        () async {
+      var commitLogInstance =
+          await (AtCommitLogManagerImpl.getInstance().getCommitLog('@alice'));
+
+      await commitLogInstance?.commit('location@alice', CommitOp.UPDATE);
+      await commitLogInstance?.commit('mobile@alice', CommitOp.UPDATE);
+      await commitLogInstance?.commit('phone@alice', CommitOp.UPDATE);
+
+      CommitEntry? commitEntry0 = await commitLogInstance?.getEntry(0);
+      await commitLogInstance?.update(commitEntry0!, 1);
+      CommitEntry? commitEntry1 = await commitLogInstance?.getEntry(1);
+      await commitLogInstance?.update(commitEntry1!, 0);
+      var lastSyncedEntry = await commitLogInstance?.lastSyncedEntry();
+      expect(lastSyncedEntry!.commitId, 1);
+      var lastSyncedCacheSize =
+          (commitLogInstance!.commitLogKeyStore as AtClientCommitLogKeyStore)
+              .getLastSyncedEntryCacheMapValues()
+              .length;
+      expect(lastSyncedCacheSize, 1);
+    });
+
+    test('test to verify the last synced entry with regex', () async {
+      var commitLogInstance =
+          await (AtCommitLogManagerImpl.getInstance().getCommitLog('@alice'));
+
+      await commitLogInstance?.commit('location.buzz@alice', CommitOp.UPDATE);
+      await commitLogInstance?.commit('mobile.wavi@alice', CommitOp.UPDATE);
+      await commitLogInstance?.commit('phone.buzz@alice', CommitOp.UPDATE);
+
+      CommitEntry? commitEntry0 = await commitLogInstance?.getEntry(0);
+      await commitLogInstance?.update(commitEntry0!, 2);
+      CommitEntry? commitEntry1 = await commitLogInstance?.getEntry(1);
+      await commitLogInstance?.update(commitEntry1!, 1);
+      CommitEntry? commitEntry2 = await commitLogInstance?.getEntry(2);
+      await commitLogInstance?.update(commitEntry2!, 0);
+      var lastSyncedEntry =
+          await commitLogInstance?.lastSyncedEntryWithRegex('buzz');
+      expect(lastSyncedEntry!.atKey!, 'location.buzz@alice');
+      expect(lastSyncedEntry.commitId!, 2);
+      lastSyncedEntry =
+          await commitLogInstance?.lastSyncedEntryWithRegex('wavi');
+      expect(lastSyncedEntry!.atKey!, 'mobile.wavi@alice');
+      expect(lastSyncedEntry.commitId!, 1);
+      var lastSyncedEntriesList =
+          (commitLogInstance!.commitLogKeyStore as AtClientCommitLogKeyStore)
+              .getLastSyncedEntryCacheMapValues();
+      expect(lastSyncedEntriesList.length, 2);
+    });
+
+    test(
+        'Test to verify that null is returned when no values are present in local keystore',
+        () async {
+      var commitLogInstance =
+          await (AtCommitLogManagerImpl.getInstance().getCommitLog('@alice'));
+      var lastSyncedEntry = await commitLogInstance?.lastSyncedEntry();
+      expect(lastSyncedEntry, null);
+    });
+
+    test(
+        'Test to verify that null is returned when matches entry for regex is not found',
+        () async {
+      var commitLogInstance =
+          await (AtCommitLogManagerImpl.getInstance().getCommitLog('@alice'));
+
+      await commitLogInstance?.commit('location.buzz@alice', CommitOp.UPDATE);
+      CommitEntry? commitEntry0 = await commitLogInstance?.getEntry(0);
+      await commitLogInstance?.update(commitEntry0!, 2);
+      var lastSyncedEntry =
+          await commitLogInstance?.lastSyncedEntryWithRegex('wavi');
+      expect(lastSyncedEntry, null);
+    });
+    tearDown(() async => await tearDownFunc());
+  });
+
+
+
+  group('A group of tests to verify local key does not add to commit log', () {
+    test('local key does not add to commit log', () async {
+      var commitLogInstance =
+          await (AtCommitLogManagerImpl.getInstance().getCommitLog('@alice'));
+
+      var commitId = await commitLogInstance?.commit(
+          'local:phone.wavi@alice', CommitOp.UPDATE);
+      expect(commitId, -1);
+    });
+
+    test(
+        'Test to verify local created with static local method does not add to commit log',
+        () async {
+      var commitLogInstance =
+          await (AtCommitLogManagerImpl.getInstance().getCommitLog('@alice'));
+
+      var atKey = AtKey.local('phone', '@alice', namespace: 'wavi').build();
+
+      var commitId =
+          await commitLogInstance?.commit(atKey.toString(), CommitOp.UPDATE);
+      expect(commitId, -1);
+    });
+
+    test('Test to verify local created with AtKey does not add to commit log',
+        () async {
+      var commitLogInstance =
+          await (AtCommitLogManagerImpl.getInstance().getCommitLog('@alice'));
+      var atKey = AtKey()
+        ..key = 'phone'
+        ..sharedBy = '@alice'
+        ..namespace = 'wavi'
+        ..isLocal = true;
+      var commitId =
+          await commitLogInstance?.commit(atKey.toString(), CommitOp.UPDATE);
+      expect(commitId, -1);
+    });
+  });
+}
+
+Future<SecondaryKeyStoreManager> setUpFunc(storageDir,
+    {bool enableCommitId = true}) async {
+  var commitLogInstance = await AtCommitLogManagerImpl.getInstance()
+      .getCommitLog('@alice',
+          commitLogPath: storageDir, enableCommitId: enableCommitId);
+  var secondaryPersistenceStore = SecondaryPersistenceStoreFactory.getInstance()
+      .getSecondaryPersistenceStore('@alice')!;
+  var persistenceManager =
+      secondaryPersistenceStore.getHivePersistenceManager()!;
+  await persistenceManager.init(storageDir);
+//  persistenceManager.scheduleKeyExpireTask(1); //commented this line for coverage test
+  var hiveKeyStore = secondaryPersistenceStore.getSecondaryKeyStore()!;
+  hiveKeyStore.commitLog = commitLogInstance;
+  var keyStoreManager =
+      secondaryPersistenceStore.getSecondaryKeyStoreManager()!;
+  keyStoreManager.keyStore = hiveKeyStore;
+  return keyStoreManager;
+}
+
+Future<void> tearDownFunc() async {
+  await AtCommitLogManagerImpl.getInstance().close();
+  var isExists = await Directory('test/hive/').exists();
+  if (isExists) {
+    Directory('test/hive').deleteSync(recursive: true);
+  }
+}

--- a/packages/at_persistence_secondary_server/test/hive_key_expiry_check.dart
+++ b/packages/at_persistence_secondary_server/test/hive_key_expiry_check.dart
@@ -1,6 +1,8 @@
-import 'dart:io';
-
+import 'package:at_commons/at_commons.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_persistence_secondary_server/src/log/commitlog/server/at_server_commit_log.dart';
+import 'package:at_persistence_secondary_server/src/log/commitlog/server/at_server_commit_log_keystore.dart';
+import 'package:test/expect.dart';
 
 void main() async {
   var secondaryPersistenceStore = SecondaryPersistenceStoreFactory.getInstance()
@@ -12,27 +14,22 @@ void main() async {
   var keyStoreManager =
       secondaryPersistenceStore.getSecondaryKeyStoreManager()!;
   var keyStore = secondaryPersistenceStore.getSecondaryKeyStore()!;
-  var commitLogKeyStore = CommitLogKeyStore('@test_user_1');
+  var commitLogKeyStore = AtServerCommitLogKeyStore('@test_user_1');
   await commitLogKeyStore.init('test/hive/commit');
-  keyStore.commitLog = AtCommitLog(commitLogKeyStore);
+  keyStore.commitLog = AtServerCommitLog(commitLogKeyStore);
   keyStoreManager.keyStore = keyStore;
   var atData = AtData();
   atData.data = 'abc';
   await keyStoreManager
       .getKeyStore()
-      .put('123', atData, time_to_live: 30 * 1000);
-  print('end');
-  var atDataResponse = await keyStoreManager.getKeyStore().get('123');
+      .put('phone.wavi@test_user_1', atData, time_to_live: 2000);
+  var atDataResponse =
+      await keyStoreManager.getKeyStore().get('phone.wavi@test_user_1');
   print(atDataResponse?.data);
   assert(atDataResponse?.data == 'abc');
-  var expiredKey =
-      await Future.delayed(Duration(minutes: 2), () => getKey(keyStoreManager));
-  assert(expiredKey == null);
-  print(expiredKey);
-  exit(0);
-}
-
-Future<String?> getKey(keyStoreManager) async {
-  AtData? atData = await keyStoreManager.getKeyStore().get('123');
-  return atData?.data;
+  await Future.delayed(Duration(seconds: 60));
+  expect(
+      () async =>
+          await keyStoreManager.getKeyStore().get('phone.wavi@test_user_1'),
+      throwsA(predicate((dynamic e) => e is KeyNotFoundException)));
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Refactor the AtCommitLog to have separate classes for the Client SDK and the Secondary Server.

**- How I did it**
- Mark the "AtCommitLog" and "CommitLogKeystore" classes as abstract classes.

- Introduce new classes AtClientCommitLog and AtClientCommitLogKeyStore that extends "AtCommitLog" and "CommitLogKeystore" respectively. 
  * AtClientCommitLogKeystore contains methods that interact with the Keystore (hive) for CRUD Operations on the commit log Keystore. 
  * AtClientCommitLog contains methods that are specific to Client SDK which calls the methods in "AtClientCommitLogKeystore"

- Similarly, for the secondary server, introduce new classes "AtServerCommitLog" and "AtServerCommitLogKeyStore" 

- Separate the "commit_log_test" test files into two files "at_client_commit_log_test" and "at_server_commit_log_test"

**- How to verify it**
- All the unit tests have to pass

**- Description for the changelog**
- Refactor AtCommitLog to have separate concrete classes for Client and Secondary Server

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->