### PR TITLE
fix: corrected assertions of the scan verb test

### DIFF
--- a/packages/at_persistence_secondary_server/CHANGELOG.md
+++ b/packages/at_persistence_secondary_server/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.48
+- fix: Ensure HiveKeystore's metaDataCache's keys are in lower case
 ## 3.0.47
 - feat: conform to at_persistence_spec 2.0.11
 ## 3.0.46

--- a/packages/at_persistence_secondary_server/lib/src/keystore/hive_keystore.dart
+++ b/packages/at_persistence_secondary_server/lib/src/keystore/hive_keystore.dart
@@ -58,6 +58,7 @@ class HiveKeystore implements SecondaryKeyStore<String, AtData?, AtMetaData?> {
 
   @override
   Future<AtData?> get(String key) async {
+    key = key.toLowerCase();
     AtData? value;
     try {
       String hiveKey = keyStoreHelper.prepareKey(key);
@@ -94,6 +95,7 @@ class HiveKeystore implements SecondaryKeyStore<String, AtData?, AtMetaData?> {
       String? sharedKeyEncrypted,
       String? publicKeyChecksum,
       String? encoding}) async {
+    key = key.toLowerCase();
     final atKey = AtKey.getKeyType(key, enforceNameSpace: false);
     if (atKey == KeyType.invalidKey) {
       logger.warning('Key $key is invalid');
@@ -182,6 +184,7 @@ class HiveKeystore implements SecondaryKeyStore<String, AtData?, AtMetaData?> {
       String? sharedKeyEncrypted,
       String? publicKeyChecksum,
       String? encoding}) async {
+    key = key.toLowerCase();
     final atKey = AtKey.getKeyType(key, enforceNameSpace: false);
     if (atKey == KeyType.invalidKey) {
       logger.warning('Key $key is invalid');
@@ -249,6 +252,7 @@ class HiveKeystore implements SecondaryKeyStore<String, AtData?, AtMetaData?> {
   /// Returns an integer if the key to be deleted is present in keystore or cache.
   @override
   Future<int?> remove(String key) async {
+    key = key.toLowerCase();
     int? result;
     try {
       await persistenceManager!.getBox().delete(keyStoreHelper.prepareKey(key));
@@ -352,6 +356,7 @@ class HiveKeystore implements SecondaryKeyStore<String, AtData?, AtMetaData?> {
 
   @override
   Future<AtMetaData?> getMeta(String key) async {
+    key = key.toLowerCase();
     if (_metaDataCache.containsKey(key)) {
       return _metaDataCache[key];
     }
@@ -361,6 +366,7 @@ class HiveKeystore implements SecondaryKeyStore<String, AtData?, AtMetaData?> {
   @override
   @client
   Future<int?> putAll(String key, AtData? value, AtMetaData? metadata) async {
+    key = key.toLowerCase();
     final atKeyType = AtKey.getKeyType(key, enforceNameSpace: false);
     if (atKeyType == KeyType.invalidKey) {
       logger.warning('Key $key is invalid');
@@ -391,6 +397,7 @@ class HiveKeystore implements SecondaryKeyStore<String, AtData?, AtMetaData?> {
 
   @override
   Future<int?> putMeta(String key, AtMetaData? metadata) async {
+    key = key.toLowerCase();
     try {
       String hive_key = keyStoreHelper.prepareKey(key);
       AtData? existingData;
@@ -421,6 +428,7 @@ class HiveKeystore implements SecondaryKeyStore<String, AtData?, AtMetaData?> {
   @override
   @server
   bool isKeyExists(String key) {
+    key = key.toLowerCase();
     return persistenceManager!
         .getBox()
         .containsKey(keyStoreHelper.prepareKey(key));

--- a/packages/at_persistence_secondary_server/pubspec.yaml
+++ b/packages/at_persistence_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_persistence_secondary_server
 description: A Dart library with the implementation classes for the persistence layer of the secondary server.
-version: 3.0.47
+version: 3.0.48
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://atsign.dev
 

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -28,6 +28,13 @@ dependencies:
   meta: 1.8.0
   mutex: ^3.0.1
 
+dependency_overrides:
+  at_persistence_secondary_server:
+   git:
+     url: https://github.com/atsign-foundation/at_server.git
+     path: packages/at_persistence_secondary_server
+     ref: issue#1194
+
 #dependency_overrides:
 #  at_server_spec:
 #    git:

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -1,10 +1,9 @@
 name: at_secondary
 description: Implementation of secondary server.
-version: 3.0.27
+version: 3.0.48
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://www.example.com
 publish_to: none
-
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
@@ -19,7 +18,7 @@ dependencies:
   collection: 1.17.0
   basic_utils: 5.4.2
   at_persistence_spec: 2.0.11
-  at_persistence_secondary_server: 3.0.47
+  at_persistence_secondary_server: 3.0.48
   at_lookup: 3.0.33
   at_server_spec: 3.0.11
   at_utils: 3.0.11
@@ -28,47 +27,17 @@ dependencies:
   meta: 1.8.0
   mutex: ^3.0.1
 
-dependency_overrides:
-  at_persistence_secondary_server:
-   git:
-     url: https://github.com/atsign-foundation/at_server.git
-     path: packages/at_persistence_secondary_server
-     ref: issue#1194
-
 #dependency_overrides:
-#  at_server_spec:
-#    git:
-#      url: https://github.com/atsign-foundation/at_server.git
-#      path: at_server_spec
-#      ref: trunk
-
-#  at_persistence_spec:
-#    git:
-#      url: https://github.com/atsign-foundation/at_server.git
-#      path: at_persistence/at_persistence_spec
-#      ref: at_persistence_encode_public_data
 #  at_persistence_secondary_server:
-#   git:
-#     url: https://github.com/atsign-foundation/at_server.git
-#     path: at_secondary/at_persistence_secondary_server
-#     ref: trunk
+#    git:
+#      url: https://github.com/atsign-foundation/at_server.git
+#      path: packages/at_persistence_secondary_server
+#      ref: trunk
 #  at_commons:
 #    git:
 #      url: https://github.com/atsign-foundation/at_tools.git
 #      path: at_commons
 #      ref: atkey_types
-#   at_persistence_spec:
-#     git:
-#       url: https://github.com/atsign-foundation/at_server.git
-#       path: at_persistence/at_persistence_spec
-#       ref: at_annotation
-#  at_utils:
-#    git:
-#      url: https://github.com/atsign-foundation/at_tools.git
-#      path: at_utils
-#      ref: trunk
-
-
 
 dev_dependencies:
   test: ^1.22.1

--- a/tests/at_functional_test/test/scan_verb_test.dart
+++ b/tests/at_functional_test/test/scan_verb_test.dart
@@ -120,7 +120,7 @@ void main() {
 
     ///UPDATE VERB
     await socket_writer(
-        socketFirstAtsign!, 'update:ttl:3000:ttlkey.me$firstAtsign 1245');
+        socketFirstAtsign!, 'update:ttl:3000:ttlKEY.me$firstAtsign 1245');
     var response = await read();
     print('update verb response : $response');
     assert(
@@ -130,11 +130,12 @@ void main() {
     await socket_writer(socketFirstAtsign!, 'scan');
     response = await read();
     print('scan verb response : $response');
-    expect(response, contains('"ttlkey.me$firstAtsign"'));
+    expect(false, response.contains('"ttlKEY.me$firstAtsign"')); // server ensures lower-case
+    expect(true, response.contains('"ttlkey.me$firstAtsign"'));
 
     // update ttl to a lesser value so that key expires for scan
     await socket_writer(
-        socketFirstAtsign!, 'update:ttl:200:ttlkey.me$firstAtsign 1245');
+        socketFirstAtsign!, 'update:ttl:200:ttlKEY.me$firstAtsign 1245');
     response = await read();
     assert(
         (!response.contains('Invalid syntax')) && (!response.contains('null')));
@@ -145,6 +146,7 @@ void main() {
     response = await read();
     print('scan verb response : $response');
     expect(false, response.contains('"ttlkey.me$firstAtsign"'));
+    expect(false, response.contains('"ttlKEY.me$firstAtsign"'));
   }, timeout: Timeout(Duration(seconds: 120)));
 
   test('Scan verb does not return unborn keys', () async {

--- a/tests/at_functional_test/test/scan_verb_test.dart
+++ b/tests/at_functional_test/test/scan_verb_test.dart
@@ -120,18 +120,31 @@ void main() {
 
     ///UPDATE VERB
     await socket_writer(
-        socketFirstAtsign!, 'update:public:verifyingTTL$firstAtsign Working?');
+        socketFirstAtsign!, 'update:ttl:3000:ttlkey.me$firstAtsign 1245');
     var response = await read();
     print('update verb response : $response');
-    //update ttl so that key is expired
-    await socket_writer(socketFirstAtsign!,
-        'update:ttl:6000:public:verifyingTTL$firstAtsign 1');
-    sleep(Duration(seconds: 2));
+    assert(
+        (!response.contains('Invalid syntax')) && (!response.contains('null')));
+
+    ///SCAN VERB should return the key before it expires
     await socket_writer(socketFirstAtsign!, 'scan');
     response = await read();
     print('scan verb response : $response');
-    expect(
-        false, response.contains('"update:public:verifyingTTL$firstAtsign"'));
+    expect(response, contains('"ttlkey.me$firstAtsign"'));
+
+    // update ttl to a lesser value so that key expires for scan
+    await socket_writer(
+        socketFirstAtsign!, 'update:ttl:200:ttlkey.me$firstAtsign 1245');
+    response = await read();
+    assert(
+        (!response.contains('Invalid syntax')) && (!response.contains('null')));
+
+    //  scan verb should not return the expired key
+    await Future.delayed(Duration(milliseconds: 300));
+    await socket_writer(socketFirstAtsign!, 'scan');
+    response = await read();
+    print('scan verb response : $response');
+    expect(false, response.contains('"ttlkey.me$firstAtsign"'));
   }, timeout: Timeout(Duration(seconds: 120)));
 
   test('Scan verb does not return unborn keys', () async {
@@ -144,17 +157,30 @@ void main() {
 
     ///UPDATE VERB
     await socket_writer(
-        socketFirstAtsign!, 'update:public:verifyingTTB$firstAtsign Working?');
+        socketFirstAtsign!, 'update:ttb:4000:ttbkey$firstAtsign Working?');
     var response = await read();
-    print('update verb response : $response');
-    //update ttb so that key is not born yet
-    await socket_writer(socketFirstAtsign!,
-        'update:ttb:6000:public:verifyingTTB$firstAtsign 600000');
+    assert(
+        (!response.contains('Invalid syntax')) && (!response.contains('null')));
+
+    // scan verb should not return the unborn key
     await socket_writer(socketFirstAtsign!, 'scan');
     response = await read();
     print('scan verb response : $response');
-    expect(
-        false, response.contains('"update:public:verifyingTTB$firstAtsign"'));
+    expect(false, response.contains('"ttbkey$firstAtsign"'));
+
+    // update ttb to a lesser value so that key becomes born
+    await socket_writer(
+        socketFirstAtsign!, 'update:ttb:200:ttbkey$firstAtsign Working?');
+    response = await read();
+    assert(
+        (!response.contains('Invalid syntax')) && (!response.contains('null')));
+
+    //  scan verb should return the born key
+    await Future.delayed(Duration(milliseconds: 300));
+    await socket_writer(socketFirstAtsign!, 'scan');
+    response = await read();
+    print('scan verb response : $response');
+    expect(response, contains('"ttbkey$firstAtsign"'));
   }, timeout: Timeout(Duration(seconds: 120)));
 
   tearDown(() {


### PR DESCRIPTION
**- What we did**
* Changed the incorrect assertions
* Added test case for keys with mixed case - discovered #1216 
* Fixed #1216

**- How we did it**
* Removed the update: public command in the scan result assertion
* Ensure HiveKeystore public methods start by converting their 'key' parameter to lower case. This ensures that the _metaDataCache's keys are in lower-case, same as the keyStore itself.

**- How to verify it**
* all tests should pass
