### PR TITLE
fix: Make plookup:all command work correctly if the data has not previously been cached in the server.

### DIFF
--- a/packages/at_secondary_server/lib/src/utils/secondary_util.dart
+++ b/packages/at_secondary_server/lib/src/utils/secondary_util.dart
@@ -99,7 +99,7 @@ class SecondaryUtil {
     return base64Encode(signature);
   }
 
-  static String? prepareResponseData(String? operation, AtData? atData) {
+  static String? prepareResponseData(String? operation, AtData? atData, {String? keyToUseIfNotAlreadySetInAtData}) {
     String? result;
     if (atData == null) {
       return result;
@@ -109,7 +109,11 @@ class SecondaryUtil {
         result = json.encode(atData.metaData!.toJson());
         break;
       case 'all':
-        result = json.encode(atData.toJson());
+        var atDataAsMap = atData.toJson();
+        if (!atDataAsMap.containsKey('key') && keyToUseIfNotAlreadySetInAtData != null) {
+          atDataAsMap['key'] = keyToUseIfNotAlreadySetInAtData;
+        }
+        result = json.encode(atDataAsMap);
         break;
       default:
         result = atData.data;

--- a/packages/at_secondary_server/lib/src/verb/handler/proxy_lookup_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/proxy_lookup_verb_handler.dart
@@ -61,14 +61,12 @@ class ProxyLookupVerbHandler extends AbstractVerbHandler {
         return;
       }
 
-      if (operation != 'all') {
-        result = SecondaryUtil.prepareResponseData(operation, atData);
-      }
-      // Caching of keys is refrained when looked up the currentAtSign user
-      // Cache keys only if currentAtSign is not equal to atSign
+      // Cache keys only if currentAtSign is not equal to the owner of the key being looked up
       if (cacheManager.atSign != atSign) {
         await cacheManager.put(cachedKeyName, atData);
       }
+
+      result = SecondaryUtil.prepareResponseData(operation, atData, keyToUseIfNotAlreadySetInAtData: keyName);
     }
     response.data = result;
     var atAccessLog = await (AtAccessLogManagerImpl.getInstance()

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_secondary
 description: Implementation of secondary server.
-version: 3.0.48
+version: 3.0.49
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://www.example.com
 publish_to: none
@@ -18,7 +18,7 @@ dependencies:
   collection: 1.17.0
   basic_utils: 5.4.2
   at_persistence_spec: 2.0.11
-  at_persistence_secondary_server: 3.0.48
+  at_persistence_secondary_server: 3.0.49
   at_lookup: 3.0.33
   at_server_spec: 3.0.11
   at_utils: 3.0.11
@@ -26,18 +26,6 @@ dependencies:
   version: 3.0.2
   meta: 1.8.0
   mutex: ^3.0.1
-
-#dependency_overrides:
-#  at_persistence_secondary_server:
-#    git:
-#      url: https://github.com/atsign-foundation/at_server.git
-#      path: packages/at_persistence_secondary_server
-#      ref: trunk
-#  at_commons:
-#    git:
-#      url: https://github.com/atsign-foundation/at_tools.git
-#      path: at_commons
-#      ref: atkey_types
 
 dev_dependencies:
   test: ^1.22.1

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_secondary
 description: Implementation of secondary server.
-version: 3.0.49
+version: 3.0.28
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://www.example.com
 publish_to: none


### PR DESCRIPTION
**Note**
1. the new unit tests which will prevent this from regressing are in another branch which will be in a follow-up PR
2. The version change in pubspec.yaml is because I messed up the version yesterday in [this PR](https://github.com/atsign-foundation/at_server/pull/1215) when I set it to 3.0.48 instead of 3.0.28. (3.0.27 is in canary and is currently being rolled out to prod)

**- What I did**
fix: Make plookup:all command work correctly if the data has not previously been cached in the server.

**- How I did it**
Previously, a plookup:all would fetch the remote value and cache it, but would return 'null' to the client because prepareResponseData wasn't being called when 'operation:all' was supplied. (Note that plookup:meta and just plain plookup both worked fine)
- Removed if statement in the ProxyLookupVerbHandler which was not preparing any response data if (1) the value was being looked up remotely rather than fetched from cache, and (2) the operation was 'all' (as in, plookup:all in this case).
  - Just a guess, but it seems highly likely that that if statement was added because prepareResponseData would previously crash when calling toJson on the AtData object constructed from the remote lookup. I've fixed that bug in [the PR just before this one.](https://github.com/atsign-foundation/at_server/pull/1218)
- Added optional parameter to SecondaryUtil.prepareResponseData so it can add a 'key' value to the JSON response in order to be consistent with the response to a plookup:all when the data is retrieved from cache.

**- How to verify it**
Tests pass

**- Description for the changelog**
fix: Make plookup:all command work correctly if the data has not previously been cached in the server.
