### PR TITLE
refactor: Added to specs to address some leaky abstractions

### DIFF
--- a/packages/at_persistence_spec/CHANGELOG.md
+++ b/packages/at_persistence_spec/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.11
+- refactor: Add some methods to KeyStore specs to reduce abstraction leakiness
+  - added `Future<void> initialize()` method to WritableKeyStore spec
+  - added `AtLogType? commitLog` setter and getter to SecondaryKeyStore spec
 ## 2.0.10
 - fix: Add AtCompaction spec for keystore compaction 
 ## 2.0.9

--- a/packages/at_persistence_spec/CHANGELOG.md
+++ b/packages/at_persistence_spec/CHANGELOG.md
@@ -1,7 +1,5 @@
 ## 2.0.11
-- feat: Added to WritableKeyStore and SecondaryKeyStore specs to address some leaked abstractions
- - added `Future<void> initialize()` method to WritableKeyStore spec
-  - added `AtLogType? commitLog` setter and getter to SecondaryKeyStore spec
+- refactor: Added to specs to address some leaky abstractions
 ## 2.0.10
 - fix: Add AtCompaction spec for keystore compaction 
 ## 2.0.9

--- a/packages/at_persistence_spec/CHANGELOG.md
+++ b/packages/at_persistence_spec/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.0.11
-- refactor: Add some methods to KeyStore specs to reduce abstraction leakiness
-  - added `Future<void> initialize()` method to WritableKeyStore spec
+- feat: Added to WritableKeyStore and SecondaryKeyStore specs to address some leaked abstractions
+ - added `Future<void> initialize()` method to WritableKeyStore spec
   - added `AtLogType? commitLog` setter and getter to SecondaryKeyStore spec
 ## 2.0.10
 - fix: Add AtCompaction spec for keystore compaction 

--- a/packages/at_persistence_spec/lib/src/keystore/keystore.dart
+++ b/packages/at_persistence_spec/lib/src/keystore/keystore.dart
@@ -13,7 +13,7 @@ abstract class Keystore<K, V> {
 abstract class WritableKeystore<K, V> implements Keystore<K, V> {
   /// Subclasses should put any necessary post-construction async initialization
   /// in this method
-  Future<void> initialize();
+  Future<void> initialize() async {}
 
   /// Associates the specified value with the specified key.
   /// If the key store previously contained a mapping for the key, the old value is replaced by the specified value.

--- a/packages/at_persistence_spec/lib/src/keystore/keystore.dart
+++ b/packages/at_persistence_spec/lib/src/keystore/keystore.dart
@@ -11,6 +11,10 @@ abstract class Keystore<K, V> {
 
 /// WritableKeystore represents a data store like a database that allows CRUD operations on the values belonging to the keys
 abstract class WritableKeystore<K, V> implements Keystore<K, V> {
+  /// Subclasses should put any necessary post-construction async initialization
+  /// in this method
+  Future<void> initialize();
+
   /// Associates the specified value with the specified key.
   /// If the key store previously contained a mapping for the key, the old value is replaced by the specified value.
   ///

--- a/packages/at_persistence_spec/lib/src/keystore/secondary_keystore.dart
+++ b/packages/at_persistence_spec/lib/src/keystore/secondary_keystore.dart
@@ -17,4 +17,10 @@ abstract class SecondaryKeyStore<K, V, T>
 
   /// Checks whether the keystore contains the key. Returns a true if key is present, else false.
   bool isKeyExists(String key);
+
+  /// A SecondaryKeyStore has an associated commit log
+  AtLogType? get commitLog;
+
+  /// A SecondaryKeyStore has an associated commit log
+  set commitLog(AtLogType? log);
 }

--- a/packages/at_persistence_spec/lib/src/keystore/secondary_keystore.dart
+++ b/packages/at_persistence_spec/lib/src/keystore/secondary_keystore.dart
@@ -19,8 +19,8 @@ abstract class SecondaryKeyStore<K, V, T>
   bool isKeyExists(String key);
 
   /// A SecondaryKeyStore has an associated commit log
-  AtLogType? get commitLog;
+  AtLogType? get commitLog => null;
 
   /// A SecondaryKeyStore has an associated commit log
-  set commitLog(AtLogType? log);
+  set commitLog(AtLogType? log) {}
 }

--- a/packages/at_persistence_spec/pubspec.yaml
+++ b/packages/at_persistence_spec/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_persistence_spec
 description: A Dart library containing abstract classes that defines what an implementation of the persistence layer is responsible for. This can be used to guide implementation of other persistence solutions for servers or SDKs as desired.
-version: 2.0.10
+version: 2.0.11
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://atsign.dev
 documentation: https://docs.atsign.com/

--- a/tests/at_functional_test/test/notify_verb_test.dart
+++ b/tests/at_functional_test/test/notify_verb_test.dart
@@ -70,7 +70,13 @@ void main() {
       await socket_writer(
           socketFirstAtsign!, 'notify:$firstAtsign:phone.me$firstAtsign');
       var response = await read();
-      var currentDateTime = DateTime.now();
+
+      await (Future.delayed(Duration(milliseconds: 5)));
+
+      var dateTimeAfterFirstNotification = DateTime.now();
+
+      await (Future.delayed(Duration(milliseconds: 5)));
+
       // Sending second notification
       await socket_writer(
           socketFirstAtsign!, 'notify:$firstAtsign:about.me$firstAtsign');
@@ -85,7 +91,7 @@ void main() {
       expect(
           DateTime.parse(atNotificationMap['notificationDateTime'])
                   .microsecondsSinceEpoch >
-              currentDateTime.microsecondsSinceEpoch,
+              dateTimeAfterFirstNotification.microsecondsSinceEpoch,
           true);
     });
   });


### PR DESCRIPTION
**- What I did**
feat: Added to WritableKeyStore and SecondaryKeyStore specs to address some leaked abstractions
Required for #1213

**- How I did it**
* added `Future<void> initialize()` method to WritableKeyStore spec
* added AtLogType? commitLog setter and getter to SecondaryKeyStore spec

**- How to verify it**

**- Description for the changelog**
feat: Added to WritableKeyStore and SecondaryKeyStore specs to address some leaked abstractions
