### PR TITLE
fix: Set provenance to false to prevent OCI image format

### DIFF
--- a/.github/workflows/promote_canary.yaml
+++ b/.github/workflows/promote_canary.yaml
@@ -39,6 +39,7 @@ jobs:
         uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 # v4.0.0
         with:
           push: true
+          provenance: false
           file: tools/build_secondary/Dockerfile.canary_to_prod
           context: .
           tags: |


### PR DESCRIPTION
Images created by the [last promotion](https://github.com/atsign-foundation/at_server/actions/runs/4251840594) aren't working with Shepherd because it can't use OCI images, which are now the default

**- What I did**

Set `provenance: false` so that a regular image is created.

**- How to verify it**

Rerun the promotion (using a `p3.0.27` release, and watch Shepherd logs.)

**- Description for the changelog**

fix: Set provenance to false to prevent OCI image format