### PR TITLE
test: Enroll functional tests

### DIFF
--- a/tests/at_functional_test/test/enroll_verb_test.dart
+++ b/tests/at_functional_test/test/enroll_verb_test.dart
@@ -26,26 +26,6 @@ void main() {
       ConfigUtil.getYaml()!['first_atsign_server']['first_atsign_name'];
 
   String atmosphereKey = 'atmospherekey.atmosphere$firstAtsign';
-  // Before the start of the tests create the keys with different namespaces
-  
-  // key with atmosphere namespace
-  Future<void> createKeys() async {
-    await socket_writer(socketConnection1!, 'from:$firstAtsign');
-    var fromResponse = await read();
-    print('from verb response : $fromResponse');
-    fromResponse = fromResponse.replaceAll('data:', '');
-    var pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
-
-    await socket_writer(socketConnection1!, 'pkam:$pkamDigest');
-    var pkamResult = await read();
-    expect(pkamResult, 'data:success\n');
-
-    await socket_writer(
-        socketConnection1!, 'update:$atmosphereKey atmospherevalue');
-    var updateResponse = await read();
-    assert((!updateResponse.contains('Invalid syntax')) &&
-        (!updateResponse.contains('null')));
-  }
 
   //Establish the client socket connection
   setUp(() async {

--- a/tests/at_functional_test/test/enroll_verb_test.dart
+++ b/tests/at_functional_test/test/enroll_verb_test.dart
@@ -8,22 +8,44 @@ import 'at_demo_data.dart';
 import 'functional_test_commons.dart';
 import 'pkam_utils.dart';
 
-Socket? socketFirstAtsign;
+Socket? socketConnection1;
+Socket? socketConnection2;
+var firstAtsignServer =
+    ConfigUtil.getYaml()!['first_atsign_server']['first_atsign_url'];
+var firstAtsignPort =
+    ConfigUtil.getYaml()!['first_atsign_server']['first_atsign_port'];
 Future<void> _connect() async {
-  var firstAtsignServer =
-      ConfigUtil.getYaml()!['first_atsign_server']['first_atsign_url'];
-  var firstAtsignPort =
-      ConfigUtil.getYaml()!['first_atsign_server']['first_atsign_port'];
-
   // socket connection for first atsign
-  socketFirstAtsign =
+  socketConnection1 =
       await secure_socket_connection(firstAtsignServer, firstAtsignPort);
-  socket_listener(socketFirstAtsign!);
+  socket_listener(socketConnection1!);
 }
 
 void main() {
   var firstAtsign =
       ConfigUtil.getYaml()!['first_atsign_server']['first_atsign_name'];
+
+  String atmosphereKey = 'atmospherekey.atmosphere$firstAtsign';
+  // Before the start of the tests create the keys with different namespaces
+  
+  // key with atmosphere namespace
+  Future<void> createKeys() async {
+    await socket_writer(socketConnection1!, 'from:$firstAtsign');
+    var fromResponse = await read();
+    print('from verb response : $fromResponse');
+    fromResponse = fromResponse.replaceAll('data:', '');
+    var pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
+
+    await socket_writer(socketConnection1!, 'pkam:$pkamDigest');
+    var pkamResult = await read();
+    expect(pkamResult, 'data:success\n');
+
+    await socket_writer(
+        socketConnection1!, 'update:$atmosphereKey atmospherevalue');
+    var updateResponse = await read();
+    assert((!updateResponse.contains('Invalid syntax')) &&
+        (!updateResponse.contains('null')));
+  }
 
   //Establish the client socket connection
   setUp(() async {
@@ -32,17 +54,17 @@ void main() {
 
   group('A group of tests to verify apkam enroll requests', () {
     test('enroll request on authenticated connection', () async {
-      await socket_writer(socketFirstAtsign!, 'from:$firstAtsign');
+      await socket_writer(socketConnection1!, 'from:$firstAtsign');
       var fromResponse = await read();
       print('from verb response : $fromResponse');
       fromResponse = fromResponse.replaceAll('data:', '');
       var pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
-      await socket_writer(socketFirstAtsign!, 'pkam:$pkamDigest');
+      await socket_writer(socketConnection1!, 'pkam:$pkamDigest');
       var pkamResult = await read();
       expect(pkamResult, 'data:success\n');
       var enrollRequest =
           'enroll:request:appName:wavi:deviceName:pixel:namespaces:[wavi,rw]:apkamPublicKey:${pkamPublicKeyMap[firstAtsign]!}\n';
-      await socket_writer(socketFirstAtsign!, enrollRequest);
+      await socket_writer(socketConnection1!, enrollRequest);
       var enrollResponse = await read();
       print(enrollResponse);
       enrollResponse = enrollResponse.replaceFirst('data:', '');
@@ -54,7 +76,7 @@ void main() {
     test('enroll request on unauthenticated connection without totp', () async {
       var enrollRequest =
           'enroll:request:appName:wavi:deviceName:pixel:namespaces:[wavi,rw]:apkamPublicKey:${pkamPublicKeyMap[firstAtsign]!}\n';
-      await socket_writer(socketFirstAtsign!, enrollRequest);
+      await socket_writer(socketConnection1!, enrollRequest);
       var enrollResponse = await read();
       print(enrollResponse);
       enrollResponse = enrollResponse.replaceFirst('data:', '');
@@ -67,7 +89,7 @@ void main() {
     test('enroll request on unauthenticated connection invalid totp', () async {
       var enrollRequest =
           'enroll:request:appName:wavi:deviceName:pixel:namespaces:[wavi,rw]:totp:1234:apkamPublicKey:${pkamPublicKeyMap[firstAtsign]!}\n';
-      await socket_writer(socketFirstAtsign!, enrollRequest);
+      await socket_writer(socketConnection1!, enrollRequest);
       var enrollResponse = await read();
       print(enrollResponse);
       enrollResponse = enrollResponse.replaceFirst('data:', '');
@@ -77,47 +99,366 @@ void main() {
           'Exception: invalid totp. Cannot process enroll request');
     });
 
-    test('second enroll request using totp', () async {
-      await socket_writer(socketFirstAtsign!, 'from:$firstAtsign');
+    // Purpose of the tests
+    // 1. Do a pkam authentication
+    // 2. Send an enroll request
+    //  3 . Get an otp from the first client
+    //  4. Send an enroll request with otp from the second client
+    //  5. First client doesn't approve the enroll request
+    //  6. Second client should get an exception as the enroll request is not approved
+    test(
+        'second enroll request using totp and client did not approved enrollment request',
+        () async {
+      await socket_writer(socketConnection1!, 'from:$firstAtsign');
       var fromResponse = await read();
       print('from verb response : $fromResponse');
       fromResponse = fromResponse.replaceAll('data:', '');
       var pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
-      await socket_writer(socketFirstAtsign!, 'pkam:$pkamDigest');
+      await socket_writer(socketConnection1!, 'pkam:$pkamDigest');
       var pkamResult = await read();
       expect(pkamResult, 'data:success\n');
       var enrollRequest =
           'enroll:request:appName:wavi:deviceName:pixel:namespaces:[wavi,rw]:apkamPublicKey:${pkamPublicKeyMap[firstAtsign]!}\n';
-      await socket_writer(socketFirstAtsign!, enrollRequest);
+      await socket_writer(socketConnection1!, enrollRequest);
       var enrollResponse = await read();
       print(enrollResponse);
       enrollResponse = enrollResponse.replaceFirst('data:', '');
       var enrollJsonMap = jsonDecode(enrollResponse);
       expect(enrollJsonMap['enrollmentId'], isNotEmpty);
       expect(enrollJsonMap['status'], 'success');
-      final enrollmentId = enrollJsonMap['enrollmentId'];
+
       var totpRequest = 'totp:get\n';
-      await socket_writer(socketFirstAtsign!, totpRequest);
+      await socket_writer(socketConnection1!, totpRequest);
       var totpResponse = await read();
       totpResponse = totpResponse.replaceFirst('data:', '');
       print(totpResponse);
       totpResponse = totpResponse.trim();
-      //destroy the authenticated connection
-      socketFirstAtsign!.destroy();
-      print('socket destroyed');
-      await _connect();
+
+      // connect to the second client
+      socketConnection2 =
+          await secure_socket_connection(firstAtsignServer, firstAtsignPort);
+      socket_listener(socketConnection2!);
+
       //send second enroll request with totp
-      var apkamPublicKey = apkamPublicKeyMap[firstAtsign];
+      var apkamPublicKey = pkamPublicKeyMap[firstAtsign];
       var secondEnrollRequest =
-          'enroll:request:appName:buzz:deviceName:pixel:namespaces:[buzz,rw]:totp:$totpResponse:apkamPublicKey:${apkamPublicKey}\n';
+          'enroll:request:appName:buzz:deviceName:pixel:namespaces:[buzz,rw]:totp:$totpResponse:apkamPublicKey:$apkamPublicKey\n';
       print(secondEnrollRequest);
-      await socket_writer(socketFirstAtsign!, secondEnrollRequest);
+      await socket_writer(socketConnection2!, secondEnrollRequest);
 
       var secondEnrollResponse = await read();
       print(secondEnrollResponse);
+      secondEnrollResponse = secondEnrollResponse.replaceFirst('data:', '');
       var enrollJson = jsonDecode(secondEnrollResponse);
       expect(enrollJson['enrollmentId'], isNotEmpty);
       expect(enrollJson['status'], 'pending');
+
+      var secondEnrollId = enrollJson['enrollmentId'];
+
+      // deny the enroll request from the first client
+      var denyEnrollCommand = 'enroll:deny:enrollmentId:$secondEnrollId\n';
+      await socket_writer(socketConnection1!, denyEnrollCommand);
+      var denyEnrollResponse = await read();
+      print(denyEnrollResponse);
+      denyEnrollResponse = denyEnrollResponse.replaceFirst('data:', '');
+      var approveJson = jsonDecode(denyEnrollResponse);
+      expect(approveJson['status'], 'denied');
+      expect(approveJson['enrollmentId'], secondEnrollId);
+
+      // now do the apkam using the enrollment id
+      await socket_writer(socketConnection2!, 'from:$firstAtsign');
+      fromResponse = await read();
+      pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
+      var apkamEnrollId = 'pkam:enrollApprovalId:$secondEnrollId:$pkamDigest\n';
+
+      await socket_writer(socketConnection2!, apkamEnrollId);
+      var apkamEnrollIdResponse = await read();
+      print(apkamEnrollIdResponse);
+      expect(apkamEnrollIdResponse,
+          'error:AT0401-Exception: enrollment id: $secondEnrollId is not approved\n');
+    });
+
+    // Purpose of the tests
+    // 1. Do a pkam authentication
+    // 2. Send an enroll request
+    //  3 . Get an otp from the first client
+    //  4. Send an enroll request with otp from the second client
+    //  5. First client approves the enroll request
+    test(
+        'second enroll request using totp and client approves enrollment request',
+        () async {
+      await socket_writer(socketConnection1!, 'from:$firstAtsign');
+      var fromResponse = await read();
+      print('from verb response : $fromResponse');
+      fromResponse = fromResponse.replaceAll('data:', '');
+      var pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
+      await socket_writer(socketConnection1!, 'pkam:$pkamDigest');
+      var pkamResult = await read();
+      expect(pkamResult, 'data:success\n');
+      var enrollRequest =
+          'enroll:request:appName:wavi:deviceName:pixel:namespaces:[wavi,rw]:apkamPublicKey:${pkamPublicKeyMap[firstAtsign]!}\n';
+      await socket_writer(socketConnection1!, enrollRequest);
+      var enrollResponse = await read();
+      print(enrollResponse);
+      enrollResponse = enrollResponse.replaceFirst('data:', '');
+      var enrollJsonMap = jsonDecode(enrollResponse);
+      expect(enrollJsonMap['enrollmentId'], isNotEmpty);
+      expect(enrollJsonMap['status'], 'success');
+
+      var totpRequest = 'totp:get\n';
+      await socket_writer(socketConnection1!, totpRequest);
+      var totpResponse = await read();
+      totpResponse = totpResponse.replaceFirst('data:', '');
+      print(totpResponse);
+      totpResponse = totpResponse.trim();
+
+      // connect to the second client
+      socketConnection2 =
+          await secure_socket_connection(firstAtsignServer, firstAtsignPort);
+      socket_listener(socketConnection2!);
+      //send second enroll request with totp
+      var apkamPublicKey = pkamPublicKeyMap[firstAtsign];
+      var secondEnrollRequest =
+          'enroll:request:appName:buzz:deviceName:pixel:namespaces:[buzz,rw]:totp:$totpResponse:apkamPublicKey:$apkamPublicKey\n';
+      print(secondEnrollRequest);
+      await socket_writer(socketConnection2!, secondEnrollRequest);
+
+      var secondEnrollResponse = await read();
+      print(secondEnrollResponse);
+      secondEnrollResponse = secondEnrollResponse.replaceFirst('data:', '');
+      var enrollJson = jsonDecode(secondEnrollResponse);
+      expect(enrollJson['enrollmentId'], isNotEmpty);
+      expect(enrollJson['status'], 'pending');
+      var secondEnrollId = enrollJson['enrollmentId'];
+
+      // connect to the first client to approve the enroll request
+      await socket_writer(
+          socketConnection1!, 'enroll:approve:enrollmentId:$secondEnrollId\n');
+      var approveResponse = await read();
+      print(approveResponse);
+      approveResponse = approveResponse.replaceFirst('data:', '');
+      var approveJson = jsonDecode(approveResponse);
+      expect(approveJson['status'], 'approved');
+      expect(approveJson['enrollmentId'], secondEnrollId);
+
+      // wait for second before doing an APKaM
+      await Future.delayed(Duration(seconds: 2));
+
+      // connect to the second client to do an apkam
+      await socket_writer(socketConnection2!, 'from:$firstAtsign');
+      fromResponse = await read();
+      // now do the apkam using the enrollment id
+      pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
+      var apkamEnrollId = 'pkam:enrollApprovalId:$secondEnrollId:$pkamDigest\n';
+
+      await socket_writer(socketConnection2!, apkamEnrollId);
+      var apkamEnrollIdResponse = await read();
+      print(apkamEnrollIdResponse);
+      expect(apkamEnrollIdResponse, 'data:success\n');
+    });
+
+    // Purppose of the tests
+    //  1. Authenticate and send the enroll request for wavi namespace
+    //  2. pkam using the enroll id
+    //  3. Create a public key with atmosphere namespace
+    //  4. Assert that key with atmosphere namespace throws an exception
+    test(
+        'enroll request on authenticated connection for wavi namespace and creating a atmosphere key should fail',
+        () async {
+      await socket_writer(socketConnection1!, 'from:$firstAtsign');
+      var fromResponse = await read();
+      print('from verb response : $fromResponse');
+      fromResponse = fromResponse.replaceAll('data:', '');
+      var pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
+      await socket_writer(socketConnection1!, 'pkam:$pkamDigest');
+      var pkamResult = await read();
+      expect(pkamResult, 'data:success\n');
+      var enrollRequest =
+          'enroll:request:appName:wavi:deviceName:pixel:namespaces:[wavi,rw]:apkamPublicKey:${pkamPublicKeyMap[firstAtsign]!}\n';
+      await socket_writer(socketConnection1!, enrollRequest);
+      var enrollResponse = await read();
+      print(enrollResponse);
+      enrollResponse = enrollResponse.replaceFirst('data:', '');
+      var enrollJsonMap = jsonDecode(enrollResponse);
+      expect(enrollJsonMap['enrollmentId'], isNotEmpty);
+      expect(enrollJsonMap['status'], 'success');
+
+      var enrollmentId = enrollJsonMap['enrollmentId'];
+
+      // now do the apkam using the enrollment id
+      pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
+      var apkamEnrollId = 'pkam:enrollApprovalId:$enrollmentId:$pkamDigest\n';
+
+      await socket_writer(socketConnection1!, apkamEnrollId);
+      var apkamEnrollIdResponse = await read();
+      print(apkamEnrollIdResponse);
+      expect(apkamEnrollIdResponse, 'data:success\n');
+
+      await socket_writer(socketConnection1!,
+          'update:public:twitter.atmosphere$firstAtsign twitterid');
+      var updateResponse = await read();
+      print(updateResponse);
+      expect(
+          updateResponse.contains(
+              'error:AT0009-UnAuthorized client in request : Enrollment Id: $enrollmentId is not authorized for update operation'),
+          true);
+    });
+
+    // Purpose of the tests
+    //  1. Authenticate and send the enroll request for wavi namespace
+    //  2. pkam using the enroll id
+    //  3. Create a public key with wavi namespace
+    //  4. Assert that wavi key is created without an exception
+    test(
+        'enroll request on authenticated connection for wavi namespace and creating a wavi key',
+        () async {
+      await socket_writer(socketConnection1!, 'from:$firstAtsign');
+      var fromResponse = await read();
+      print('from verb response : $fromResponse');
+      fromResponse = fromResponse.replaceAll('data:', '');
+      var pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
+      await socket_writer(socketConnection1!, 'pkam:$pkamDigest');
+      var pkamResult = await read();
+      expect(pkamResult, 'data:success\n');
+      var enrollRequest =
+          'enroll:request:appName:wavi:deviceName:pixel:namespaces:[wavi,rw]:apkamPublicKey:${pkamPublicKeyMap[firstAtsign]!}\n';
+      await socket_writer(socketConnection1!, enrollRequest);
+      var enrollResponse = await read();
+      print(enrollResponse);
+      enrollResponse = enrollResponse.replaceFirst('data:', '');
+      var enrollJsonMap = jsonDecode(enrollResponse);
+      expect(enrollJsonMap['enrollmentId'], isNotEmpty);
+      expect(enrollJsonMap['status'], 'success');
+
+      var enrollmentId = enrollJsonMap['enrollmentId'];
+
+      // now do the apkam using the enrollment id
+      pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
+      var apkamEnrollId = 'pkam:enrollApprovalId:$enrollmentId:$pkamDigest\n';
+
+      await socket_writer(socketConnection1!, apkamEnrollId);
+      var apkamEnrollIdResponse = await read();
+      expect(apkamEnrollIdResponse, 'data:success\n');
+
+      await socket_writer(socketConnection1!,
+          'update:public:lastname.wavi$firstAtsign twitterid');
+      var updateResponse = await read();
+      print(updateResponse);
+      assert((!updateResponse.contains('Invalid syntax')) &&
+          (!updateResponse.contains('null')));
+    });
+
+    // Purpose of the tests
+    //  1. Authenticate and send the enroll request for wavi namespace
+    //  2. pkam using the enroll id
+    //  3. Already there is a atmosphere key in server
+    //  4. Do a llookup for the atmosphere key
+    //  5. Assert that the llookup throws an exception
+    test(
+        'enroll request on authenticated connection for wavi namespace and llookup for a atmosphere key',
+        () async {
+      await socket_writer(socketConnection1!, 'from:$firstAtsign');
+      var fromResponse = await read();
+      print('from verb response : $fromResponse');
+      fromResponse = fromResponse.replaceAll('data:', '');
+      var pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
+      await socket_writer(socketConnection1!, 'pkam:$pkamDigest');
+      var pkamResult = await read();
+      expect(pkamResult, 'data:success\n');
+
+      // Before creating a enroll request with wavi namespace
+      // create a atmosphere key
+      await socket_writer(
+          socketConnection1!, 'update:$atmosphereKey atmospherevalue');
+      var updateResponse = await read();
+      assert((!updateResponse.contains('Invalid syntax')) &&
+          (!updateResponse.contains('null')));
+      
+      var enrollRequest =
+          'enroll:request:appName:wavi:deviceName:pixel:namespaces:[wavi,rw]:apkamPublicKey:${pkamPublicKeyMap[firstAtsign]!}\n';
+      await socket_writer(socketConnection1!, enrollRequest);
+      var enrollResponse = await read();
+      print(enrollResponse);
+      enrollResponse = enrollResponse.replaceFirst('data:', '');
+      var enrollJsonMap = jsonDecode(enrollResponse);
+      expect(enrollJsonMap['enrollmentId'], isNotEmpty);
+      expect(enrollJsonMap['status'], 'success');
+
+      var enrollmentId = enrollJsonMap['enrollmentId'];
+
+      // now do the apkam using the enrollment id
+      pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
+      var apkamEnrollId = 'pkam:enrollApprovalId:$enrollmentId:$pkamDigest\n';
+
+      await socket_writer(socketConnection1!, apkamEnrollId);
+      var apkamEnrollIdResponse = await read();
+      expect(apkamEnrollIdResponse, 'data:success\n');
+
+      await socket_writer(socketConnection1!, 'llookup:$atmosphereKey');
+      var llookupResponse = await read();
+      print(llookupResponse);
+      expect(llookupResponse,
+          'error:AT0009-UnAuthorized client in request : Enrollment Id: $enrollmentId is not authorized for local lookup operation\n');
+    });
+
+    // Purpose of the tests
+    //  1. Authenticate and send the enroll request for wavi namespace
+    //  2. pkam using the enroll id
+    //  3. Already there is a atmosphere key in server
+    //  4. Do a scan
+    //  5. Assert that the scan verb doesn't return the atmosphere key
+    test(
+        'enroll request on authenticated connection for wavi namespace and scan should not display atmosphere key',
+        () async {
+      await socket_writer(socketConnection1!, 'from:$firstAtsign');
+      var fromResponse = await read();
+      print('from verb response : $fromResponse');
+      fromResponse = fromResponse.replaceAll('data:', '');
+      var pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
+      await socket_writer(socketConnection1!, 'pkam:$pkamDigest');
+      var pkamResult = await read();
+      expect(pkamResult, 'data:success\n');
+
+      // Before creating a enroll request with wavi namespace
+      // create a atmosphere key
+      await socket_writer(
+          socketConnection1!, 'update:$atmosphereKey atmospherevalue');
+      var updateResponse = await read();
+      assert((!updateResponse.contains('Invalid syntax')) &&
+          (!updateResponse.contains('null')));
+
+      // enroll request with wavi namespace
+      var enrollRequest =
+          'enroll:request:appName:wavi:deviceName:pixel:namespaces:[wavi,rw]:apkamPublicKey:${pkamPublicKeyMap[firstAtsign]!}\n';
+      await socket_writer(socketConnection1!, enrollRequest);
+      var enrollResponse = await read();
+      print(enrollResponse);
+      enrollResponse = enrollResponse.replaceFirst('data:', '');
+      var enrollJsonMap = jsonDecode(enrollResponse);
+      expect(enrollJsonMap['enrollmentId'], isNotEmpty);
+      expect(enrollJsonMap['status'], 'success');
+
+      var enrollmentId = enrollJsonMap['enrollmentId'];
+
+      // now do the apkam using the enrollment id
+      pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
+      var apkamEnrollId = 'pkam:enrollApprovalId:$enrollmentId:$pkamDigest\n';
+
+      await socket_writer(socketConnection1!, apkamEnrollId);
+      var apkamEnrollIdResponse = await read();
+      expect(apkamEnrollIdResponse, 'data:success\n');
+
+      await socket_writer(socketConnection1!, 'scan');
+      var scanResponse = await read();
+      print(scanResponse);
+      expect(!(scanResponse.contains(atmosphereKey)), true);
+    });
+
+    tearDown(() {
+      //Closing the socket connection
+      clear();
+      socketConnection1!.destroy();
+      
     });
   });
 }

--- a/tests/at_functional_test/test/enroll_verb_test.dart
+++ b/tests/at_functional_test/test/enroll_verb_test.dart
@@ -25,8 +25,6 @@ void main() {
   var firstAtsign =
       ConfigUtil.getYaml()!['first_atsign_server']['first_atsign_name'];
 
-  String atmosphereKey = 'atmospherekey.atmosphere$firstAtsign';
-
   //Establish the client socket connection
   setUp(() async {
     await _connect();
@@ -236,7 +234,7 @@ void main() {
       expect(apkamEnrollIdResponse, 'data:success\n');
     });
 
-    // Purppose of the tests
+    // Purpose of the tests
     //  1. Authenticate and send the enroll request for wavi namespace
     //  2. pkam using the enroll id
     //  3. Create a public key with atmosphere namespace
@@ -328,11 +326,11 @@ void main() {
     });
 
     // Purpose of the tests
+    // Prerequisite - create a atmosphere key
     //  1. Authenticate and send the enroll request for wavi namespace
     //  2. pkam using the enroll id
-    //  3. Already there is a atmosphere key in server
-    //  4. Do a llookup for the atmosphere key
-    //  5. Assert that the llookup throws an exception
+    //  3. Do a llookup for the atmosphere key
+    //  4. Assert that the llookup throws an exception
     test(
         'enroll request on authenticated connection for wavi namespace and llookup for a atmosphere key',
         () async {
@@ -347,6 +345,7 @@ void main() {
 
       // Before creating a enroll request with wavi namespace
       // create a atmosphere key
+      String atmosphereKey = 'firstcontact.atmosphere$firstAtsign';
       await socket_writer(
           socketConnection1!, 'update:$atmosphereKey atmospherevalue');
       var updateResponse = await read();
@@ -381,6 +380,112 @@ void main() {
     });
 
     // Purpose of the tests
+    // Prerequisite - create a public atmosphere key
+    //  1. Authenticate and send the enroll request for wavi namespace
+    //  2. pkam using the enroll id
+    //  3. Do a llookup for the atmosphere key
+    //  4. Assert that the llookup returns a value without an exception
+    test(
+        'enroll request on authenticated connection for wavi namespace and llookup for a atmosphere key',
+        () async {
+      await socket_writer(socketConnection1!, 'from:$firstAtsign');
+      var fromResponse = await read();
+      print('from verb response : $fromResponse');
+      fromResponse = fromResponse.replaceAll('data:', '');
+      var pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
+      await socket_writer(socketConnection1!, 'pkam:$pkamDigest');
+      var pkamResult = await read();
+      expect(pkamResult, 'data:success\n');
+
+      // Before creating a enroll request with wavi namespace
+      // create a atmosphere key
+      String atmosphereKey = 'public:secondcontact.atmosphere$firstAtsign';
+      await socket_writer(
+          socketConnection1!, 'update:$atmosphereKey atmospherevalue');
+      var updateResponse = await read();
+      assert((!updateResponse.contains('Invalid syntax')) &&
+          (!updateResponse.contains('null')));
+
+      var enrollRequest =
+          'enroll:request:appName:wavi:deviceName:pixel:namespaces:[wavi,rw]:apkamPublicKey:${pkamPublicKeyMap[firstAtsign]!}\n';
+      await socket_writer(socketConnection1!, enrollRequest);
+      var enrollResponse = await read();
+      print(enrollResponse);
+      enrollResponse = enrollResponse.replaceFirst('data:', '');
+      var enrollJsonMap = jsonDecode(enrollResponse);
+      expect(enrollJsonMap['enrollmentId'], isNotEmpty);
+      expect(enrollJsonMap['status'], 'success');
+
+      var enrollmentId = enrollJsonMap['enrollmentId'];
+
+      // now do the apkam using the enrollment id
+      pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
+      var apkamEnrollId = 'pkam:enrollApprovalId:$enrollmentId:$pkamDigest\n';
+
+      await socket_writer(socketConnection1!, apkamEnrollId);
+      var apkamEnrollIdResponse = await read();
+      expect(apkamEnrollIdResponse, 'data:success\n');
+
+      await socket_writer(socketConnection1!, 'llookup:$atmosphereKey');
+      var llookupResponse = await read();
+      print(llookupResponse);
+      expect(llookupResponse, 'data:atmospherevalue\n');
+    });
+
+    // Purpose of the tests
+    // Prerequisite - create a wavi key
+    //  1. Authenticate and send the enroll request for wavi namespace
+    //  2. pkam using the enroll id
+    //  4. Do a llookup for the wavi key
+    //  5. Assert that the llookup returns correct value and does not throw an exception
+    test(
+        'enroll request on authenticated connection for wavi namespace and llookup for a wavi key',
+        () async {
+      await socket_writer(socketConnection1!, 'from:$firstAtsign');
+      var fromResponse = await read();
+      print('from verb response : $fromResponse');
+      fromResponse = fromResponse.replaceAll('data:', '');
+      var pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
+      await socket_writer(socketConnection1!, 'pkam:$pkamDigest');
+      var pkamResult = await read();
+      expect(pkamResult, 'data:success\n');
+
+      // Before creating a enroll request with wavi namespace
+      // create a atmosphere key
+      String waviKey = 'firstname.wavi$firstAtsign';
+      String waviValue = 'wavivalue';
+      await socket_writer(socketConnection1!, 'update:$waviKey $waviValue');
+      var updateResponse = await read();
+      assert((!updateResponse.contains('Invalid syntax')) &&
+          (!updateResponse.contains('null')));
+
+      var enrollRequest =
+          'enroll:request:appName:wavi:deviceName:pixel:namespaces:[wavi,rw]:apkamPublicKey:${pkamPublicKeyMap[firstAtsign]!}\n';
+      await socket_writer(socketConnection1!, enrollRequest);
+      var enrollResponse = await read();
+      print(enrollResponse);
+      enrollResponse = enrollResponse.replaceFirst('data:', '');
+      var enrollJsonMap = jsonDecode(enrollResponse);
+      expect(enrollJsonMap['enrollmentId'], isNotEmpty);
+      expect(enrollJsonMap['status'], 'success');
+
+      var enrollmentId = enrollJsonMap['enrollmentId'];
+
+      // now do the apkam using the enrollment id
+      pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
+      var apkamEnrollId = 'pkam:enrollApprovalId:$enrollmentId:$pkamDigest\n';
+
+      await socket_writer(socketConnection1!, apkamEnrollId);
+      var apkamEnrollIdResponse = await read();
+      expect(apkamEnrollIdResponse, 'data:success\n');
+
+      await socket_writer(socketConnection1!, 'llookup:$waviKey');
+      var llookupResponse = await read();
+      print(llookupResponse);
+      expect(llookupResponse, 'data:$waviValue\n');
+    });
+
+    // Purpose of the tests
     //  1. Authenticate and send the enroll request for wavi namespace
     //  2. pkam using the enroll id
     //  3. Already there is a atmosphere key in server
@@ -400,6 +505,7 @@ void main() {
 
       // Before creating a enroll request with wavi namespace
       // create a atmosphere key
+      String atmosphereKey = 'filename.atmosphere$firstAtsign';
       await socket_writer(
           socketConnection1!, 'update:$atmosphereKey atmospherevalue');
       var updateResponse = await read();
@@ -431,6 +537,226 @@ void main() {
       var scanResponse = await read();
       print(scanResponse);
       expect(!(scanResponse.contains(atmosphereKey)), true);
+    });
+
+    // Purpose of the tests
+    //  Pre-requisite - create a wavi key
+    //  1. Authenticate and send the enroll request for wavi namespace
+    //  2. pkam using the enroll id
+    //  4. Do a scan
+    //  5. Assert that the scan verb returns the wavi key
+    test(
+        'enroll request on authenticated connection for wavi namespace and scan should display wavi key',
+        () async {
+      await socket_writer(socketConnection1!, 'from:$firstAtsign');
+      var fromResponse = await read();
+      print('from verb response : $fromResponse');
+      fromResponse = fromResponse.replaceAll('data:', '');
+      var pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
+      await socket_writer(socketConnection1!, 'pkam:$pkamDigest');
+      var pkamResult = await read();
+      expect(pkamResult, 'data:success\n');
+
+      // Before creating a enroll request with wavi namespace
+      // create a atmosphere key
+      String waviKey = 'lastname.wavi$firstAtsign';
+      String value = 'checkingValue';
+      await socket_writer(socketConnection1!, 'update:$waviKey $value');
+      var updateResponse = await read();
+      assert((!updateResponse.contains('Invalid syntax')) &&
+          (!updateResponse.contains('null')));
+
+      // enroll request with wavi namespace
+      var enrollRequest =
+          'enroll:request:appName:wavi:deviceName:pixel:namespaces:[wavi,rw]:apkamPublicKey:${pkamPublicKeyMap[firstAtsign]!}\n';
+      await socket_writer(socketConnection1!, enrollRequest);
+      var enrollResponse = await read();
+      print(enrollResponse);
+      enrollResponse = enrollResponse.replaceFirst('data:', '');
+      var enrollJsonMap = jsonDecode(enrollResponse);
+      expect(enrollJsonMap['enrollmentId'], isNotEmpty);
+      expect(enrollJsonMap['status'], 'success');
+
+      var enrollmentId = enrollJsonMap['enrollmentId'];
+
+      // now do the apkam using the enrollment id
+      pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
+      var apkamEnrollId = 'pkam:enrollApprovalId:$enrollmentId:$pkamDigest\n';
+
+      await socket_writer(socketConnection1!, apkamEnrollId);
+      var apkamEnrollIdResponse = await read();
+      expect(apkamEnrollIdResponse, 'data:success\n');
+
+      await socket_writer(socketConnection1!, 'scan');
+      var scanResponse = await read();
+      print(scanResponse);
+      expect((scanResponse.contains(waviKey)), true);
+    });
+
+    // Purpose of the tests
+    //  Pre-requisite - create a public atmosphere key
+    //  1. Authenticate and send the enroll request for wavi namespace
+    //  2. pkam using the enroll id
+    //  4. Do a scan
+    //  5. Assert that the scan verb returns the public atmosphere key
+    test(
+        'enroll request on authenticated connection for wavi namespace and scan should display the public atmosphere key',
+        () async {
+      await socket_writer(socketConnection1!, 'from:$firstAtsign');
+      var fromResponse = await read();
+      print('from verb response : $fromResponse');
+      fromResponse = fromResponse.replaceAll('data:', '');
+      var pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
+      await socket_writer(socketConnection1!, 'pkam:$pkamDigest');
+      var pkamResult = await read();
+      expect(pkamResult, 'data:success\n');
+
+      // Before creating a enroll request with wavi namespace
+      // create a atmosphere key
+      String atmosphereKey = 'group.atmosphere$firstAtsign';
+      String value = 'checkingValue';
+      await socket_writer(
+          socketConnection1!, 'update:public:$atmosphereKey $value');
+      var updateResponse = await read();
+      assert((!updateResponse.contains('Invalid syntax')) &&
+          (!updateResponse.contains('null')));
+
+      // enroll request with wavi namespace
+      var enrollRequest =
+          'enroll:request:appName:wavi:deviceName:pixel:namespaces:[wavi,rw]:apkamPublicKey:${pkamPublicKeyMap[firstAtsign]!}\n';
+      await socket_writer(socketConnection1!, enrollRequest);
+      var enrollResponse = await read();
+      print(enrollResponse);
+      enrollResponse = enrollResponse.replaceFirst('data:', '');
+      var enrollJsonMap = jsonDecode(enrollResponse);
+      expect(enrollJsonMap['enrollmentId'], isNotEmpty);
+      expect(enrollJsonMap['status'], 'success');
+
+      var enrollmentId = enrollJsonMap['enrollmentId'];
+
+      // now do the apkam using the enrollment id
+      pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
+      var apkamEnrollId = 'pkam:enrollApprovalId:$enrollmentId:$pkamDigest\n';
+
+      await socket_writer(socketConnection1!, apkamEnrollId);
+      var apkamEnrollIdResponse = await read();
+      expect(apkamEnrollIdResponse, 'data:success\n');
+
+      await socket_writer(socketConnection1!, 'scan');
+      var scanResponse = await read();
+      print(scanResponse);
+      expect((scanResponse.contains('public:$atmosphereKey')), true);
+    });
+
+    // Purpose of the tests
+    //  Pre-requisite - create a wavi key
+    //  1. Authenticate and send the enroll request for wavi namespace
+    //  2. pkam using the enroll id
+    //  3. Delete the created wavi key
+    //  4. Assert that wavi key is deleted without an exception
+    test(
+        'enroll request on authenticated connection for wavi namespace and delete a wavi key',
+        () async {
+      await socket_writer(socketConnection1!, 'from:$firstAtsign');
+      var fromResponse = await read();
+      print('from verb response : $fromResponse');
+      fromResponse = fromResponse.replaceAll('data:', '');
+      var pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
+      await socket_writer(socketConnection1!, 'pkam:$pkamDigest');
+      var pkamResult = await read();
+      expect(pkamResult, 'data:success\n');
+
+      // create a wavi key
+      String waviKey = 'public:email.wavi$firstAtsign';
+      await socket_writer(socketConnection1!, 'update:$waviKey twitterid');
+      var updateResponse = await read();
+      print(updateResponse);
+      assert((!updateResponse.contains('Invalid syntax')) &&
+          (!updateResponse.contains('null')));
+
+      // enroll request with wavi namespace
+      var enrollRequest =
+          'enroll:request:appName:wavi:deviceName:pixel:namespaces:[wavi,rw]:apkamPublicKey:${pkamPublicKeyMap[firstAtsign]!}\n';
+      await socket_writer(socketConnection1!, enrollRequest);
+      var enrollResponse = await read();
+      print(enrollResponse);
+      enrollResponse = enrollResponse.replaceFirst('data:', '');
+      var enrollJsonMap = jsonDecode(enrollResponse);
+      expect(enrollJsonMap['enrollmentId'], isNotEmpty);
+      expect(enrollJsonMap['status'], 'success');
+
+      var enrollmentId = enrollJsonMap['enrollmentId'];
+
+      // now do the apkam using the enrollment id
+      pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
+      var apkamEnrollId = 'pkam:enrollApprovalId:$enrollmentId:$pkamDigest\n';
+
+      await socket_writer(socketConnection1!, apkamEnrollId);
+      var apkamEnrollIdResponse = await read();
+      expect(apkamEnrollIdResponse, 'data:success\n');
+
+      // delete the wavi key
+      await socket_writer(socketConnection1!, 'delete:$waviKey');
+      var deleteResponse = await read();
+      print(deleteResponse);
+      assert((!deleteResponse.contains('Invalid syntax')) &&
+          (!deleteResponse.contains('null')));
+    });
+
+    // Purpose of the tests
+    //  Pre-requisite - create a atmosphere key
+    //  1. Authenticate and send the enroll request for wavi namespace
+    //  2. pkam using the enroll id
+    //  3. Delete the created atmosphere key
+    //  4. Assert that deletion of the created key throws an exception
+    test(
+        'enroll request on authenticated connection for wavi namespace and delete a atmosphere key',
+        () async {
+      await socket_writer(socketConnection1!, 'from:$firstAtsign');
+      var fromResponse = await read();
+      print('from verb response : $fromResponse');
+      fromResponse = fromResponse.replaceAll('data:', '');
+      var pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
+      await socket_writer(socketConnection1!, 'pkam:$pkamDigest');
+      var pkamResult = await read();
+      expect(pkamResult, 'data:success\n');
+
+      // create a wavi key
+      String atmosphereKey = 'files.atmosphere$firstAtsign';
+      await socket_writer(
+          socketConnection1!, 'update:$atmosphereKey atmospherevalue');
+      var updateResponse = await read();
+      print(updateResponse);
+      assert((!updateResponse.contains('Invalid syntax')) &&
+          (!updateResponse.contains('null')));
+
+      // enroll request with wavi namespace
+      var enrollRequest =
+          'enroll:request:appName:wavi:deviceName:pixel:namespaces:[wavi,rw]:apkamPublicKey:${pkamPublicKeyMap[firstAtsign]!}\n';
+      await socket_writer(socketConnection1!, enrollRequest);
+      var enrollResponse = await read();
+      print(enrollResponse);
+      enrollResponse = enrollResponse.replaceFirst('data:', '');
+      var enrollJsonMap = jsonDecode(enrollResponse);
+      expect(enrollJsonMap['enrollmentId'], isNotEmpty);
+      expect(enrollJsonMap['status'], 'success');
+
+      var enrollmentId = enrollJsonMap['enrollmentId'];
+
+      // now do the apkam using the enrollment id
+      pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
+      var apkamEnrollId = 'pkam:enrollApprovalId:$enrollmentId:$pkamDigest\n';
+
+      await socket_writer(socketConnection1!, apkamEnrollId);
+      var apkamEnrollIdResponse = await read();
+      expect(apkamEnrollIdResponse, 'data:success\n');
+
+      // delete the wavi key
+      await socket_writer(socketConnection1!, 'delete:$atmosphereKey');
+      var deleteResponse = await read();
+      print(deleteResponse);
+      expect(deleteResponse,
+          'error:AT0009-UnAuthorized client in request : Enrollment Id: $enrollmentId is not authorized for delete operation\n');
     });
 
     tearDown(() {

--- a/tests/at_functional_test/test/enroll_verb_test.dart
+++ b/tests/at_functional_test/test/enroll_verb_test.dart
@@ -148,6 +148,7 @@ void main() {
       // now do the apkam using the enrollment id
       await socket_writer(socketConnection2!, 'from:$firstAtsign');
       fromResponse = await read();
+      fromResponse = fromResponse.replaceAll('data:', '');
       pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
       var apkamEnrollId = 'pkam:enrollApprovalId:$secondEnrollId:$pkamDigest\n';
 
@@ -221,12 +222,10 @@ void main() {
       expect(approveJson['status'], 'approved');
       expect(approveJson['enrollmentId'], secondEnrollId);
 
-      // wait for second before doing an APKaM
-      await Future.delayed(Duration(seconds: 2));
-
       // connect to the second client to do an apkam
       await socket_writer(socketConnection2!, 'from:$firstAtsign');
       fromResponse = await read();
+      fromResponse = fromResponse.replaceAll('data:', '');
       // now do the apkam using the enrollment id
       pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
       var apkamEnrollId = 'pkam:enrollApprovalId:$secondEnrollId:$pkamDigest\n';
@@ -353,7 +352,7 @@ void main() {
       var updateResponse = await read();
       assert((!updateResponse.contains('Invalid syntax')) &&
           (!updateResponse.contains('null')));
-      
+
       var enrollRequest =
           'enroll:request:appName:wavi:deviceName:pixel:namespaces:[wavi,rw]:apkamPublicKey:${pkamPublicKeyMap[firstAtsign]!}\n';
       await socket_writer(socketConnection1!, enrollRequest);
@@ -438,7 +437,6 @@ void main() {
       //Closing the socket connection
       clear();
       socketConnection1!.destroy();
-      
     });
   });
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added functional tests for the enroll verb

**- How I did it**
  Added tests for the following scenarios
-   Enroll request from the second client approved by the first client
-  Enroll request from the second client denied by the first client
-   Enroll request only for wavi namespace
        Update operation for a key with atmosphere namespace, should throw an exception
        Scan should not return the atmosphere key
        local lookup for an atmosphere key should throw an exception


**- How to verify it**
 enroll_verb_test.dart should pass
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->