### PR TITLE
fix: APKAM revoke and list changes

### DIFF
--- a/packages/at_secondary_server/lib/src/enroll/enroll_datastore_value.dart
+++ b/packages/at_secondary_server/lib/src/enroll/enroll_datastore_value.dart
@@ -53,6 +53,6 @@ class EnrollApproval {
   }
 }
 
-enum EnrollStatus { pending, approved, denied }
+enum EnrollStatus { pending, approved, denied, revoked }
 
 enum EnrollRequestType { newEnrollment, changeEnrollment }

--- a/packages/at_secondary_server/lib/src/verb/handler/abstract_update_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/abstract_update_verb_handler.dart
@@ -75,11 +75,6 @@ abstract class AbstractUpdateVerbHandler extends ChangeVerbHandler {
         isAuthorized = await super.isAuthorized(enrollApprovalId, keyNamespace);
       }
     }
-    if (!isAuthorized) {
-      throw UnAuthorizedException(
-          'Enrollment Id: $enrollApprovalId is not authorized for update operation');
-    }
-
     // Get the key using verbParams (forAtSign, key, atSign)
     if (sharedWith != null && sharedWith.isNotEmpty) {
       atKey = '$sharedWith:$atKey';
@@ -91,6 +86,10 @@ abstract class AbstractUpdateVerbHandler extends ChangeVerbHandler {
     if (updateParams.metadata!.isPublic != null &&
         updateParams.metadata!.isPublic!) {
       atKey = 'public:$atKey';
+    }
+    if (!isAuthorized) {
+      throw UnAuthorizedException(
+          'Enrollment Id: $enrollApprovalId is not authorized for update operation on the key: ${atKey.toString()}');
     }
 
     var keyType = AtKey.getKeyType(atKey, enforceNameSpace: false);

--- a/packages/at_secondary_server/lib/src/verb/handler/abstract_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/abstract_verb_handler.dart
@@ -83,26 +83,52 @@ abstract class AbstractVerbHandler implements VerbHandler {
   Future<List<EnrollNamespace>> getEnrollmentNamespaces(
       String enrollmentId, String currentAtSign) async {
     final key = '$enrollmentId.$newEnrollmentKeyPattern.$enrollManageNamespace';
-    var enrollData;
+    EnrollDataStoreValue enrollDataStoreValue;
     try {
-      enrollData = await keyStore.get('$key$currentAtSign');
+      enrollDataStoreValue =
+          await getEnrollDataStoreValue('$key$currentAtSign');
     } on KeyNotFoundException {
       logger.warning('enrollment key not found in keystore $key');
       return [];
     }
-    if (enrollData != null) {
-      final atData = enrollData.data;
+    logger.finer('scan namespaces: ${enrollDataStoreValue.namespaces}');
+    return enrollDataStoreValue.namespaces;
+  }
 
-      final enrollDataStoreValue =
-          EnrollDataStoreValue.fromJson(jsonDecode(atData));
-      logger.finer('scan namespaces: ${enrollDataStoreValue.namespaces}');
-      return enrollDataStoreValue.namespaces;
+  /// Fetch for an enrollment key in the keystore.
+  /// If key is available returns [EnrollDataStoreValue],
+  /// else throws [KeyNotFoundException]
+  Future<EnrollDataStoreValue> getEnrollDataStoreValue(
+      String enrollmentKey) async {
+    try {
+      AtData enrollData = await keyStore.get(enrollmentKey);
+      EnrollDataStoreValue enrollDataStoreValue =
+          EnrollDataStoreValue.fromJson(jsonDecode(enrollData.data!));
+      return enrollDataStoreValue;
+    } on KeyNotFoundException {
+      logger.severe('$enrollmentKey does not exist in the keystore');
+      rethrow;
     }
-    return [];
   }
 
   Future<bool> isAuthorized(
       String enrollApprovalId, String keyNamespace) async {
+    EnrollDataStoreValue enrollDataStoreValue;
+    final enrollmentKey =
+        '$enrollApprovalId.$newEnrollmentKeyPattern.$enrollManageNamespace';
+    try {
+      enrollDataStoreValue = await getEnrollDataStoreValue(
+          '$enrollmentKey${AtSecondaryServerImpl.getInstance().currentAtSign}');
+    } on KeyNotFoundException {
+      // When a key with enrollmentId is not found, atSign is not authorized to
+      // perform enrollment actions. Return false.
+      return false;
+    }
+
+    if (enrollDataStoreValue.approval?.state != EnrollStatus.approved.name) {
+      return false;
+    }
+
     final enrollNamespaces = await getEnrollmentNamespaces(
         enrollApprovalId, AtSecondaryServerImpl.getInstance().currentAtSign);
 

--- a/packages/at_secondary_server/lib/src/verb/handler/delete_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/delete_verb_handler.dart
@@ -89,7 +89,7 @@ class DeleteVerbHandler extends ChangeVerbHandler {
     }
     if (!isAuthorized) {
       throw UnAuthorizedException(
-          'Enrollment Id: $enrollApprovalId is not authorized for delete operation');
+          'Enrollment Id: $enrollApprovalId is not authorized for delete operation on the key: $deleteKey');
     }
     try {
       var result = await keyStore.remove(deleteKey);

--- a/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
@@ -66,6 +66,7 @@ class EnrollVerbHandler extends AbstractVerbHandler {
       responseJson['status'] = 'exception';
       responseJson['reason'] = e.toString();
       logger.severe('Exception: $e\n$stackTrace');
+      rethrow;
     }
     response.data = jsonEncode(responseJson);
   }

--- a/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:collection';
 import 'dart:convert';
 import 'package:at_commons/at_commons.dart';
+import 'package:at_secondary/src/connection/inbound/inbound_connection_metadata.dart';
 import 'package:at_secondary/src/server/at_secondary_impl.dart';
 import 'package:at_secondary/src/constants/enroll_constants.dart';
 import 'package:at_secondary/src/enroll/enroll_datastore_value.dart';
@@ -34,102 +35,193 @@ class EnrollVerbHandler extends AbstractVerbHandler {
     logger.finer('verb params: $verbParams');
     final operation = verbParams['operation'];
     final currentAtSign = AtSecondaryServerImpl.getInstance().currentAtSign;
+    //Approve, deny, revoke or list enrollments only on authenticated connections
+    if (operation != 'request' && !atConnection.getMetaData().isAuthenticated) {
+      throw UnAuthenticatedException(
+          'Cannot $operation enrollment without authentication');
+    }
 
     try {
       switch (operation) {
         case 'request':
-          if (!atConnection.getMetaData().isAuthenticated) {
-            var totp = verbParams['totp'];
-            if (totp == null ||
-                (await TotpVerbHandler.cache.get(totp)) == null) {
-              throw AtEnrollmentException(
-                  'invalid totp. Cannot process enroll request');
-            }
-          }
-          List<EnrollNamespace> enrollNamespaces =
-              (verbParams['namespaces'] ?? '')
-                  .split(';')
-                  .map((namespace) => EnrollNamespace(
-                      namespace.split(',')[0], namespace.split(',')[1]))
-                  .toList();
-          logger.finer('enrollNamespaces: $enrollNamespaces');
-
-          var enrollmentId = Uuid().v4();
-          var key =
-              '$enrollmentId.$newEnrollmentKeyPattern.$enrollManageNamespace';
-          logger.finer('key: $key$currentAtSign');
-
-          responseJson['enrollmentId'] = enrollmentId;
-          final enrollmentValue = EnrollDataStoreValue(
-              atConnection.getMetaData().sessionID!,
-              verbParams['appName']!,
-              verbParams['deviceName']!,
-              verbParams['apkamPublicKey']!);
-
-          if (atConnection.getMetaData().isAuthenticated) {
-            // approve request from connection that are authenticated. This connection may be cram or legacyPkam authenticated
-            enrollNamespaces.add(EnrollNamespace(enrollManageNamespace, 'rw'));
-            enrollmentValue.approval =
-                EnrollApproval(EnrollStatus.approved.name);
-            responseJson['status'] = 'success';
-          } else {
-            enrollmentValue.approval =
-                EnrollApproval(EnrollStatus.pending.name);
-            await _storeNotification(key, currentAtSign);
-            responseJson['status'] = 'pending';
-          }
-
-          enrollmentValue.namespaces = enrollNamespaces;
-          enrollmentValue.requestType = EnrollRequestType.newEnrollment;
-          AtData enrollData = AtData()
-            ..data = jsonEncode(enrollmentValue.toJson());
-          logger.finer('enrollData: $enrollData');
-
-          await keyStore.put('$key$currentAtSign', enrollData);
+          await _handleEnrollmentRequest(
+              verbParams, currentAtSign, responseJson, atConnection);
           break;
 
         case 'approve':
         case 'deny':
-          final enrollmentId = verbParams['enrollmentId'];
-          var key =
-              '$enrollmentId.$newEnrollmentKeyPattern.$enrollManageNamespace';
-          logger.finer('key: $key$currentAtSign');
-          var enrollData;
-          try {
-            enrollData = await keyStore.get('$key$currentAtSign');
-          } on KeyNotFoundException {
-            throw AtEnrollmentException(
-                'enrollment id: $enrollmentId not found in keystore');
-          }
-          if (enrollData != null) {
-            final existingAtData = enrollData.data;
-            var enrollDataStoreValue =
-                EnrollDataStoreValue.fromJson(jsonDecode(existingAtData));
-
-            if (operation == 'approve') {
-              enrollDataStoreValue.approval!.state = EnrollStatus.approved.name;
-              responseJson['status'] = 'approved';
-            } else if (operation == 'deny') {
-              enrollDataStoreValue.approval!.state = EnrollStatus.denied.name;
-              responseJson['status'] = 'denied';
-            }
-
-            AtData updatedEnrollData = AtData()
-              ..data = jsonEncode(enrollDataStoreValue.toJson());
-
-            await keyStore.put('$key$currentAtSign', updatedEnrollData);
-          }
-
-          responseJson['enrollmentId'] = enrollmentId;
+        case 'revoke':
+          await _handleEnrollmentPermissions(
+              verbParams, currentAtSign, operation, responseJson);
           break;
+
+        case 'list':
+          response.data =
+              await _fetchEnrollmentRequests(atConnection, currentAtSign);
+          return;
       }
     } catch (e, stackTrace) {
+      response.isError = true;
+      response.errorMessage = e.toString();
       responseJson['status'] = 'exception';
       responseJson['reason'] = e.toString();
       logger.severe('Exception: $e\n$stackTrace');
     }
-
     response.data = jsonEncode(responseJson);
+  }
+
+  Future<void> _handleEnrollmentRequest(
+      HashMap<String, String?> verbParams,
+      currentAtSign,
+      Map<dynamic, dynamic> responseJson,
+      InboundConnection atConnection) async {
+    if (!atConnection.getMetaData().isAuthenticated) {
+      var totp = verbParams['totp'];
+      if (totp == null || (await TotpVerbHandler.cache.get(totp)) == null) {
+        throw AtEnrollmentException(
+            'invalid totp. Cannot process enroll request');
+      }
+    }
+    List<EnrollNamespace> enrollNamespaces = (verbParams['namespaces'] ?? '')
+        .split(';')
+        .map((namespace) =>
+            EnrollNamespace(namespace.split(',')[0], namespace.split(',')[1]))
+        .toList();
+    logger.finer('enrollNamespaces: $enrollNamespaces');
+
+    var enrollmentId = Uuid().v4();
+    var key = '$enrollmentId.$newEnrollmentKeyPattern.$enrollManageNamespace';
+    logger.finer('key: $key$currentAtSign');
+
+    responseJson['enrollmentId'] = enrollmentId;
+    final enrollmentValue = EnrollDataStoreValue(
+        atConnection.getMetaData().sessionID!,
+        verbParams['appName']!,
+        verbParams['deviceName']!,
+        verbParams['apkamPublicKey']!);
+
+    if (atConnection.getMetaData().isAuthenticated) {
+      // approve request from connection that are authenticated. This connection may be cram or legacyPkam authenticated
+      enrollNamespaces.add(EnrollNamespace(enrollManageNamespace, 'rw'));
+      enrollmentValue.approval = EnrollApproval(EnrollStatus.approved.name);
+      responseJson['status'] = 'success';
+    } else {
+      enrollmentValue.approval = EnrollApproval(EnrollStatus.pending.name);
+      await _storeNotification(key, currentAtSign);
+      responseJson['status'] = 'pending';
+    }
+
+    enrollmentValue.namespaces = enrollNamespaces;
+    enrollmentValue.requestType = EnrollRequestType.newEnrollment;
+    AtData enrollData = AtData()..data = jsonEncode(enrollmentValue.toJson());
+    logger.finer('enrollData: $enrollData');
+
+    await keyStore.put('$key$currentAtSign', enrollData);
+  }
+
+  Future<void> _handleEnrollmentPermissions(
+      HashMap<String, String?> verbParams,
+      currentAtSign,
+      String? operation,
+      Map<dynamic, dynamic> responseJson) async {
+    final enrollmentId = verbParams['enrollmentId'];
+    var key = '$enrollmentId.$newEnrollmentKeyPattern.$enrollManageNamespace';
+    logger.finer('key: $key$currentAtSign');
+    var enrollData;
+    try {
+      enrollData = await keyStore.get('$key$currentAtSign');
+    } on KeyNotFoundException {
+      throw AtEnrollmentException(
+          'enrollment id: $enrollmentId not found in keystore');
+    }
+    if (enrollData != null) {
+      final existingAtData = enrollData.data;
+      var enrollDataStoreValue =
+          EnrollDataStoreValue.fromJson(jsonDecode(existingAtData));
+
+      enrollDataStoreValue.approval!.state =
+          _getEnrollStatusEnum(operation).name;
+      responseJson['status'] = _getEnrollStatusEnum(operation).name;
+
+      AtData updatedEnrollData = AtData()
+        ..data = jsonEncode(enrollDataStoreValue.toJson());
+
+      await keyStore.put('$key$currentAtSign', updatedEnrollData);
+    }
+    responseJson['enrollmentId'] = enrollmentId;
+  }
+
+  EnrollStatus _getEnrollStatusEnum(String? enrollmentOperation) {
+    switch (enrollmentOperation) {
+      case 'approve':
+        return EnrollStatus.approved;
+      case 'deny':
+        return EnrollStatus.denied;
+      case 'revoke':
+        return EnrollStatus.revoked;
+      default:
+        return EnrollStatus.pending;
+    }
+  }
+
+  /// Returns a Map where key is an enrollment key and value is a
+  /// Map of "appName","deviceName" and "namespaces"
+  Future<String> _fetchEnrollmentRequests(
+      AtConnection atConnection, String currentAtSign) async {
+    Map<String, Map<String, dynamic>> enrollmentRequestsMap = {};
+    String? enrollApprovalId =
+        (atConnection.getMetaData() as InboundConnectionMetadata)
+            .enrollApprovalId;
+    List<String> enrollmentKeysList =
+        keyStore.getKeys(regex: newEnrollmentKeyPattern) as List<String>;
+    // If connection is authenticated via legacy PKAM, then enrollApprovalId is null.
+    // Return all the enrollments.
+    if (enrollApprovalId == null || enrollApprovalId.isEmpty) {
+      await _fetchAllEnrollments(enrollmentKeysList, enrollmentRequestsMap);
+      return jsonEncode(enrollmentRequestsMap);
+    }
+    // If connection is authenticated via APKAM, then enrollApprovalId is populated,
+    // check if the enrollment has access to __manage namespace.
+    // If enrollApprovalId has access to __manage namespace, return all the enrollments,
+    // Else return only the specific enrollment.
+    final enrollmentKey =
+        '$enrollApprovalId.$newEnrollmentKeyPattern.$enrollManageNamespace$currentAtSign';
+    EnrollDataStoreValue enrollDataStoreValue =
+        await getEnrollDataStoreValue(enrollmentKey);
+
+    if (_doesEnrollmentHaveManageNamespace(enrollDataStoreValue)) {
+      await _fetchAllEnrollments(enrollmentKeysList, enrollmentRequestsMap);
+    } else {
+      enrollmentRequestsMap[enrollmentKey] = {
+        'appName': enrollDataStoreValue.appName,
+        'deviceName': enrollDataStoreValue.deviceName,
+        'namespace': enrollDataStoreValue.namespaces
+      };
+    }
+    return jsonEncode(enrollmentRequestsMap);
+  }
+
+  Future<void> _fetchAllEnrollments(List<String> enrollmentKeysList,
+      Map<String, Map<String, dynamic>> enrollmentRequestsMap) async {
+    for (var enrollmentKey in enrollmentKeysList) {
+      EnrollDataStoreValue enrollDataStoreValue =
+          await getEnrollDataStoreValue(enrollmentKey);
+      enrollmentRequestsMap[enrollmentKey] = {
+        'appName': enrollDataStoreValue.appName,
+        'deviceName': enrollDataStoreValue.deviceName,
+        'namespace': enrollDataStoreValue.namespaces
+      };
+    }
+  }
+
+  bool _doesEnrollmentHaveManageNamespace(
+      EnrollDataStoreValue enrollDataStoreValue) {
+    for (var enrollmentNamespace in enrollDataStoreValue.namespaces) {
+      if (enrollmentNamespace.name == enrollManageNamespace) {
+        return true;
+      }
+    }
+    return false;
   }
 
   Future<void> _storeNotification(String notificationKey, String atSign) async {

--- a/packages/at_secondary_server/lib/src/verb/handler/local_lookup_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/local_lookup_verb_handler.dart
@@ -69,7 +69,7 @@ class LocalLookupVerbHandler extends AbstractVerbHandler {
     }
     if (!isAuthorized) {
       throw UnAuthorizedException(
-          'Enrollment Id: $enrollApprovalId is not authorized for local lookup operation');
+          'Enrollment Id: $enrollApprovalId is not authorized for local lookup operation on the key: $key');
     }
     AtData? atData = await keyStore.get(key);
     var isActive = false;

--- a/packages/at_secondary_server/lib/src/verb/handler/lookup_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/lookup_verb_handler.dart
@@ -74,7 +74,7 @@ class LookupVerbHandler extends AbstractVerbHandler {
         }
         if (!isAuthorized) {
           throw UnAuthorizedException(
-              'Enrollment Id: $enrollApprovalId is not authorized for lookup operation');
+              'Enrollment Id: $enrollApprovalId is not authorized for lookup operation on the key: $lookupKey');
         }
         var lookupValue = await keyStore.get(lookupKey);
         response.data =

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   collection: 1.17.2
   basic_utils: 5.6.0
   ecdsa: 0.0.4
-  at_commons: 3.0.51
+  at_commons: 3.0.52
   at_utils: 3.0.14
   at_chops: 1.0.3
   at_lookup: 3.0.37

--- a/packages/at_secondary_server/test/enroll_data_store_value_test.dart
+++ b/packages/at_secondary_server/test/enroll_data_store_value_test.dart
@@ -1,5 +1,18 @@
+import 'dart:collection';
+import 'dart:convert';
+
+import 'package:at_commons/at_commons.dart';
+import 'package:at_secondary/src/connection/inbound/inbound_connection_metadata.dart';
+import 'package:at_secondary/src/constants/enroll_constants.dart';
 import 'package:at_secondary/src/enroll/enroll_datastore_value.dart';
+import 'package:at_secondary/src/utils/handler_util.dart';
+import 'package:at_secondary/src/verb/handler/delete_verb_handler.dart';
+import 'package:at_secondary/src/verb/handler/enroll_verb_handler.dart';
+import 'package:at_secondary/src/verb/handler/totp_verb_handler.dart';
+import 'package:at_secondary/src/verb/handler/update_verb_handler.dart';
 import 'package:test/test.dart';
+
+import 'test_utils.dart';
 
 void main() {
   group(
@@ -76,5 +89,304 @@ void main() {
       expect(enrollValueObject.apkamPublicKey, 'mykey');
       expect(enrollValueObject.requestType, EnrollRequestType.newEnrollment);
     });
+  });
+
+  group('A group of tests on enroll list operation', () {
+    setUp(() async {
+      await verbTestsSetUp();
+    });
+
+    test('A test to verify enrollment list', () async {
+      String enrollmentRequest =
+          'enroll:request:appname:wavi:devicename:mydevice:namespaces:[wavi,r]:apkampublickey:dummy_apkam_public_key';
+      HashMap<String, String?> verbParams =
+          getVerbParam(VerbSyntax.enroll, enrollmentRequest);
+      inboundConnection.getMetaData().isAuthenticated = true;
+      inboundConnection.getMetaData().sessionID = 'dummy_session';
+      Response response = Response();
+      EnrollVerbHandler enrollVerbHandler =
+          EnrollVerbHandler(secondaryKeyStore);
+      await enrollVerbHandler.processVerb(
+          response, verbParams, inboundConnection);
+      String enrollmentId = jsonDecode(response.data!)['enrollmentId'];
+
+      String enrollmentList = 'enroll:list';
+      verbParams = getVerbParam(VerbSyntax.enroll, enrollmentList);
+      await enrollVerbHandler.processVerb(
+          response, verbParams, inboundConnection);
+      expect(response.data?.contains(enrollmentId), true);
+    });
+
+    test('A test to verify enrollment list with enrollApprovalId is populated',
+        () async {
+      String enrollmentRequest =
+          'enroll:request:appname:wavi:devicename:mydevice:namespaces:[wavi,r]:apkampublickey:dummy_apkam_public_key';
+      HashMap<String, String?> verbParams =
+          getVerbParam(VerbSyntax.enroll, enrollmentRequest);
+      inboundConnection.getMetaData().isAuthenticated = true;
+      inboundConnection.getMetaData().sessionID = 'dummy_session';
+      Response response = Response();
+      EnrollVerbHandler enrollVerbHandler =
+          EnrollVerbHandler(secondaryKeyStore);
+      await enrollVerbHandler.processVerb(
+          response, verbParams, inboundConnection);
+      String enrollmentId = jsonDecode(response.data!)['enrollmentId'];
+
+      String enrollmentList = 'enroll:list';
+      (inboundConnection.getMetaData() as InboundConnectionMetadata)
+          .enrollApprovalId = enrollmentId;
+      verbParams = getVerbParam(VerbSyntax.enroll, enrollmentList);
+      await enrollVerbHandler.processVerb(
+          response, verbParams, inboundConnection);
+      expect(response.data?.contains(enrollmentId), true);
+    });
+
+    test(
+        'A test to verify enrollment list without __manage namespace returns enrollment info of given enrollmentId',
+        () async {
+      Response response = Response();
+      inboundConnection.getMetaData().isAuthenticated = true;
+      inboundConnection.getMetaData().sessionID = 'dummy_session';
+      // Enroll request
+      String enrollmentRequest =
+          'enroll:request:appname:wavi:devicename:mydevice:namespaces:[wavi,r]:apkampublickey:dummy_apkam_public_key';
+      HashMap<String, String?> enrollmentRequestVerbParams =
+          getVerbParam(VerbSyntax.enroll, enrollmentRequest);
+      inboundConnection.getMetaData().isAuthenticated = true;
+      EnrollVerbHandler enrollVerbHandler =
+          EnrollVerbHandler(secondaryKeyStore);
+      await enrollVerbHandler.processVerb(
+          response, enrollmentRequestVerbParams, inboundConnection);
+      String enrollmentIdOne = jsonDecode(response.data!)['enrollmentId'];
+      // TOTP Verb
+      HashMap<String, String?> totpVerbParams =
+          getVerbParam(VerbSyntax.totp, 'totp:get');
+      TotpVerbHandler totpVerbHandler = TotpVerbHandler(secondaryKeyStore);
+      await totpVerbHandler.processVerb(
+          response, totpVerbParams, inboundConnection);
+      print('TOTP: ${response.data}');
+
+      // Enroll request
+      enrollmentRequest =
+          'enroll:request:appname:wavi:devicename:mydevice:namespaces:[wavi,r]:totp:${response.data}:apkampublickey:dummy_apkam_public_key';
+      enrollmentRequestVerbParams =
+          getVerbParam(VerbSyntax.enroll, enrollmentRequest);
+      inboundConnection.getMetaData().isAuthenticated = false;
+      enrollVerbHandler = EnrollVerbHandler(secondaryKeyStore);
+      await enrollVerbHandler.processVerb(
+          response, enrollmentRequestVerbParams, inboundConnection);
+      String enrollmentId = jsonDecode(response.data!)['enrollmentId'];
+
+      //Approve enrollment
+      String approveEnrollmentRequest =
+          'enroll:approve:enrollmentId:$enrollmentId';
+      HashMap<String, String?> approveEnrollmentVerbParams =
+          getVerbParam(VerbSyntax.enroll, approveEnrollmentRequest);
+      inboundConnection.getMetaData().isAuthenticated = true;
+      enrollVerbHandler = EnrollVerbHandler(secondaryKeyStore);
+      await enrollVerbHandler.processVerb(
+          response, approveEnrollmentVerbParams, inboundConnection);
+
+      // Enroll list
+      String enrollmentList = 'enroll:list';
+      (inboundConnection.getMetaData() as InboundConnectionMetadata)
+          .enrollApprovalId = enrollmentId;
+      HashMap<String, String?> verbParams =
+          getVerbParam(VerbSyntax.enroll, enrollmentList);
+      await enrollVerbHandler.processVerb(
+          response, verbParams, inboundConnection);
+      Map<String, dynamic> enrollListResponse = jsonDecode(response.data!);
+      var responseTest = enrollListResponse[
+          '$enrollmentId.$newEnrollmentKeyPattern.$enrollManageNamespace$alice'];
+      expect(responseTest['appName'], 'wavi');
+      expect(responseTest['deviceName'], 'mydevice');
+      expect(responseTest['namespace'][0]['name'], 'wavi');
+      expect(responseTest['namespace'][0]['access'], 'r');
+      expect(
+          enrollListResponse.containsKey(
+              '$enrollmentIdOne.$newEnrollmentKeyPattern.$enrollManageNamespace$alice'),
+          false);
+    });
+
+    tearDown(() async => await verbTestsTearDown());
+  });
+
+  group(
+      'A group of tests to assert enroll operations cannot performed on unauthenticated connection',
+      () {
+    setUp(() async {
+      await verbTestsSetUp();
+    });
+    test(
+        'A test to verify enrollment cannot be approved on an unauthenticated connection',
+        () async {
+      String enrollmentRequest = 'enroll:approve:enrollmentid:123';
+      HashMap<String, String?> verbParams =
+          getVerbParam(VerbSyntax.enroll, enrollmentRequest);
+      inboundConnection.getMetaData().isAuthenticated = false;
+      inboundConnection.getMetaData().sessionID = 'dummy_session';
+      Response response = Response();
+      EnrollVerbHandler enrollVerbHandler =
+          EnrollVerbHandler(secondaryKeyStore);
+      expect(
+          () async => await enrollVerbHandler.processVerb(
+              response, verbParams, inboundConnection),
+          throwsA(predicate((dynamic e) =>
+              e is UnAuthenticatedException &&
+              e.message ==
+                  'Cannot approve enrollment without authentication')));
+    });
+
+    test(
+        'A test to verify enrollment cannot be denied on an unauthenticated connection',
+        () async {
+      String enrollmentRequest = 'enroll:deny:enrollmentid:123';
+      HashMap<String, String?> verbParams =
+          getVerbParam(VerbSyntax.enroll, enrollmentRequest);
+      inboundConnection.getMetaData().isAuthenticated = false;
+      inboundConnection.getMetaData().sessionID = 'dummy_session';
+      Response response = Response();
+      EnrollVerbHandler enrollVerbHandler =
+          EnrollVerbHandler(secondaryKeyStore);
+      expect(
+          () async => await enrollVerbHandler.processVerb(
+              response, verbParams, inboundConnection),
+          throwsA(predicate((dynamic e) =>
+              e is UnAuthenticatedException &&
+              e.message == 'Cannot deny enrollment without authentication')));
+    });
+
+    test(
+        'A test to verify enrollment cannot be revoked on an unauthenticated connection',
+        () async {
+      String enrollmentRequest = 'enroll:revoke:enrollmentid:123';
+      HashMap<String, String?> verbParams =
+          getVerbParam(VerbSyntax.enroll, enrollmentRequest);
+      inboundConnection.getMetaData().isAuthenticated = false;
+      inboundConnection.getMetaData().sessionID = 'dummy_session';
+      Response response = Response();
+      EnrollVerbHandler enrollVerbHandler =
+          EnrollVerbHandler(secondaryKeyStore);
+      expect(
+          () async => await enrollVerbHandler.processVerb(
+              response, verbParams, inboundConnection),
+          throwsA(predicate((dynamic e) =>
+              e is UnAuthenticatedException &&
+              e.message == 'Cannot revoke enrollment without authentication')));
+    });
+
+    test('A test to verify enrollment request without totp throws exception',
+        () async {
+      String enrollmentRequest =
+          'enroll:request:appname:wavi:devicename:mydevice:namespaces:[wavi,r]:apkampublickey:dummy_apkam_public_key';
+      HashMap<String, String?> verbParams =
+          getVerbParam(VerbSyntax.enroll, enrollmentRequest);
+      inboundConnection.getMetaData().isAuthenticated = false;
+      inboundConnection.getMetaData().sessionID = 'dummy_session';
+      Response response = Response();
+      EnrollVerbHandler enrollVerbHandler =
+          EnrollVerbHandler(secondaryKeyStore);
+      await enrollVerbHandler.processVerb(
+          response, verbParams, inboundConnection);
+      expect(response.isError, true);
+    });
+    tearDown(() async => await verbTestsTearDown());
+  });
+
+  group('A group of tests related to enrollment authorization', () {
+    setUp(() async {
+      await verbTestsSetUp();
+    });
+
+    test(
+        'A test to verify delete verb is not allowed when enrollment is not authorized for write operations',
+        () async {
+      String enrollmentRequest =
+          'enroll:request:appname:wavi:devicename:mydevice:namespaces:[wavi,r]:apkampublickey:dummy_apkam_public_key';
+      HashMap<String, String?> verbParams =
+          getVerbParam(VerbSyntax.enroll, enrollmentRequest);
+      inboundConnection.getMetaData().isAuthenticated = true;
+      inboundConnection.getMetaData().sessionID = 'dummy_session';
+      Response response = Response();
+      EnrollVerbHandler enrollVerbHandler =
+          EnrollVerbHandler(secondaryKeyStore);
+      await enrollVerbHandler.processVerb(
+          response, verbParams, inboundConnection);
+      String enrollmentId = jsonDecode(response.data!)['enrollmentId'];
+      (inboundConnection.getMetaData() as InboundConnectionMetadata)
+          .enrollApprovalId = enrollmentId;
+
+      String deleteCommand = 'delete:dummykey.wavi$alice';
+      HashMap<String, String?> deleteVerbParams =
+          getVerbParam(VerbSyntax.delete, deleteCommand);
+      DeleteVerbHandler deleteVerbHandler =
+          DeleteVerbHandler(secondaryKeyStore, statsNotificationService);
+      expect(
+          () async => await deleteVerbHandler.processVerb(
+              response, deleteVerbParams, inboundConnection),
+          throwsA(predicate((dynamic e) =>
+              e is UnAuthorizedException &&
+              e.message ==
+                  'Enrollment Id: $enrollmentId is not authorized for delete operation on the key: dummykey.wavi@alice')));
+    });
+
+    test(
+        'A test to verify update verb is not allowed when enrollment is not authorized for write operations',
+        () async {
+      String enrollmentRequest =
+          'enroll:request:appname:wavi:devicename:mydevice:namespaces:[wavi,r]:apkampublickey:dummy_apkam_public_key';
+      HashMap<String, String?> verbParams =
+          getVerbParam(VerbSyntax.enroll, enrollmentRequest);
+      inboundConnection.getMetaData().isAuthenticated = true;
+      inboundConnection.getMetaData().sessionID = 'dummy_session';
+      Response response = Response();
+      EnrollVerbHandler enrollVerbHandler =
+          EnrollVerbHandler(secondaryKeyStore);
+      await enrollVerbHandler.processVerb(
+          response, verbParams, inboundConnection);
+      String enrollmentId = jsonDecode(response.data!)['enrollmentId'];
+      (inboundConnection.getMetaData() as InboundConnectionMetadata)
+          .enrollApprovalId = enrollmentId;
+
+      String updateCommand = 'update:$alice:dummykey.wavi$alice dummyValue';
+      HashMap<String, String?> updateVerbParams =
+          getVerbParam(VerbSyntax.update, updateCommand);
+      UpdateVerbHandler updateVerbHandler = UpdateVerbHandler(
+          secondaryKeyStore, statsNotificationService, notificationManager);
+      expect(
+          () async => await updateVerbHandler.processVerb(
+              response, updateVerbParams, inboundConnection),
+          throwsA(predicate((dynamic e) =>
+              e is UnAuthorizedException &&
+              e.message ==
+                  'Enrollment Id: $enrollmentId is not authorized for update operation on the key: @alice:dummykey.wavi@alice')));
+    });
+    tearDown(() async => await verbTestsTearDown());
+  });
+
+  group('A group of tests related to enroll revoke operations', () {
+    setUp(() async {
+      await verbTestsSetUp();
+    });
+    test(
+        'A test to verify revoke operations thrown exception when given enrollmentId is not in keystore',
+        () async {
+      String enrollmentRequest = 'enroll:revoke:enrollmentid:123';
+      HashMap<String, String?> verbParams =
+          getVerbParam(VerbSyntax.enroll, enrollmentRequest);
+      inboundConnection.getMetaData().isAuthenticated = true;
+      inboundConnection.getMetaData().sessionID = 'dummy_session';
+      (inboundConnection.getMetaData() as InboundConnectionMetadata)
+          .enrollApprovalId = '123';
+      Response response = Response();
+      EnrollVerbHandler enrollVerbHandler =
+          EnrollVerbHandler(secondaryKeyStore);
+      await enrollVerbHandler.processVerb(
+          response, verbParams, inboundConnection);
+      expect(response.isError, true);
+      expect(response.errorMessage,
+          'Exception: enrollment id: 123 not found in keystore');
+    });
+    tearDown(() async => await verbTestsTearDown());
   });
 }

--- a/packages/at_secondary_server/test/enroll_data_store_value_test.dart
+++ b/packages/at_secondary_server/test/enroll_data_store_value_test.dart
@@ -286,9 +286,12 @@ void main() {
       Response response = Response();
       EnrollVerbHandler enrollVerbHandler =
           EnrollVerbHandler(secondaryKeyStore);
-      await enrollVerbHandler.processVerb(
-          response, verbParams, inboundConnection);
-      expect(response.isError, true);
+      expect(
+          () async => await enrollVerbHandler.processVerb(
+              response, verbParams, inboundConnection),
+          throwsA(predicate((dynamic e) =>
+              e is AtEnrollmentException &&
+              e.message == 'invalid totp. Cannot process enroll request')));
     });
     tearDown(() async => await verbTestsTearDown());
   });
@@ -381,11 +384,12 @@ void main() {
       Response response = Response();
       EnrollVerbHandler enrollVerbHandler =
           EnrollVerbHandler(secondaryKeyStore);
-      await enrollVerbHandler.processVerb(
-          response, verbParams, inboundConnection);
-      expect(response.isError, true);
-      expect(response.errorMessage,
-          'Exception: enrollment id: 123 not found in keystore');
+      expect(
+          () async => await enrollVerbHandler.processVerb(
+              response, verbParams, inboundConnection),
+          throwsA(predicate((dynamic e) =>
+              e is AtEnrollmentException &&
+              e.message == 'enrollment id: 123 not found in keystore')));
     });
     tearDown(() async => await verbTestsTearDown());
   });

--- a/packages/at_secondary_server/test/test_utils.dart
+++ b/packages/at_secondary_server/test/test_utils.dart
@@ -104,8 +104,9 @@ verbTestsSetUp() async {
 
   mockOutboundConnection = MockOutboundConnection();
   mockOutboundConnectionFactory = MockOutboundConnectionFactory();
-  when(() => mockOutboundConnectionFactory.createOutboundConnection(
-      bobHost, bobPort, bob)).thenAnswer((invocation) async {
+  when(() =>
+      mockOutboundConnectionFactory.createOutboundConnection(
+          bobHost, bobPort, bob)).thenAnswer((invocation) async {
     return mockOutboundConnection;
   });
 
@@ -135,13 +136,13 @@ verbTestsSetUp() async {
     return outboundClientWithHandshake;
   });
   when(() =>
-          mockOutboundClientManager.getClient(bob, any(), isHandShake: false))
+      mockOutboundClientManager.getClient(bob, any(), isHandShake: false))
       .thenAnswer((_) {
     return outboundClientWithoutHandshake;
   });
 
   AtConnectionMetaData outboundConnectionMetadata =
-      OutboundConnectionMetadata();
+  OutboundConnectionMetadata();
   outboundConnectionMetadata.sessionID = 'mock-session-id';
   when(() => mockOutboundConnection.getMetaData())
       .thenReturn(outboundConnectionMetadata);
@@ -153,9 +154,10 @@ verbTestsSetUp() async {
       .thenAnswer((_) => mockSecureSocket);
   when(() => mockOutboundConnection.close()).thenAnswer((_) async => {});
 
-  when(() => mockSecureSocket.listen(any(),
-      onError: any(named: "onError"),
-      onDone: any(named: "onDone"))).thenAnswer((Invocation invocation) {
+  when(() =>
+      mockSecureSocket.listen(any(),
+          onError: any(named: "onError"),
+          onDone: any(named: "onDone"))).thenAnswer((Invocation invocation) {
     socketOnDataFn = invocation.positionalArguments[0];
     socketOnDoneFn = invocation.namedArguments[#onDone];
     socketOnErrorFn = invocation.namedArguments[#onError];
@@ -166,12 +168,22 @@ verbTestsSetUp() async {
   cacheManager =
       AtCacheManager(alice, secondaryKeyStore, mockOutboundClientManager);
 
-  AtSecondaryServerImpl.getInstance().cacheManager = cacheManager;
-  AtSecondaryServerImpl.getInstance().secondaryKeyStore = secondaryKeyStore;
-  AtSecondaryServerImpl.getInstance().outboundClientManager =
+  AtSecondaryServerImpl
+      .getInstance()
+      .cacheManager = cacheManager;
+  AtSecondaryServerImpl
+      .getInstance()
+      .secondaryKeyStore = secondaryKeyStore;
+  AtSecondaryServerImpl
+      .getInstance()
+      .outboundClientManager =
       mockOutboundClientManager;
-  AtSecondaryServerImpl.getInstance().currentAtSign = alice;
-  AtSecondaryServerImpl.getInstance().signingKey =
+  AtSecondaryServerImpl
+      .getInstance()
+      .currentAtSign = alice;
+  AtSecondaryServerImpl
+      .getInstance()
+      .signingKey =
       bobServerSigningKeypair.privateKey.toString();
 
   DateTime now = DateTime.now().toUtcMillisecondsPrecision();
@@ -191,8 +203,8 @@ verbTestsSetUp() async {
   when(() => mockOutboundConnection.write(any()))
       .thenAnswer((Invocation invocation) async {
     socketOnDataFn('error:AT0001-Mock exception : '
-            'No mock response defined for request '
-            '[${invocation.positionalArguments[0]}]\n$alice@'
+        'No mock response defined for request '
+        '[${invocation.positionalArguments[0]}]\n$alice@'
         .codeUnits);
   });
   when(() => mockOutboundConnection.write('from:$alice\n'))
@@ -219,7 +231,7 @@ verbTestsSetUp() async {
       .thenAnswer((invocation) {});
 }
 
-verbTestsTearDown() async {
+Future<void> verbTestsTearDown() async {
   await SecondaryPersistenceStoreFactory.getInstance().close();
   await AtCommitLogManagerImpl.getInstance().close();
   var isExists = await Directory(storageDir).exists();
@@ -344,9 +356,10 @@ bool createRandomBoolean() {
 
 const String characters =
     '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_';
+
 String createRandomString(int length) {
   return String.fromCharCodes(Iterable.generate(
       length,
-      (index) =>
+          (index) =>
           characters.codeUnitAt(testUtilsRandom.nextInt(characters.length))));
 }

--- a/tests/at_functional_test/test/enroll_namespace_access_test.dart
+++ b/tests/at_functional_test/test/enroll_namespace_access_test.dart
@@ -171,7 +171,7 @@ void main() {
       var llookupResponse = await read();
       print(llookupResponse);
       expect(llookupResponse,
-          'error:AT0009-UnAuthorized client in request : Enrollment Id: $enrollmentId is not authorized for local lookup operation\n');
+          'error:AT0009-UnAuthorized client in request : Enrollment Id: $enrollmentId is not authorized for local lookup operation on the key: firstcontact.atmosphere$firstAtsign\n');
     });
 
     // Prerequisite - create a public atmosphere key
@@ -544,7 +544,7 @@ void main() {
       var deleteResponse = await read();
       print(deleteResponse);
       expect(deleteResponse,
-          'error:AT0009-UnAuthorized client in request : Enrollment Id: $enrollmentId is not authorized for delete operation\n');
+          'error:AT0009-UnAuthorized client in request : Enrollment Id: $enrollmentId is not authorized for delete operation on the key: files.atmosphere$firstAtsign\n');
     });
   });
 

--- a/tests/at_functional_test/test/enroll_verb_test.dart
+++ b/tests/at_functional_test/test/enroll_verb_test.dart
@@ -78,7 +78,7 @@ void main() {
           'Exception: invalid totp. Cannot process enroll request');
     });
 
-   // Purpose of the tests
+    // Purpose of the tests
     // 1. Do a pkam authentication
     // 2. Send an enroll request
     //  3 . Get an otp from the first client
@@ -233,6 +233,94 @@ void main() {
       var apkamEnrollIdResponse = await read();
       print(apkamEnrollIdResponse);
       expect(apkamEnrollIdResponse, 'data:success\n');
+    });
+  });
+
+  group('A group of tests related to APKAM revoke operation', () {
+    test('A test to verify enrollment revoke operation', () async {
+      // Send an enrollment request on the authenticated connection
+      await socket_writer(socketConnection1!, 'from:$firstAtsign');
+      var fromResponse = await read();
+      print('from verb response : $fromResponse');
+      fromResponse = fromResponse.replaceAll('data:', '');
+      var pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
+      await socket_writer(socketConnection1!, 'pkam:$pkamDigest');
+      var pkamResult = await read();
+      expect(pkamResult, 'data:success\n');
+      String enrollRequest =
+          'enroll:request:appName:wavi:deviceName:pixel:namespaces:[wavi,rw]:apkamPublicKey:${pkamPublicKeyMap[firstAtsign]!}';
+      await socket_writer(socketConnection1!, enrollRequest);
+      var enrollmentResponse = await read();
+      String enrollmentId = jsonDecode(
+          enrollmentResponse.replaceAll('data:', ''))['enrollmentId'];
+
+      //Create a new connection to login using the APKAM
+      socketConnection2 =
+          await secure_socket_connection(firstAtsignServer, firstAtsignPort);
+      socket_listener(socketConnection2!);
+      await socket_writer(socketConnection2!, 'from:$firstAtsign');
+      fromResponse = await read();
+      print('from verb response : $fromResponse');
+      fromResponse = fromResponse.replaceAll('data:', '');
+      pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
+      String pkamCommand = 'pkam:enrollapprovalid:$enrollmentId:$pkamDigest';
+      await socket_writer(socketConnection2!, pkamCommand);
+      pkamResult = await read();
+      expect(pkamResult, 'data:success\n');
+      socketConnection2?.close();
+
+      // Revoke the enrollment
+      String revokeEnrollmentCommand =
+          'enroll:revoke:enrollmentid:$enrollmentId';
+      await socket_writer(socketConnection1!, revokeEnrollmentCommand);
+      var revokeEnrollmentResponse = await read();
+      var revokeEnrollmentMap =
+          jsonDecode(revokeEnrollmentResponse.replaceAll('data:', ''));
+      expect(revokeEnrollmentMap['status'], 'revoked');
+      expect(revokeEnrollmentMap['enrollmentId'], enrollmentId);
+
+      socketConnection2 =
+          await secure_socket_connection(firstAtsignServer, firstAtsignPort);
+      socket_listener(socketConnection2!);
+      await socket_writer(socketConnection2!, 'from:$firstAtsign');
+      fromResponse = await read();
+      print('from verb response : $fromResponse');
+      fromResponse = fromResponse.replaceAll('data:', '');
+      pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
+      pkamCommand = 'pkam:enrollapprovalid:$enrollmentId:$pkamDigest';
+      await socket_writer(socketConnection2!, pkamCommand);
+      pkamResult = await read();
+      socketConnection2?.close();
+      expect(pkamResult.contains('$enrollmentId is not approved'), true);
+    });
+
+    test(
+        'A test to verify revoke operation cannot be performed on an unauthenticated connection',
+        () async {
+      // Send an enrollment request on the authenticated connection
+      await socket_writer(socketConnection1!, 'from:$firstAtsign');
+      var fromResponse = await read();
+      print('from verb response : $fromResponse');
+      fromResponse = fromResponse.replaceAll('data:', '');
+      var pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
+      await socket_writer(socketConnection1!, 'pkam:$pkamDigest');
+      var pkamResult = await read();
+      expect(pkamResult, 'data:success\n');
+      String enrollRequest =
+          'enroll:request:appName:wavi:deviceName:pixel:namespaces:[wavi,rw]:apkamPublicKey:${pkamPublicKeyMap[firstAtsign]!}';
+      await socket_writer(socketConnection1!, enrollRequest);
+      var enrollmentResponse = await read();
+      String enrollmentId = jsonDecode(
+          enrollmentResponse.replaceAll('data:', ''))['enrollmentId'];
+
+      socketConnection2 =
+          await secure_socket_connection(firstAtsignServer, firstAtsignPort);
+      socket_listener(socketConnection2!);
+      String revokeEnrollmentCommand =
+          'enroll:revoke:enrollmentid:$enrollmentId';
+      await socket_writer(socketConnection2!, revokeEnrollmentCommand);
+      var revokeEnrollmentResponse = await read();
+      expect(revokeEnrollmentResponse.trim(), 'error:AT0401-Exception: Cannot revoke enrollment without authentication');
     });
   });
 }

--- a/tests/at_functional_test/test/enroll_verb_test.dart
+++ b/tests/at_functional_test/test/enroll_verb_test.dart
@@ -58,11 +58,11 @@ void main() {
       await socket_writer(socketConnection1!, enrollRequest);
       var enrollResponse = await read();
       print(enrollResponse);
-      enrollResponse = enrollResponse.replaceFirst('data:', '');
-      var enrollJsonMap = jsonDecode(enrollResponse);
-      expect(enrollJsonMap['status'], 'exception');
-      expect(enrollJsonMap['reason'],
-          'Exception: invalid totp. Cannot process enroll request');
+      enrollResponse = enrollResponse.replaceFirst('error:', '');
+      expect(
+          enrollResponse
+              .contains('invalid totp. Cannot process enroll request'),
+          true);
     });
 
     test('enroll request on unauthenticated connection invalid totp', () async {
@@ -72,10 +72,10 @@ void main() {
       var enrollResponse = await read();
       print(enrollResponse);
       enrollResponse = enrollResponse.replaceFirst('data:', '');
-      var enrollJsonMap = jsonDecode(enrollResponse);
-      expect(enrollJsonMap['status'], 'exception');
-      expect(enrollJsonMap['reason'],
-          'Exception: invalid totp. Cannot process enroll request');
+      expect(
+          enrollResponse
+              .contains('invalid totp. Cannot process enroll request'),
+          true);
     });
 
     // Purpose of the tests
@@ -320,7 +320,8 @@ void main() {
           'enroll:revoke:enrollmentid:$enrollmentId';
       await socket_writer(socketConnection2!, revokeEnrollmentCommand);
       var revokeEnrollmentResponse = await read();
-      expect(revokeEnrollmentResponse.trim(), 'error:AT0401-Exception: Cannot revoke enrollment without authentication');
+      expect(revokeEnrollmentResponse.trim(),
+          'error:AT0401-Exception: Cannot revoke enrollment without authentication');
     });
   });
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Add `revoked` operation in the `EnrollStatus` .
- Verify if an enrollment is authorized to perform operation. If yes, allow the operation else throw `UnAuthorizedException`.
- Add `revoke` functionality in the `enroll_verb_handler.dart`
- Refactor the `enroll_verb_handler.dart` as follows:
  - Move the logic of enrollment request, approval/deny/revoke into private method.

**- How to verify it**
- Added unit tests enrollment list operations
- Unit tests to verify if an enrollment is authorized to perform operations
- Added negative tests to ensure the enrollment approval/deny/revoke cannot be performed on an unauthenticated connection
- Added functional tests related to enrollment revoke functionality

**- Description for the changelog**
- Add revoke operation to enroll verb
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->