### PR TITLE
feat: monitor verb handler changes for apkam self notification

### DIFF
--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.33
+- feat: modified monitor verb handler to process self notification for apkam
+- chore: upgraded at_commons to 3.0.50 and at_utils 3.0.14
 ## 3.0.32
 - fix: Enhance stats verb to return latest commitEntry of each key
 - chore: Ignore melos files
@@ -6,7 +9,7 @@
 - chore: Uptake at_utils v3.0.13 which enables logging to StandardError
 - feat: Retain current inbound pool management logic, but be a **LOT** less 
   aggressive when closing idle **authenticated** inbound connections
-- ## 3.0.31
+## 3.0.31
 - feat: Introduce clientId, appName, appVersion and platform to distinguish requests from several clients in server logs.
 ## 3.0.30
 - fix: When metadata attributes are not set, merge the existing metadata attributes

--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 3.0.33
 - feat: modified monitor verb handler to process self notification for apkam
-- chore: upgraded at_commons to 3.0.50 and at_utils 3.0.14
+- chore: upgraded at_persistence_secondary_server to 3.0.53, at_commons to 3.0.50 and at_utils 3.0.14
 ## 3.0.32
 - fix: Enhance stats verb to return latest commitEntry of each key
 - chore: Ignore melos files

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -18,8 +18,8 @@ dependencies:
   collection: 1.17.2
   basic_utils: 5.6.0
   ecdsa: 0.0.4
-  at_commons: 3.0.48
-  at_utils: 3.0.13
+  at_commons: 3.0.50
+  at_utils: 3.0.14
   at_chops: 1.0.3
   at_lookup: 3.0.37
   at_server_spec: 3.0.11
@@ -29,6 +29,13 @@ dependencies:
   meta: 1.9.1
   mutex: 3.0.1
   yaml: 3.1.2
+
+dependency_overrides:
+  at_persistence_secondary_server:
+    git:
+      url: https://github.com/atsign-foundation/at_server
+      path: packages/at_persistence_secondary_server
+      ref: apkam_persistence_changes
 
 dev_dependencies:
   test: ^1.24.4

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -24,18 +24,11 @@ dependencies:
   at_lookup: 3.0.37
   at_server_spec: 3.0.11
   at_persistence_spec: 2.0.12
-  at_persistence_secondary_server: 3.0.52
+  at_persistence_secondary_server: 3.0.53
   version: 3.0.2
   meta: 1.9.1
   mutex: 3.0.1
   yaml: 3.1.2
-
-dependency_overrides:
-  at_persistence_secondary_server:
-    git:
-      url: https://github.com/atsign-foundation/at_server
-      path: packages/at_persistence_secondary_server
-      ref: apkam_persistence_changes
 
 dev_dependencies:
   test: ^1.24.4


### PR DESCRIPTION
**- What I did**
- upgraded package versions in pubspec
- changes in monitor verb handler to register callback for self notification
**- How I did it**
- upgraded at_commons to 3.0.50 and at_utils to 3.0.14 in pubspec.yaml
- upgraded at_persistence_secondary_server to 3.0.53 which contains self notification type changes
- modified monitor_verb_handler.dart to register self notification callback. Callback will be registered only when self notification flag is set from the client. This is to preserve backward compatibility for old clients with latest server version
- renamed few method names in monitor_verb_handler
**- How to verify it**
- unit and functional tests should pass
- changes in monitor_verb_handler.dart can be tested along with enroll feature changes since self notification type is currently not used else where.
