### PR TITLE
feat: Add new encryption metadata fields to core persistence classes

### DIFF
--- a/packages/at_persistence_secondary_server/CHANGELOG.md
+++ b/packages/at_persistence_secondary_server/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.52
+- feat: Add new encryption metadata fields to core persistence classes
 ## 3.0.51
 - feat: Extend sanity-checking of server-side commitLog upon startup
 ## 3.0.50

--- a/packages/at_persistence_secondary_server/lib/src/config/at_config.dart
+++ b/packages/at_persistence_secondary_server/lib/src/config/at_config.dart
@@ -121,17 +121,15 @@ class AtConfig {
     }
   }
 
-  ///Returns 'success' after successfully persisiting data into secondary.
+  ///Returns 'success' after successfully persisting data into secondary.
   Future<String> prepareAndStoreData(config, [existingData]) async {
     String result;
     configKey = keyStoreHelper.prepareKey(configKey);
     var newData = AtData();
     newData.data = jsonEncode(config);
-    if (existingData == null) {
-      newData = keyStoreHelper.prepareDataForCreate(newData);
-    } else {
-      newData = keyStoreHelper.prepareDataForUpdate(existingData, newData);
-    }
+
+    newData = keyStoreHelper.prepareDataForKeystoreOperation(newData, existingAtData: existingData);
+
     logger.finest('hive key:$configKey');
     logger.finest('hive value:$newData');
     await persistenceManager.getBox().put(configKey, newData);

--- a/packages/at_persistence_secondary_server/lib/src/keystore/hive_keystore.dart
+++ b/packages/at_persistence_secondary_server/lib/src/keystore/hive_keystore.dart
@@ -94,7 +94,12 @@ class HiveKeystore implements SecondaryKeyStore<String, AtData?, AtMetaData?> {
       String? dataSignature,
       String? sharedKeyEncrypted,
       String? publicKeyChecksum,
-      String? encoding}) async {
+      String? encoding,
+      String? encKeyName,
+      String? encAlgo,
+      String? ivNonce,
+      String? skeEncKeyName,
+      String? skeEncAlgo}) async {
     key = key.toLowerCase();
     final atKey = AtKey.getKeyType(key, enforceNameSpace: false);
     if (atKey == KeyType.invalidKey) {
@@ -105,21 +110,20 @@ class HiveKeystore implements SecondaryKeyStore<String, AtData?, AtMetaData?> {
     var result;
     // Default the commit op to just the value update
     CommitOp commitOp = CommitOp.UPDATE;
-    // Verifies if any of the args are not null
-    bool isMetadataNotNull = ObjectsUtil.isAnyNotNull(
-        a1: time_to_live,
-        a2: time_to_born,
-        a3: time_to_refresh,
-        a4: isCascade,
-        a5: isBinary,
-        a6: isEncrypted);
-    if (isMetadataNotNull) {
-      // Set commit op to UPDATE_META
+
+    // Set CommitOp to UPDATE_META if any of the metadata args are not null
+    var hasNonNullMetadata = ObjectsUtil.anyNotNull({time_to_live,time_to_born,time_to_refresh,
+      isCascade,isBinary,isEncrypted,
+      dataSignature, sharedKeyEncrypted, publicKeyChecksum, encoding,
+      encKeyName, encAlgo, ivNonce, skeEncKeyName, skeEncAlgo});
+    if (hasNonNullMetadata) {
       commitOp = CommitOp.UPDATE_META;
     }
+    // But if the value is not null, the CommitOp will always  be UPDATE_ALL
     if (value != null) {
       commitOp = CommitOp.UPDATE_ALL;
     }
+
     try {
       // If does not exist, create a new key,
       // else update existing key.
@@ -134,12 +138,18 @@ class HiveKeystore implements SecondaryKeyStore<String, AtData?, AtMetaData?> {
             dataSignature: dataSignature,
             sharedKeyEncrypted: sharedKeyEncrypted,
             publicKeyChecksum: publicKeyChecksum,
-            encoding: encoding);
+            encoding: encoding,
+            encKeyName: encKeyName,
+            encAlgo: encAlgo,
+            ivNonce: ivNonce,
+            skeEncKeyName: skeEncKeyName,
+            skeEncAlgo: skeEncAlgo);
       } else {
         AtData? existingData = await get(key);
         String hive_key = keyStoreHelper.prepareKey(key);
-        var hive_value = keyStoreHelper.prepareDataForUpdate(
-            existingData!, value!,
+        var hive_value = keyStoreHelper.prepareDataForKeystoreOperation(
+            value!,
+            existingAtData: existingData!,
             ttl: time_to_live,
             ttb: time_to_born,
             ttr: time_to_refresh,
@@ -150,6 +160,11 @@ class HiveKeystore implements SecondaryKeyStore<String, AtData?, AtMetaData?> {
             sharedKeyEncrypted: sharedKeyEncrypted,
             publicKeyChecksum: publicKeyChecksum,
             encoding: encoding,
+            encKeyName: encKeyName,
+            encAlgo: encAlgo,
+            ivNonce: ivNonce,
+            skeEncKeyName: skeEncKeyName,
+            skeEncAlgo: skeEncAlgo,
             atSign: persistenceManager?.atsign);
         logger.finest('hive key:$hive_key');
         logger.finest('hive value:$hive_value');
@@ -183,7 +198,12 @@ class HiveKeystore implements SecondaryKeyStore<String, AtData?, AtMetaData?> {
       String? dataSignature,
       String? sharedKeyEncrypted,
       String? publicKeyChecksum,
-      String? encoding}) async {
+      String? encoding,
+      String? encKeyName,
+      String? encAlgo,
+      String? ivNonce,
+      String? skeEncKeyName,
+      String? skeEncAlgo}) async {
     key = key.toLowerCase();
     final atKey = AtKey.getKeyType(key, enforceNameSpace: false);
     if (atKey == KeyType.invalidKey) {
@@ -194,7 +214,7 @@ class HiveKeystore implements SecondaryKeyStore<String, AtData?, AtMetaData?> {
     int? result;
     CommitOp commitOp;
     String hive_key = keyStoreHelper.prepareKey(key);
-    var hive_data = keyStoreHelper.prepareDataForCreate(value!,
+    var hive_data = keyStoreHelper.prepareDataForKeystoreOperation(value!,
         atSign: persistenceManager?.atsign,
         ttl: time_to_live,
         ttb: time_to_born,
@@ -205,7 +225,12 @@ class HiveKeystore implements SecondaryKeyStore<String, AtData?, AtMetaData?> {
         dataSignature: dataSignature,
         sharedKeyEncrypted: sharedKeyEncrypted,
         publicKeyChecksum: publicKeyChecksum,
-        encoding: encoding);
+        encoding: encoding,
+        encKeyName: encKeyName,
+        encAlgo: encAlgo,
+        ivNonce: ivNonce,
+        skeEncKeyName: skeEncKeyName,
+        skeEncAlgo: skeEncAlgo);
     // Default commitOp to Update.
     commitOp = CommitOp.UPDATE;
 
@@ -221,16 +246,18 @@ class HiveKeystore implements SecondaryKeyStore<String, AtData?, AtMetaData?> {
       sharedKeyEncrypted ??= value.metaData!.sharedKeyEnc;
       publicKeyChecksum ??= value.metaData!.pubKeyCS;
       encoding ??= value.metaData!.encoding;
+      encKeyName ??= value.metaData!.encKeyName;
+      encAlgo ??= value.metaData!.encAlgo;
+      ivNonce ??= value.metaData!.ivNonce;
+      skeEncKeyName ??= value.metaData!.skeEncKeyName;
+      skeEncAlgo ??= value.metaData!.skeEncAlgo;
     }
 
-    // If metadata is set, set commitOp to Update all
-    if (ObjectsUtil.isAnyNotNull(
-        a1: time_to_live,
-        a2: time_to_born,
-        a3: time_to_refresh,
-        a4: isCascade,
-        a5: isBinary,
-        a6: isEncrypted)) {
+    // Set CommitOp to UPDATE_ALL if any of the metadata args are not null
+    if (ObjectsUtil.anyNotNull({time_to_live,time_to_born,time_to_refresh,
+      isCascade,isBinary,isEncrypted,
+      dataSignature, sharedKeyEncrypted, publicKeyChecksum, encoding,
+      encKeyName, encAlgo, ivNonce, skeEncKeyName, skeEncAlgo})) {
       commitOp = CommitOp.UPDATE_ALL;
     }
 

--- a/packages/at_persistence_secondary_server/lib/src/keystore/hive_keystore_helper.dart
+++ b/packages/at_persistence_secondary_server/lib/src/keystore/hive_keystore_helper.dart
@@ -19,8 +19,9 @@ class HiveKeyStoreHelper {
     return Utf7.encode(key);
   }
 
-  AtData prepareDataForCreate(AtData newData,
-      {int? ttl,
+  AtData prepareDataForKeystoreOperation(AtData newAtData,
+      {AtData? existingAtData,
+      int? ttl,
       int? ttb,
       int? ttr,
       bool? isCascade,
@@ -30,12 +31,18 @@ class HiveKeyStoreHelper {
       String? sharedKeyEncrypted,
       String? publicKeyChecksum,
       String? encoding,
+      String? encKeyName,
+      String? encAlgo,
+      String? ivNonce,
+      String? skeEncKeyName,
+      String? skeEncAlgo,
       String? atSign}) {
     var atData = AtData();
-    atData.data = newData.data;
+    atData.data = newAtData.data;
     atData.metaData = AtMetadataBuilder(
             atSign: atSign,
-            newAtMetaData: newData.metaData,
+            newAtMetaData: newAtData.metaData,
+            existingMetaData: existingAtData?.metaData,
             ttl: ttl,
             ttb: ttb,
             ttr: ttr,
@@ -45,44 +52,13 @@ class HiveKeyStoreHelper {
             dataSignature: dataSignature,
             sharedKeyEncrypted: sharedKeyEncrypted,
             publicKeyChecksum: publicKeyChecksum,
-            encoding: encoding)
+            encoding: encoding,
+            encKeyName: encKeyName,
+            encAlgo: encAlgo,
+            ivNonce: ivNonce,
+            skeEncKeyName: skeEncKeyName,
+            skeEncAlgo: skeEncAlgo)
         .build();
-
     return atData;
-  }
-
-  AtData prepareDataForUpdate(AtData existingData, AtData newData,
-      {int? ttl,
-      int? ttb,
-      int? ttr,
-      bool? isCascade,
-      bool? isBinary,
-      bool? isEncrypted,
-      String? dataSignature,
-      String? sharedKeyEncrypted,
-      String? publicKeyChecksum,
-      String? encoding,
-      String? atSign}) {
-    newData.metaData = AtMetadataBuilder(
-            atSign: atSign,
-            newAtMetaData: newData.metaData,
-            existingMetaData: existingData.metaData,
-            ttl: ttl,
-            ttb: ttb,
-            ttr: ttr,
-            ccd: isCascade,
-            isBinary: isBinary,
-            isEncrypted: isEncrypted,
-            dataSignature: dataSignature,
-            sharedKeyEncrypted: sharedKeyEncrypted,
-            publicKeyChecksum: publicKeyChecksum,
-            encoding: encoding)
-        .build();
-    return newData;
-  }
-
-  static bool hasValueChanged(AtData newData, AtData oldData) {
-    return (newData.data != null && oldData.data == null) ||
-        newData.data != oldData.data;
   }
 }

--- a/packages/at_persistence_secondary_server/lib/src/model/at_meta_data.dart
+++ b/packages/at_persistence_secondary_server/lib/src/model/at_meta_data.dart
@@ -62,6 +62,21 @@ class AtMetaData extends HiveObject {
   @HiveField(18)
   String? encoding;
 
+  @HiveField(19)
+  String? encKeyName;
+
+  @HiveField(20)
+  String? encAlgo;
+
+  @HiveField(21)
+  String? ivNonce;
+
+  @HiveField(22)
+  String? skeEncKeyName;
+
+  @HiveField(23)
+  String? skeEncAlgo;
+
   @override
   String toString() {
     return toJson().toString();
@@ -122,6 +137,11 @@ class AtMetaData extends HiveObject {
     map[SHARED_KEY_ENCRYPTED] = sharedKeyEnc;
     map[SHARED_WITH_PUBLIC_KEY_CHECK_SUM] = pubKeyCS;
     map[ENCODING] = encoding;
+    map[ENCRYPTING_KEY_NAME] = encKeyName;
+    map[ENCRYPTING_ALGO] = encAlgo;
+    map[IV_OR_NONCE] = ivNonce;
+    map[SHARED_KEY_ENCRYPTED_ENCRYPTING_KEY_NAME] = skeEncKeyName;
+    map[SHARED_KEY_ENCRYPTED_ENCRYPTING_ALGO] = skeEncAlgo;
     return map;
   }
 
@@ -173,6 +193,11 @@ class AtMetaData extends HiveObject {
       sharedKeyEnc = json[SHARED_KEY_ENCRYPTED];
       pubKeyCS = json[SHARED_WITH_PUBLIC_KEY_CHECK_SUM];
       encoding = json[ENCODING];
+      encKeyName = json[ENCRYPTING_KEY_NAME];
+      encAlgo = json[ENCRYPTING_ALGO];
+      ivNonce = json[IV_OR_NONCE];
+      skeEncKeyName = json[SHARED_KEY_ENCRYPTED_ENCRYPTING_KEY_NAME];
+      skeEncAlgo = json[SHARED_KEY_ENCRYPTED_ENCRYPTING_ALGO];
 
     return this;
   }
@@ -254,13 +279,18 @@ class AtMetaDataAdapter extends TypeAdapter<AtMetaData> {
       ..dataSignature = fields[15]
       ..sharedKeyEnc = fields[16]
       ..pubKeyCS = fields[17]
-      ..encoding = fields[18];
+      ..encoding = fields[18]
+      ..encKeyName = fields[19]
+      ..encAlgo = fields[20]
+      ..ivNonce = fields[21]
+      ..skeEncKeyName = fields[22]
+      ..skeEncAlgo = fields[23];
   }
 
   @override
   void write(BinaryWriter writer, AtMetaData obj) {
     writer
-      ..writeByte(19)
+      ..writeByte(24)
       ..writeByte(0)
       ..write(obj.createdBy)
       ..writeByte(1)
@@ -298,6 +328,16 @@ class AtMetaDataAdapter extends TypeAdapter<AtMetaData> {
       ..writeByte(17)
       ..write(obj.pubKeyCS)
       ..writeByte(18)
-      ..write(obj.encoding);
+      ..write(obj.encoding)
+      ..writeByte(19)
+      ..write(obj.encKeyName)
+      ..writeByte(20)
+      ..write(obj.encAlgo)
+      ..writeByte(21)
+      ..write(obj.ivNonce)
+      ..writeByte(22)
+      ..write(obj.skeEncKeyName)
+      ..writeByte(23)
+      ..write(obj.skeEncAlgo);
   }
 }

--- a/packages/at_persistence_secondary_server/lib/src/model/at_metadata_builder.dart
+++ b/packages/at_persistence_secondary_server/lib/src/model/at_metadata_builder.dart
@@ -2,7 +2,7 @@ import 'package:at_persistence_secondary_server/at_persistence_secondary_server.
 
 /// Builder class to build [AtMetaData] object.
 class AtMetadataBuilder {
-  AtMetaData? atMetaData;
+  late AtMetaData atMetaData;
   var currentUtcTime = DateTime.now().toUtc();
 
   /// AtMetadata Object : Optional parameter, If atMetadata object is null a new AtMetadata object is created.
@@ -23,28 +23,34 @@ class AtMetadataBuilder {
       String? dataSignature,
       String? sharedKeyEncrypted,
       String? publicKeyChecksum,
-      String? encoding}) {
+      String? encoding,
+      String? encKeyName,
+      String? encAlgo,
+      String? ivNonce,
+      String? skeEncKeyName,
+      String? skeEncAlgo,
+      }) {
     newAtMetaData ??= AtMetaData();
     atMetaData = newAtMetaData;
     // createdAt indicates the date and time of the key created.
     // For a new key, the currentDateTime is set and remains unchanged
     // on an update event.
     (existingMetaData?.createdAt == null)
-        ? atMetaData!.createdAt = currentUtcTime
-        : atMetaData!.createdAt = existingMetaData?.createdAt;
-    atMetaData!.createdBy ??= atSign;
-    atMetaData!.updatedBy = atSign;
+        ? atMetaData.createdAt = currentUtcTime
+        : atMetaData.createdAt = existingMetaData?.createdAt;
+    atMetaData.createdBy ??= atSign;
+    atMetaData.updatedBy = atSign;
     // updatedAt indicates the date and time of the key updated.
     // For a new key, the updatedAt is same as createdAt and on key
     // update, set the updatedAt to the currentDateTime.
-    atMetaData!.updatedAt = currentUtcTime;
-    atMetaData!.status = 'active';
+    atMetaData.updatedAt = currentUtcTime;
+    atMetaData.status = 'active';
     // The version indicates the number of updates a key has received.
     // Version is set to 0 for a new key and for each update the key receives,
     // the version increases by 1
     (existingMetaData?.version == null)
-        ? atMetaData?.version = 0
-        : atMetaData?.version = (existingMetaData!.version! + 1);
+        ? atMetaData.version = 0
+        : atMetaData.version = (existingMetaData!.version! + 1);
 
     //If new metadata is available, consider new metadata, else if existing metadata is available consider it.
     ttl ??= newAtMetaData.ttl;
@@ -66,6 +72,11 @@ class AtMetadataBuilder {
     sharedKeyEncrypted ??= newAtMetaData.sharedKeyEnc;
     publicKeyChecksum ??= newAtMetaData.pubKeyCS;
     encoding ??= newAtMetaData.encoding;
+    encKeyName ??= newAtMetaData.encKeyName;
+    encAlgo ??= newAtMetaData.encAlgo;
+    ivNonce ??= newAtMetaData.ivNonce;
+    skeEncKeyName ??= newAtMetaData.skeEncKeyName;
+    skeEncAlgo ??= newAtMetaData.skeEncAlgo;
 
     if (ttl != null && ttl >= 0) {
       setTTL(ttl, ttb: ttb);
@@ -80,75 +91,44 @@ class AtMetadataBuilder {
     if (ccd != null) {
       setCCD(ccd);
     }
-    setIsBinary(isBinary);
-    setIsEncrypted(isEncrypted);
-    setDataSignature(dataSignature);
-    setSharedKeyEncrypted(sharedKeyEncrypted);
-    setPublicKeyChecksum(publicKeyChecksum);
-    setEncoding(encoding);
+    atMetaData.isBinary = isBinary;
+    atMetaData.isEncrypted = isEncrypted;
+    atMetaData.dataSignature = dataSignature;
+    atMetaData.sharedKeyEnc = sharedKeyEncrypted;
+    atMetaData.pubKeyCS = publicKeyChecksum;
+    atMetaData.encoding = encoding;
+    atMetaData.encKeyName = encKeyName;
+    atMetaData.encAlgo = encAlgo;
+    atMetaData.ivNonce = ivNonce;
+    atMetaData.skeEncKeyName = skeEncKeyName;
+    atMetaData.skeEncAlgo = skeEncAlgo;
   }
 
   void setTTL(int? ttl, {int? ttb}) {
     if (ttl != null) {
-      atMetaData!.ttl = ttl;
-      atMetaData!.expiresAt =
+      atMetaData.ttl = ttl;
+      atMetaData.expiresAt =
           _getExpiresAt(currentUtcTime.millisecondsSinceEpoch, ttl, ttb: ttb);
     }
   }
 
   void setTTB(int? ttb) {
     if (ttb != null) {
-      atMetaData!.ttb = ttb;
-      atMetaData!.availableAt =
+      atMetaData.ttb = ttb;
+      atMetaData.availableAt =
           _getAvailableAt(currentUtcTime.millisecondsSinceEpoch, ttb);
     }
   }
 
   void setTTR(int? ttr) {
     if (ttr != null) {
-      atMetaData!.ttr = ttr;
-      atMetaData!.refreshAt = _getRefreshAt(currentUtcTime, ttr);
+      atMetaData.ttr = ttr;
+      atMetaData.refreshAt = _getRefreshAt(currentUtcTime, ttr);
     }
   }
 
   void setCCD(bool ccd) {
-    atMetaData!.isCascade = ccd;
-  }
-
-  void setIsBinary(bool? isBinary) {
-    if (isBinary != null) {
-      atMetaData!.isBinary = isBinary;
-    }
-  }
-
-  void setIsEncrypted(bool? isEncrypted) {
-    if (isEncrypted != null) {
-      atMetaData!.isEncrypted = isEncrypted;
-    }
-  }
-
-  void setDataSignature(String? dataSignature) {
-    if (dataSignature != null) {
-      atMetaData!.dataSignature = dataSignature;
-    }
-  }
-
-  void setSharedKeyEncrypted(String? sharedKeyEncrypted) {
-    if (sharedKeyEncrypted != null) {
-      atMetaData!.sharedKeyEnc = sharedKeyEncrypted;
-    }
-  }
-
-  void setPublicKeyChecksum(String? publicKeyChecksum) {
-    if (publicKeyChecksum != null) {
-      atMetaData!.pubKeyCS = publicKeyChecksum;
-    }
-  }
-
-  void setEncoding(String? encoding) {
-    if (encoding != null && encoding.isNotEmpty) {
-      atMetaData!.encoding = encoding;
-    }
+    atMetaData.isCascade = ccd;
   }
 
   DateTime? _getAvailableAt(int epochNow, int ttb) {
@@ -177,6 +157,6 @@ class AtMetadataBuilder {
   }
 
   AtMetaData build() {
-    return atMetaData!;
+    return atMetaData;
   }
 }

--- a/packages/at_persistence_secondary_server/lib/src/notification/at_notification_keystore.dart
+++ b/packages/at_persistence_secondary_server/lib/src/notification/at_notification_keystore.dart
@@ -76,7 +76,12 @@ class AtNotificationKeystore
       String? dataSignature,
       String? sharedKeyEncrypted,
       String? publicKeyChecksum,
-      String? encoding}) async {
+      String? encoding,
+      String? encKeyName,
+      String? encAlgo,
+      String? ivNonce,
+      String? skeEncKeyName,
+      String? skeEncAlgo}) async {
     AtNotificationCallback.getInstance().invokeCallbacks(value);
     await _getBox().put(key, value);
   }
@@ -92,7 +97,12 @@ class AtNotificationKeystore
       String? dataSignature,
       String? sharedKeyEncrypted,
       String? publicKeyChecksum,
-      String? encoding}) async {
+      String? encoding,
+      String? encKeyName,
+      String? encAlgo,
+      String? ivNonce,
+      String? skeEncKeyName,
+      String? skeEncAlgo}) async {
     throw UnimplementedError();
   }
 

--- a/packages/at_persistence_secondary_server/lib/src/utils/object_util.dart
+++ b/packages/at_persistence_secondary_server/lib/src/utils/object_util.dart
@@ -1,33 +1,5 @@
 class ObjectsUtil {
-  /// Verifies if any of the named optional args are not null
-  static bool isAnyNotNull(
-      {dynamic a1,
-      dynamic a2,
-      dynamic a3,
-      dynamic a4,
-      dynamic a5,
-      dynamic a6}) {
-    return ((a1 != null) ||
-            (a2 != null) ||
-            (a3 != null) ||
-            (a4 != null) ||
-            (a5 != null)) ||
-        (a6 != null);
-  }
-
-  /// Verifies if all of the named optional args are not null. Initializing to initial value of '@'
-  static bool isNotNull(
-      {dynamic a1 = '@',
-      dynamic a2 = '@',
-      dynamic a3 = '@',
-      dynamic a4 = '@',
-      dynamic a5 = '@',
-      dynamic a6 = '@'}) {
-    return ((a1 != null) &&
-        (a2 != null) &&
-        (a3 != null) &&
-        (a4 != null) &&
-        (a5 != null) &&
-        (a6 != null));
+  static bool anyNotNull(Set objs) {
+    return objs.any((element) => element != null);
   }
 }

--- a/packages/at_persistence_secondary_server/pubspec.yaml
+++ b/packages/at_persistence_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_persistence_secondary_server
 description: A Dart library with the implementation classes for the persistence layer of the secondary server.
-version: 3.0.51
+version: 3.0.52
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://atsign.dev
 
@@ -13,7 +13,7 @@ dependencies:
   cron: ^0.5.0
   crypto: ^3.0.2
   uuid: ^3.0.6
-  at_persistence_spec: ^2.0.11
+  at_persistence_spec: ^2.0.12
   at_utils: ^3.0.11
   at_commons: ^3.0.42
   at_utf7: ^1.0.0

--- a/packages/at_persistence_secondary_server/test/at_metadata_test.dart
+++ b/packages/at_persistence_secondary_server/test/at_metadata_test.dart
@@ -46,7 +46,7 @@ void main() async {
     });
 
     /// The below test is to verify the default fields in the metadata are populated
-    /// on updation of an existing key
+    /// on update of an existing key
     /// The default fields are:
     /// a) CreatedAt - DateTime when the key is created
     /// b) UpdatedAt - DateTime when the key is updated


### PR DESCRIPTION
**- What I did**
Added new encryption metadata fields to core persistence classes

**- How I did it**
* Take up at_persistence_spec version 2.0.12
* Mostly simple boilerplate adding to parameter lists and making sure they are passed around OK
* Refactored hive_keystore_helper.dart to eliminate duplicate code

**- How to verify it**
Tests pass
