### PR TITLE
fix: AtData.toJson() now works when the key is null

### DIFF
--- a/packages/at_persistence_secondary_server/CHANGELOG.md
+++ b/packages/at_persistence_secondary_server/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.49
+- fix: AtData.toJson() now works when the key is null
 ## 3.0.48
 - fix: Ensure HiveKeystore's metaDataCache's keys are in lower case
 ## 3.0.47

--- a/packages/at_persistence_secondary_server/lib/src/model/at_data.dart
+++ b/packages/at_persistence_secondary_server/lib/src/model/at_data.dart
@@ -13,13 +13,17 @@ class AtData extends HiveObject {
 
   @override
   String toString() {
-    return 'AtData{data: $data, metaData: ${metaData.toString()}';
+    return 'AtData{key:$key, data: $data, metaData: ${metaData.toString()}';
   }
 
   Map toJson() {
-    // ignore: omit_local_variable_types
     Map map = {};
-    map['key'] = Utf7.decode(key);
+    // If this AtData has been constructed from json there is no 'key' in the AtData object, since
+    // [fromJson] does not set a key (indeed, it cannot set a key as HiveObject doesn't allow that).
+    // So we do a null check here to ensure we don't cause Utf7.decode to throw an exception
+    if (key != null) {
+      map['key'] = Utf7.decode(key);
+    }
     map['data'] = data;
     map['metaData'] = metaData!.toJson();
     return map;

--- a/packages/at_persistence_secondary_server/pubspec.yaml
+++ b/packages/at_persistence_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_persistence_secondary_server
 description: A Dart library with the implementation classes for the persistence layer of the secondary server.
-version: 3.0.48
+version: 3.0.49
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://atsign.dev
 

--- a/packages/at_secondary_server/lib/src/verb/handler/proxy_lookup_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/proxy_lookup_verb_handler.dart
@@ -51,7 +51,7 @@ class ProxyLookupVerbHandler extends AbstractVerbHandler {
     var cachedKeyName = 'cached:public:$keyName';
 
     //If key is cached, return cached value.
-    var atData = await cacheManager.get(cachedKeyName, applyMetadataRules: false);
+     var atData = await cacheManager.get(cachedKeyName, applyMetadataRules: false);
     var result = SecondaryUtil.prepareResponseData(operation, atData);
     // If cached key value is null or byPassCache is true, perform a remote plookup.
     if (result == null || byPassCacheStr == 'true') {


### PR DESCRIPTION
**- What I did**
Fixed a bug where calling `toJson` on an `AtData` object would throw an exception if the `key` was null.
* This is never a problem when retrieving an AtData from the keyStore, as the `key` is never null.
* However if the AtData object is populated by using its fromJson method then we have a problem, because the `key` is **_always_** null

**- How I did it**
Added a null check in AtData's toJson method

**- How to verify it**
Tests pass

**- Description for the changelog**
fix: AtData.toJson() now works when the key is null