### PR TITLE
fix: Fix bug introduced in 3.0.28

### DIFF
--- a/packages/at_secondary_server/lib/src/connection/outbound/outbound_client_manager.dart
+++ b/packages/at_secondary_server/lib/src/connection/outbound/outbound_client_manager.dart
@@ -60,11 +60,6 @@ class OutboundClientManager {
     return newClient;
   }
 
-  close() {
-    closed = true;
-    _pool.close();
-  }
-
   int getActiveConnectionSize() {
     return _pool.getActiveConnectionSize();
   }

--- a/packages/at_secondary_server/lib/src/connection/outbound/outbound_client_pool.dart
+++ b/packages/at_secondary_server/lib/src/connection/outbound/outbound_client_pool.dart
@@ -19,11 +19,6 @@ class OutboundClientPool {
     return _clients.length < size;
   }
 
-  close() {
-    closed = true;
-    clearAllClients();
-  }
-
   /// Removes the least recently used OutboundClient from the pool. Returns the removed client,
   /// or returns null if there are fewer than 2 items currently in the pool.
   OutboundClient? removeLeastRecentlyUsed() {

--- a/packages/at_secondary_server/lib/src/server/at_secondary_impl.dart
+++ b/packages/at_secondary_server/lib/src/server/at_secondary_impl.dart
@@ -550,9 +550,6 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
       logger.info("Terminating all inbound connections");
       inboundConnectionFactory.removeAllConnections();
 
-      logger.info("Terminating all outbound connections");
-      outboundClientManager.close();
-
       logger.info("Stopping Notification Resource Manager");
       notificationResourceManager.stop();
 


### PR DESCRIPTION
**- What I did**
* In release 3.0.28 I introduced a new bug into the server's behaviour when doing a soft restart. This reverts the change which results in that bug
* Specifically, I introduced a change where `SecondaryServerImpl.stop()` would call a new method, `close()`, on its outboundClientManager which in turn would call a  new method, `close()`, on its outboundClientPool
* However OutboundClientManager is still a singleton (its tentacles reach far and wide), and I did not provide a mechanism to _reopen_ an OutboundClientManager

**- How I did it**
* SecondaryServerImpl.stop() no longer calls outboundClientManager.close()
* For good measure, removed the `close` methods from OutboundClientManager and OutboundClientPool

**- How to verify it**
Tests pass

