### PR TITLE
fix: Filter LatestCommitEntryOfEachKey with regex in stats verb

### DIFF
--- a/packages/at_secondary_server/lib/src/verb/handler/stats_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/stats_verb_handler.dart
@@ -113,7 +113,7 @@ class StatsVerbHandler extends AbstractVerbHandler {
     var metric = _getMetrics(id);
     var name = metric.name!.getName();
     dynamic value;
-    if (id == '3' && _regex != null) {
+    if ((id == '3' || id == '15') && _regex != null) {
       value = await metric.name!.getMetrics(regex: _regex);
     } else {
       value = await metric.name!.getMetrics();

--- a/packages/at_secondary_server/lib/src/verb/metrics/metrics_impl.dart
+++ b/packages/at_secondary_server/lib/src/verb/metrics/metrics_impl.dart
@@ -484,12 +484,12 @@ class NotificationCompactionStats implements MetricProvider {
 
 class LatestCommitEntryOfEachKey implements MetricProvider {
   @override
-  getMetrics({String? regex}) async {
+  getMetrics({String? regex = '.*'}) async {
     var responseMap = <String, List<dynamic>>{};
     var atCommitLog = await (AtCommitLogManagerImpl.getInstance()
         .getCommitLog(AtSecondaryServerImpl.getInstance().currentAtSign));
 
-    Iterator commitEntryIterator = atCommitLog!.getEntries(-1);
+    Iterator commitEntryIterator = atCommitLog!.getEntries(-1, regex: regex);
 
     while (commitEntryIterator.moveNext()) {
       CommitEntry commitEntry = commitEntryIterator.current.value;

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   collection: 1.17.0
   basic_utils: 5.4.2
   ecdsa: 0.0.4
-  at_commons: 3.0.46
+  at_commons: 3.0.47
   at_utils: 3.0.13
   at_chops: 1.0.3
   at_lookup: 3.0.36


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
* Uptake the at_commons version 3.0.47 which filters the LatestCommitEntryOfEachKey with regex
* In stats_verb_handler, fetch the regex and pass it to "getEntries" method to filter the keys

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->