### PR TITLE
fix: Set provenance to false for docker/build-push-action

### DIFF
--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -235,6 +235,7 @@ jobs:
         uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3 # v3.3.0
         with:
           push: true
+          provenance: false
           file: tools/build_secondary/Dockerfile
           context: .
           tags: |
@@ -386,6 +387,7 @@ jobs:
           file: tools/build_virtual_environment/ve/Dockerfile.vip
           context: .
           push: true
+          provenance: false
           tags: |
             atsigncompany/virtualenv:dev_env
             atsigncompany/virtualenv:${{ env.BRANCH }}-gha${{ github.run_number }}
@@ -437,6 +439,7 @@ jobs:
         uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3 # v3.3.0
         with:
           push: true
+          provenance: false
           file: tools/build_secondary/Dockerfile
           context: .
           tags: |
@@ -491,6 +494,7 @@ jobs:
         uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3 # v3.3.0
         with:
           push: true
+          provenance: false
           file: tools/build_secondary/Dockerfile.observe
           context: .
           tags: |
@@ -543,6 +547,7 @@ jobs:
         uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3 # v3.3.0
         with:
           push: true
+          provenance: false
           file: tools/build_secondary/Dockerfile
           context: .
           tags: |
@@ -588,6 +593,7 @@ jobs:
           file: tools/build_virtual_environment/ve/Dockerfile.vip
           context: .
           push: true
+          provenance: false
           tags: |
             atsigncompany/virtualenv:canary
             atsigncompany/virtualenv:canary-${{ env.VERSION }}
@@ -632,6 +638,7 @@ jobs:
         uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3 # v3.3.0
         with:
           push: true
+          provenance: false
           file: tools/build_secondary/Dockerfile
           context: .
           tags: |
@@ -667,6 +674,7 @@ jobs:
           file: tools/build_virtual_environment/ve/Dockerfile.vip
           context: .
           push: true
+          provenance: false
           tags: |
             atsigncompany/virtualenv:vip
             atsigncompany/virtualenv:GHA${{ github.run_number }}


### PR DESCRIPTION
https://github.com/atsign-foundation/at_server/issues/1167

**- What I did**

Modified actions workflow to disable provenance per warning at https://github.com/docker/build-push-action/releases/tag/v3.3.0

> Buildx v0.10 enables support for a minimal [SLSA Provenance](https://slsa.dev/provenance/) attestation, which requires support for [OCI-compliant](https://github.com/opencontainers/image-spec) multi-platform images. This may introduce issues with registry and runtime support (e.g. https://github.com/docker/buildx/issues/1533). You can optionally disable the default provenance attestation functionality using `provenance: false`.

**- How to verify it**

Run the workflows manually to rebuild the images then run `docker manifest inspect atsigncompany/dartshowplatform:automated'

**- Description for the changelog**

fix: Set provenance to false for docker/build-push-action