### PR TITLE
fix: root pubspec to use git ref for at_persistence_root_server

### DIFF
--- a/packages/at_root_server/Dockerfile
+++ b/packages/at_root_server/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 # If building manually then (from packages/at_root_server):
 ## sudo docker build -t atsigncompany/root .
 COPY . .
-RUN \
+RUN set -eux ; \
   mkdir -p $HOMEDIR/config ; \
   mkdir -p $BINARYDIR/config ; \
   dart pub get ; \

--- a/packages/at_root_server/pubspec.yaml
+++ b/packages/at_root_server/pubspec.yaml
@@ -16,7 +16,11 @@ dependencies:
   at_utils: ^3.0.0
   at_server_spec: ^3.0.0
   at_persistence_root_server:
-    path: ../at_persistence_root_server
+    git:
+      url: https://github.com/atsign-foundation/at_server.git
+      path: packages/at_persistence_root_server
+      ref: trunk
+      version: ^2.0.5
 
 dev_dependencies:
   # Adding test_cov for generating the test coverage.


### PR DESCRIPTION
Recent build of the dev root image haven't had the root binary in them due to `../at_persistence_root_server` not resolving within Docker.

**- What I did**

* Reverted to using a git reference for the package
* `set -eux` so that any future failures will cause the build to fail in a noticeable way

**- How to verify it**

I have verified locally with `sudo docker build -t atsigncompany/root .`

**- Description for the changelog**

fix: root pubspec to use git ref for at_persistence_root_server