### PR TITLE
feat: skipCommit param in keystore - put,create and remove

### DIFF
--- a/packages/at_persistence_spec/CHANGELOG.md
+++ b/packages/at_persistence_spec/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.0.13
+- feat: add optional param skipCommit to keystore - put,create and remove methods
 ## 2.0.12
 - feat: Added new optional encryption metadata parameters to the WritableKeystore spec for `put` and `create`
 ## 2.0.11

--- a/packages/at_persistence_spec/lib/src/keystore/keystore.dart
+++ b/packages/at_persistence_spec/lib/src/keystore/keystore.dart
@@ -22,6 +22,7 @@ abstract class WritableKeystore<K, V> implements Keystore<K, V> {
   /// @param value - Value to be associated with the specified key.
   /// @param time_to_live - Duration in milliseconds after which the key should expire automatically.
   /// @param time_to_born - Duration in milliseconds after which the key will become active.
+  /// @param skipCommit - if set to true, will skip adding entry to commit log for this update. Set to false by default.
   /// @returns sequence number from commit log if put is success. null otherwise
   /// Throws a [DataStoreException] if the the operation fails due to some issue with the data store.
   Future<dynamic> put(K key, V value,
@@ -39,7 +40,8 @@ abstract class WritableKeystore<K, V> implements Keystore<K, V> {
       String? encAlgo,
       String? ivNonce,
       String? skeEncKeyName,
-      String? skeEncAlgo});
+      String? skeEncAlgo,
+      bool skipCommit = false});
 
   /// If the specified key is not already associated with a value (or is mapped to null) associates it with the given value and returns null, else returns the current value.
   ///
@@ -47,6 +49,7 @@ abstract class WritableKeystore<K, V> implements Keystore<K, V> {
   /// @param value - Value to be associated with the specified key
   /// @param time_to_live - Duration in milliseconds after which the key should expire automatically.
   /// @param time_to_born - Duration in milliseconds after which the key will become active.
+  /// @param skipCommit - if set to true, will skip adding entry to commit log for this create operation. Set to false by default.
   /// @return - sequence number from commit log if put is success. null otherwise
   /// Throws a [DataStoreException] if the the operation fails due to some issue with the data store.
   Future<dynamic> create(K key, V value,
@@ -64,14 +67,16 @@ abstract class WritableKeystore<K, V> implements Keystore<K, V> {
       String? encAlgo,
       String? ivNonce,
       String? skeEncKeyName,
-      String? skeEncAlgo});
+      String? skeEncAlgo,
+      bool skipCommit = false});
 
   /// Removes the mapping for a key from this key store if it is present
   ///
   /// @param key - Key associated with a value.
+  /// @param skipCommit - if set to true, will skip adding entry to commit log for this remove operation. Set to false by default.
   /// @return - sequence number from commit log if remove is success. null otherwise
   /// Throws a [DataStoreException] if the operation fails due to some issue with the data store.
-  Future<dynamic> remove(K key);
+  Future<dynamic> remove(K key, {bool skipCommit = false});
 }
 
 abstract class SynchronizableKeyStore<K, V, T> {

--- a/packages/at_persistence_spec/pubspec.yaml
+++ b/packages/at_persistence_spec/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_persistence_spec
 description: A Dart library containing abstract classes that defines what an implementation of the persistence layer is responsible for. This can be used to guide implementation of other persistence solutions for servers or SDKs as desired.
-version: 2.0.12
+version: 2.0.13
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://atsign.dev
 documentation: https://docs.atsign.com/


### PR DESCRIPTION
**- What I did**
- added param skipCommit to keystore.dart in persistence spec
**- How I did it**
- added skipCommit param in create, put and remove methods of WritableKeystore. Will be set to false by default. If set to true, then commit log entry will not be added for the create/put/remove operation
- added changes to pubspec and changelog for publishing.
**- How to verify it**
n/a
