### PR TITLE
fix: migrate melos to 3.0

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -1,7 +1,7 @@
 name: at_server
 
 packages:
-- packages/*
+- packages/**
 
-- tests/*
+- tests/**
 - tools/build_virtual_environment/install_PKAM_Keys

--- a/melos.yaml
+++ b/melos.yaml
@@ -1,7 +1,7 @@
 name: at_server
 
 packages:
-- packages/**
+- packages/*
 
-- tests/**
-- tools/build_virtual_environment/install_PKAM_Keys/*
+- tests/*
+- tools/build_virtual_environment/install_PKAM_Keys

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,7 @@
+name: at_server_workspace
+
+environment:
+  sdk: ">=2.18.0 <4.0.0"
+
+dev_dependencies:
+  melos: ^3.0.1


### PR DESCRIPTION
**- What I did**
Melos needs a pubspec and has some formatting changes in melos.yaml.
.gitignore already ignores pubspec_overrides.yaml

**- How I did it**

**- How to verify it**

**- Description for the changelog**
migrate melos from 2.0 to 3.0