### PR TITLE
feat: add new encryption metadata fields to WritableKeystore spec

### DIFF
--- a/packages/at_persistence_spec/CHANGELOG.md
+++ b/packages/at_persistence_spec/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.0.12
+- feat: Added new optional encryption metadata parameters to the WritableKeystore spec for `put` and `create`
 ## 2.0.11
 - refactor: Added to specs to address some leaky abstractions
 ## 2.0.10

--- a/packages/at_persistence_spec/lib/src/keystore/keystore.dart
+++ b/packages/at_persistence_spec/lib/src/keystore/keystore.dart
@@ -34,7 +34,12 @@ abstract class WritableKeystore<K, V> implements Keystore<K, V> {
       String? dataSignature,
       String? sharedKeyEncrypted,
       String? publicKeyChecksum,
-      String? encoding});
+      String? encoding,
+      String? encKeyName,
+      String? encAlgo,
+      String? ivNonce,
+      String? skeEncKeyName,
+      String? skeEncAlgo});
 
   /// If the specified key is not already associated with a value (or is mapped to null) associates it with the given value and returns null, else returns the current value.
   ///
@@ -54,7 +59,12 @@ abstract class WritableKeystore<K, V> implements Keystore<K, V> {
       String? dataSignature,
       String? sharedKeyEncrypted,
       String? publicKeyChecksum,
-      String? encoding});
+      String? encoding,
+      String? encKeyName,
+      String? encAlgo,
+      String? ivNonce,
+      String? skeEncKeyName,
+      String? skeEncAlgo});
 
   /// Removes the mapping for a key from this key store if it is present
   ///

--- a/packages/at_persistence_spec/pubspec.yaml
+++ b/packages/at_persistence_spec/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_persistence_spec
 description: A Dart library containing abstract classes that defines what an implementation of the persistence layer is responsible for. This can be used to guide implementation of other persistence solutions for servers or SDKs as desired.
-version: 2.0.11
+version: 2.0.12
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://atsign.dev
 documentation: https://docs.atsign.com/

--- a/tests/at_end2end_test/test/cached_key_test.dart
+++ b/tests/at_end2end_test/test/cached_key_test.dart
@@ -205,6 +205,9 @@ void main() {
     response = response.replaceAll('data:', '');
     expect(response, isNot('null'));
 
+    // Give it a second to propagate to the other atServer
+    await Future.delayed(Duration(seconds: 1));
+
     // verify if cached key is created on the receiver side
     await sh2.writeCommand('llookup:cached:$atSign_2:$key$atSign_1');
     response = await sh2.read();
@@ -216,6 +219,9 @@ void main() {
     response = await sh1.read();
     response = response.replaceAll('data:', '');
     expect(response, isNot('null'));
+
+    // Give it a second to propagate to the other atServer
+    await Future.delayed(Duration(seconds: 1));
 
     //Check if cached key is deleted
     await sh2.writeCommand('llookup:cached:$atSign_2:$key$atSign_1');


### PR DESCRIPTION
**- What I did**
feat: add new encryption metadata fields to WritableKeystore spec

**- How I did it**
* added optional parameters for new encryption metadata fields to WritableKeystore `put` and `create` methods
* backwards compatibility preserved because the new parameters are optional
