### PR TITLE
feat: Retain current pool management logic, but be a **LOT** less aggressive when closing idle **authenticated** connections

### DIFF
--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,9 +1,12 @@
 ## 3.0.32
 - fix: Enhance stats verb to return latest commitEntry of each key
 - chore: Ignore melos files
-- chore: Uptake at_commons v3.0.46 which fixes failure of server when atSign has emoji with variation selector
+- chore: Uptake at_commons v3.0.46 which fixes failure of server when atSign
+  has emoji with variation selector
 - chore: Uptake at_utils v3.0.13 which enables logging to StandardError
-## 3.0.31
+- feat: Retain current inbound pool management logic, but be a **LOT** less 
+  aggressive when closing idle **authenticated** inbound connections
+- ## 3.0.31
 - feat: Introduce clientId, appName, appVersion and platform to distinguish requests from several clients in server logs.
 ## 3.0.30
 - fix: When metadata attributes are not set, merge the existing metadata attributes

--- a/packages/at_secondary_server/config/config.yaml
+++ b/packages/at_secondary_server/config/config.yaml
@@ -45,20 +45,31 @@ hive:
 
 # The @Protocol connection configurations.
 connection:
-  # The maximum time in milliseconds for an inbound connection to expire.
-  # This should NEVER be set to less than 60 seconds. Internally, the effective
-  # value used is reduced progressively as the number of connections approaches the max limit
+  # At any point, at most [inbound_max_limit] inbound connections are allowed. The inbound connection
+  # pool takes care of ensuring that idle connections are closed as necessary
+  inbound_max_limit: 200
+
+  # The maximum time in milliseconds for an **unauthenticated** inbound connection to expire.
+  # Default value is 10 minutes (10 * 60 * 1000 == 600000)
+  # Internally, the effective value used is reduced progressively towards 5 seconds as the current
+  # number of connections approaches the inbound_max_limit.
   inbound_idle_time_millis: 600000
+
+  # The maximum time in milliseconds for an **AUTHENTICATED** inbound connection to expire.
+  # Default value is 30 days (30 * 24 * 60 * 60 * 1000 == 2592000000)
+  # Internally, the effective value used is reduced progressively towards 60 seconds as the current
+  # number of connections approaches the max limit. So for example if the max number of connections is
+  # 200, and there are currently 200 connections, and a new client tries to connect,
+  # then any authenticated connection which has been idle for more than 60 seconds will be closed
+  # However: if there are only, say, 100 connections currently, then only authenticated connections
+  # which have been idle for more than 30 days will be closed
+  authenticated_inbound_idletime_millis: 2592000000
+
   # The maximum time in milliseconds for an outbound connection to expire.
   outbound_idle_time_millis: 600000
-  # Creates an inbound connection and adds the connection to inbound connection pool. At any point, at most [inbound_max_limit] connections can only be created.
-  # When all connections are active, additional connection requested can be served upon one of the active connection is closed.
-  # The connection in the pool will exist until its [inbound_idle_time_millis] expires.
-  inbound_max_limit: 50
-  # Creates an outbound connection and adds the connection to outbound connection pool. At any point, at most [outbound_max_limit] connections can only be created.
-  # When all connections are active, additional connection requested can be served upon one of the active connection is closed.
-  # The connection in the pool will exist until its [outbound_idle_time_millis] expires.
-  outbound_max_limit: 50
+
+  # At any point, at most [outbound_max_limit] outbound connections are allowed.
+  outbound_max_limit: 200
 
 # The @Protocol commit log compaction job configurations.
 commit_log_compaction:

--- a/packages/at_secondary_server/config/config.yaml
+++ b/packages/at_secondary_server/config/config.yaml
@@ -1,17 +1,17 @@
-# The @Protocol secondary server configurations.
+# The atProtocol secondary server configurations.
 
-# The @Protocol root server configuration
+# The atProtocol atDirectory (aka root server) configuration
 root_server:
-  # The port to connect to root server
+  # The atDirectory's port
   port: 64
-  # The url to connect to root server
+  # The atDirectory's host
   url: 'root.atsign.org'
 
-# The @Protocol application log configurations
+# Default logger settings
 log:
   level: INFO
 
-# The @Protocol security configurations.
+# The atProtocol security configurations.
 security:
   # To start secondary server in Secure/UnSecure mode. When [useTLS] is set to false, the secondary server starts in un-secure mode.
   # When [useTLS] is set to true, the secondary server starts in secure mode. On setting [useTLS] to true, the [certificateChainLocation] and
@@ -22,7 +22,7 @@ security:
   trustedCertificateLocation: '/etc/cacert/cacert.pem'
   clientCertificateRequired: true
 
-# The @Protocol storage configurations
+# The atProtocol storage configurations
 hive:
   # The storage path for secondary storage.
 
@@ -43,7 +43,7 @@ hive:
   # set the flag to false.
   shouldRemoveMalformedKeys: true
 
-# The @Protocol connection configurations.
+# The atProtocol connection configurations.
 connection:
   # At any point, at most [inbound_max_limit] inbound connections are allowed. The inbound connection
   # pool takes care of ensuring that idle connections are closed as necessary
@@ -71,7 +71,7 @@ connection:
   # At any point, at most [outbound_max_limit] outbound connections are allowed.
   outbound_max_limit: 200
 
-# The @Protocol commit log compaction job configurations.
+# The atProtocol commit log compaction job configurations.
 commit_log_compaction:
   # The frequent time interval (in minutes) to initiate the commit log compaction job service.
   compactionFrequencyMins: 18
@@ -82,7 +82,7 @@ commit_log_compaction:
   # The size of the log persistent storage (in KiloBytes) when reached, initiates the commit log compaction job service.
   sizeInKB: 10
 
-# The @Protocol access log compaction job configurations.
+# The atProtocol access log compaction job configurations.
 access_log_compaction:
   # The frequent time interval (in minutes) to initiate the access log compaction job service.
   compactionFrequencyMins: 15
@@ -93,19 +93,19 @@ access_log_compaction:
   # The size of the log persistent storage (in KiloBytes) when reached, initiates the access log compaction job service.
   sizeInKB: 2
 
-# The @Protocol notification keystore compaction job configurations.
+# The atProtocol notification keystore compaction job configurations.
 notification_keystore_compaction:
   compactionFrequencyMins: 5
   compactionPercentage: 30
   expiryInDays: 1
   sizeInKB: -1
 
-# The @Protocol key lookup configurations.
+# The atProtocol key lookup configurations.
 lookup:
   # The number of iterations to resolve the atSign value references.
   depth_of_resolution: 3
 
-# The configurations for @Protocol statistics
+# The configurations for atProtocol statistics
 stats:
   # Return the other atSign users who visited the current atSign for maximum number of times in the descending order.
   top_visits: 5

--- a/packages/at_secondary_server/lib/src/server/at_secondary_config.dart
+++ b/packages/at_secondary_server/lib/src/server/at_secondary_config.dart
@@ -61,9 +61,10 @@ class AtSecondaryConfig {
   static final int _runRefreshJobHour = 3;
 
   //Connection
-  static final int _inboundMaxLimit = 10;
-  static final int _outboundMaxLimit = 10;
-  static final int _inboundIdleTimeMillis = 600000;
+  static final int _inboundMaxLimit = 200;
+  static final int _outboundMaxLimit = 200;
+  static final int _unauthenticatedInboundIdleTimeMillis = 10 * 60 * 1000; // 10 minutes
+  static final int _authenticatedInboundIdleTimeMillis = 30 * 24 * 60 * 60 * 1000; // 30 days
   static final int _outboundIdleTimeMillis = 600000;
 
   //Lookup
@@ -403,7 +404,20 @@ class AtSecondaryConfig {
     try {
       return getConfigFromYaml(['connection', 'inbound_idle_time_millis']);
     } on ElementNotFoundException {
-      return _inboundIdleTimeMillis;
+      return _unauthenticatedInboundIdleTimeMillis;
+    }
+  }
+
+  // ignore: non_constant_identifier_names
+  static int get authenticated_inbound_idletime_millis {
+    var result = _getIntEnvVar('authenticated_inbound_idletime_millis');
+    if (result != null) {
+      return result;
+    }
+    try {
+      return getConfigFromYaml(['connection', 'authenticated_inbound_idle_time_millis']);
+    } on ElementNotFoundException {
+      return _authenticatedInboundIdleTimeMillis;
     }
   }
 

--- a/packages/at_secondary_server/lib/src/server/at_secondary_config.dart
+++ b/packages/at_secondary_server/lib/src/server/at_secondary_config.dart
@@ -5,7 +5,7 @@ import 'package:at_commons/at_commons.dart';
 import 'package:at_secondary/src/conf/config_util.dart';
 
 class AtSecondaryConfig {
-  static const Map<ModifiableConfigs, ModifiableConfigurationEntry>
+  static final Map<ModifiableConfigs, ModifiableConfigurationEntry>
       _streamListeners = {};
   //Certs
   static const bool _useTLS = true;
@@ -89,7 +89,7 @@ class AtSecondaryConfig {
   static const int _syncPageLimit = 100;
 
   // Malformed Keys
-  static const List<String> _malformedKeys = [];
+  static final List<String> _malformedKeys = [];
   static const bool _shouldRemoveMalformedKeys = true;
 
   //version

--- a/packages/at_secondary_server/lib/src/server/at_secondary_config.dart
+++ b/packages/at_secondary_server/lib/src/server/at_secondary_config.dart
@@ -5,92 +5,92 @@ import 'package:at_commons/at_commons.dart';
 import 'package:at_secondary/src/conf/config_util.dart';
 
 class AtSecondaryConfig {
-  static final Map<ModifiableConfigs, ModifiableConfigurationEntry>
+  static const Map<ModifiableConfigs, ModifiableConfigurationEntry>
       _streamListeners = {};
   //Certs
-  static final bool _useTLS = true;
-  static final bool _clientCertificateRequired = true;
-  static final bool _testingMode = false;
+  static const bool _useTLS = true;
+  static const bool _clientCertificateRequired = true;
+  static const bool _testingMode = false;
 
   //Certificate Paths
-  static final String _certificateChainLocation = 'certs/fullchain.pem';
-  static final String _privateKeyLocation = 'certs/privkey.pem';
-  static final String _trustedCertificateLocation = '/etc/cacert/cacert.pem';
+  static const String _certificateChainLocation = 'certs/fullchain.pem';
+  static const String _privateKeyLocation = 'certs/privkey.pem';
+  static const String _trustedCertificateLocation = '/etc/cacert/cacert.pem';
 
   //Secondary Storage
-  static final String _storagePath = 'storage/hive';
-  static final String _commitLogPath = 'storage/commitLog';
-  static final String _accessLogPath = 'storage/accessLog';
-  static final String _notificationStoragePath = 'storage/notificationLog.v1';
-  static final int _expiringRunFreqMins = 10;
+  static const String _storagePath = 'storage/hive';
+  static const String _commitLogPath = 'storage/commitLog';
+  static const String _accessLogPath = 'storage/accessLog';
+  static const String _notificationStoragePath = 'storage/notificationLog.v1';
+  static const int _expiringRunFreqMins = 10;
 
   //Commit Log
-  static final int _commitLogCompactionFrequencyMins = 18;
-  static final int _commitLogCompactionPercentage = 20;
-  static final int _commitLogExpiryInDays = 15;
-  static final int _commitLogSizeInKB = 2;
+  static const int _commitLogCompactionFrequencyMins = 18;
+  static const int _commitLogCompactionPercentage = 20;
+  static const int _commitLogExpiryInDays = 15;
+  static const int _commitLogSizeInKB = 2;
 
   //Access Log
-  static final int _accessLogCompactionFrequencyMins = 15;
-  static final int _accessLogCompactionPercentage = 30;
-  static final int _accessLogExpiryInDays = 15;
-  static final int _accessLogSizeInKB = 2;
+  static const int _accessLogCompactionFrequencyMins = 15;
+  static const int _accessLogCompactionPercentage = 30;
+  static const int _accessLogExpiryInDays = 15;
+  static const int _accessLogSizeInKB = 2;
 
   //Notification
-  static final bool _autoNotify = true;
+  static const bool _autoNotify = true;
   // The maximum number of retries for a notification.
-  static final int _maxNotificationRetries = 30;
+  static const int _maxNotificationRetries = 30;
   // The quarantine duration of an atsign. Notifications will be retried max_retries times, every quarantineDuration seconds approximately.
-  static final int _notificationQuarantineDuration = 10;
+  static const int _notificationQuarantineDuration = 10;
   // The notifications queue will be processed every jobFrequency seconds. However, the notifications queue will always be processed
   // *immediately* when a new notification is queued. When that happens, the queue processing will not run again until jobFrequency
   // seconds have passed since the last queue-processing run completed.
-  static final int _notificationJobFrequency = 11;
+  static const int _notificationJobFrequency = 11;
   // The time interval(in seconds) to notify latest commitID to monitor connections
   // To disable to the feature, set to -1.
-  static final int _statsNotificationJobTimeInterval = 15;
+  static const int _statsNotificationJobTimeInterval = 15;
   // defines the time after which a notification expires in units of minutes. Notifications expire after 1440 minutes or 24 hours by default.
-  static final int _notificationExpiresAfterMins = 1440;
+  static const int _notificationExpiresAfterMins = 1440;
 
-  static final int _notificationKeyStoreCompactionFrequencyMins = 5;
-  static final int _notificationKeyStoreCompactionPercentage = 30;
-  static final int _notificationKeyStoreExpiryInDays = 1;
-  static final int _notificationKeyStoreSizeInKB = -1;
+  static const int _notificationKeyStoreCompactionFrequencyMins = 5;
+  static const int _notificationKeyStoreCompactionPercentage = 30;
+  static const int _notificationKeyStoreExpiryInDays = 1;
+  static const int _notificationKeyStoreSizeInKB = -1;
 
   //Refresh Job
-  static final int _runRefreshJobHour = 3;
+  static const int _runRefreshJobHour = 3;
 
   //Connection
-  static final int _inboundMaxLimit = 200;
-  static final int _outboundMaxLimit = 200;
-  static final int _unauthenticatedInboundIdleTimeMillis = 10 * 60 * 1000; // 10 minutes
-  static final int _authenticatedInboundIdleTimeMillis = 30 * 24 * 60 * 60 * 1000; // 30 days
-  static final int _outboundIdleTimeMillis = 600000;
+  static const int _inboundMaxLimit = 200;
+  static const int _outboundMaxLimit = 200;
+  static const int _unauthenticatedInboundIdleTimeMillis = 10 * 60 * 1000; // 10 minutes
+  static const int _authenticatedInboundIdleTimeMillis = 30 * 24 * 60 * 60 * 1000; // 30 days
+  static const int _outboundIdleTimeMillis = 600000;
 
   //Lookup
-  static final int _lookupDepthOfResolution = 3;
+  static const int _lookupDepthOfResolution = 3;
 
   //Stats
-  static final int _statsTopKeys = 5;
-  static final int _statsTopVisits = 5;
+  static const int _statsTopKeys = 5;
+  static const int _statsTopVisits = 5;
 
   //log level configuration. Value should match the name of one of dart logging package's Level.LEVELS
-  static final String _defaultLogLevel = 'INFO';
+  static const String _defaultLogLevel = 'INFO';
 
   //root server configurations
-  static final String _rootServerUrl = 'root.atsign.org';
-  static final int _rootServerPort = 64;
+  static const String _rootServerUrl = 'root.atsign.org';
+  static const int _rootServerPort = 64;
 
   //force restart
-  static final bool _isForceRestart = false;
+  static const bool _isForceRestart = false;
 
   //Sync Configurations
-  static final int _syncBufferSize = 5242880;
-  static final int _syncPageLimit = 100;
+  static const int _syncBufferSize = 5242880;
+  static const int _syncPageLimit = 100;
 
   // Malformed Keys
-  static final List<String> _malformedKeys = [];
-  static final bool _shouldRemoveMalformedKeys = true;
+  static const List<String> _malformedKeys = [];
+  static const bool _shouldRemoveMalformedKeys = true;
 
   //version
   static final String? _secondaryServerVersion =

--- a/packages/at_secondary_server/lib/src/server/bootstrapper.dart
+++ b/packages/at_secondary_server/lib/src/server/bootstrapper.dart
@@ -14,12 +14,6 @@ import 'package:at_utils/at_utils.dart';
 class SecondaryServerBootStrapper {
   List<String> arguments;
   static final bool? useTLS = AtSecondaryConfig.useTLS;
-  static final int inboundMaxLimit = AtSecondaryConfig.inbound_max_limit;
-  static final int outboundMaxLimit = AtSecondaryConfig.outbound_max_limit;
-  static final int inboundIdleTimeMillis =
-      AtSecondaryConfig.inbound_idletime_millis;
-  static final int outboundIdleTimeMillis =
-      AtSecondaryConfig.outbound_idletime_millis;
 
   SecondaryServerBootStrapper(this.arguments);
 
@@ -37,10 +31,16 @@ class SecondaryServerBootStrapper {
       secondaryContext.port = int.parse(results['server_port']);
       secondaryContext.currentAtSign = AtUtils.fixAtSign(results['at_sign']);
       secondaryContext.sharedSecret = results['shared_secret'];
-      secondaryContext.inboundConnectionLimit = inboundMaxLimit;
-      secondaryContext.outboundConnectionLimit = outboundMaxLimit;
-      secondaryContext.inboundIdleTimeMillis = inboundIdleTimeMillis;
-      secondaryContext.outboundIdleTimeMillis = outboundIdleTimeMillis;
+      secondaryContext.inboundConnectionLimit =
+          AtSecondaryConfig.inbound_max_limit;
+      secondaryContext.outboundConnectionLimit =
+          AtSecondaryConfig.outbound_max_limit;
+      secondaryContext.unauthenticatedInboundIdleTimeMillis =
+          AtSecondaryConfig.inbound_idletime_millis;
+      secondaryContext.authenticatedInboundIdleTimeMillis =
+          AtSecondaryConfig.authenticated_inbound_idletime_millis;
+      secondaryContext.outboundIdleTimeMillis =
+          AtSecondaryConfig.outbound_idletime_millis;
       if (useTLS!) {
         secondaryContext.securityContext = AtSecurityContextImpl();
       }

--- a/packages/at_secondary_server/lib/src/server/server_context.dart
+++ b/packages/at_secondary_server/lib/src/server/server_context.dart
@@ -6,20 +6,49 @@ class AtSecondaryContext extends AtServerContext {
   String host = 'localhost';
   late int port;
   bool isKeyStoreInitialized = false;
-  int inboundConnectionLimit = 50;
-  int outboundConnectionLimit = 50;
-  int inboundIdleTimeMillis = 600000;
-  int outboundIdleTimeMillis = 600000;
 
-  int unauthenticatedMinAllowableIdleTimeMillis =
-      5000; // have to allow time for connection handshakes // TODO Run tests to identify a p99.999 value
+  /// This value is normally initialized with the value from
+  /// [AtSecondaryConfig.inbound_max_limit]
+  int inboundConnectionLimit = 200;
+
+  /// This value is normally initialized with the value from
+  /// [AtSecondaryConfig.outbound_max_limit]
+  int outboundConnectionLimit = 200;
+
+  /// This value is normally initialized with the value from
+  /// [AtSecondaryConfig.inbound_idletime_millis]
+  int unauthenticatedInboundIdleTimeMillis = 10 * 60 * 1000; // 10 minutes
+
+  /// This value is normally initialized with the value from
+  /// [AtSecondaryConfig.authenticated_inbound_idletime_millis]
+  int authenticatedInboundIdleTimeMillis = 30 * 24 * 60 * 60 * 1000; // 30 days
+
+  /// This value is normally initialized with the value from
+  /// [AtSecondaryConfig.outbound_idletime_millis]
+  int outboundIdleTimeMillis = 10 * 60 * 1000; // ten minutes
+
+  /// Even when number of connections is close to max allowed, we don't want to
+  /// close unauthenticated connections before they've had a change to send
+  /// a cram or pkam request
+  int unauthenticatedMinAllowableIdleTimeMillis = 5 * 1000;
+
+  /// Even when number of connections is close to max allowed, we don't want to
+  /// be overly aggressive when closing authenticated connections
+  int authenticatedMinAllowableIdleTimeMillis = 60 * 1000;
+
+  /// When the number of connections grows beyond this proportion of the max
+  /// allowed number of connections, in effect we start to reduce the 'max'
+  /// idle time permitted before the server starts to close existing 'idle'
+  /// connections. See [InboundConnectionImpl.isInValid]
   double inboundConnectionLowWaterMarkRatio = 0.5;
   bool progressivelyReduceAllowableInboundIdleTime = true;
+
   String? currentAtSign;
   String? sharedSecret;
   AtSecurityContext? securityContext;
   SecondaryKeyStore? secondaryKeyStore;
   VerbExecutor? verbExecutor;
+
   // When true, SecondaryServerImpl will gracefully shut down the service immediately
   // after fully starting up.
   bool trainingMode = false;

--- a/packages/at_secondary_server/test/inbound_connection_manager_test.dart
+++ b/packages/at_secondary_server/test/inbound_connection_manager_test.dart
@@ -10,7 +10,7 @@ import 'package:test/test.dart';
 void main() {
   setUp(() {
     var serverContext = AtSecondaryContext();
-    serverContext.inboundIdleTimeMillis = 10000;
+    serverContext.unauthenticatedInboundIdleTimeMillis = 10000;
     AtSecondaryServerImpl.getInstance().serverContext = serverContext;
   });
 

--- a/packages/at_secondary_server/test/inbound_connection_pool_test.dart
+++ b/packages/at_secondary_server/test/inbound_connection_pool_test.dart
@@ -149,7 +149,7 @@ void main() async {
     /// - Wait until we pass the allowable idle time for unauthenticated
     /// - Verify that the number of connections in the pool is now 55, comprised of
     ///   10 unauthenticated connections, and all 45 of the 'authenticated' ones
-    /// - Wait until we pass the cureently allowable idle time for 'authenticated'
+    /// - Wait until we pass the currently allowable idle time for 'authenticated'
     /// - Verify that the number of connections in the pool is now 3, since only
     ///   the 3 that we wrote to earlier are still not 'idle'
     test('test connection pool - 90% capacity - clear idle connection', () {
@@ -160,13 +160,11 @@ void main() async {
       List<MockInboundConnectionImpl> connections = [];
 
       int desiredPoolSize = (maxPoolSize * 0.9).floor();
-      int numAuthenticated = 0;
       int numUnauthenticated = 0;
       for (int i = 0; i < desiredPoolSize; i++) {
         var mockConnection = MockInboundConnectionImpl(null, 'mock session $i');
         if (i.isEven) {
           mockConnection.getMetaData().isAuthenticated = true;
-          numAuthenticated++;
         } else {
           numUnauthenticated++;
         }

--- a/packages/at_secondary_server/test/inbound_connection_pool_test.dart
+++ b/packages/at_secondary_server/test/inbound_connection_pool_test.dart
@@ -14,9 +14,11 @@ AtSignLogger logger = AtSignLogger('inbound_connection_pool_test');
 
 void main() async {
   setUpAll(() {
-    serverContext.inboundIdleTimeMillis = 250;
+    serverContext.unauthenticatedInboundIdleTimeMillis = 250;
+    serverContext.authenticatedInboundIdleTimeMillis = 500;
     serverContext.inboundConnectionLowWaterMarkRatio = 0.5;
     serverContext.unauthenticatedMinAllowableIdleTimeMillis = 20;
+    serverContext.authenticatedMinAllowableIdleTimeMillis = 100;
     AtSecondaryServerImpl.getInstance().serverContext = serverContext;
     InboundConnectionPool.getInstance().init(10);
   });
@@ -86,11 +88,15 @@ void main() async {
       poolInstance.add(connection2);
       poolInstance.add(connection3);
       sleep(Duration(
-          milliseconds: (serverContext.inboundIdleTimeMillis * 0.9).floor()));
+          milliseconds:
+              (serverContext.unauthenticatedInboundIdleTimeMillis * 0.9)
+                  .floor()));
       connection2.write('test data');
       expect(poolInstance.getCurrentSize(), 3);
       sleep(Duration(
-          milliseconds: (serverContext.inboundIdleTimeMillis * 0.2).floor()));
+          milliseconds:
+              (serverContext.unauthenticatedInboundIdleTimeMillis * 0.2)
+                  .floor()));
       print('connection 1: ${connection1.getMetaData().created} '
           '${connection1.getMetaData().lastAccessed} ${connection1.isInValid()}');
       print('connection 2: ${connection2.getMetaData().created} '
@@ -119,19 +125,33 @@ void main() async {
       }
 
       sleep(Duration(
-          milliseconds: (serverContext.inboundIdleTimeMillis * 0.9).floor()));
+          milliseconds:
+              (serverContext.unauthenticatedInboundIdleTimeMillis * 0.9)
+                  .floor()));
 
       connections[1].write('test data');
       expect(poolInstance.getCurrentSize(), lowWaterMark);
       sleep(Duration(
           milliseconds:
-              ((serverContext.inboundIdleTimeMillis * 0.1) + 1).floor()));
+              ((serverContext.unauthenticatedInboundIdleTimeMillis * 0.1) + 1)
+                  .floor()));
 
       poolInstance.clearInvalidConnections();
       expect(poolInstance.getCurrentSize(), 1);
     });
 
     /// Verify that, beyond lowWaterMark, allowable idle time progressively reduces
+    /// - Create a pool of 90 connections with a max pool size of 100
+    /// - Mark half of them as 'authenticated'
+    /// - Wait for 80% of the _currently_ allowable idle time
+    /// - Write to 3 of the 'authenticated' connections to reset their idle time
+    /// - Write to 10 of the 'unauthenticated' connections to reset their idle time
+    /// - Wait until we pass the allowable idle time for unauthenticated
+    /// - Verify that the number of connections in the pool is now 55, comprised of
+    ///   10 unauthenticated connections, and all 45 of the 'authenticated' ones
+    /// - Wait until we pass the cureently allowable idle time for 'authenticated'
+    /// - Verify that the number of connections in the pool is now 3, since only
+    ///   the 3 that we wrote to earlier are still not 'idle'
     test('test connection pool - 90% capacity - clear idle connection', () {
       int maxPoolSize = 100; // Please don't change this
 
@@ -163,14 +183,11 @@ void main() async {
         connections[i].metaData.lastAccessed = startTimeAsDateTime;
       }
 
-      int unauthenticatedMinAllowableIdleTimeMillis =
-          serverContext.unauthenticatedMinAllowableIdleTimeMillis;
-      int authenticatedMinAllowableIdleTimeMillis =
-          (serverContext.inboundIdleTimeMillis / 5).floor();
-
-      // Actual allowable idle time should be as per InboundConnectionImpl.dart - i.e.
       int unauthenticatedActualAllowableIdleTime = calcActualAllowableIdleTime(
-          poolInstance, maxPoolSize, unauthenticatedMinAllowableIdleTimeMillis);
+          poolInstance,
+          maxPoolSize,
+          serverContext.unauthenticatedMinAllowableIdleTimeMillis,
+          serverContext.unauthenticatedInboundIdleTimeMillis);
       logger.info(
           "unAuth actual allowed idle time: $unauthenticatedActualAllowableIdleTime");
 
@@ -210,17 +227,21 @@ void main() async {
 
       // now when we clear invalid connections, we're going to see all of the unused unauthenticated connections returned to pool
       // Since we wrote to 10 unauthenticated connections, that means we will clean up numUnauthenticated - 10
+      var preClearSize = poolInstance.getCurrentSize();
       poolInstance.clearInvalidConnections();
       int expected =
           desiredPoolSize - (numUnauthenticated - numUnAuthToWriteTo);
       elapsed = DateTime.now().millisecondsSinceEpoch - startTimeAsMillis;
       logger.info(
-          'After $elapsed : expect pool size after unauthenticated clean up to be $expected (pre-clear size was $desiredPoolSize)');
+          '$elapsed milliseconds after start: expect pool size after unauthenticated clean up to be $expected (pre-clear size was $preClearSize)');
       expect(poolInstance.getCurrentSize(), expected);
 
       // now let's sleep until the unused connections will have been idle for longer than the currently allowable idle time for AUTHENTICATED connections
       int authenticatedActualAllowableIdleTime = calcActualAllowableIdleTime(
-          poolInstance, maxPoolSize, authenticatedMinAllowableIdleTimeMillis);
+          poolInstance,
+          maxPoolSize,
+          serverContext.authenticatedMinAllowableIdleTimeMillis,
+          serverContext.authenticatedInboundIdleTimeMillis);
       logger.info(
           "auth actual allowed idle time: $authenticatedActualAllowableIdleTime");
 
@@ -232,25 +253,28 @@ void main() async {
 
       // now when we clear invalid connections, we're going to additionally see all of the unused AUTHENTICATED connections returned to pool
       // Since we wrote to 3 (numAuthToWriteTo variable above) authenticated connections, that means we will clean up an additional numAuthenticated - 3 connections
+      // And we'll also be cleaning up all of the UN-Authenticated connections, leaving us
+      // with just the 3 'authenticated' connections
+      preClearSize = poolInstance.getCurrentSize();
       poolInstance.clearInvalidConnections();
-      expected -= (numAuthenticated - numAuthToWriteTo);
+      expected = numAuthToWriteTo;
       elapsed = DateTime.now().millisecondsSinceEpoch - startTimeAsMillis;
       logger.info(
-          'After $elapsed : expect pool size after AUTHenticated clean up to be $expected (pre-clear size was $desiredPoolSize)');
+          '$elapsed milliseconds after start : expect pool size after AUTHenticated clean up to be $expected (pre-clear size was $preClearSize)');
       expect(poolInstance.getCurrentSize(), expected);
     });
   });
 }
 
 int calcActualAllowableIdleTime(
-    poolInstance, maxPoolSize, minAllowableIdleTime) {
+    poolInstance, maxPoolSize, minAllowableIdleTime, maxAllowableIdleTime) {
   int lowWaterMark =
       (maxPoolSize * serverContext.inboundConnectionLowWaterMarkRatio).floor();
   int numConnectionsOverLwm =
       max(poolInstance.getCurrentSize() - lowWaterMark, 0);
   double idleTimeReductionFactor =
       1 - (numConnectionsOverLwm / (maxPoolSize - lowWaterMark));
-  return (((serverContext.inboundIdleTimeMillis - minAllowableIdleTime) *
+  return (((maxAllowableIdleTime - minAllowableIdleTime) *
               idleTimeReductionFactor) +
           minAllowableIdleTime)
       .floor();

--- a/packages/at_secondary_server/test/outbound_client_manager_test.dart
+++ b/packages/at_secondary_server/test/outbound_client_manager_test.dart
@@ -10,7 +10,7 @@ import 'package:test/test.dart';
 void main() {
   setUp(() {
     var serverContext = AtSecondaryContext();
-    serverContext.inboundIdleTimeMillis = 50;
+    serverContext.unauthenticatedInboundIdleTimeMillis = 50;
     serverContext.outboundIdleTimeMillis = 30;
     AtSecondaryServerImpl.getInstance().serverContext = serverContext;
   });


### PR DESCRIPTION
**- What I did**
feat: Retain current inbound pool management logic, but be a **LOT** less aggressive when closing idle **authenticated** inbound connections

**- How I did it**
- Added new atServer config for 'authenticatedInboundIdleTime', defaulting to 30 days. Why 30 days? Well, there's a bug in at_lookup (there's [a PR in at_libraries](https://github.com/atsign-foundation/at_libraries/pull/354) to fix that) which leads to unhandled exceptions when server destroys idle connections. This change will ensure that that problem no longer affects existing clients
- Left existing `inboundIdleTime` at its current default value of 10 minutes, but we are now using it as the configured value for **unauthenticated** connections only
- Set default limit on total number of inbound and outbound connections to 200
- Added better instance variable comments to AtSecondaryContext
- Modified existing inbound connection pool management test accordingly. Note that the test remains essentially unchanged. Added plenty of commentary to explain the test behaviour in more detail
- Sprinkled some more comments throughout

**- How to verify it**
Tests pass

**- Description for the changelog**
feat: Retain current inbound pool management logic, but be a **LOT** less aggressive when closing idle **authenticated** inbound connections