### PR TITLE
fix: add actions to check the git repo

### DIFF
--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -558,6 +558,8 @@ jobs:
     if: ${{ github.repository == 'atsign-foundation/at_server' && github.event_name == 'push' && contains(github.ref, 'refs/tags/c') }}
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+
       - name: Get version
         run: echo "VERSION=${GITHUB_REF##*/}" >> $GITHUB_ENV
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
In the latest canary release - 3.0.26, the "push_canary_virtualenv_image" job has failed with the below error message

Following is the link to the pipeline: https://github.com/atsign-foundation/at_server/actions/runs/3585170429/jobs/6032895099

```
Run sed -i "0,/version/ s/version\:.*/&+${GITHUB_REF#refs/tags/}/" pubspec.yaml
Error: An error occurred trying to start process '/usr/bin/bash' with working directory /home/runner/work/at_server/at_server/./packages/at_secondary_server'. No such file or directory
```

Looks like the actions/checkout is missing in the job and hence the repo is not checked-out.

**- How I did it**

- Added actions step to checkout the repo.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->