### PR TITLE
fix: Remove commitLog entries with malformed atKeys at server startup time

### DIFF
--- a/packages/at_persistence_secondary_server/CHANGELOG.md
+++ b/packages/at_persistence_secondary_server/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.51
+- feat: Extend sanity-checking of server-side commitLog upon startup
 ## 3.0.50
 - fix: AtMetaData.fromJson now preserves null values for ttl, ttb and ttr
 - test: Add '==' & hashCode to AtMetaData in order to be able to test equality

--- a/packages/at_persistence_secondary_server/lib/src/log/commitlog/commit_log_keystore.dart
+++ b/packages/at_persistence_secondary_server/lib/src/log/commitlog/commit_log_keystore.dart
@@ -460,6 +460,7 @@ class CommitLogKeyStore
       CommitEntry? commitEntry = allEntries[seqNum];
       if (commitEntry == null) {
         _logger.warning('CommitLog seqNum $seqNum has a null commitEntry - removing');
+
         remove(seqNum);
         return;
       }
@@ -472,6 +473,8 @@ class CommitLogKeyStore
       if (keyType == KeyType.invalidKey) {
         _logger.warning('CommitLog seqNum $seqNum has an entry with an invalid atKey $atKey - removed');
         removed.add(atKey);
+
+        remove(seqNum);
         return;
       } else {
         _logger.finer('CommitLog seqNum $seqNum has valid type $keyType for atkey $atKey');

--- a/packages/at_persistence_secondary_server/lib/src/log/commitlog/commit_log_keystore.dart
+++ b/packages/at_persistence_secondary_server/lib/src/log/commitlog/commit_log_keystore.dart
@@ -40,18 +40,7 @@ class CommitLogKeyStore
     var lastCommittedSequenceNum = lastCommittedSequenceNumber();
     _logger.finer('last committed sequence: $lastCommittedSequenceNum');
 
-    // Ensures the below code runs only when initialized from secondary server.
-    // enableCommitId is set to true in secondary server and to false in client SDK.
-    if (enableCommitId) {
-      // Repairs the commit log.
-      // If null commit id's exist in commitEntry, replaces the commitId with
-      // respective hive internal key
-      await repairCommitLog(await toMap());
-      // Cache the latest commitId of each key.
-      // Add entries to commitLogCacheMap when initialized from at_secondary_server
-      // and refrain for at_client_sdk.
-      _commitLogCacheMap.addAll(await _getCommitIdMap());
-    }
+    await repairCommitLogAndCreateCachedMap();
   }
 
   @override
@@ -436,9 +425,65 @@ class CommitLogKeyStore
     return _lastSyncedEntryCacheMap.values.toList();
   }
 
-  /// Replaces the null commit id's with hive internal key's
   @visibleForTesting
-  Future<void> repairCommitLog(Map<int, CommitEntry> commitLogMap) async {
+  /// Removes entries with malformed keys
+  /// Repairs entries with null commit IDs
+  /// Clears and repopulates the [_commitLogCacheMap]
+  Future<bool> repairCommitLogAndCreateCachedMap() async {
+    // Ensures the below code runs only when initialized from secondary server.
+    // enableCommitId is set to true in secondary server and to false in client SDK.
+    if (! enableCommitId) {
+      return false;
+    }
+
+    Map<int, CommitEntry> allEntries = await toMap();
+
+    await removeEntriesWithMalformedAtKeys(allEntries);
+
+    await repairNullCommitIDs(allEntries);
+
+    // Cache the latest commitId of each key.
+    // Add entries to commitLogCacheMap when initialized from at_secondary_server
+    // and refrain for at_client_sdk.
+    _commitLogCacheMap.clear();
+    _commitLogCacheMap.addAll(await _getCommitIdMap());
+
+    return true;
+  }
+
+  @visibleForTesting
+  /// Removes all entries which have a malformed [CommitEntry.atKey]
+  /// Returns the list of [CommitEntry.atKey]s which were removed
+  Future<List<String>> removeEntriesWithMalformedAtKeys(Map<int, CommitEntry> allEntries) async {
+    List<String> removed = [];
+    await Future.forEach(allEntries.keys, (int seqNum) async {
+      CommitEntry? commitEntry = allEntries[seqNum];
+      if (commitEntry == null) {
+        _logger.warning('CommitLog seqNum $seqNum has a null commitEntry - removing');
+        remove(seqNum);
+        return;
+      }
+      String? atKey = commitEntry.atKey;
+      if (atKey == null) {
+        _logger.warning('CommitLog seqNum $seqNum has an entry with a null atKey - removed');
+        return;
+      }
+      KeyType keyType = AtKey.getKeyType(atKey, enforceNameSpace: false);
+      if (keyType == KeyType.invalidKey) {
+        _logger.warning('CommitLog seqNum $seqNum has an entry with an invalid atKey $atKey - removed');
+        removed.add(atKey);
+        return;
+      } else {
+        _logger.finer('CommitLog seqNum $seqNum has valid type $keyType for atkey $atKey');
+      }
+    });
+    return removed;
+  }
+
+  @visibleForTesting
+  /// For each commitEntry with a null commitId, replace the commitId with
+  /// the hive internal key
+  Future<void> repairNullCommitIDs(Map<int, CommitEntry> commitLogMap) async {
     await Future.forEach(commitLogMap.keys, (key) async {
       CommitEntry? commitEntry = commitLogMap[key];
       if (commitEntry?.commitId == null) {

--- a/packages/at_persistence_secondary_server/pubspec.yaml
+++ b/packages/at_persistence_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_persistence_secondary_server
 description: A Dart library with the implementation classes for the persistence layer of the secondary server.
-version: 3.0.50
+version: 3.0.51
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://atsign.dev
 
@@ -15,7 +15,7 @@ dependencies:
   uuid: ^3.0.6
   at_persistence_spec: ^2.0.11
   at_utils: ^3.0.11
-  at_commons: ^3.0.35
+  at_commons: ^3.0.42
   at_utf7: ^1.0.0
   meta: ^1.8.0
 

--- a/packages/at_persistence_secondary_server/test/commit_log_test.dart
+++ b/packages/at_persistence_secondary_server/test/commit_log_test.dart
@@ -265,7 +265,7 @@ void main() async {
       commitLogInstance?.commit('location@alice', CommitOp.UPDATE);
       var commitLogMap = await commitLogInstance?.commitLogKeyStore.toMap();
       expect(commitLogMap?.values.first.commitId, null);
-      await commitLogInstance?.commitLogKeyStore.repairCommitLog(commitLogMap!);
+      await commitLogInstance?.commitLogKeyStore.repairNullCommitIDs(commitLogMap!);
       commitLogMap = await commitLogInstance?.commitLogKeyStore.toMap();
       expect(commitLogMap?.values.first.commitId, 0);
     });
@@ -293,7 +293,7 @@ void main() async {
           .add(CommitEntry('mobile@alice', CommitOp.UPDATE, DateTime.now()));
 
       var commitLogMap = await commitLogInstance.commitLogKeyStore.toMap();
-      await commitLogInstance.commitLogKeyStore.repairCommitLog(commitLogMap);
+      await commitLogInstance.commitLogKeyStore.repairNullCommitIDs(commitLogMap);
       commitLogMap = await commitLogInstance.commitLogKeyStore.toMap();
       commitLogMap.forEach((key, value) {
         assert(value.commitId != null);


### PR DESCRIPTION
**- What I did**
fix: Remove commitLog entries with malformed atKeys at server startup time

**- How I did it**
- Uses at_commons version 3.0.42 which has improved key validation
- Add a step to commitLogKeyStore initialization which looks through all commit log entries and removes those which have invalid atKey values

**- How to verify it**
- [x] Tests pass
- [x] Manual testing using the 0living storage: entries with malformed atKeys were successfully removed; other entries were left untouched
  - See attached log file [0living.commitLogCleanUp.log](https://github.com/atsign-foundation/at_server/files/10948902/0living.commitLogCleanUp.log) showing all of the commit entries which were removed.
  - In total there were 227 malformed entries
    - 35 started with `public:@public`
    - 93 started with `cached:public:cached:public`
    - 93 started with `public:cached:public`
    - the remaining 6 were
      ```
      cached:@0living:i_live_in_a_pretty_little_spot_in_belmont,_ca**company_persona_info.buzz@wonderfulpelican
      cached:@0living:happy_testing!**company_persona_info.buzz@wonderfulpelican
      cached:@0living:welcome!**welcome.buzz@k
      cached:public:spacechat-9a978390-a0ad-11ec-a726-d7cca24342e7.spacesignal@barbaras+2D3cFdg93BU-
      cached:@0living:file_transfer_3db2e49f-8ec0-416c-883b-d9822a3b9f9b.mospherepro@barbaras+2D3cFdg93BU-
      cached:public:spacechat-68742ac0-a0ae-11ec-8290-4b0c6a949be1.spacesignal@barbaras+2D3cFdg93BU-
      ```

**See also**
the bug report which led to this work https://github.com/atsign-foundation/at_client_sdk/issues/951
some supporting work in at_commons
- https://github.com/atsign-foundation/at_tools/pull/297
- https://github.com/atsign-foundation/at_tools/pull/298
