### PR TITLE
feat:info verb changes

### DIFF
--- a/packages/at_secondary_server/lib/src/connection/inbound/inbound_connection_metadata.dart
+++ b/packages/at_secondary_server/lib/src/connection/inbound/inbound_connection_metadata.dart
@@ -23,4 +23,7 @@ class InboundConnectionMetadata extends AtConnectionMetaData {
 
   /// The platform on which the client(origin of connection) is running
   String? platform;
+
+  /// A unique identifier generated for a client's APKAM enroll request
+  String? enrollApprovalId;
 }

--- a/packages/at_secondary_server/lib/src/constants/key_constants.dart
+++ b/packages/at_secondary_server/lib/src/constants/key_constants.dart
@@ -1,0 +1,2 @@
+const String enrollManageNamespace = '__manage';
+const String newEnrollmentKeyPattern = 'new.enrollments';

--- a/packages/at_secondary_server/lib/src/verb/handler/info_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/info_verb_handler.dart
@@ -1,16 +1,22 @@
 import 'dart:collection';
 import 'dart:convert';
+
 import 'package:at_commons/at_commons.dart';
-import 'package:at_secondary/src/server/at_secondary_config.dart';
-import 'package:at_server_spec/at_server_spec.dart';
-import 'abstract_verb_handler.dart';
-import 'package:at_server_spec/at_verb_spec.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_secondary/src/connection/inbound/inbound_connection_metadata.dart';
+import 'package:at_secondary/src/constants/key_constants.dart';
+import 'package:at_secondary/src/server/at_secondary_config.dart';
+import 'package:at_secondary/src/server/at_secondary_impl.dart';
+import 'package:at_server_spec/at_server_spec.dart';
+import 'package:at_server_spec/at_verb_spec.dart';
+
+import 'abstract_verb_handler.dart';
 
 /// Handler for the 'info' verb. Usage of info verb is documented in at_server_spec/lib/src/verb/info.dart
 class InfoVerbHandler extends AbstractVerbHandler {
   static Info infoVerb = Info();
   static int? approximateStartTimeMillis;
+
   InfoVerbHandler(SecondaryKeyStore keyStore) : super(keyStore) {
     approximateStartTimeMillis ??= DateTime.now().millisecondsSinceEpoch;
   }
@@ -26,8 +32,15 @@ class InfoVerbHandler extends AbstractVerbHandler {
       Response response,
       HashMap<String, String?> verbParams,
       InboundConnection atConnection) async {
-    Map infoMap =
-        {}; // structure of what is returned is documented in the [Info] verb in at_server_spec
+    Map infoMap = {};
+    String? apkamMetadataKey;
+    String? result;
+    InboundConnectionMetadata atConnectionMetadata = atConnection.getMetaData()
+        as InboundConnectionMetadata; // structure of what is returned is documented in the [Info] verb in at_server_spec
+    var atSign = AtSecondaryServerImpl.getInstance().currentAtSign;
+    final enrollApprovalId = atConnectionMetadata.enrollApprovalId;
+    apkamMetadataKey =
+        '$enrollApprovalId.$newEnrollmentKeyPattern.$enrollManageNamespace$atSign';
 
     infoMap['version'] = AtSecondaryConfig.secondaryServerVersion;
     Duration uptime = Duration(
@@ -36,6 +49,12 @@ class InfoVerbHandler extends AbstractVerbHandler {
     if (verbParams[paramFullCommandAsReceived] == 'info') {
       String uptimeAsWords = durationToWords(uptime);
       infoMap['uptimeAsWords'] = uptimeAsWords;
+      if (atConnectionMetadata.isAuthenticated) {
+        result = await _getapkamMetadataKey(apkamMetadataKey);
+        if (result != null) {
+          infoMap['apkam_metadata'] = result;
+        }
+      }
       infoMap['features'] = [
         {
           "name": "noop:",
@@ -53,7 +72,7 @@ class InfoVerbHandler extends AbstractVerbHandler {
               "The Info verb returns some information about the server "
                   "including uptime and some info about available features. ",
           "syntax": VerbSyntax.info
-        }
+        },
       ];
     } else {
       infoMap['uptimeAsMillis'] = uptime.inMilliseconds;
@@ -72,5 +91,15 @@ class InfoVerbHandler extends AbstractVerbHandler {
         ((uDays > 0 || uHours > 0 || uMins > 0) ? "$uMins minutes " : "") +
         "$uSeconds seconds";
     return uptimeAsWords;
+  }
+
+  Future<String?> _getapkamMetadataKey(String? apkamMetadataKey) async {
+    AtData? result;
+    try {
+      result = await keyStore.get(apkamMetadataKey);
+    } on Exception catch (e) {
+      logger.severe('apkam_metadata not found | $e');
+    }
+    return result?.data;
   }
 }

--- a/packages/at_secondary_server/lib/src/verb/handler/info_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/info_verb_handler.dart
@@ -50,7 +50,7 @@ class InfoVerbHandler extends AbstractVerbHandler {
       String uptimeAsWords = durationToWords(uptime);
       infoMap['uptimeAsWords'] = uptimeAsWords;
       if (atConnectionMetadata.isAuthenticated) {
-        result = await _getapkamMetadataKey(apkamMetadataKey);
+        result = await _getApkamMetadataKey(apkamMetadataKey);
         if (result != null) {
           infoMap['apkam_metadata'] = result;
         }
@@ -93,11 +93,11 @@ class InfoVerbHandler extends AbstractVerbHandler {
     return uptimeAsWords;
   }
 
-  Future<String?> _getapkamMetadataKey(String? apkamMetadataKey) async {
+  Future<String?> _getApkamMetadataKey(String? apkamMetadataKey) async {
     AtData? result;
     try {
       result = await keyStore.get(apkamMetadataKey);
-    } on Exception catch (e) {
+    } on AtKeyNotFoundException catch (e) {
       logger.severe('apkam_metadata not found | $e');
     }
     return result?.data;

--- a/tests/at_functional_test/test/delete_verb_test.dart
+++ b/tests/at_functional_test/test/delete_verb_test.dart
@@ -101,7 +101,6 @@ void main() {
     print('update verb response : $response');
     assert(
         (!response.contains('Invalid syntax')) && (!response.contains('null')));
-    ;
 
     ///SCAN VERB in the first atsign
     await socket_writer(socketFirstAtsign!, 'scan');

--- a/tests/at_functional_test/test/functional_test_commons.dart
+++ b/tests/at_functional_test/test/functional_test_commons.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: non_constant_identifier_names
+
 import 'dart:collection';
 import 'dart:convert';
 import 'dart:io';
@@ -11,7 +13,7 @@ var maxRetryCount = 10;
 var retryCount = 1;
 
 ///Socket Connection
-Future<SecureSocket> socket_connection(host, port) async {
+Future<SecureSocket> socketConnection(host, port) async {
   var context = SecurityContext();
   print(Directory.current);
   context.setTrustedCertificates('lib/secondary/base/certs/cacert.pem');
@@ -27,6 +29,7 @@ void clear() {
 
 ///Secure Socket Connection
 Future<SecureSocket> secure_socket_connection(host, port) async {
+  // ignore: prefer_typing_uninitialized_variables
   var socket;
   while (true) {
     try {

--- a/tests/at_functional_test/test/info_verb_test.dart
+++ b/tests/at_functional_test/test/info_verb_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: unused_import
+
 import 'dart:convert';
 import 'dart:io';
 
@@ -9,6 +11,7 @@ import 'functional_test_commons.dart';
 import 'pkam_utils.dart';
 
 void main() {
+  // ignore: unused_local_variable
   var firstAtsign =
       ConfigUtil.getYaml()!['first_atsign_server']['first_atsign_name'];
   Socket? socketFirstAtsign;

--- a/tests/at_functional_test/test/info_verb_test.dart
+++ b/tests/at_functional_test/test/info_verb_test.dart
@@ -24,7 +24,7 @@ void main() {
         ConfigUtil.getYaml()!['first_atsign_server']['first_atsign_port'];
 
     socketFirstAtsign =
-        await socketConnection(firstAtsignServer, firstAtsignPort);
+        await secure_socket_connection(firstAtsignServer, firstAtsignPort);
     socket_listener(socketFirstAtsign!);
   });
 

--- a/tests/at_functional_test/test/info_verb_test.dart
+++ b/tests/at_functional_test/test/info_verb_test.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 
 import 'package:at_functional_test/conf/config_util.dart';
 import 'package:test/test.dart';
+import 'package:version/version.dart';
 
 import 'at_demo_data.dart';
 import 'functional_test_commons.dart';
@@ -23,46 +24,48 @@ void main() {
         ConfigUtil.getYaml()!['first_atsign_server']['first_atsign_port'];
 
     socketFirstAtsign =
-        await secure_socket_connection(firstAtsignServer, firstAtsignPort);
+        await socketConnection(firstAtsignServer, firstAtsignPort);
     socket_listener(socketFirstAtsign!);
   });
 
   test('info verb test without authentication', () async {
     await socket_writer(socketFirstAtsign!, 'info');
     var infoVerbResponse = await read();
-    print('info verb response : $infoVerbResponse');
     infoVerbResponse = infoVerbResponse.replaceAll('data:', '');
     var infoResponse = jsonDecode(infoVerbResponse);
     expect(infoResponse['version'], isNotEmpty);
   });
 
   // commenting the test as the server doesn't have enroll verb changes yet
-  // test('info verb with enroll verb changes', () async {
-  //   await socket_writer(socketFirstAtsign!, 'from:$firstAtsign');
-  //   var fromResponse = await read();
-  //   print('from verb response : $fromResponse');
-  //   fromResponse = fromResponse.replaceAll('data:', '');
-  //   var pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
-  //   await socket_writer(socketFirstAtsign!, 'pkam:$pkamDigest');
-  //   var pkamResult = await read();
-  //   expect(pkamResult, 'data:success\n');
+  test('info verb with enroll verb changes', () async {
+    await socket_writer(socketFirstAtsign!, 'info:brief');
+    var infoResponse = await read();
+    infoResponse = infoResponse.replaceFirst('data:', '');
+    var serverVersion = jsonDecode(infoResponse)['version'];
+    if (Version.parse(serverVersion) > Version(3, 0, 34)) {
+      await socket_writer(socketFirstAtsign!, 'from:$firstAtsign');
+      var fromResponse = await read();
+      fromResponse = fromResponse.replaceAll('data:', '');
+      var pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
+      await socket_writer(socketFirstAtsign!, 'pkam:$pkamDigest');
+      var pkamResult = await read();
+      expect(pkamResult, 'data:success\n');
 
-  //   // create a key with the _manage namespace
-  //   var enrollRequest =
-  //       'enroll:request:appName:wavi:deviceName:pixel:namespaces:[wavi,rw]:apkamPublicKey:${pkamPublicKeyMap[firstAtsign]!}\n';
-  //   await socket_writer(socketFirstAtsign!, enrollRequest);
-  //   var enrollResponse = await read();
-  //   print(enrollResponse);
-  //   enrollResponse = enrollResponse.replaceFirst('data:', '');
-  //   var enrollJsonMap = jsonDecode(enrollResponse);
-  //   expect(enrollJsonMap['enrollmentId'], isNotEmpty);
+      // create a key with the _manage namespace
+      var enrollRequest =
+          'enroll:request:appName:wavi:deviceName:pixel:namespaces:[wavi,rw]:apkamPublicKey:${pkamPublicKeyMap[firstAtsign]!}\n';
+      await socket_writer(socketFirstAtsign!, enrollRequest);
+      var enrollResponse = await read();
+      enrollResponse = enrollResponse.replaceFirst('data:', '');
+      var enrollJsonMap = jsonDecode(enrollResponse);
+      expect(enrollJsonMap['enrollmentId'], isNotEmpty);
 
-  //   // check the info verb.. It should return the result
-  //   await socket_writer(socketFirstAtsign!, 'info');
-  //   var infoVerbResponse = await read();
-  //   print('info verb response : $infoVerbResponse');
-  //   infoVerbResponse = infoVerbResponse.replaceAll('data:', '');
-  //   var infoResponse = jsonDecode(infoVerbResponse);
-  //   expect(infoResponse['apkam_metadata'], isNotEmpty);
-  // });
+      // check the info verb.. It should return the result
+      await socket_writer(socketFirstAtsign!, 'info');
+      var infoVerbResponse = await read();
+      infoVerbResponse = infoVerbResponse.replaceAll('data:', '');
+      var infoResponse = jsonDecode(infoVerbResponse);
+      expect(infoResponse['apkam_metadata'], isNotEmpty);
+    }
+  });
 }

--- a/tests/at_functional_test/test/info_verb_test.dart
+++ b/tests/at_functional_test/test/info_verb_test.dart
@@ -1,0 +1,65 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:at_functional_test/conf/config_util.dart';
+import 'package:test/test.dart';
+
+import 'at_demo_data.dart';
+import 'functional_test_commons.dart';
+import 'pkam_utils.dart';
+
+void main() {
+  var firstAtsign =
+      ConfigUtil.getYaml()!['first_atsign_server']['first_atsign_name'];
+  Socket? socketFirstAtsign;
+
+  setUp(() async {
+    var firstAtsignServer =
+        ConfigUtil.getYaml()!['first_atsign_server']['first_atsign_url'];
+    var firstAtsignPort =
+        ConfigUtil.getYaml()!['first_atsign_server']['first_atsign_port'];
+
+    socketFirstAtsign =
+        await secure_socket_connection(firstAtsignServer, firstAtsignPort);
+    socket_listener(socketFirstAtsign!);
+  });
+
+  test('info verb test without authentication', () async {
+    await socket_writer(socketFirstAtsign!, 'info');
+    var infoVerbResponse = await read();
+    print('info verb response : $infoVerbResponse');
+    infoVerbResponse = infoVerbResponse.replaceAll('data:', '');
+    var infoResponse = jsonDecode(infoVerbResponse);
+    expect(infoResponse['version'], isNotEmpty);
+  });
+
+  // commenting the test as the server doesn't have enroll verb changes yet
+  // test('info verb with enroll verb changes', () async {
+  //   await socket_writer(socketFirstAtsign!, 'from:$firstAtsign');
+  //   var fromResponse = await read();
+  //   print('from verb response : $fromResponse');
+  //   fromResponse = fromResponse.replaceAll('data:', '');
+  //   var pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
+  //   await socket_writer(socketFirstAtsign!, 'pkam:$pkamDigest');
+  //   var pkamResult = await read();
+  //   expect(pkamResult, 'data:success\n');
+
+  //   // create a key with the _manage namespace
+  //   var enrollRequest =
+  //       'enroll:request:appName:wavi:deviceName:pixel:namespaces:[wavi,rw]:apkamPublicKey:${pkamPublicKeyMap[firstAtsign]!}\n';
+  //   await socket_writer(socketFirstAtsign!, enrollRequest);
+  //   var enrollResponse = await read();
+  //   print(enrollResponse);
+  //   enrollResponse = enrollResponse.replaceFirst('data:', '');
+  //   var enrollJsonMap = jsonDecode(enrollResponse);
+  //   expect(enrollJsonMap['enrollmentId'], isNotEmpty);
+
+  //   // check the info verb.. It should return the result
+  //   await socket_writer(socketFirstAtsign!, 'info');
+  //   var infoVerbResponse = await read();
+  //   print('info verb response : $infoVerbResponse');
+  //   infoVerbResponse = infoVerbResponse.replaceAll('data:', '');
+  //   var infoResponse = jsonDecode(infoVerbResponse);
+  //   expect(infoResponse['apkam_metadata'], isNotEmpty);
+  // });
+}


### PR DESCRIPTION
**- What I did**
- Added enroll namespace details in the info_verb_handler
**- How I did it**
- check whether enrollId is not null, connection is authenticated and fetch the details of key $enrollId.$newEnrollmentKeyPattern.$enrollManageNamespace$atSign from keystore and add to info verb response 

**- How to verify it**
- run the info verb functional tests to validate regression
- functional test added and commented. Can be uncommented along with enroll changes PR
