### PR TITLE
test: Added some utility scripts at tools/run_locally to make it a little easier to run things locally

### DIFF
--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,0 +1,3 @@
+
+# Output logs, storage directories etc are held in run_locally/runtime
+run_locally/runtime

--- a/tools/run_locally/scripts/macos/at_redis
+++ b/tools/run_locally/scripts/macos/at_redis
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+scriptName=$(basename -- "$0")
+cd "$(dirname -- "$0")"
+scriptDir=$(pwd)
+
+# Script dir is <repo_root>/tools/run_locally/scripts/<platform>
+# We will create logs etc in <repo_root>/tools/run_locally/runtime which
+# is in .gitignore
+cd "$scriptDir"/../../runtime
+
+mkdir -p rootServer
+cd rootServer
+echo "Running $scriptDir/$scriptName in working directory $(pwd)"
+
+# We need to run a redis server, with a password required.
+# (Un-comment "requirepass foobared" in redis.conf)
+
+echo "Starting redis server"
+redis-server /usr/local/etc/redis.conf

--- a/tools/run_locally/scripts/macos/at_rmkeys
+++ b/tools/run_locally/scripts/macos/at_rmkeys
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+scriptName=$(basename -- "$0")
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $scriptName <atSign>"
+    exit 1
+fi
+
+keysFile="$HOME/.atsign/keys/${1}_key.atKeys"
+echo "Removing client keys (if any) at $keysFile"
+rm -f "$keysFile"

--- a/tools/run_locally/scripts/macos/at_root
+++ b/tools/run_locally/scripts/macos/at_root
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+scriptName=$(basename -- "$0")
+cd "$(dirname -- "$0")"
+scriptDir=$(pwd)
+
+# Script dir is <repo_root>/tools/run_locally/scripts/<platform>
+# We will create logs etc in <repo_root>/tools/run_locally/runtime which
+# is in .gitignore
+cd "$scriptDir"/../../runtime
+
+mkdir -p rootServer
+cd rootServer
+echo "Running $scriptName in working directory $(pwd)"
+
+if [ ! -L certs ]; then
+  echo "Linking root certs"
+  ln -s "$scriptDir"/../../../../tools/build_virtual_environment/ve_base/contents/atsign/root/certs .
+fi
+
+echo "Starting root server on default port 64"
+dart "$scriptDir"/../../../../packages/at_root_server/bin/main.dart -h vip.ve.atsign.zone -p 6379 -a foobared

--- a/tools/run_locally/scripts/macos/at_server
+++ b/tools/run_locally/scripts/macos/at_server
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+function usage {
+  echo "Usage: $scriptName -a <@sign> -p <port> -s <secret> [-r]"
+  echo "       When '-r' (for 'reset') is provided, we remove existing storage files before starting the atServer"
+  exit 1
+}
+
+scriptName=$(basename -- "$0")
+cd "$(dirname -- "$0")"
+scriptDir=$(pwd)
+
+unset atSign
+unset port
+unset secret
+unset reset
+
+while getopts a:p:s:r opt; do
+  case $opt in
+    a) atSign=$OPTARG ;;
+    p) port=$OPTARG ;;
+    s) secret=$OPTARG ;;
+    r) reset="true" ;;
+    *) usage ;;
+  esac
+done
+
+shift "$(( OPTIND - 1 ))"
+
+if [ -z "$atSign" ] || [ -z "$port" ] || [ -z "$secret" ] ; then
+  usage
+fi
+
+# Script dir is <repo_root>/tools/run_locally/scripts/<platform>
+# We will create logs etc in <repo_root>/tools/run_locally/runtime which
+# is in .gitignore
+cd "$scriptDir"/../../runtime
+
+mkdir -p atServers
+cd atServers
+echo "Running $scriptName in working directory $(pwd)"
+
+storageDir="storage_$atSign"
+
+if [ "$reset" == "true" ] ; then
+  echo "Removing server storage at $storageDir"
+  mkdir -p trash
+  mv "$storageDir" trash
+  rm -rf trash
+  sleep 10
+fi
+
+# Export various environment variables which the atServer recognizes
+export rootServerUrl="vip.ve.atsign.zone"
+export rootServerPort=64
+
+export secondaryStoragePath="$storageDir/hive"
+export commitLogPath="$storageDir/commitLog"
+export accessLogPath="$storageDir/accessLog"
+export notificationStoragePath="$storageDir/notificationLog.v1"
+
+export logLevel="INFO"
+
+export testingMode="true"
+
+# Set up on the local root server
+redis-cli << EOF
+auth foobared
+set ${atSign:1} vip.ve.atsign.zone:$port
+exit
+EOF
+
+if [ ! -L certs ]; then
+  echo "Linking secondary certs"
+  ln -s "$scriptDir"/../../../../tools/build_virtual_environment/ve_base/contents/atsign/secondary/base/certs .
+fi
+
+dart "$scriptDir"/../../../../packages/at_secondary_server/bin/main.dart -a "$atSign" -p "$port" -s "$secret"


### PR DESCRIPTION
**- What I did**
test: Added some utility scripts at tools/run_locally to make it a little easier to run things locally

**- How to verify it**
Try them out!
* at_redis: runs a redis server (requires you to have already installed redis)
* at_root: runs a root server which connects to the local redis server
* at_server: runs a secondary server which 'registers' its atSign with the locally running root server

**NOTE** To start with, there are only scripts for macos (although will probably also work on any linux)

**- Description for the changelog**
test: Added some utility scripts at tools/run_locally to make it a little easier to run things locally