### PR TITLE
fix: upgrade dependencies

### DIFF
--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -26,13 +26,12 @@ dependencies:
   at_persistence_spec: 2.0.12
   at_persistence_secondary_server: 3.0.52
   version: 3.0.2
-  meta: 1.8.0
+  meta: ^1.9.1
   mutex: 3.0.1
   yaml: 3.1.1
 
 dev_dependencies:
-  test: ^1.22.1
+  test: ^1.24.4
   coverage: ^1.6.1
-  lints: ^2.0.1
+  lints: ^2.1.1
   mocktail: ^0.3.0
-  _fe_analyzer_shared: 61.0.0

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -9,26 +9,26 @@ environment:
   sdk: '>=2.15.0 <4.0.0'
 
 dependencies:
-  args: 2.4.1
+  args: 2.4.2
   uuid: 3.0.7
   convert: 3.1.1
   cron: 0.5.1
-  crypto: 3.0.2
+  crypto: 3.0.3
   crypton: 2.1.0
-  collection: 1.17.0
-  basic_utils: 5.4.2
+  collection: 1.17.2
+  basic_utils: 5.6.0
   ecdsa: 0.0.4
-  at_commons: 3.0.47
+  at_commons: 3.0.48
   at_utils: 3.0.13
   at_chops: 1.0.3
-  at_lookup: 3.0.36
+  at_lookup: 3.0.37
   at_server_spec: 3.0.11
   at_persistence_spec: 2.0.12
   at_persistence_secondary_server: 3.0.52
   version: 3.0.2
-  meta: ^1.9.1
+  meta: 1.9.1
   mutex: 3.0.1
-  yaml: 3.1.1
+  yaml: 3.1.2
 
 dev_dependencies:
   test: ^1.24.4


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Referring to the discussion in https://github.com/dart-lang/sdk/issues/52815, the cause of the issue is `package:meta` pointing to v1.8.0. Since, we have the restricted the package version, the `dart pub upgrade`, did not pull the latest version of `package:meta`. Upgrading the meta package resolves the issue - "Failed to build "test" package..
- Also, upgraded the version of "test" and "lints" package dependencies.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->