### PR TITLE
feat: write new encryption metadata to monitor connections

### DIFF
--- a/packages/at_secondary_server/lib/src/verb/handler/monitor_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/monitor_verb_handler.dart
@@ -116,7 +116,14 @@ class MonitorVerbHandler extends AbstractVerbHandler {
         ..isTextMessageEncrypted =
             atNotification.atMetadata?.isEncrypted != null
                 ? atNotification.atMetadata!.isEncrypted!
-                : false;
+                : false
+        ..metadata = {
+          "encKeyName": atNotification.atMetadata?.encKeyName,
+          "encAlgo": atNotification.atMetadata?.encAlgo,
+          "ivNonce": atNotification.atMetadata?.ivNonce,
+          "skeEncKeyName": atNotification.atMetadata?.skeEncKeyName,
+          "skeEncAlgo": atNotification.atMetadata?.skeEncAlgo,
+        };
       processReceivedNotification(notification);
     }
   }
@@ -168,6 +175,7 @@ class Notification {
   String? value;
   late String messageType;
   late bool isTextMessageEncrypted = false;
+  Map? metadata;
 
   Notification.empty();
 
@@ -184,6 +192,13 @@ class Notification {
     isTextMessageEncrypted = atNotification.atMetadata?.isEncrypted != null
         ? atNotification.atMetadata!.isEncrypted!
         : false;
+    metadata = {
+      "encKeyName" : atNotification.atMetadata?.encKeyName,
+      "encAlgo" : atNotification.atMetadata?.encAlgo,
+      "ivNonce" : atNotification.atMetadata?.ivNonce,
+      "skeEncKeyName" : atNotification.atMetadata?.skeEncKeyName,
+      "skeEncAlgo" : atNotification.atMetadata?.skeEncAlgo,
+    };
   }
 
   Map toJson() => {
@@ -195,6 +210,12 @@ class Notification {
         OPERATION: operation,
         EPOCH_MILLIS: dateTime,
         MESSAGE_TYPE: messageType,
-        IS_ENCRYPTED: isTextMessageEncrypted
+        IS_ENCRYPTED: isTextMessageEncrypted,
+        "metadata": metadata
       };
+
+  @override
+  String toString() {
+    return toJson().toString();
+  }
 }

--- a/tests/at_end2end_test/test/notify_verb_test.dart
+++ b/tests/at_end2end_test/test/notify_verb_test.dart
@@ -412,7 +412,7 @@ void main() {
 
     /// notify status after ttln expiry time
     response = await getNotifyStatus(sh2, notificationId,
-        returnWhenStatusIn: ['expired'], timeOutMillis: 1000);
+        returnWhenStatusIn: ['expired'], timeOutMillis: 5000);
     print('notify status response : $response');
     expect(response, contains('data:expired'));
   });

--- a/tests/at_end2end_test/test/notify_verb_test.dart
+++ b/tests/at_end2end_test/test/notify_verb_test.dart
@@ -472,6 +472,8 @@ void main() {
     response = response.replaceAll('data:', '');
     // assert the notification-id is not null.
     assert(response.isNotEmpty);
+
+    await Future.delayed(Duration(seconds: 1));
     // fetch the notification for status
     await sh1.writeCommand('notify:fetch:$response');
     response = await sh1.read();
@@ -494,6 +496,8 @@ void main() {
     await sh1.writeCommand('notify:delete:$atSign_2:$key$atSign_1');
     response = await sh1.read();
     assert(response.isNotEmpty);
+
+    await Future.delayed(Duration(seconds: 1));
 
     // Look for the delete of the cached key
     await sh2.writeCommand('llookup:cached:$atSign_2:$key$atSign_1');


### PR DESCRIPTION
fix: added the required fields to yet another class called Notification which is local to the MonitorVerbHandler and is used for serializing notifications in yet another way