### PR TITLE
fix: AtMetaData.fromJson now preserves null values for ttl, ttb and ttr

### DIFF
--- a/packages/at_persistence_secondary_server/.gitignore
+++ b/packages/at_persistence_secondary_server/.gitignore
@@ -24,3 +24,5 @@ doc/api/
 *.ipr
 *.iws
 *.idea/
+
+test/hive/

--- a/packages/at_persistence_secondary_server/CHANGELOG.md
+++ b/packages/at_persistence_secondary_server/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.50
+- fix: AtMetaData.fromJson now preserves null values for ttl, ttb and ttr
+- test: Add '==' & hashCode to AtMetaData in order to be able to test equality
+- test: Added tests which verify JSON round-tripping of AtMetaData objects
+- refactor: Deprecate at_metadata_adapter; extract the 'to' and 'from' commons Metadata methods from there into the AtMetaData class itself
 ## 3.0.49
 - fix: AtData.toJson() now works when the key is null
 ## 3.0.48

--- a/packages/at_persistence_secondary_server/lib/src/model/at_meta_data.dart
+++ b/packages/at_persistence_secondary_server/lib/src/model/at_meta_data.dart
@@ -1,4 +1,5 @@
 import 'package:at_commons/at_commons.dart';
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:at_persistence_secondary_server/src/utils/type_adapter_util.dart';
 import 'package:hive/hive.dart';
 
@@ -66,6 +67,39 @@ class AtMetaData extends HiveObject {
     return toJson().toString();
   }
 
+  AtMetaData();
+
+  Metadata toCommonsMetadata() {
+    return Metadata()
+      ..ttl = ttl
+      ..ttb = ttb
+      ..ttr = ttr
+      ..ccd = isCascade
+      ..isBinary = isBinary
+      ..isEncrypted = isEncrypted
+      ..dataSignature = dataSignature
+      ..sharedKeyEnc = sharedKeyEnc
+      ..pubKeyCS = pubKeyCS
+      ..encoding = encoding;
+  }
+
+  factory AtMetaData.fromCommonsMetadata(Metadata metadata) {
+    var atMetadata = AtMetaData();
+    atMetadata
+      ..ttl = metadata.ttl
+      ..ttb = metadata.ttb
+      ..ttr = metadata.ttr
+      ..isCascade = metadata.ccd
+      ..isBinary = metadata.isBinary
+      ..isEncrypted = metadata.isEncrypted
+      ..dataSignature = metadata.dataSignature
+      ..sharedKeyEnc = metadata.sharedKeyEnc
+      ..pubKeyCS = metadata.pubKeyCS
+      ..encoding = metadata.encoding;
+
+    return AtMetadataBuilder(newAtMetaData: atMetadata).build();
+  }
+
   Map toJson() {
     // ignore: omit_local_variable_types
     Map map = {};
@@ -89,6 +123,10 @@ class AtMetaData extends HiveObject {
     map[SHARED_WITH_PUBLIC_KEY_CHECK_SUM] = pubKeyCS;
     map[ENCODING] = encoding;
     return map;
+  }
+
+  factory AtMetaData.fromJson(Map json) {
+    return AtMetaData().fromJson(json);
   }
 
   AtMetaData fromJson(Map json) {
@@ -116,17 +154,17 @@ class AtMetaData extends HiveObject {
       ttl = (json[AT_TTL] is String)
           ? int.parse(json[AT_TTL])
           : (json[AT_TTL] == null)
-              ? 0
+              ? null
               : json[AT_TTL];
       ttb = (json[AT_TTB] is String)
           ? int.parse(json[AT_TTB])
           : (json[AT_TTB] == null)
-              ? 0
+              ? null
               : json[AT_TTB];
       ttr = (json[AT_TTR] is String)
           ? int.parse(json[AT_TTR])
           : (json[AT_TTR] == null)
-              ? 0
+              ? null
               : json[AT_TTR];
       isCascade = json[CCD];
       isBinary = json[IS_BINARY];
@@ -140,6 +178,53 @@ class AtMetaData extends HiveObject {
     }
     return this;
   }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is AtMetaData &&
+          runtimeType == other.runtimeType &&
+          createdBy == other.createdBy &&
+          updatedBy == other.updatedBy &&
+          createdAt == other.createdAt &&
+          updatedAt == other.updatedAt &&
+          expiresAt == other.expiresAt &&
+          status == other.status &&
+          version == other.version &&
+          availableAt == other.availableAt &&
+          ttb == other.ttb &&
+          ttl == other.ttl &&
+          ttr == other.ttr &&
+          refreshAt == other.refreshAt &&
+          isCascade == other.isCascade &&
+          isBinary == other.isBinary &&
+          isEncrypted == other.isEncrypted &&
+          dataSignature == other.dataSignature &&
+          sharedKeyEnc == other.sharedKeyEnc &&
+          pubKeyCS == other.pubKeyCS &&
+          encoding == other.encoding;
+
+  @override
+  int get hashCode =>
+      createdBy.hashCode ^
+      updatedBy.hashCode ^
+      createdAt.hashCode ^
+      updatedAt.hashCode ^
+      expiresAt.hashCode ^
+      status.hashCode ^
+      version.hashCode ^
+      availableAt.hashCode ^
+      ttb.hashCode ^
+      ttl.hashCode ^
+      ttr.hashCode ^
+      refreshAt.hashCode ^
+      isCascade.hashCode ^
+      isBinary.hashCode ^
+      isEncrypted.hashCode ^
+      dataSignature.hashCode ^
+      sharedKeyEnc.hashCode ^
+      pubKeyCS.hashCode ^
+      encoding.hashCode;
 }
 
 class AtMetaDataAdapter extends TypeAdapter<AtMetaData> {

--- a/packages/at_persistence_secondary_server/lib/src/utils/at_metadata_adapter.dart
+++ b/packages/at_persistence_secondary_server/lib/src/utils/at_metadata_adapter.dart
@@ -1,35 +1,13 @@
 import 'package:at_commons/at_commons.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 
+@Deprecated("use AtMetaData.fromCommonsMetadata")
 // ignore: non_constant_identifier_names
 AtMetaData? AtMetadataAdapter(Metadata metadata) {
-  var atMetadata = AtMetaData();
-  atMetadata
-    ..ttl = metadata.ttl
-    ..ttb = metadata.ttb
-    ..ttr = metadata.ttr
-    ..isCascade = metadata.ccd
-    ..isBinary = metadata.isBinary
-    ..isEncrypted = metadata.isEncrypted
-    ..dataSignature = metadata.dataSignature
-    ..sharedKeyEnc = metadata.sharedKeyEnc
-    ..pubKeyCS = metadata.pubKeyCS
-    ..encoding = metadata.encoding;
-
-  return AtMetadataBuilder(newAtMetaData: atMetadata).build();
+  return AtMetaData.fromCommonsMetadata(metadata);
 }
 
+@Deprecated('Use AtMetaData.toCommonsMetadata')
 Metadata metadataAdapter(AtMetaData atMetaData) {
-  var metadata = Metadata()
-    ..ttl = atMetaData.ttl
-    ..ttb = atMetaData.ttb
-    ..ttr = atMetaData.ttr
-    ..ccd = atMetaData.isCascade
-    ..isBinary = atMetaData.isBinary
-    ..isEncrypted = atMetaData.isEncrypted
-    ..dataSignature = atMetaData.dataSignature
-    ..sharedKeyEnc = atMetaData.sharedKeyEnc
-    ..pubKeyCS = atMetaData.pubKeyCS
-    ..encoding = atMetaData.encoding;
-  return metadata;
+  return atMetaData.toCommonsMetadata();
 }

--- a/packages/at_persistence_secondary_server/pubspec.yaml
+++ b/packages/at_persistence_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_persistence_secondary_server
 description: A Dart library with the implementation classes for the persistence layer of the secondary server.
-version: 3.0.49
+version: 3.0.50
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://atsign.dev
 
@@ -23,3 +23,4 @@ dev_dependencies:
   lints: ^2.0.0
   test: ^1.21.4
   coverage: ^1.5.0
+  collection: ^1.17.1


### PR DESCRIPTION
Fixes #1210 

**What I did**
- fix: AtMetaData.fromJson now preserves null values for ttl, ttb and ttr (See #1210 )
- refactor: Deprecate at_metadata_adapter; extract the 'to' and 'from' commons Metadata methods from there into the AtMetaData class itself
- test: Add '==' & hashCode to AtMetaData in order to be able to test equality
- test: Added tests which verify JSON round-tripping of AtMetaData objects
- build: added test/hive to .gitignore in at_persistence_secondary_server
- build: Updated at_persistence_secondary_server version to 3.0.50
- docs: Updated changelog for version 3.0.50

**How to verify it**
- [x] Tests pass
- And tests pass in packages which depend on at_persistence_secondary_server
  - [x] at_client_sdk [PR](https://github.com/atsign-foundation/at_client_sdk/pull/941) and [checks](https://github.com/atsign-foundation/at_client_sdk/actions/runs/4331526130)
  - [x] at_secondary_server [PR](https://github.com/atsign-foundation/at_server/pull/1240) and [checks](https://github.com/atsign-foundation/at_server/actions/runs/4331535506)

**Description for the changelog**
- fix: AtMetaData.fromJson now preserves null values for ttl, ttb and ttr
- test: Add '==' & hashCode to AtMetaData in order to be able to test equality
- test: Added tests which verify JSON round-tripping of AtMetaData objects
- refactor: Deprecate at_metadata_adapter; extract the 'to' and 'from' commons Metadata methods from there into the AtMetaData class itself
