### PR TITLE
test: extended at_persistence_secondary_server tests to cover all new metadata fields

### DIFF
--- a/packages/at_persistence_secondary_server/example/main.dart
+++ b/packages/at_persistence_secondary_server/example/main.dart
@@ -25,7 +25,7 @@ Future<void> main(List<String> arguments) async {
   var atNotification = (AtNotificationBuilder()
         ..id = '123'
         ..fromAtSign = '@alice'
-        ..notificationDateTime = DateTime.now().toUtc()
+        ..notificationDateTime = DateTime.now().toUtcMillisecondsPrecision()
         ..toAtSign = '@alice'
         ..notification = 'self_received_notification'
         ..type = NotificationType.received

--- a/packages/at_persistence_secondary_server/lib/at_persistence_secondary_server.dart
+++ b/packages/at_persistence_secondary_server/lib/at_persistence_secondary_server.dart
@@ -25,5 +25,6 @@ export 'package:at_persistence_secondary_server/src/notification/at_notification
 export 'package:at_persistence_secondary_server/src/notification/at_notification_manager.dart';
 export 'package:at_persistence_secondary_server/src/notification/at_notification_strategy.dart';
 export 'package:at_persistence_secondary_server/src/utils/at_metadata_adapter.dart';
+export 'package:at_persistence_secondary_server/src/utils/date_time_extensions.dart';
 export 'package:at_persistence_spec/at_persistence_spec.dart';
 export 'package:at_persistence_secondary_server/src/compaction/at_compaction_service.dart';

--- a/packages/at_persistence_secondary_server/lib/src/keystore/hive_keystore.dart
+++ b/packages/at_persistence_secondary_server/lib/src/keystore/hive_keystore.dart
@@ -112,7 +112,8 @@ class HiveKeystore implements SecondaryKeyStore<String, AtData?, AtMetaData?> {
     CommitOp commitOp = CommitOp.UPDATE;
 
     // Set CommitOp to UPDATE_META if any of the metadata args are not null
-    var hasNonNullMetadata = ObjectsUtil.anyNotNull({time_to_live,time_to_born,time_to_refresh,
+    var hasNonNullMetadata = ObjectsUtil.anyNotNull({
+      time_to_live,time_to_born,time_to_refresh,
       isCascade,isBinary,isEncrypted,
       dataSignature, sharedKeyEncrypted, publicKeyChecksum, encoding,
       encKeyName, encAlgo, ivNonce, skeEncKeyName, skeEncAlgo});
@@ -384,10 +385,7 @@ class HiveKeystore implements SecondaryKeyStore<String, AtData?, AtMetaData?> {
   @override
   Future<AtMetaData?> getMeta(String key) async {
     key = key.toLowerCase();
-    if (_metaDataCache.containsKey(key)) {
-      return _metaDataCache[key];
-    }
-    return null;
+    return _metaDataCache[key];
   }
 
   @override

--- a/packages/at_persistence_secondary_server/lib/src/log/commitlog/at_commit_log.dart
+++ b/packages/at_persistence_secondary_server/lib/src/log/commitlog/at_commit_log.dart
@@ -39,7 +39,7 @@ class AtCommitLog implements AtLogType<int, CommitEntry> {
     }
     int result;
     key = Utf7.decode(key);
-    var entry = CommitEntry(key, operation, DateTime.now().toUtc());
+    var entry = CommitEntry(key, operation, DateTime.now().toUtcMillisecondsPrecision());
     try {
       result = await _commitLogKeyStore.add(entry);
       await _publishChangeEvent(entry);

--- a/packages/at_persistence_secondary_server/lib/src/model/at_meta_data.dart
+++ b/packages/at_persistence_secondary_server/lib/src/model/at_meta_data.dart
@@ -95,7 +95,12 @@ class AtMetaData extends HiveObject {
       ..dataSignature = dataSignature
       ..sharedKeyEnc = sharedKeyEnc
       ..pubKeyCS = pubKeyCS
-      ..encoding = encoding;
+      ..encoding = encoding
+      ..encKeyName=encKeyName
+      ..encAlgo=encAlgo
+      ..ivNonce=ivNonce
+      ..skeEncKeyName=skeEncKeyName
+      ..skeEncAlgo=skeEncAlgo;
   }
 
   factory AtMetaData.fromCommonsMetadata(Metadata metadata) {
@@ -110,8 +115,12 @@ class AtMetaData extends HiveObject {
       ..dataSignature = metadata.dataSignature
       ..sharedKeyEnc = metadata.sharedKeyEnc
       ..pubKeyCS = metadata.pubKeyCS
-      ..encoding = metadata.encoding;
-
+      ..encoding = metadata.encoding
+      ..encKeyName=metadata.encKeyName
+      ..encAlgo=metadata.encAlgo
+      ..ivNonce=metadata.ivNonce
+      ..skeEncKeyName=metadata.skeEncKeyName
+      ..skeEncAlgo=metadata.skeEncAlgo;
     return AtMetadataBuilder(newAtMetaData: atMetadata).build();
   }
 
@@ -225,7 +234,12 @@ class AtMetaData extends HiveObject {
           dataSignature == other.dataSignature &&
           sharedKeyEnc == other.sharedKeyEnc &&
           pubKeyCS == other.pubKeyCS &&
-          encoding == other.encoding;
+          encoding == other.encoding &&
+          encKeyName == other.encKeyName &&
+          encAlgo == other.encAlgo &&
+          ivNonce == other.ivNonce &&
+          skeEncKeyName == other.skeEncKeyName &&
+          skeEncAlgo == other.skeEncAlgo;
 
   @override
   int get hashCode =>
@@ -247,7 +261,12 @@ class AtMetaData extends HiveObject {
       dataSignature.hashCode ^
       sharedKeyEnc.hashCode ^
       pubKeyCS.hashCode ^
-      encoding.hashCode;
+      encoding.hashCode ^
+      encKeyName.hashCode ^
+      encAlgo.hashCode ^
+      ivNonce.hashCode ^
+      skeEncKeyName.hashCode ^
+      skeEncAlgo.hashCode;
 }
 
 class AtMetaDataAdapter extends TypeAdapter<AtMetaData> {

--- a/packages/at_persistence_secondary_server/lib/src/model/at_metadata_builder.dart
+++ b/packages/at_persistence_secondary_server/lib/src/model/at_metadata_builder.dart
@@ -3,7 +3,10 @@ import 'package:at_persistence_secondary_server/at_persistence_secondary_server.
 /// Builder class to build [AtMetaData] object.
 class AtMetadataBuilder {
   late AtMetaData atMetaData;
-  var currentUtcTime = DateTime.now().toUtc();
+  /// We will constrain to millisecond precision because Hive only stores
+  /// [DateTime]s to millisecond precision - see https://github.com/hivedb/hive/issues/474
+  /// for details.
+  var currentUtcTimeToMillisecondPrecision = DateTime.now().toUtcMillisecondsPrecision();
 
   /// AtMetadata Object : Optional parameter, If atMetadata object is null a new AtMetadata object is created.
   /// ttl : Time to live of the key. If ttl is null, atMetadata's ttl is assigned to ttl.
@@ -36,14 +39,14 @@ class AtMetadataBuilder {
     // For a new key, the currentDateTime is set and remains unchanged
     // on an update event.
     (existingMetaData?.createdAt == null)
-        ? atMetaData.createdAt = currentUtcTime
+        ? atMetaData.createdAt = currentUtcTimeToMillisecondPrecision
         : atMetaData.createdAt = existingMetaData?.createdAt;
     atMetaData.createdBy ??= atSign;
     atMetaData.updatedBy = atSign;
     // updatedAt indicates the date and time of the key updated.
     // For a new key, the updatedAt is same as createdAt and on key
     // update, set the updatedAt to the currentDateTime.
-    atMetaData.updatedAt = currentUtcTime;
+    atMetaData.updatedAt = currentUtcTimeToMillisecondPrecision;
     atMetaData.status = 'active';
     // The version indicates the number of updates a key has received.
     // Version is set to 0 for a new key and for each update the key receives,
@@ -108,7 +111,7 @@ class AtMetadataBuilder {
     if (ttl != null) {
       atMetaData.ttl = ttl;
       atMetaData.expiresAt =
-          _getExpiresAt(currentUtcTime.millisecondsSinceEpoch, ttl, ttb: ttb);
+          _getExpiresAt(currentUtcTimeToMillisecondPrecision.millisecondsSinceEpoch, ttl, ttb: ttb);
     }
   }
 
@@ -116,14 +119,14 @@ class AtMetadataBuilder {
     if (ttb != null) {
       atMetaData.ttb = ttb;
       atMetaData.availableAt =
-          _getAvailableAt(currentUtcTime.millisecondsSinceEpoch, ttb);
+          _getAvailableAt(currentUtcTimeToMillisecondPrecision.millisecondsSinceEpoch, ttb);
     }
   }
 
   void setTTR(int? ttr) {
     if (ttr != null) {
       atMetaData.ttr = ttr;
-      atMetaData.refreshAt = _getRefreshAt(currentUtcTime, ttr);
+      atMetaData.refreshAt = _getRefreshAt(currentUtcTimeToMillisecondPrecision, ttr);
     }
   }
 

--- a/packages/at_persistence_secondary_server/lib/src/notification/at_notification.dart
+++ b/packages/at_persistence_secondary_server/lib/src/notification/at_notification.dart
@@ -456,7 +456,7 @@ class AtNotificationBuilder {
 
   AtNotification build() {
     if ((ttl != null && ttl! > 0) && expiresAt == null) {
-      expiresAt = DateTime.now().toUtc().add(Duration(milliseconds: ttl!));
+      expiresAt = DateTime.now().toUtcMillisecondsPrecision().add(Duration(milliseconds: ttl!));
     }
     return AtNotification._builder(this);
   }

--- a/packages/at_persistence_secondary_server/lib/src/utils/date_time_extensions.dart
+++ b/packages/at_persistence_secondary_server/lib/src/utils/date_time_extensions.dart
@@ -1,0 +1,15 @@
+extension AtDateTimeExtensions on DateTime {
+  /// Returns a new DateTime object, in UTC timezone, with microseconds zeroed out.
+  /// We currently need to constrain various DateTime values to millisecond
+  /// precision because Hive only stores [DateTime]s to millisecond precision.
+  /// see https://github.com/hivedb/hive/issues/474 for details.
+  DateTime toUtcMillisecondsPrecision() {
+    return DateTime.fromMillisecondsSinceEpoch((microsecondsSinceEpoch / 1000).floor(), isUtc: true);
+  }
+}
+
+void main() {
+  DateTime now = DateTime.now().toUtc();
+  print (now.microsecondsSinceEpoch);
+  print (now.toUtcMillisecondsPrecision().microsecondsSinceEpoch);
+}

--- a/packages/at_persistence_secondary_server/test/at_metadata_test.dart
+++ b/packages/at_persistence_secondary_server/test/at_metadata_test.dart
@@ -24,7 +24,7 @@ void main() async {
     ///              For a new key version is set to 0
     test('A test to default field in metadata is set on a new key creation',
         () async {
-      var keyCreationDateTime = DateTime.now().toUtc();
+      var keyCreationDateTime = DateTime.now().toUtcMillisecondsPrecision();
       var hiveKeyStore = SecondaryPersistenceStoreFactory.getInstance()
           .getSecondaryPersistenceStore(atSign)!
           .getSecondaryKeyStore();
@@ -56,7 +56,7 @@ void main() async {
     test(
         'A test to verify version field in metadata is set to 1 on updating the existing key',
         () async {
-      var keyCreationDateTime = DateTime.now().toUtc();
+      var keyCreationDateTime = DateTime.now().toUtcMillisecondsPrecision();
       var hiveKeyStore = SecondaryPersistenceStoreFactory.getInstance()
           .getSecondaryPersistenceStore(atSign)!
           .getSecondaryKeyStore();
@@ -64,7 +64,7 @@ void main() async {
       var value = '9878123321';
       await hiveKeyStore?.put(key, AtData()..data = value);
       // Update the same key
-      var updateKeyDateTime = DateTime.now().toUtc();
+      var updateKeyDateTime = DateTime.now().toUtcMillisecondsPrecision();
       await hiveKeyStore?.put(key, AtData()..data = '9878123322');
       var atData = await hiveKeyStore?.get(key);
       expect(atData?.data, '9878123322');
@@ -83,7 +83,7 @@ void main() async {
     test(
         'A test to verify version field in metadata is set to 1 when updating metadata using putMeta method',
         () async {
-      var keyCreationDateTime = DateTime.now().toUtc();
+      var keyCreationDateTime = DateTime.now().toUtcMillisecondsPrecision();
       var hiveKeyStore = SecondaryPersistenceStoreFactory.getInstance()
           .getSecondaryPersistenceStore(atSign)!
           .getSecondaryKeyStore();
@@ -91,7 +91,7 @@ void main() async {
       var value = '9878123321';
       await hiveKeyStore?.put(key, AtData()..data = value);
       // Update the same key
-      var updateKeyDateTime = DateTime.now().toUtc();
+      var updateKeyDateTime = DateTime.now().toUtcMillisecondsPrecision();
       await hiveKeyStore?.putMeta(key, AtMetaData()..ttl = 10000);
       var atData = await hiveKeyStore?.get(key);
       expect(atData?.data, value);
@@ -110,7 +110,7 @@ void main() async {
     test(
         'A test to verify version field in metadata is set to 1 when using putAll method',
         () async {
-      var keyCreationDateTime = DateTime.now().toUtc();
+      var keyCreationDateTime = DateTime.now().toUtcMillisecondsPrecision();
       var hiveKeyStore = SecondaryPersistenceStoreFactory.getInstance()
           .getSecondaryPersistenceStore(atSign)!
           .getSecondaryKeyStore();
@@ -118,7 +118,7 @@ void main() async {
       await hiveKeyStore?.putAll(
           key, AtData()..data = '9878123322', AtMetaData());
       // Update the same key
-      var updateKeyDateTime = DateTime.now().toUtc();
+      var updateKeyDateTime = DateTime.now().toUtcMillisecondsPrecision();
       await hiveKeyStore?.putAll(key, AtData()..data = '9878123322', AtMetaData()..ttl = 10000);
       var atData = await hiveKeyStore?.get(key);
       expect(atData?.data, '9878123322');
@@ -161,7 +161,12 @@ void main() async {
           ..dataSignature='dataSignature'
           ..pubKeyCS='pubKeyChecksum'
           ..sharedKeyEnc='sharedKeyEncrypted'
-          ..encoding='someEncoding';
+          ..encoding='someEncoding'
+          ..encKeyName='someEncKeyName'
+          ..encAlgo='AES/CTR/PKCS7Padding'
+          ..ivNonce='someIvNonce'
+          ..skeEncKeyName='someSkeEncKeyName'
+          ..skeEncAlgo='someSkeEncAlgo';
       final AtMetaData startAtMetaData = AtMetaData.fromCommonsMetadata(startMetaData);
       final Map startMap = startAtMetaData.toJson();
       final String startJson = jsonEncode(startMap);
@@ -179,7 +184,12 @@ void main() async {
         ..dataSignature=null
         ..pubKeyCS=null
         ..sharedKeyEnc=null
-        ..encoding=null;
+        ..encoding=null
+        ..encKeyName=null
+        ..encAlgo=null
+        ..ivNonce=null
+        ..skeEncKeyName=null
+        ..skeEncAlgo=null;
       final AtMetaData startAtMetaData = AtMetaData.fromCommonsMetadata(startMetaData);
       final Map startMap = startAtMetaData.toJson();
       final String startJson = jsonEncode(startMap);
@@ -197,7 +207,12 @@ void main() async {
         ..dataSignature='foo'
         ..pubKeyCS=null
         ..sharedKeyEnc=null
-        ..encoding='base64';
+        ..encoding='base64'
+        ..encKeyName='someEncKeyName'
+        ..encAlgo='AES/CTR/PKCS7Padding'
+        ..ivNonce='someIvOrNonce'
+        ..skeEncKeyName=null
+        ..skeEncAlgo=null;
       final AtMetaData startAtMetaData = AtMetaData.fromCommonsMetadata(startMetaData);
       final Map startMap = startAtMetaData.toJson();
       final String startJson = jsonEncode(startMap);

--- a/packages/at_persistence_secondary_server/test/at_notification_keystore_test.dart
+++ b/packages/at_persistence_secondary_server/test/at_notification_keystore_test.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'package:at_commons/at_commons.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:test/test.dart';
 import 'package:uuid/uuid.dart';
@@ -9,15 +10,35 @@ void main() async {
   group('A group of notification keystore impl tests', () {
     test('test put and get', () async {
       var keyStore = AtNotificationKeystore.getInstance();
+      var commonsMetadata = Metadata()
+            ..ttl = 100
+            ..ttb = 200
+            ..ttr = 3600
+            ..ccd = true
+            ..isBinary = false
+            ..isEncrypted = true
+            ..dataSignature = 'dataSignature'
+            ..pubKeyCS = 'pubKeyChecksum'
+            ..sharedKeyEnc = 'sharedKeyEncrypted'
+            ..encoding = 'someEncoding'
+            ..encKeyName = 'someEncKeyName'
+            ..encAlgo = 'AES/CTR/PKCS7Padding'
+            ..ivNonce = 'someIvNonce'
+            ..skeEncKeyName = 'someSkeEncKeyName'
+            ..skeEncAlgo = 'someSkeEncAlgo';
+      var atMetaData = AtMetaData.fromCommonsMetadata(commonsMetadata);
       var atNotification = (AtNotificationBuilder()
-            ..toAtSign = '@bob'
-            ..fromAtSign = '@alice'
-            ..id = '123')
+        ..toAtSign = '@bob'
+        ..fromAtSign = '@alice'
+        ..id = '123'
+        ..atMetaData = atMetaData)
           .build();
       await keyStore.put(atNotification.id, atNotification);
       final value = await keyStore.get(atNotification.id);
       expect(value, isNotNull);
       expect(value!.id, '123');
+      expect(value.atMetadata?.skeEncKeyName, commonsMetadata.skeEncKeyName);
+      expect(value.atMetadata?.toCommonsMetadata(), commonsMetadata);
     });
     test('test remove', () async {
       var keyStore = AtNotificationKeystore.getInstance();


### PR DESCRIPTION
**- What I did**
test: extended at_persistence_secondary_server tests to cover all new metadata fields

**- How I did it**
- feat: Created an extension on DateTime `toUtcMillisecondsPrecision` which returns a new DateTime object, in UTC timezone, with microseconds zeroed out. Why? Well, we currently need to constrain various DateTime values to millisecond precision, because Hive only stores [DateTime]s to millisecond precision. And because Hive only stores to millisecond precision, it makes asserting equality in tests rather painful. When in the future we move to a datastore which supports microsecond precision, we can refactor to remove use of this extension method
- feat: Added the new encryption metadata fields to `AtMetaData`'s `toCommonsMetadata` and `fromCommonsMetadata` methods which were added in another PR.
- feat: Likewise, added the new fields to AtMetaData's equals and hashCode methods
- test: Extended tests to cover new encryption metadata fields

**- How to verify it**
Tests pass
