### PR TITLE
fix: Add validation to prevent adding invalid key into sync response

### DIFF
--- a/packages/at_secondary_server/test/sync_verb_test.dart
+++ b/packages/at_secondary_server/test/sync_verb_test.dart
@@ -140,15 +140,15 @@ void main() {
       AtCommitLog atCommitLog = (await (AtCommitLogManagerImpl.getInstance().getCommitLog('@alice')))!;
 
       // Creating dummy commit entries
-      await atCommitLog.commit('test_key_alpha', CommitOp.UPDATE_ALL);
-      await atCommitLog.commit('test_key2_beta', CommitOp.UPDATE);
+      await atCommitLog.commit('test_key_alpha@alice', CommitOp.UPDATE_ALL);
+      await atCommitLog.commit('test_key2_beta@alice', CommitOp.UPDATE);
       // ensure commitLog is not empty
       assert(atCommitLog.entriesCount() > 0);
 
       List<KeyStoreEntry> syncResponse = [];
       await verbHandler.prepareResponse(0, syncResponse, atCommitLog.getEntries(0));
       expect(syncResponse.length, 1);
-      expect(syncResponse[0].key, 'test_key_alpha');
+      expect(syncResponse[0].key, 'test_key_alpha@alice');
     });
 
     test('overflowing entry not added to syncResponse when syncResponse not empty', () async {
@@ -158,8 +158,8 @@ void main() {
       List<KeyStoreEntry> syncResponse = [];
 
       // Creating dummy commit entries
-      await atCommitLog.commit('test_key_alpha', CommitOp.UPDATE_ALL);
-      await atCommitLog.commit('test_key2_beta', CommitOp.UPDATE);
+      await atCommitLog.commit('test_key_alpha@alice', CommitOp.UPDATE_ALL);
+      await atCommitLog.commit('test_key2_beta@alice', CommitOp.UPDATE);
       // Ensure commitLog is not empty
       expect(atCommitLog.entriesCount(), greaterThan(0));
 
@@ -179,12 +179,12 @@ void main() {
       syncResponse.clear();
       await verbHandler.prepareResponse(0, syncResponse, atCommitLog.getEntries(0));
       expect(syncResponse.length, 1);
-      expect(syncResponse[0].key, 'test_key_alpha');
+      expect(syncResponse[0].key, 'test_key_alpha@alice');
 
       syncResponse.clear();
       await verbHandler.prepareResponse(0, syncResponse, atCommitLog.getEntries(1));
       expect(syncResponse.length, 1);
-      expect(syncResponse[0].key, 'test_key2_beta');
+      expect(syncResponse[0].key, 'test_key2_beta@alice');
     });
 
     test('test to ensure all entries are synced if buffer does not overflow', () async {
@@ -192,10 +192,10 @@ void main() {
       AtCommitLog atCommitLog = (await (AtCommitLogManagerImpl.getInstance().getCommitLog('@alice')))!;
 
       // Creating dummy commit entries
-      await atCommitLog.commit('test_key_alpha', CommitOp.UPDATE_ALL);
-      await atCommitLog.commit('test_key2_beta', CommitOp.UPDATE);
-      await atCommitLog.commit('abcd', CommitOp.UPDATE_ALL);
-      await atCommitLog.commit('another_random_key', CommitOp.UPDATE_META);
+      await atCommitLog.commit('test_key_alpha@alice', CommitOp.UPDATE_ALL);
+      await atCommitLog.commit('test_key2_beta@alice', CommitOp.UPDATE);
+      await atCommitLog.commit('abcd@alice', CommitOp.UPDATE_ALL);
+      await atCommitLog.commit('another_random_key@alice', CommitOp.UPDATE_META);
 
       // ensure commitLog is not empty
       var commitLogLength = atCommitLog.entriesCount();
@@ -216,10 +216,10 @@ void main() {
       // added to syncResponse
       expect(syncResponse.length, commitLogLength + 1);
       expect(syncResponse[0], entry);
-      expect(syncResponse[1].key, 'test_key_alpha');
-      expect(syncResponse[2].key, 'test_key2_beta');
-      expect(syncResponse[3].key, 'abcd');
-      expect(syncResponse[4].key, 'another_random_key');
+      expect(syncResponse[1].key, 'test_key_alpha@alice');
+      expect(syncResponse[2].key, 'test_key2_beta@alice');
+      expect(syncResponse[3].key, 'abcd@alice');
+      expect(syncResponse[4].key, 'another_random_key@alice');
     });
 
     test('ensure only one overflowing entry is added to syncResponse when commitLog has two large entries', () async {
@@ -227,20 +227,20 @@ void main() {
       AtCommitLog atCommitLog = (await (AtCommitLogManagerImpl.getInstance().getCommitLog('@alice')))!;
 
       // Creating dummy commit entries
-      await atCommitLog.commit('test_key1', CommitOp.UPDATE_ALL);
-      await atCommitLog.commit('test_key2', CommitOp.UPDATE);
+      await atCommitLog.commit('test_key1@alice', CommitOp.UPDATE_ALL);
+      await atCommitLog.commit('test_key2@alice', CommitOp.UPDATE);
       // ensure commitLog is not empty
       assert(atCommitLog.entriesCount() == 2);
 
       List<KeyStoreEntry> syncResponse = [];
       await verbHandler.prepareResponse(0, syncResponse, atCommitLog.getEntries(0));
       expect(syncResponse.length, 1);
-      expect(syncResponse[0].key, 'test_key1');
+      expect(syncResponse[0].key, 'test_key1@alice');
 
       syncResponse.clear();
       await verbHandler.prepareResponse(0, syncResponse, atCommitLog.getEntries(1));
       expect(syncResponse.length, 1);
-      expect(syncResponse[0].key, 'test_key2');
+      expect(syncResponse[0].key, 'test_key2@alice');
 
       // test with empty iterator
       syncResponse.clear();


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
* Add check in sync_progressive_verb_handler.dart to prevent invalid keys in the sync response.

**- How to verify it**
* Added a unit test that skip's invalid key into the sync response.

**- Description for the changelog**
* Add check to prevent invalid keys in sync response.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->