### PR TITLE
fix: Refactor getEntries method to improve time and space complexity

### DIFF
--- a/packages/at_persistence_secondary_server/lib/src/log/commitlog/at_commit_log.dart
+++ b/packages/at_persistence_secondary_server/lib/src/log/commitlog/at_commit_log.dart
@@ -158,12 +158,13 @@ class AtCommitLog implements AtLogType<int, CommitEntry> {
 
   /// Returns the Iterator of [_commitLogCacheMap] from the commitId specified.
   @server
-  Iterator getEntries(int commitId, {String? regex}) {
+  Iterator<MapEntry<String, CommitEntry>> getEntries(int commitId,
+      {String? regex, int limit = 25}) {
     // If regex is null or isEmpty set regex to match all keys
     if (regex == null || regex.isEmpty) {
       regex = '.*';
     }
-    return _commitLogKeyStore.getEntries(commitId, regex: regex);
+    return _commitLogKeyStore.getEntries(commitId, regex: regex, limit: limit);
   }
 
   Future<void> _publishChangeEvent(CommitEntry commitEntry) async {

--- a/packages/at_persistence_secondary_server/lib/src/log/commitlog/commit_log_keystore.dart
+++ b/packages/at_persistence_secondary_server/lib/src/log/commitlog/commit_log_keystore.dart
@@ -289,7 +289,7 @@ class CommitLogKeyStore
   Future<List<CommitEntry>> getChanges(int sequenceNumber,
       {String? regex, int? limit}) async {
     try {
-      if (_getBox().keys.isEmpty) {
+      if (_getBox().isEmpty) {
         return <CommitEntry>[];
       }
       var changes = <CommitEntry>[];

--- a/packages/at_persistence_secondary_server/test/commit_log_test.dart
+++ b/packages/at_persistence_secondary_server/test/commit_log_test.dart
@@ -433,7 +433,7 @@ void main() async {
     });
 
     test(
-        'A test to verify entries in commit cache map are sorted by commit-id in descending order',
+        'A test to verify entries in commit cache map are sorted by commit-id in ascending order',
         () async {
       var commitLogInstance =
           await (AtCommitLogManagerImpl.getInstance().getCommitLog('@alice'));
@@ -451,20 +451,20 @@ void main() async {
           .repairCommitLogAndCreateCachedMap();
       Iterator<MapEntry<String, CommitEntry>> itr =
           commitLogInstance.getEntries(-1);
-      while (itr.moveNext()) {
-        if (itr.current.key == '@alice:key3.wavi@alice') {
-          expect(itr.current.value.commitId, 2);
-          expect(itr.current.value.operation, CommitOp.UPDATE);
-        }
-        if (itr.current.key == '@alice:key2.wavi@alice') {
-          expect(itr.current.value.commitId, 3);
-          expect(itr.current.value.operation, CommitOp.DELETE);
-        }
-        if (itr.current.key == '@alice:key1.wavi@alice') {
-          expect(itr.current.value.commitId, 4);
-          expect(itr.current.value.operation, CommitOp.UPDATE);
-        }
-      }
+      itr.moveNext();
+      expect(itr.current.key, '@alice:key3.wavi@alice');
+      expect(itr.current.value.commitId, 2);
+      expect(itr.current.value.operation, CommitOp.UPDATE);
+
+      itr.moveNext();
+      expect(itr.current.key, '@alice:key2.wavi@alice');
+      expect(itr.current.value.commitId, 3);
+      expect(itr.current.value.operation, CommitOp.DELETE);
+
+      itr.moveNext();
+      expect(itr.current.key, '@alice:key1.wavi@alice');
+      expect(itr.current.value.commitId, 4);
+      expect(itr.current.value.operation, CommitOp.UPDATE);
     });
 
     test(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Refactor methods in commit_log_keystore.dart to improve time and space complexity.

**- How I did it**
- Refactor "_getCommitIdMap" and "_updateCacheLog" method to sort the entries in ascending order by commit-ids.
   - To maintain the entries in sorted order, if a key exists in the map, remove the entry and add the key again to ensure the key is added to end of the map. 
- Refactor "getEntries" method 
  - The "getEntries" at the moment loads all the keys from the commit log keystore into the memory. However, the server only returns 25 keys or untill the buffer is full (which ever happens first). So loading all the keys each time to consumes a lot of memory and time as well.
  - Refactored the method to load only specific number of keys. Added an optional field "limit" to configure how many keys to load into the memory for a batch. The "limit" is defaulted to 25.

Pending Work:
- [x] Add unit tests
- [x] Improve dart docs and code comments
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->