### PR TITLE
feat:Apkam spec changes and keys verb impl

### DIFF
--- a/packages/at_secondary_server/lib/src/connection/inbound/inbound_connection_metadata.dart
+++ b/packages/at_secondary_server/lib/src/connection/inbound/inbound_connection_metadata.dart
@@ -25,5 +25,5 @@ class InboundConnectionMetadata extends AtConnectionMetaData {
   String? platform;
 
   /// A unique identifier generated for a client's APKAM enroll request
-  String? enrollApprovalId;
+  String? enrollmentId;
 }

--- a/packages/at_secondary_server/lib/src/constants/enroll_constants.dart
+++ b/packages/at_secondary_server/lib/src/constants/enroll_constants.dart
@@ -1,2 +1,3 @@
 const String enrollManageNamespace = '__manage';
 const String newEnrollmentKeyPattern = 'new.enrollments';
+const String pkamNamespace = '__pkams';

--- a/packages/at_secondary_server/lib/src/constants/enroll_constants.dart
+++ b/packages/at_secondary_server/lib/src/constants/enroll_constants.dart
@@ -1,3 +1,4 @@
 const String enrollManageNamespace = '__manage';
 const String newEnrollmentKeyPattern = 'new.enrollments';
 const String pkamNamespace = '__pkams';
+const String globalNamespace = '__global';

--- a/packages/at_secondary_server/lib/src/enroll/enroll_datastore_value.dart
+++ b/packages/at_secondary_server/lib/src/enroll/enroll_datastore_value.dart
@@ -8,7 +8,9 @@ class EnrollDataStoreValue {
   late String sessionId;
   late String appName;
   late String deviceName;
-  List<EnrollNamespace> namespaces = [];
+  // map for representing namespace access. key will be the namespace, value will be the access
+  // e.g {'wavi':'r', 'buzz':'rw'}
+  Map<String, String> namespaces = {};
   late String apkamPublicKey;
   EnrollRequestType? requestType;
   EnrollApproval? approval;
@@ -19,24 +21,6 @@ class EnrollDataStoreValue {
       _$EnrollDataStoreValueFromJson(json);
 
   Map<String, dynamic> toJson() => _$EnrollDataStoreValueToJson(this);
-}
-
-class EnrollNamespace {
-  String name;
-  String access;
-  EnrollNamespace(this.name, this.access);
-  EnrollNamespace.fromJson(Map<String, dynamic> json)
-      : name = json['name'],
-        access = json['access'];
-  Map<String, dynamic> toJson() => {
-        'name': name,
-        'access': access,
-      };
-
-  @override
-  String toString() {
-    return '{name: $name, access: $access}';
-  }
 }
 
 class EnrollApproval {

--- a/packages/at_secondary_server/lib/src/enroll/enroll_datastore_value.g.dart
+++ b/packages/at_secondary_server/lib/src/enroll/enroll_datastore_value.g.dart
@@ -1,6 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// dart run build_runner build - to generate this file
-
+// dart run build_runner build to generate this file
 part of 'enroll_datastore_value.dart';
 
 // **************************************************************************
@@ -15,9 +14,7 @@ EnrollDataStoreValue _$EnrollDataStoreValueFromJson(
       json['deviceName'] as String,
       json['apkamPublicKey'] as String,
     )
-      ..namespaces = (json['namespaces'] as List<dynamic>)
-          .map((e) => EnrollNamespace.fromJson(e as Map<String, dynamic>))
-          .toList()
+      ..namespaces = Map<String, String>.from(json['namespaces'] as Map)
       ..requestType =
           $enumDecodeNullable(_$EnrollRequestTypeEnumMap, json['requestType'])
       ..approval = json['approval'] == null

--- a/packages/at_secondary_server/lib/src/exception/global_exception_handler.dart
+++ b/packages/at_secondary_server/lib/src/exception/global_exception_handler.dart
@@ -63,6 +63,7 @@ class GlobalExceptionHandler {
         exception is HandShakeException ||
         exception is UnAuthenticatedException ||
         exception is UnAuthorizedException ||
+        exception is AtEnrollmentException ||
         exception is OutBoundConnectionInvalidException ||
         exception is KeyNotFoundException ||
         exception is AtConnectException ||

--- a/packages/at_secondary_server/lib/src/verb/handler/abstract_update_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/abstract_update_verb_handler.dart
@@ -67,7 +67,7 @@ abstract class AbstractUpdateVerbHandler extends ChangeVerbHandler {
 
     final enrollApprovalId =
         (atConnection.getMetaData() as InboundConnectionMetadata)
-            .enrollApprovalId;
+            .enrollmentId;
     bool isAuthorized = true; // for legacy clients allow access by default
     if (enrollApprovalId != null) {
       if (atKey.contains('.')) {

--- a/packages/at_secondary_server/lib/src/verb/handler/abstract_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/abstract_verb_handler.dart
@@ -134,7 +134,9 @@ abstract class AbstractVerbHandler implements VerbHandler {
 
     logger.finer(
         'keyNamespace: $keyNamespace enrollNamespaces: $enrollNamespaces');
-    if (enrollNamespaces.containsKey(keyNamespace)) {
+    // keys in __manage namespace should not be accessible
+    if (keyNamespace != enrollManageNamespace &&
+        enrollNamespaces.containsKey(keyNamespace)) {
       var access = enrollNamespaces[keyNamespace];
       logger.finer('current verb: ${getVerb()}');
       if (getVerb() is LocalLookup || getVerb() is Lookup) {

--- a/packages/at_secondary_server/lib/src/verb/handler/abstract_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/abstract_verb_handler.dart
@@ -114,6 +114,12 @@ abstract class AbstractVerbHandler implements VerbHandler {
   Future<bool> isAuthorized(
       String enrollApprovalId, String keyNamespace) async {
     EnrollDataStoreValue enrollDataStoreValue;
+    // global/manage namespace can be accessed only by keys: verb.
+    // Restrict other verbs access
+    if (keyNamespace == globalNamespace ||
+        keyNamespace == enrollManageNamespace) {
+      return false;
+    }
     final enrollmentKey =
         '$enrollApprovalId.$newEnrollmentKeyPattern.$enrollManageNamespace';
     try {

--- a/packages/at_secondary_server/lib/src/verb/handler/delete_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/delete_verb_handler.dart
@@ -82,7 +82,7 @@ class DeleteVerbHandler extends ChangeVerbHandler {
     }
     final enrollApprovalId =
         (atConnection.getMetaData() as InboundConnectionMetadata)
-            .enrollApprovalId;
+            .enrollmentId;
     bool isAuthorized = true; // for legacy clients allow access by default
     if (enrollApprovalId != null) {
       isAuthorized = await super.isAuthorized(enrollApprovalId, keyNamespace);

--- a/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
@@ -106,13 +106,17 @@ class EnrollVerbHandler extends AbstractVerbHandler {
       responseJson['status'] = 'success';
       // Store default encryption private key and self encryption key(both encrypted)
       // for future retrieval during approval flow
+      var privKeyJson = {};
+      privKeyJson['value'] = enrollParams.encryptedDefaultEncryptedPrivateKey;
       await keyStore.put(
           '$enrollmentId.$defaultEncryptionPrivateKey.$enrollManageNamespace$currentAtSign',
-          AtData()..data = enrollParams.encryptedDefaultEncryptedPrivateKey,
+          AtData()..data = jsonEncode(privKeyJson),
           skipCommit: true);
+      var selfKeyJson = {};
+      selfKeyJson['value'] = enrollParams.encryptedDefaultSelfEncryptionKey;
       await keyStore.put(
           '$enrollmentId.$defaultSelfEncryptionKey.$enrollManageNamespace$currentAtSign',
-          AtData()..data = enrollParams.encryptedDefaultSelfEncryptionKey,
+          AtData()..data = jsonEncode(selfKeyJson),
           skipCommit: true);
       // store this apkam as default pkam public key for old clients
       await keyStore.put(

--- a/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
@@ -107,6 +107,9 @@ class EnrollVerbHandler extends AbstractVerbHandler {
       enrollNamespaces[enrollManageNamespace] = 'rw';
       enrollmentValue.approval = EnrollApproval(EnrollStatus.approved.name);
       responseJson['status'] = 'success';
+      final inboundConnectionMetadata =
+      atConnection.getMetaData() as InboundConnectionMetadata;
+      inboundConnectionMetadata.enrollApprovalId = newEnrollmentId;
       // Store default encryption private key and self encryption key(both encrypted)
       // for future retrieval
       await _storeEncryptionKeys(newEnrollmentId, enrollParams, currentAtSign);

--- a/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
@@ -109,7 +109,7 @@ class EnrollVerbHandler extends AbstractVerbHandler {
       responseJson['status'] = 'success';
       final inboundConnectionMetadata =
       atConnection.getMetaData() as InboundConnectionMetadata;
-      inboundConnectionMetadata.enrollApprovalId = newEnrollmentId;
+      inboundConnectionMetadata.enrollmentId = newEnrollmentId;
       // Store default encryption private key and self encryption key(both encrypted)
       // for future retrieval
       await _storeEncryptionKeys(newEnrollmentId, enrollParams, currentAtSign);
@@ -208,7 +208,7 @@ class EnrollVerbHandler extends AbstractVerbHandler {
     Map<String, Map<String, dynamic>> enrollmentRequestsMap = {};
     String? enrollApprovalId =
         (atConnection.getMetaData() as InboundConnectionMetadata)
-            .enrollApprovalId;
+            .enrollmentId;
     List<String> enrollmentKeysList =
         keyStore.getKeys(regex: newEnrollmentKeyPattern) as List<String>;
     // If connection is authenticated via legacy PKAM, then enrollApprovalId is null.

--- a/packages/at_secondary_server/lib/src/verb/handler/info_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/info_verb_handler.dart
@@ -46,7 +46,7 @@ class InfoVerbHandler extends AbstractVerbHandler {
     if (verbParams[paramFullCommandAsReceived] == 'info') {
       String uptimeAsWords = durationToWords(uptime);
       infoMap['uptimeAsWords'] = uptimeAsWords;
-      final enrollApprovalId = atConnectionMetadata.enrollApprovalId;
+      final enrollApprovalId = atConnectionMetadata.enrollmentId;
       if (atConnectionMetadata.isAuthenticated && enrollApprovalId != null) {
         apkamMetadataKey =
             '$enrollApprovalId.$newEnrollmentKeyPattern.$enrollManageNamespace$atSign';

--- a/packages/at_secondary_server/lib/src/verb/handler/keys_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/keys_verb_handler.dart
@@ -40,7 +40,7 @@ class KeysVerbHandler extends AbstractVerbHandler {
     bool hasManageAccess = false;
     var connectionMetadata =
         atConnection.getMetaData() as InboundConnectionMetadata;
-    final enrollIdFromMetadata = connectionMetadata.enrollApprovalId;
+    final enrollIdFromMetadata = connectionMetadata.enrollmentId;
     logger.finer('enrollIdFromMetadata:$enrollIdFromMetadata');
     final key =
         '$enrollIdFromMetadata.$newEnrollmentKeyPattern.$enrollManageNamespace';
@@ -76,27 +76,16 @@ class KeysVerbHandler extends AbstractVerbHandler {
           // update the key in data store
           final atData = AtData();
           atData.data = jsonEncode(valueJson);
-          var result;
-          // for backward compatibility, store the default encryption public key as ref key to public:publickey
-          // for now skip commit log for keys created through this verb. If we update/create other keys in the future e.g publickey@alice, @bob:shared_key@alice, change the impl
-          if (keyVisibility == 'public') {
-            final publicKeyName = _getPublicKeyName(verbParams, atSign);
-            result =
-                await keyStore.put(publicKeyName, atData, skipCommit: true);
-            logger.finer('publicKeyName:$publicKeyName');
-          } else if (keyVisibility == 'private') {
-            final privateKeyName = _getPrivateKeyName(verbParams, atSign);
-            logger.finer('privateKeyName:$privateKeyName');
+          dynamic result;
+          var keyName = _getKeyName(verbParams, atSign, keyVisibility);
+
+          if (keyName != null) {
+            logger.finer('keyName:$keyName');
             valueJson['encryptionKeyName'] = verbParams[encryptionKeyName];
             atData.data = jsonEncode(valueJson);
-            result =
-                await keyStore.put(privateKeyName, atData, skipCommit: true);
-          } else if (keyVisibility == 'self') {
-            final selfKeyName = _getSelfKeyName(verbParams, atSign);
-            logger.finer('selfKeyName:$selfKeyName');
-            valueJson['encryptionKeyName'] = verbParams[encryptionKeyName];
-            atData.data = jsonEncode(valueJson);
-            result = await keyStore.put(selfKeyName, atData, skipCommit: true);
+            // for now skip commit log for keys created through this verb.
+            // If we update/create other keys in the future e.g publickey@alice, @bob:shared_key@alice, change the impl
+            result = await keyStore.put(keyName, atData, skipCommit: true);
           }
           response.data = result.toString();
         } catch (e, st) {
@@ -108,12 +97,11 @@ class KeysVerbHandler extends AbstractVerbHandler {
         final keyNameFromParams = verbParams[keyName];
         logger.finer('keyVisibility: $keyVisibility');
         logger.finer('keyNameFromParams: $keyNameFromParams');
-        var result;
+        List<dynamic> result;
         final filteredKeys = [];
         if (keyNameFromParams != null && keyNameFromParams.isNotEmpty) {
-          var value;
           try {
-            value = await keyStore.get(keyNameFromParams);
+            final value = await keyStore.get(keyNameFromParams);
             response.data = value.data;
             break;
           } on KeyNotFoundException {
@@ -121,30 +109,37 @@ class KeysVerbHandler extends AbstractVerbHandler {
                 'key $keyNameFromParams not found in keystore');
           }
         }
-        if (hasManageAccess) {
-          result = await keyStore.getKeys(
-              regex:
-                  '.*$keyVisibility.*__global$atSign\$|.*$keyVisibility.*__manage$atSign\$');
-          logger.finer('get keys result:$result');
+        if (keyVisibility != null && keyVisibility.isNotEmpty) {
+          if (hasManageAccess) {
+            result = keyStore.getKeys(
+                regex:
+                    '.*$keyVisibility.*__global$atSign\$|.*$keyVisibility.*__manage$atSign\$');
+          } else {
+            result = keyStore.getKeys(
+                regex: '.*__${keyVisibility}_keys.__global$atSign\$');
 
-          for (String key in result) {
-            filteredKeys.add(key);
-          }
-          response.data = jsonEncode(filteredKeys);
-        } else {
-          if (keyVisibility == 'private') {
-            final value = await keyStore.get(
-                '$enrollIdFromMetadata.$defaultEncryptionPrivateKey.$enrollManageNamespace$atSign');
-            if (value != null && value.data != null) {
-              filteredKeys.add(
-                  '$enrollIdFromMetadata.$defaultEncryptionPrivateKey.$enrollManageNamespace$atSign');
+            for (String key in result) {
+              await _addKeyIfEnrollmentIdMatches(
+                  filteredKeys, key, enrollIdFromMetadata!);
             }
-          } else if (keyVisibility == 'self') {
-            final value = await keyStore.get(
-                '$enrollIdFromMetadata.$defaultSelfEncryptionKey.$enrollManageNamespace$atSign');
-            if (value != null && value.data != null) {
-              filteredKeys.add(
-                  '$enrollIdFromMetadata.$defaultSelfEncryptionKey.$enrollManageNamespace$atSign');
+            var keyMap = {
+              'private':
+                  '$enrollIdFromMetadata.$defaultEncryptionPrivateKey.$enrollManageNamespace\$atSign',
+              'self':
+                  '$enrollIdFromMetadata.$defaultSelfEncryptionKey.$enrollManageNamespace\$atSign',
+            };
+
+            var keyString = keyMap[keyVisibility];
+            if (keyString != null) {
+              dynamic value;
+              try {
+                value = await keyStore.get(keyString);
+              } on KeyNotFoundException {
+                logger.warning('key $keyString not found');
+              }
+              if (value != null && value.data != null) {
+                filteredKeys.add(keyString);
+              }
             }
           }
           response.data = jsonEncode(filteredKeys);
@@ -158,6 +153,30 @@ class KeysVerbHandler extends AbstractVerbHandler {
                 .toString();
         break;
     }
+  }
+
+  // Function to add a key to filteredKeys if enrollmentId matches
+  Future<void> _addKeyIfEnrollmentIdMatches(List<dynamic> filteredKeys,
+      String key, String enrollIdFromMetadata) async {
+    final value = await keyStore.get(key);
+    if (value != null && value.data != null) {
+      final valueJson = jsonDecode(value.data);
+      if (valueJson[enrollmentId] == enrollIdFromMetadata) {
+        filteredKeys.add(key);
+      }
+    }
+  }
+
+  String? _getKeyName(HashMap<String, String?> verbParams, String atSign,
+      String? keyVisibility) {
+    if (keyVisibility == 'public') {
+      return _getPublicKeyName(verbParams, atSign);
+    } else if (keyVisibility == 'private') {
+      return _getPrivateKeyName(verbParams, atSign);
+    } else if (keyVisibility == 'self') {
+      return _getSelfKeyName(verbParams, atSign);
+    }
+    return null;
   }
 
   String _getPublicKeyName(HashMap<String, String?> verbParams, String atSign) {

--- a/packages/at_secondary_server/lib/src/verb/handler/keys_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/keys_verb_handler.dart
@@ -1,0 +1,180 @@
+import 'dart:collection';
+import 'dart:convert';
+
+import 'package:at_commons/at_commons.dart';
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_secondary/src/connection/inbound/inbound_connection_metadata.dart';
+import 'package:at_secondary/src/constants/enroll_constants.dart';
+import 'package:at_secondary/src/enroll/enroll_datastore_value.dart';
+import 'package:at_secondary/src/server/at_secondary_impl.dart';
+import 'package:at_secondary/src/verb/handler/abstract_verb_handler.dart';
+import 'package:at_server_spec/at_server_spec.dart';
+import 'package:at_server_spec/at_verb_spec.dart';
+
+class KeysVerbHandler extends AbstractVerbHandler {
+  static Keys keys = Keys();
+
+  KeysVerbHandler(SecondaryKeyStore keyStore) : super(keyStore);
+
+  // Method to verify whether command is accepted or not
+  // Input: command
+  @override
+  bool accept(String command) => command.startsWith('keys:');
+
+  // Method to return Instance of verb belongs to this VerbHandler
+  @override
+  Verb getVerb() {
+    return keys;
+  }
+
+  // Method which will process update Verb
+  // This will process given verb and write response to response object
+  // Input : Response, verbParams, AtConnection
+  @override
+  Future<void> processVerb(
+      Response response,
+      HashMap<String, String?> verbParams,
+      InboundConnection atConnection) async {
+    final keyVisibility = verbParams[visibility];
+    final atSign = AtSecondaryServerImpl.getInstance().currentAtSign;
+    var connectionMetadata =
+        atConnection.getMetaData() as InboundConnectionMetadata;
+    final enrollIdFromMetadata = connectionMetadata.enrollApprovalId;
+    final key =
+        '$enrollIdFromMetadata.$newEnrollmentKeyPattern.$enrollManageNamespace';
+    var enrollData;
+    try {
+      enrollData = await keyStore.get('$key$atSign');
+    } on KeyNotFoundException {
+      logger.warning('enrollment key not found in keystore $key');
+      throw AtEnrollmentException(
+          'Enrollment Id $enrollIdFromMetadata not found in keystore');
+    }
+    if (enrollData != null) {
+      final enrollDataStoreValue =
+          EnrollDataStoreValue.fromJson(jsonDecode(enrollData.data));
+      if (enrollDataStoreValue.approval!.state != 'approved') {
+        throw AtEnrollmentException(
+            'Enrollment Id $enrollmentId is not approved. current state :${enrollDataStoreValue.approval!.state}');
+      }
+    }
+    final value = verbParams[keyValue];
+    final valueJson = {};
+    valueJson['value'] = value;
+    valueJson['keyType'] = verbParams[keyType];
+    valueJson[enrollmentId] = enrollIdFromMetadata;
+    final operation = verbParams[AT_OPERATION];
+    switch (operation) {
+      case 'put':
+        try {
+          logger.finer('value:$valueJson');
+          // update the key in data store
+          final atData = AtData();
+          atData.data = jsonEncode(valueJson);
+          var result;
+          // for backward compatibility, store the default encryption public key as ref key to public:publickey
+          // for now skip commit log for keys created through this verb. If we update/create other keys in the future e.g publickey@alice, @bob:shared_key@alice, change the impl
+          if (keyVisibility == 'public') {
+            final publicKeyName = _getPublicKeyName(verbParams, atSign);
+            result =
+                await keyStore.put(publicKeyName, atData, skipCommit: true);
+            logger.finer('publicKeyName:$publicKeyName');
+          } else if (keyVisibility == 'private') {
+            final privateKeyName = _getPrivateKeyName(verbParams, atSign);
+            logger.finer('privateKeyName:$privateKeyName');
+            valueJson['encryptionKeyName'] = verbParams[encryptionKeyName];
+            atData.data = jsonEncode(valueJson);
+            result =
+                await keyStore.put(privateKeyName, atData, skipCommit: true);
+          } else if (keyVisibility == 'self') {
+            final selfKeyName = _getSelfKeyName(verbParams, atSign);
+            logger.finer('selfKeyName:$selfKeyName');
+            valueJson['encryptionKeyName'] = verbParams[encryptionKeyName];
+            atData.data = jsonEncode(valueJson);
+            result = await keyStore.put(selfKeyName, atData, skipCommit: true);
+          }
+          response.data = result.toString();
+        } catch (e, st) {
+          logger.warning('$e\n$st');
+        }
+        break;
+      case 'get':
+        final keyVisibility = verbParams[visibility];
+        final keyNameFromParams = verbParams[keyName];
+        logger.finer('keyVisibility: $keyVisibility');
+        logger.finer('keyNameFromParams: $keyNameFromParams');
+        var result;
+        if (keyVisibility != null && keyVisibility.isNotEmpty) {
+          result = await keyStore.getKeys(
+              regex: '.*$keyVisibility.*__global$atSign\$');
+          logger.finer('get keys result:$result');
+          final filteredKeys = [];
+          // filter values by enrollmentId
+          for (String key in result) {
+            final value = await keyStore.get(key);
+            if (value != null && value.data != null) {
+              final valueJson = jsonDecode(value.data);
+              if (valueJson[enrollmentId] == enrollIdFromMetadata) {
+                filteredKeys.add(key);
+              }
+            }
+          }
+          if (keyVisibility == 'private') {
+            final value = await keyStore.get(
+                '$enrollIdFromMetadata.$defaultEncryptionPrivateKey.$enrollManageNamespace$atSign');
+            if (value != null && value.data != null) {
+              filteredKeys.add(
+                  '$enrollIdFromMetadata.$defaultEncryptionPrivateKey.$enrollManageNamespace$atSign');
+            }
+          } else if (keyVisibility == 'self') {
+            final value = await keyStore.get(
+                '$enrollIdFromMetadata.$defaultSelfEncryptionKey.$enrollManageNamespace$atSign');
+            if (value != null && value.data != null) {
+              filteredKeys.add(
+                  '$enrollIdFromMetadata.$defaultSelfEncryptionKey.$enrollManageNamespace$atSign');
+            }
+          }
+          response.data = jsonEncode(filteredKeys);
+        } else if (keyNameFromParams != null && keyNameFromParams.isNotEmpty) {
+          var value;
+          try {
+            value = await keyStore.get(keyNameFromParams);
+          } on KeyNotFoundException {
+            throw KeyNotFoundException(
+                'key $keyNameFromParams not found in keystore');
+          }
+          if (value != null && value.data != null) {
+            final valueJson = jsonDecode(value.data);
+            if (valueJson[enrollmentId] == enrollIdFromMetadata) {
+              response.data = value.data;
+            } else {
+              throw AtEnrollmentException(
+                  'Enrollment Id for key $keyNameFromParams does not match the current APKAM enrollmentId');
+            }
+          }
+          logger.finer('get key result: $result');
+        }
+        break;
+      case 'delete':
+        final keyNameFromParams = verbParams[keyName];
+        logger.finer('keyNameFromParams: $keyNameFromParams');
+        response.data =
+            (await keyStore.remove(keyNameFromParams, skipCommit: true))
+                .toString();
+        break;
+    }
+  }
+
+  String _getPublicKeyName(HashMap<String, String?> verbParams, String atSign) {
+    return '${verbParams[visibility]}:${verbParams[keyName]}.__${verbParams[visibility]}_keys.${verbParams[namespace]}$atSign';
+  }
+
+  String _getPrivateKeyName(
+      HashMap<String, String?> verbParams, String atSign) {
+    return '${verbParams[visibility]}:${verbParams[APP_NAME]}.${verbParams[deviceName]}.${verbParams[keyName]}.__${verbParams[visibility]}_keys.${verbParams[namespace]}$atSign';
+  }
+
+  String _getSelfKeyName(HashMap<String, String?> verbParams, String atSign) {
+    return '${verbParams[APP_NAME]}.${verbParams[deviceName]}.${verbParams[keyName]}.__${verbParams[visibility]}_keys.${verbParams[namespace]}$atSign';
+  }
+}

--- a/packages/at_secondary_server/lib/src/verb/handler/keys_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/keys_verb_handler.dart
@@ -115,6 +115,7 @@ class KeysVerbHandler extends AbstractVerbHandler {
           try {
             value = await keyStore.get(keyNameFromParams);
             response.data = value.data;
+            break;
           } on KeyNotFoundException {
             throw KeyNotFoundException(
                 'key $keyNameFromParams not found in keystore');

--- a/packages/at_secondary_server/lib/src/verb/handler/keys_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/keys_verb_handler.dart
@@ -124,9 +124,9 @@ class KeysVerbHandler extends AbstractVerbHandler {
             }
             var keyMap = {
               'private':
-                  '$enrollIdFromMetadata.$defaultEncryptionPrivateKey.$enrollManageNamespace\$atSign',
+                  '$enrollIdFromMetadata.$defaultEncryptionPrivateKey.$enrollManageNamespace$atSign',
               'self':
-                  '$enrollIdFromMetadata.$defaultSelfEncryptionKey.$enrollManageNamespace\$atSign',
+                  '$enrollIdFromMetadata.$defaultSelfEncryptionKey.$enrollManageNamespace$atSign',
             };
 
             var keyString = keyMap[keyVisibility];

--- a/packages/at_secondary_server/lib/src/verb/handler/keys_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/keys_verb_handler.dart
@@ -40,6 +40,7 @@ class KeysVerbHandler extends AbstractVerbHandler {
     var connectionMetadata =
         atConnection.getMetaData() as InboundConnectionMetadata;
     final enrollIdFromMetadata = connectionMetadata.enrollApprovalId;
+    logger.finer('enrollIdFromMetadata:$enrollIdFromMetadata');
     final key =
         '$enrollIdFromMetadata.$newEnrollmentKeyPattern.$enrollManageNamespace';
     var enrollData;
@@ -139,20 +140,11 @@ class KeysVerbHandler extends AbstractVerbHandler {
           var value;
           try {
             value = await keyStore.get(keyNameFromParams);
+            response.data = value.data;
           } on KeyNotFoundException {
             throw KeyNotFoundException(
                 'key $keyNameFromParams not found in keystore');
           }
-          if (value != null && value.data != null) {
-            final valueJson = jsonDecode(value.data);
-            if (valueJson[enrollmentId] == enrollIdFromMetadata) {
-              response.data = value.data;
-            } else {
-              throw AtEnrollmentException(
-                  'Enrollment Id for key $keyNameFromParams does not match the current APKAM enrollmentId');
-            }
-          }
-          logger.finer('get key result: $result');
         }
         break;
       case 'delete':

--- a/packages/at_secondary_server/lib/src/verb/handler/local_lookup_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/local_lookup_verb_handler.dart
@@ -62,7 +62,7 @@ class LocalLookupVerbHandler extends AbstractVerbHandler {
     }
     final enrollApprovalId =
         (atConnection.getMetaData() as InboundConnectionMetadata)
-            .enrollApprovalId;
+            .enrollmentId;
     bool isAuthorized = true; // for legacy clients allow access by default
     if (!isPublic && enrollApprovalId != null && keyNamespace != null) {
       isAuthorized = await super.isAuthorized(enrollApprovalId, keyNamespace);

--- a/packages/at_secondary_server/lib/src/verb/handler/lookup_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/lookup_verb_handler.dart
@@ -64,7 +64,7 @@ class LookupVerbHandler extends AbstractVerbHandler {
         var lookupKey = '$thisServersAtSign:$keyAtAtSign';
         final enrollApprovalId =
             (atConnection.getMetaData() as InboundConnectionMetadata)
-                .enrollApprovalId;
+                .enrollmentId;
         bool isAuthorized = true; // for legacy clients allow access by default
         if (enrollApprovalId != null) {
           var keyNamespace =

--- a/packages/at_secondary_server/lib/src/verb/handler/pkam_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/pkam_verb_handler.dart
@@ -42,7 +42,7 @@ class PkamVerbHandler extends AbstractVerbHandler {
     var signature = verbParams[AT_PKAM_SIGNATURE]!;
     var signingAlgo = verbParams[AT_PKAM_SIGNING_ALGO];
     var hashingAlgo = verbParams[AT_PKAM_HASHING_ALGO];
-    var enrollId = verbParams[enrollApprovalId];
+    var enrollId = verbParams[enrollmentId];
     var atSign = AtSecondaryServerImpl.getInstance().currentAtSign;
     var pkamAuthType = AuthType.pkamLegacy;
     var publicKey;

--- a/packages/at_secondary_server/lib/src/verb/handler/pkam_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/pkam_verb_handler.dart
@@ -135,7 +135,7 @@ class PkamVerbHandler extends AbstractVerbHandler {
     if (isValidSignature) {
       atConnectionMetadata.isAuthenticated = true;
       atConnectionMetadata.authType = pkamAuthType;
-      atConnectionMetadata.enrollApprovalId = enrollId;
+      atConnectionMetadata.enrollmentId = enrollId;
       response.data = 'success';
     } else {
       atConnectionMetadata.isAuthenticated = false;

--- a/packages/at_secondary_server/lib/src/verb/handler/scan_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/scan_verb_handler.dart
@@ -78,7 +78,7 @@ class ScanVerbHandler extends AbstractVerbHandler {
       } else {
         List<String> keys = keyStore.getKeys(regex: scanRegex) as List<String>;
         List<String> filteredKeys = [];
-        final enrollmentId = atConnectionMetadata.enrollApprovalId;
+        final enrollmentId = atConnectionMetadata.enrollmentId;
         logger.finer('inside scan: $enrollmentId');
         if (enrollmentId != null && enrollmentId.isNotEmpty) {
           enrollnamespaces =

--- a/packages/at_secondary_server/lib/src/verb/handler/scan_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/scan_verb_handler.dart
@@ -6,6 +6,7 @@ import 'package:at_persistence_secondary_server/at_persistence_secondary_server.
 import 'package:at_secondary/src/caching/cache_manager.dart';
 import 'package:at_secondary/src/connection/inbound/inbound_connection_metadata.dart';
 import 'package:at_secondary/src/connection/outbound/outbound_client_manager.dart';
+import 'package:at_secondary/src/constants/enroll_constants.dart';
 import 'package:at_secondary/src/server/at_secondary_impl.dart';
 import 'package:at_secondary/src/verb/handler/abstract_verb_handler.dart';
 import 'package:at_secondary/src/verb/verb_enum.dart';
@@ -88,7 +89,11 @@ class ScanVerbHandler extends AbstractVerbHandler {
             _getLocalKeys(atConnectionMetadata, keys, showHiddenKeys);
         for (var key in keyString) {
           for (var namespace in enrollnamespaces.keys) {
-            var namespaceRegex = namespace.name;
+            // do not show keys in __manage namespace
+            if (namespace == enrollManageNamespace) {
+              continue;
+            }
+            var namespaceRegex = namespace;
             if (!namespaceRegex.startsWith('.')) {
               namespaceRegex = '.$namespaceRegex';
             }

--- a/packages/at_secondary_server/lib/src/verb/handler/scan_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/scan_verb_handler.dart
@@ -68,7 +68,7 @@ class ScanVerbHandler extends AbstractVerbHandler {
       // If forAtSign is not null and connection is authenticated, scan keys of another user's atsign,
       // else scan local keys.
       var currentAtSign = AtSecondaryServerImpl.getInstance().currentAtSign;
-      var enrollnamespaces = [];
+      var enrollnamespaces = {};
       if (forAtSign != null &&
           atConnectionMetadata.isAuthenticated &&
           forAtSign != currentAtSign) {
@@ -87,7 +87,7 @@ class ScanVerbHandler extends AbstractVerbHandler {
         List<String> keyString =
             _getLocalKeys(atConnectionMetadata, keys, showHiddenKeys);
         for (var key in keyString) {
-          for (var namespace in enrollnamespaces) {
+          for (var namespace in enrollnamespaces.keys) {
             var namespaceRegex = namespace.name;
             if (!namespaceRegex.startsWith('.')) {
               namespaceRegex = '.$namespaceRegex';

--- a/packages/at_secondary_server/lib/src/verb/manager/verb_handler_manager.dart
+++ b/packages/at_secondary_server/lib/src/verb/manager/verb_handler_manager.dart
@@ -10,6 +10,7 @@ import 'package:at_secondary/src/verb/handler/delete_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/enroll_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/from_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/info_verb_handler.dart';
+import 'package:at_secondary/src/verb/handler/keys_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/local_lookup_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/lookup_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/monitor_verb_handler.dart';
@@ -104,6 +105,7 @@ class DefaultVerbHandlerManager implements VerbHandlerManager {
     _verbHandlers.add(NotifyFetchVerbHandler(keyStore));
     _verbHandlers.add(EnrollVerbHandler(keyStore));
     _verbHandlers.add(TotpVerbHandler(keyStore));
+    _verbHandlers.add(KeysVerbHandler(keyStore));
     return _verbHandlers;
   }
 }

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   collection: 1.17.2
   basic_utils: 5.6.0
   ecdsa: 0.0.4
-  at_commons: 3.0.52
+  at_commons: 3.0.53
   at_utils: 3.0.14
   at_chops: 1.0.3
   at_lookup: 3.0.37
@@ -33,13 +33,6 @@ dependencies:
   mutex: 3.0.1
   yaml: 3.1.2
 
-dependency_overrides:
-  at_commons:
-#    path: ../../../at_libraries/packages/at_commons
-    git:
-      url: https://github.com/atsign-foundation/at_libraries
-      path: packages/at_commons
-      ref: apkam_enc_dec_changes
 
 dev_dependencies:
   build_runner: ^2.3.3

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -33,8 +33,20 @@ dependencies:
   mutex: 3.0.1
   yaml: 3.1.2
 
+dependency_overrides:
+  at_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_libraries
+      path: packages/at_commons
+      branch: apkam_enc_dec_changes
+
 dev_dependencies:
-  test: ^1.24.4
+  build_runner: ^2.3.3
   coverage: ^1.6.1
+  json_serializable: ^6.6.0
   lints: ^2.1.1
   mocktail: ^0.3.0
+  test: ^1.24.4
+
+
+

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -23,8 +23,8 @@ dependencies:
   at_chops: 1.0.3
   at_lookup: 3.0.37
   at_server_spec: 3.0.13
-  at_persistence_spec: 2.0.12
-  at_persistence_secondary_server: 3.0.54
+  at_persistence_spec: 2.0.14
+  at_persistence_secondary_server: 3.0.56
   expire_cache: ^2.0.1
   intl: ^0.18.1
   json_annotation: ^4.8.0

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -35,10 +35,11 @@ dependencies:
 
 dependency_overrides:
   at_commons:
+#    path: ../../../at_libraries/packages/at_commons
     git:
       url: https://github.com/atsign-foundation/at_libraries
       path: packages/at_commons
-      branch: apkam_enc_dec_changes
+      ref: apkam_enc_dec_changes
 
 dev_dependencies:
   build_runner: ^2.3.3

--- a/packages/at_secondary_server/test/enroll_data_store_value_test.dart
+++ b/packages/at_secondary_server/test/enroll_data_store_value_test.dart
@@ -10,6 +10,7 @@ import 'package:at_secondary/src/verb/handler/delete_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/enroll_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/totp_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/update_verb_handler.dart';
+import 'package:at_server_spec/at_server_spec.dart';
 import 'package:test/test.dart';
 
 import 'test_utils.dart';
@@ -77,10 +78,11 @@ void main() {
 
     test('A test to verify enrollment list', () async {
       String enrollmentRequest =
-          'enroll:request:appname:wavi:devicename:mydevice:namespaces:[wavi,r]:apkampublickey:dummy_apkam_public_key';
+          'enroll:request:{"appName":"wavi","deviceName":"mydevice","namespaces":{"wavi":"r"},"apkamPublicKey":"dummy_apkam_public_key"}';
       HashMap<String, String?> verbParams =
           getVerbParam(VerbSyntax.enroll, enrollmentRequest);
       inboundConnection.getMetaData().isAuthenticated = true;
+      inboundConnection.getMetaData().authType = AuthType.cram;
       inboundConnection.getMetaData().sessionID = 'dummy_session';
       Response response = Response();
       EnrollVerbHandler enrollVerbHandler =
@@ -99,7 +101,7 @@ void main() {
     test('A test to verify enrollment list with enrollApprovalId is populated',
         () async {
       String enrollmentRequest =
-          'enroll:request:appname:wavi:devicename:mydevice:namespaces:[wavi,r]:apkampublickey:dummy_apkam_public_key';
+          'enroll:request:{"appName":"wavi","deviceName":"mydevice","namespaces":{"wavi":"r"},"apkamPublicKey":"dummy_apkam_public_key"}';
       HashMap<String, String?> verbParams =
           getVerbParam(VerbSyntax.enroll, enrollmentRequest);
       inboundConnection.getMetaData().isAuthenticated = true;
@@ -128,7 +130,7 @@ void main() {
       inboundConnection.getMetaData().sessionID = 'dummy_session';
       // Enroll request
       String enrollmentRequest =
-          'enroll:request:appname:wavi:devicename:mydevice:namespaces:[wavi,r]:apkampublickey:dummy_apkam_public_key';
+          'enroll:request:{"appName":"wavi","deviceName":"mydevice","namespaces":{"wavi":"r"},"apkamPublicKey":"dummy_apkam_public_key"}';
       HashMap<String, String?> enrollmentRequestVerbParams =
           getVerbParam(VerbSyntax.enroll, enrollmentRequest);
       inboundConnection.getMetaData().isAuthenticated = true;
@@ -144,10 +146,9 @@ void main() {
       await totpVerbHandler.processVerb(
           response, totpVerbParams, inboundConnection);
       print('TOTP: ${response.data}');
-
       // Enroll request
       enrollmentRequest =
-          'enroll:request:appname:wavi:devicename:mydevice:namespaces:[wavi,r]:totp:${response.data}:apkampublickey:dummy_apkam_public_key';
+          'enroll:request:{"appName":"wavi","deviceName":"mydevice","namespaces":{"wavi":"r"},"totp":"${response.data}","apkamPublicKey":"dummy_apkam_public_key"}';
       enrollmentRequestVerbParams =
           getVerbParam(VerbSyntax.enroll, enrollmentRequest);
       inboundConnection.getMetaData().isAuthenticated = false;
@@ -155,17 +156,15 @@ void main() {
       await enrollVerbHandler.processVerb(
           response, enrollmentRequestVerbParams, inboundConnection);
       String enrollmentId = jsonDecode(response.data!)['enrollmentId'];
-
       //Approve enrollment
       String approveEnrollmentRequest =
-          'enroll:approve:enrollmentId:$enrollmentId';
+          'enroll:approve:{"enrollmentId":"$enrollmentId"}';
       HashMap<String, String?> approveEnrollmentVerbParams =
           getVerbParam(VerbSyntax.enroll, approveEnrollmentRequest);
       inboundConnection.getMetaData().isAuthenticated = true;
       enrollVerbHandler = EnrollVerbHandler(secondaryKeyStore);
       await enrollVerbHandler.processVerb(
           response, approveEnrollmentVerbParams, inboundConnection);
-
       // Enroll list
       String enrollmentList = 'enroll:list';
       (inboundConnection.getMetaData() as InboundConnectionMetadata)
@@ -257,7 +256,7 @@ void main() {
     test('A test to verify enrollment request without totp throws exception',
         () async {
       String enrollmentRequest =
-          'enroll:request:appname:wavi:devicename:mydevice:namespaces:[wavi,r]:apkampublickey:dummy_apkam_public_key';
+          'enroll:request:{"appname":"wavi","devicename":"mydevice","namespaces":{"wavi":"r"},"apkampublickey":"dummy_apkam_public_key"}';
       HashMap<String, String?> verbParams =
           getVerbParam(VerbSyntax.enroll, enrollmentRequest);
       inboundConnection.getMetaData().isAuthenticated = false;
@@ -284,7 +283,7 @@ void main() {
         'A test to verify delete verb is not allowed when enrollment is not authorized for write operations',
         () async {
       String enrollmentRequest =
-          'enroll:request:appname:wavi:devicename:mydevice:namespaces:[wavi,r]:apkampublickey:dummy_apkam_public_key';
+          'enroll:request:{"appName":"wavi","deviceName":"mydevice","namespaces":{"wavi":"r"},"apkamPublicKey":"dummy_apkam_public_key"}';
       HashMap<String, String?> verbParams =
           getVerbParam(VerbSyntax.enroll, enrollmentRequest);
       inboundConnection.getMetaData().isAuthenticated = true;
@@ -297,7 +296,6 @@ void main() {
       String enrollmentId = jsonDecode(response.data!)['enrollmentId'];
       (inboundConnection.getMetaData() as InboundConnectionMetadata)
           .enrollApprovalId = enrollmentId;
-
       String deleteCommand = 'delete:dummykey.wavi$alice';
       HashMap<String, String?> deleteVerbParams =
           getVerbParam(VerbSyntax.delete, deleteCommand);
@@ -316,7 +314,7 @@ void main() {
         'A test to verify update verb is not allowed when enrollment is not authorized for write operations',
         () async {
       String enrollmentRequest =
-          'enroll:request:appname:wavi:devicename:mydevice:namespaces:[wavi,r]:apkampublickey:dummy_apkam_public_key';
+          'enroll:request:{"appName":"wavi","deviceName":"mydevice","namespaces":{"wavi":"r"},"apkamPublicKey":"dummy_apkam_public_key"}';
       HashMap<String, String?> verbParams =
           getVerbParam(VerbSyntax.enroll, enrollmentRequest);
       inboundConnection.getMetaData().isAuthenticated = true;
@@ -353,7 +351,7 @@ void main() {
     test(
         'A test to verify revoke operations thrown exception when given enrollmentId is not in keystore',
         () async {
-      String enrollmentRequest = 'enroll:revoke:enrollmentid:123';
+      String enrollmentRequest = 'enroll:revoke:{"enrollmentId":"123"}';
       HashMap<String, String?> verbParams =
           getVerbParam(VerbSyntax.enroll, enrollmentRequest);
       inboundConnection.getMetaData().isAuthenticated = true;

--- a/packages/at_secondary_server/test/enroll_data_store_value_test.dart
+++ b/packages/at_secondary_server/test/enroll_data_store_value_test.dart
@@ -30,30 +30,12 @@ void main() {
       expect(enrollApprovalJson['state'], 'requested');
     });
 
-    test('enroll namespace object fromJson', () {
-      final enrollNamespaceJson = {'name': 'buzz', 'access': 'r'};
-      final enrollNamespaceObject =
-          EnrollNamespace.fromJson(enrollNamespaceJson);
-      expect(enrollNamespaceObject, isA<EnrollNamespace>());
-      expect(enrollNamespaceObject.name, 'buzz');
-      expect(enrollNamespaceObject.access, 'r');
-    });
-
-    test('enroll namespace object toJson', () {
-      final enrollNamespace = EnrollNamespace('wavi', 'rw');
-      final enrollNamespaceJson = enrollNamespace.toJson();
-      expect(enrollNamespaceJson['name'], 'wavi');
-      expect(enrollNamespaceJson['access'], 'rw');
-    });
-
     test('enroll data store value object toJson', () {
-      final enrollNamespace1 = EnrollNamespace('wavi', 'rw');
-      final enrollNamespace2 = EnrollNamespace('buzz', 'r');
+      var namespaceMap = {'wavi': 'rw', 'buzz': 'r'};
       final enrollApproval = EnrollApproval('requested');
-      final namespaceList = [enrollNamespace1, enrollNamespace2];
       final enrollDataStoreValue =
           EnrollDataStoreValue('123', 'testclient', 'iphone', 'mykey')
-            ..namespaces = namespaceList
+            ..namespaces = namespaceMap
             ..approval = enrollApproval
             ..requestType = EnrollRequestType.newEnrollment;
       final enrollJson = enrollDataStoreValue.toJson();
@@ -62,8 +44,8 @@ void main() {
       expect(enrollJson['deviceName'], 'iphone');
       expect(enrollJson['apkamPublicKey'], 'mykey');
       expect(enrollJson['requestType'], 'newEnrollment');
-      expect(enrollJson['namespaces'][0], enrollNamespace1);
-      expect(enrollJson['namespaces'][1], enrollNamespace2);
+      expect(enrollJson['namespaces']['wavi'], 'rw');
+      expect(enrollJson['namespaces']['buzz'], 'r');
       expect(enrollJson['approval'], enrollApproval);
     });
     test('enroll data store value object fromJson', () {
@@ -71,10 +53,7 @@ void main() {
         'sessionId': '123',
         'appName': 'testclient',
         'deviceName': 'iphone',
-        'namespaces': [
-          {'name': 'wavi', 'access': 'rw'},
-          {'name': 'buzz', 'access': 'r'}
-        ],
+        'namespaces': {'wavi': 'rw', 'buzz': 'r'},
         'apkamPublicKey': 'mykey',
         'requestType': 'newEnrollment',
         'approval': {'state': 'requested'}
@@ -82,7 +61,7 @@ void main() {
       final enrollValueObject = EnrollDataStoreValue.fromJson(enrollJson);
       expect(enrollValueObject, isA<EnrollDataStoreValue>());
       expect(enrollValueObject.approval, isA<EnrollApproval>());
-      expect(enrollValueObject.namespaces, isA<List<EnrollNamespace>>());
+      expect(enrollValueObject.namespaces, isA<Map<String, String>>());
       expect(enrollValueObject.sessionId, '123');
       expect(enrollValueObject.appName, 'testclient');
       expect(enrollValueObject.deviceName, 'iphone');
@@ -198,10 +177,10 @@ void main() {
       Map<String, dynamic> enrollListResponse = jsonDecode(response.data!);
       var responseTest = enrollListResponse[
           '$enrollmentId.$newEnrollmentKeyPattern.$enrollManageNamespace$alice'];
+      print(responseTest);
       expect(responseTest['appName'], 'wavi');
       expect(responseTest['deviceName'], 'mydevice');
-      expect(responseTest['namespace'][0]['name'], 'wavi');
-      expect(responseTest['namespace'][0]['access'], 'r');
+      expect(responseTest['namespace']['wavi'], 'r');
       expect(
           enrollListResponse.containsKey(
               '$enrollmentIdOne.$newEnrollmentKeyPattern.$enrollManageNamespace$alice'),

--- a/packages/at_secondary_server/test/enroll_data_store_value_test.dart
+++ b/packages/at_secondary_server/test/enroll_data_store_value_test.dart
@@ -115,7 +115,7 @@ void main() {
 
       String enrollmentList = 'enroll:list';
       (inboundConnection.getMetaData() as InboundConnectionMetadata)
-          .enrollApprovalId = enrollmentId;
+          .enrollmentId = enrollmentId;
       verbParams = getVerbParam(VerbSyntax.enroll, enrollmentList);
       await enrollVerbHandler.processVerb(
           response, verbParams, inboundConnection);
@@ -168,7 +168,7 @@ void main() {
       // Enroll list
       String enrollmentList = 'enroll:list';
       (inboundConnection.getMetaData() as InboundConnectionMetadata)
-          .enrollApprovalId = enrollmentId;
+          .enrollmentId = enrollmentId;
       HashMap<String, String?> verbParams =
           getVerbParam(VerbSyntax.enroll, enrollmentList);
       await enrollVerbHandler.processVerb(
@@ -295,7 +295,7 @@ void main() {
           response, verbParams, inboundConnection);
       String enrollmentId = jsonDecode(response.data!)['enrollmentId'];
       (inboundConnection.getMetaData() as InboundConnectionMetadata)
-          .enrollApprovalId = enrollmentId;
+          .enrollmentId = enrollmentId;
       String deleteCommand = 'delete:dummykey.wavi$alice';
       HashMap<String, String?> deleteVerbParams =
           getVerbParam(VerbSyntax.delete, deleteCommand);
@@ -326,7 +326,7 @@ void main() {
           response, verbParams, inboundConnection);
       String enrollmentId = jsonDecode(response.data!)['enrollmentId'];
       (inboundConnection.getMetaData() as InboundConnectionMetadata)
-          .enrollApprovalId = enrollmentId;
+          .enrollmentId = enrollmentId;
 
       String updateCommand = 'update:$alice:dummykey.wavi$alice dummyValue';
       HashMap<String, String?> updateVerbParams =
@@ -357,7 +357,7 @@ void main() {
       inboundConnection.getMetaData().isAuthenticated = true;
       inboundConnection.getMetaData().sessionID = 'dummy_session';
       (inboundConnection.getMetaData() as InboundConnectionMetadata)
-          .enrollApprovalId = '123';
+          .enrollmentId = '123';
       Response response = Response();
       EnrollVerbHandler enrollVerbHandler =
           EnrollVerbHandler(secondaryKeyStore);

--- a/packages/at_secondary_server/test/keys_verb_test.dart
+++ b/packages/at_secondary_server/test/keys_verb_test.dart
@@ -1,0 +1,696 @@
+import 'dart:convert';
+
+import 'package:at_commons/at_commons.dart';
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_secondary/src/server/at_secondary_impl.dart';
+import 'package:at_secondary/src/utils/handler_util.dart';
+import 'package:at_secondary/src/verb/handler/keys_verb_handler.dart';
+import 'package:at_secondary/src/verb/handler/local_lookup_verb_handler.dart';
+import 'package:at_server_spec/at_verb_spec.dart';
+import 'package:at_utils/at_logger.dart';
+import 'package:test/test.dart';
+import 'package:uuid/uuid.dart';
+
+import 'test_utils.dart';
+
+void main() {
+  AtSignLogger.root_level = 'WARNING';
+  group('keys verb tests', () {
+    late KeysVerbHandler keysVerbHandler;
+    late LocalLookupVerbHandler localLookupVerbHandler;
+
+    setUpAll(() async {
+      await verbTestsSetUpAll();
+    });
+
+    setUp(() async {
+      await verbTestsSetUp();
+      keysVerbHandler = KeysVerbHandler(secondaryKeyStore);
+      localLookupVerbHandler = LocalLookupVerbHandler(secondaryKeyStore);
+    });
+
+    tearDown(() async {
+      await verbTestsTearDown();
+    });
+
+    test('keys verb  - put public key and check keys:get:public, llookup',
+        () async {
+      inboundConnection.metadata.isAuthenticated =
+          true; // owner connection, authenticated
+      var enrollId = Uuid().v4();
+      inboundConnection.metadata.enrollmentId = enrollId;
+      final enrollJson = {
+        'sessionId': '123',
+        'appName': 'wavi',
+        'deviceName': 'pixel',
+        'namespaces': {'name': 'wavi', 'access': 'rw'},
+        'apkamPublicKey': 'testPublicKeyValue',
+        'requestType': 'newEnrollment',
+        'approval': {'state': 'approved'}
+      };
+      var keyName = '$enrollId.new.enrollments.__manage@alice';
+      await secondaryKeyStore.put(
+          keyName, AtData()..data = jsonEncode(enrollJson));
+
+      var keysCommand =
+          'keys:put:public:namespace:__global:keyType:rsa2048:keyName:encryption_$enrollId testPublicKeyValue';
+
+      await keysVerbHandler.process(keysCommand, inboundConnection);
+
+      expect(inboundConnection.lastWrittenData, "data:-1\n$alice@");
+      expect(secondaryKeyStore.isKeyExists(keyName), true);
+      expect(
+          secondaryKeyStore.isKeyExists(
+              'public:encryption_$enrollId.__public_keys.__global@alice'),
+          true);
+      var keysGetCommand = 'keys:get:public';
+      await keysVerbHandler.process(keysGetCommand, inboundConnection);
+      expect(inboundConnection.lastWrittenData,
+          "data:[\"public:encryption_$enrollId.__public_keys.__global@alice\"]\n$alice@");
+      // llookup of keys is not allowed
+      var llookUpCommand =
+          'llookup:public:encryption_$enrollId.__public_keys.__global@alice';
+      await localLookupVerbHandler.process(llookUpCommand, inboundConnection);
+      var llookupResultMap = decodeResponse(inboundConnection.lastWrittenData!);
+      expect(llookupResultMap['value'], 'testPublicKeyValue');
+      expect(llookupResultMap['keyType'], 'rsa2048');
+      expect(llookupResultMap['enrollmentId'], enrollId);
+    });
+
+    test(
+        'keys verb  - put public key and check keys:get:public for an emoji atsign',
+        () async {
+      inboundConnection.metadata.isAuthenticated =
+          true; // owner connection, authenticated
+      AtSecondaryServerImpl.getInstance().currentAtSign = '@alice🛠';
+      var enrollId = Uuid().v4();
+      inboundConnection.metadata.enrollmentId = enrollId;
+      final enrollJson = {
+        'sessionId': '123',
+        'appName': 'wavi',
+        'deviceName': 'pixel',
+        'namespaces': {'name': 'wavi', 'access': 'rw'},
+        'apkamPublicKey': 'publicKeyTest',
+        'requestType': 'newEnrollment',
+        'approval': {'state': 'approved'}
+      };
+      var keyName = '$enrollId.new.enrollments.__manage@alice🛠';
+      await secondaryKeyStore.put(
+          keyName, AtData()..data = jsonEncode(enrollJson));
+
+      var keysCommand =
+          'keys:put:public:namespace:__global:keyType:rsa2048:keyName:encryption_$enrollId publicKeyTest';
+
+      await keysVerbHandler.process(keysCommand, inboundConnection);
+
+      expect(inboundConnection.lastWrittenData, "data:-1\n$aliceEmoji@");
+      expect(secondaryKeyStore.isKeyExists(keyName), true);
+      expect(
+          secondaryKeyStore.isKeyExists(
+              'public:encryption_$enrollId.__public_keys.__global@alice🛠'),
+          true);
+      var keysGetCommand = 'keys:get:public';
+      await keysVerbHandler.process(keysGetCommand, inboundConnection);
+      expect(inboundConnection.lastWrittenData,
+          "data:[\"public:encryption_$enrollId.__public_keys.__global@alice🛠\"]\n$aliceEmoji@");
+      // llookup of keys is not allowed
+      var llookUpCommand =
+          'llookup:public:encryption_$enrollId.__public_keys.__global@alice🛠';
+      await localLookupVerbHandler.process(llookUpCommand, inboundConnection);
+      var llookupResultMap = decodeResponse(inboundConnection.lastWrittenData!);
+      expect(llookupResultMap['value'], 'publicKeyTest');
+      expect(llookupResultMap['keyType'], 'rsa2048');
+      expect(llookupResultMap['enrollmentId'], enrollId);
+    }, timeout: Timeout(Duration(minutes: 5)));
+
+    test('keys verb  - put self key and check keys:get, llookup', () async {
+      inboundConnection.metadata.isAuthenticated =
+          true; // owner connection, authenticated
+      var enrollId = Uuid().v4();
+      inboundConnection.metadata.enrollmentId = enrollId;
+      final enrollJson = {
+        'sessionId': '123',
+        'appName': 'wavi',
+        'deviceName': 'pixel',
+        'namespaces': {'name': 'wavi', 'access': 'rw'},
+        'apkamPublicKey': 'testPublicKeyValue',
+        'requestType': 'newEnrollment',
+        'approval': {'state': 'approved'}
+      };
+      var keyName = '$enrollId.new.enrollments.__manage@alice';
+      await secondaryKeyStore.put(
+          keyName, AtData()..data = jsonEncode(enrollJson));
+
+      var keysCommand =
+          'keys:put:self:namespace:__global:appName:wavi:deviceName:pixel:keyType:aes256:encryptionKeyName:encryption_$enrollId:keyName:mykey selfKeyValue';
+
+      await keysVerbHandler.process(keysCommand, inboundConnection);
+
+      expect(inboundConnection.lastWrittenData, "data:-1\n$alice@");
+      expect(secondaryKeyStore.isKeyExists(keyName), true);
+      expect(
+          secondaryKeyStore
+              .isKeyExists('wavi.pixel.mykey.__self_keys.__global@alice'),
+          true);
+
+      var keysGetCommand = 'keys:get:self';
+      await keysVerbHandler.process(keysGetCommand, inboundConnection);
+      expect(inboundConnection.lastWrittenData,
+          "data:[\"wavi.pixel.mykey.__self_keys.__global@alice\"]\n$alice@");
+
+      var llookUpCommand =
+          'llookup:wavi.pixel.mykey.__self_keys.__global@alice';
+      expect(
+          () async => await localLookupVerbHandler.process(
+              llookUpCommand, inboundConnection),
+          throwsA(predicate((dynamic e) => e is UnAuthorizedException)));
+    });
+
+    test('keys verb  - put self key and check keys:get for an emoji atsign',
+        () async {
+      inboundConnection.metadata.isAuthenticated =
+          true; // owner connection, authenticated
+      AtSecondaryServerImpl.getInstance().currentAtSign = '@alice🛠';
+      var enrollId = Uuid().v4();
+      inboundConnection.metadata.enrollmentId = enrollId;
+      final enrollJson = {
+        'sessionId': '123',
+        'appName': 'wavi',
+        'deviceName': 'pixel',
+        'namespaces': {'name': 'wavi', 'access': 'rw'},
+        'apkamPublicKey': 'testPublicKeyValue',
+        'requestType': 'newEnrollment',
+        'approval': {'state': 'approved'}
+      };
+      var keyName = '$enrollId.new.enrollments.__manage@alice🛠';
+      await secondaryKeyStore.put(
+          keyName, AtData()..data = jsonEncode(enrollJson));
+
+      var keysCommand =
+          'keys:put:self:namespace:__global:appName:wavi:deviceName:pixel:keyType:aes256:encryptionKeyName:encryption_$enrollId:keyName:mykey selfKeyValue';
+
+      await keysVerbHandler.process(keysCommand, inboundConnection);
+
+      expect(inboundConnection.lastWrittenData, "data:-1\n$aliceEmoji@");
+      expect(secondaryKeyStore.isKeyExists(keyName), true);
+      expect(
+          secondaryKeyStore
+              .isKeyExists('wavi.pixel.mykey.__self_keys.__global@alice🛠'),
+          true);
+
+      var keysGetCommand = 'keys:get:self';
+      await keysVerbHandler.process(keysGetCommand, inboundConnection);
+      expect(inboundConnection.lastWrittenData,
+          "data:[\"wavi.pixel.mykey.__self_keys.__global@alice🛠\"]\n$aliceEmoji@");
+
+      var llookUpCommand =
+          'llookup:wavi.pixel.mykey.__self_keys.__global@alice🛠';
+      expect(
+          () async => await localLookupVerbHandler.process(
+              llookUpCommand, inboundConnection),
+          throwsA(predicate((dynamic e) => e is UnAuthorizedException)));
+    });
+
+    test('keys verb  - put private key and check keys:get', () async {
+      inboundConnection.metadata.isAuthenticated =
+          true; // owner connection, authenticated
+      var enrollId = Uuid().v4();
+      inboundConnection.metadata.enrollmentId = enrollId;
+      final enrollJson = {
+        'sessionId': '123',
+        'appName': 'wavi',
+        'deviceName': 'pixel',
+        'namespaces': {'name': 'wavi', 'access': 'rw'},
+        'apkamPublicKey': 'testPublicKeyValue',
+        'requestType': 'newEnrollment',
+        'approval': {'state': 'approved'}
+      };
+      var keyName = '$enrollId.new.enrollments.__manage@alice';
+      await secondaryKeyStore.put(
+          keyName, AtData()..data = jsonEncode(enrollJson));
+
+      var keysCommand =
+          'keys:put:private:namespace:__global:appName:wavi:deviceName:pixel:keyType:aes:encryptionKeyName:mykey:keyName:secretKey abcd1234';
+
+      await keysVerbHandler.process(keysCommand, inboundConnection);
+
+      expect(inboundConnection.lastWrittenData, "data:-1\n$alice@");
+      expect(secondaryKeyStore.isKeyExists(keyName), true);
+      expect(
+          secondaryKeyStore.isKeyExists(
+              'private:wavi.pixel.secretKey.__private_keys.__global@alice'),
+          true);
+      var keysGetCommand = 'keys:get:private';
+      await keysVerbHandler.process(keysGetCommand, inboundConnection);
+      expect(inboundConnection.lastWrittenData,
+          "data:[\"private:wavi.pixel.secretkey.__private_keys.__global@alice\"]\n$alice@");
+
+      var llookUpCommand =
+          'llookup:private:wavi.pixel.secretkey.__private_keys.__global@alice';
+      expect(
+          () async => await localLookupVerbHandler.process(
+              llookUpCommand, inboundConnection),
+          throwsA(predicate((dynamic e) => e is UnAuthorizedException)));
+    });
+
+    test('keys verb  - put private key and check keys:get for an emoji atsign',
+        () async {
+      inboundConnection.metadata.isAuthenticated =
+          true; // owner connection, authenticated
+      AtSecondaryServerImpl.getInstance().currentAtSign = '@alice🛠';
+      var enrollId = Uuid().v4();
+      inboundConnection.metadata.enrollmentId = enrollId;
+      final enrollJson = {
+        'sessionId': '123',
+        'appName': 'wavi',
+        'deviceName': 'pixel',
+        'namespaces': {'name': 'wavi', 'access': 'rw'},
+        'apkamPublicKey': 'testPublicKeyValue',
+        'requestType': 'newEnrollment',
+        'approval': {'state': 'approved'}
+      };
+      var keyName = '$enrollId.new.enrollments.__manage@alice🛠';
+      await secondaryKeyStore.put(
+          keyName, AtData()..data = jsonEncode(enrollJson));
+
+      var keysCommand =
+          'keys:put:private:namespace:__global:appName:wavi:deviceName:pixel:keyType:aes:encryptionKeyName:mykey:keyName:secretKey abcd1234';
+
+      await keysVerbHandler.process(keysCommand, inboundConnection);
+
+      expect(inboundConnection.lastWrittenData, "data:-1\n$aliceEmoji@");
+      expect(secondaryKeyStore.isKeyExists(keyName), true);
+      expect(
+          secondaryKeyStore.isKeyExists(
+              'private:wavi.pixel.secretKey.__private_keys.__global@alice🛠'),
+          true);
+      var keysGetCommand = 'keys:get:private';
+      await keysVerbHandler.process(keysGetCommand, inboundConnection);
+      expect(inboundConnection.lastWrittenData,
+          "data:[\"private:wavi.pixel.secretkey.__private_keys.__global@alice🛠\"]\n$aliceEmoji@");
+
+      var llookUpCommand =
+          'llookup:private:wavi.pixel.secretkey.__private_keys.__global@alice🛠';
+      expect(
+          () async => await localLookupVerbHandler.process(
+              llookUpCommand, inboundConnection),
+          throwsA(predicate((dynamic e) => e is UnAuthorizedException)));
+    });
+
+    test('keys verb  - put public key and check getKeyName, delete key',
+        () async {
+      inboundConnection.metadata.isAuthenticated =
+          true; // owner connection, authenticated
+      var enrollId = Uuid().v4();
+      inboundConnection.metadata.enrollmentId = enrollId;
+      final enrollJson = {
+        'sessionId': '123',
+        'appName': 'wavi',
+        'deviceName': 'pixel',
+        'namespaces': {'name': 'wavi', 'access': 'rw'},
+        'apkamPublicKey': 'testPublicKeyValue',
+        'requestType': 'newEnrollment',
+        'approval': {'state': 'approved'}
+      };
+      var enrollkeyName = '$enrollId.new.enrollments.__manage@alice';
+      await secondaryKeyStore.put(
+          enrollkeyName, AtData()..data = jsonEncode(enrollJson));
+
+      var keysCommand =
+          'keys:put:public:namespace:__global:keyType:rsa2048:keyName:encryption_$enrollId testPublicKeyValue';
+
+      await keysVerbHandler.process(keysCommand, inboundConnection);
+
+      expect(inboundConnection.lastWrittenData, "data:-1\n$alice@");
+      expect(secondaryKeyStore.isKeyExists(enrollkeyName), true);
+      expect(
+          secondaryKeyStore.isKeyExists(
+              'public:encryption_$enrollId.__public_keys.__global@alice'),
+          true);
+      var publicKeyName =
+          'public:encryption_$enrollId.__public_keys.__global@alice';
+      var keysGetCommand = 'keys:get:keyName:$publicKeyName';
+      await keysVerbHandler.process(keysGetCommand, inboundConnection);
+      var getKeysResponse = decodeResponse(inboundConnection.lastWrittenData!);
+      expect(getKeysResponse['value'], 'testPublicKeyValue');
+      expect(getKeysResponse['enrollmentId'], enrollId);
+      expect(getKeysResponse['keyType'], 'rsa2048');
+      var deleteKeyCommand = 'keys:delete:keyName:$publicKeyName';
+      await keysVerbHandler.process(deleteKeyCommand, inboundConnection);
+      expect(inboundConnection.lastWrittenData, "data:-1\n$alice@");
+      expect(secondaryKeyStore.isKeyExists(publicKeyName), false);
+    });
+
+    test(
+        'keys verb with emoji atsign- put public key and check getKeyName, delete key',
+        () async {
+      inboundConnection.metadata.isAuthenticated =
+          true; // owner connection, authenticated
+      AtSecondaryServerImpl.getInstance().currentAtSign = '@alice🛠';
+      var enrollId = Uuid().v4();
+      inboundConnection.metadata.enrollmentId = enrollId;
+      final enrollJson = {
+        'sessionId': '123',
+        'appName': 'wavi',
+        'deviceName': 'pixel',
+        'namespaces': {'name': 'wavi', 'access': 'rw'},
+        'apkamPublicKey': 'testPublicKeyValue',
+        'requestType': 'newEnrollment',
+        'approval': {'state': 'approved'}
+      };
+      var enrollkeyName = '$enrollId.new.enrollments.__manage@alice🛠';
+      await secondaryKeyStore.put(
+          enrollkeyName, AtData()..data = jsonEncode(enrollJson));
+
+      var keysCommand =
+          'keys:put:public:namespace:__global:keyType:rsa2048:keyName:encryption_$enrollId testPublicKeyValue';
+
+      await keysVerbHandler.process(keysCommand, inboundConnection);
+
+      expect(inboundConnection.lastWrittenData, "data:-1\n$aliceEmoji@");
+      expect(secondaryKeyStore.isKeyExists(enrollkeyName), true);
+      expect(
+          secondaryKeyStore.isKeyExists(
+              'public:encryption_$enrollId.__public_keys.__global@alice🛠'),
+          true);
+      var publicKeyName =
+          'public:encryption_$enrollId.__public_keys.__global@alice🛠';
+      var keysGetCommand = 'keys:get:keyName:$publicKeyName';
+      await keysVerbHandler.process(keysGetCommand, inboundConnection);
+      var getKeysResponse = decodeResponse(inboundConnection.lastWrittenData!);
+      expect(getKeysResponse['value'], 'testPublicKeyValue');
+      expect(getKeysResponse['enrollmentId'], enrollId);
+      expect(getKeysResponse['keyType'], 'rsa2048');
+      var deleteKeyCommand = 'keys:delete:keyName:$publicKeyName';
+      await keysVerbHandler.process(deleteKeyCommand, inboundConnection);
+      expect(inboundConnection.lastWrittenData, "data:-1\n$aliceEmoji@");
+      expect(secondaryKeyStore.isKeyExists(publicKeyName), false);
+    });
+
+    test('keys verb  - put self key and check getKeyName,delete key ',
+        () async {
+      inboundConnection.metadata.isAuthenticated =
+          true; // owner connection, authenticated
+      var enrollId = Uuid().v4();
+      inboundConnection.metadata.enrollmentId = enrollId;
+      final enrollJson = {
+        'sessionId': '123',
+        'appName': 'wavi',
+        'deviceName': 'pixel',
+        'namespaces': {'name': 'wavi', 'access': 'rw'},
+        'apkamPublicKey': 'testPublicKeyValue',
+        'requestType': 'newEnrollment',
+        'approval': {'state': 'approved'}
+      };
+      var enrollKeyName = '$enrollId.new.enrollments.__manage@alice';
+      await secondaryKeyStore.put(
+          enrollKeyName, AtData()..data = jsonEncode(enrollJson));
+
+      var keysCommand =
+          'keys:put:self:namespace:__global:appName:wavi:deviceName:pixel:keyType:aes256:encryptionKeyName:encryption_$enrollId:keyName:mykey selfKeyValue';
+
+      await keysVerbHandler.process(keysCommand, inboundConnection);
+
+      expect(inboundConnection.lastWrittenData, "data:-1\n$alice@");
+      expect(secondaryKeyStore.isKeyExists(enrollKeyName), true);
+      expect(
+          secondaryKeyStore
+              .isKeyExists('wavi.pixel.mykey.__self_keys.__global@alice'),
+          true);
+      var selfKeyName = 'wavi.pixel.mykey.__self_keys.__global@alice';
+      var keysGetCommand = 'keys:get:keyName:$selfKeyName';
+      await keysVerbHandler.process(keysGetCommand, inboundConnection);
+      var getKeysResponse = decodeResponse(inboundConnection.lastWrittenData!);
+      expect(getKeysResponse['value'], 'selfKeyValue');
+      expect(getKeysResponse['enrollmentId'], enrollId);
+      expect(getKeysResponse['keyType'], 'aes256');
+      var deleteKeyCommand = 'keys:delete:keyName:$selfKeyName';
+      await keysVerbHandler.process(deleteKeyCommand, inboundConnection);
+      expect(inboundConnection.lastWrittenData, "data:-1\n$alice@");
+      expect(secondaryKeyStore.isKeyExists(selfKeyName), false);
+    });
+
+    test(
+        'keys verb with Emoji atsign - put self key and check getKeyName,delete key ',
+        () async {
+      inboundConnection.metadata.isAuthenticated =
+          true; // owner connection, authenticated
+      AtSecondaryServerImpl.getInstance().currentAtSign = '@alice🛠';
+      var enrollId = Uuid().v4();
+      inboundConnection.metadata.enrollmentId = enrollId;
+      final enrollJson = {
+        'sessionId': '123',
+        'appName': 'wavi',
+        'deviceName': 'pixel',
+        'namespaces': {'name': 'wavi', 'access': 'rw'},
+        'apkamPublicKey': 'testPublicKeyValue',
+        'requestType': 'newEnrollment',
+        'approval': {'state': 'approved'}
+      };
+      var enrollKeyName = '$enrollId.new.enrollments.__manage@alice🛠';
+      await secondaryKeyStore.put(
+          enrollKeyName, AtData()..data = jsonEncode(enrollJson));
+
+      var keysCommand =
+          'keys:put:self:namespace:__global:appName:wavi:deviceName:pixel:keyType:aes256:encryptionKeyName:encryption_$enrollId:keyName:mykey selfKeyValue';
+
+      await keysVerbHandler.process(keysCommand, inboundConnection);
+
+      expect(inboundConnection.lastWrittenData, "data:-1\n$aliceEmoji@");
+      expect(secondaryKeyStore.isKeyExists(enrollKeyName), true);
+      expect(
+          secondaryKeyStore
+              .isKeyExists('wavi.pixel.mykey.__self_keys.__global@alice🛠'),
+          true);
+      var selfKeyName = 'wavi.pixel.mykey.__self_keys.__global@alice🛠';
+      var keysGetCommand = 'keys:get:keyName:$selfKeyName';
+      await keysVerbHandler.process(keysGetCommand, inboundConnection);
+      var getKeysResponse = decodeResponse(inboundConnection.lastWrittenData!);
+      expect(getKeysResponse['value'], 'selfKeyValue');
+      expect(getKeysResponse['enrollmentId'], enrollId);
+      expect(getKeysResponse['keyType'], 'aes256');
+      var deleteKeyCommand = 'keys:delete:keyName:$selfKeyName';
+      await keysVerbHandler.process(deleteKeyCommand, inboundConnection);
+      expect(inboundConnection.lastWrittenData, "data:-1\n$aliceEmoji@");
+      expect(secondaryKeyStore.isKeyExists(selfKeyName), false);
+    });
+
+    test('keys verb  - put private key and check getKeyName, delete', () async {
+      inboundConnection.metadata.isAuthenticated =
+          true; // owner connection, authenticated
+      var enrollId = Uuid().v4();
+      inboundConnection.metadata.enrollmentId = enrollId;
+      final enrollJson = {
+        'sessionId': '123',
+        'appName': 'wavi',
+        'deviceName': 'pixel',
+        'namespaces': {'name': 'wavi', 'access': 'rw'},
+        'apkamPublicKey': 'testPublicKeyValue',
+        'requestType': 'newEnrollment',
+        'approval': {'state': 'approved'}
+      };
+      var keyName = '$enrollId.new.enrollments.__manage@alice';
+      await secondaryKeyStore.put(
+          keyName, AtData()..data = jsonEncode(enrollJson));
+
+      var keysCommand =
+          'keys:put:private:namespace:__global:appName:wavi:deviceName:pixel:keyType:aes256:encryptionKeyName:mykey:keyName:secretKey abcd1234';
+
+      await keysVerbHandler.process(keysCommand, inboundConnection);
+
+      expect(inboundConnection.lastWrittenData, "data:-1\n$alice@");
+      expect(secondaryKeyStore.isKeyExists(keyName), true);
+      expect(
+          secondaryKeyStore.isKeyExists(
+              'private:wavi.pixel.secretKey.__private_keys.__global@alice'),
+          true);
+      var privateKeyName =
+          'private:wavi.pixel.secretKey.__private_keys.__global@alice';
+      var keysGetCommand = 'keys:get:keyName:$privateKeyName';
+      await keysVerbHandler.process(keysGetCommand, inboundConnection);
+      var getKeysResponse = decodeResponse(inboundConnection.lastWrittenData!);
+      expect(getKeysResponse['value'], 'abcd1234');
+      expect(getKeysResponse['enrollmentId'], enrollId);
+      expect(getKeysResponse['keyType'], 'aes256');
+      expect(getKeysResponse['encryptionKeyName'], 'mykey');
+      var deleteKeyCommand = 'keys:delete:keyName:$privateKeyName';
+      await keysVerbHandler.process(deleteKeyCommand, inboundConnection);
+      expect(inboundConnection.lastWrittenData, "data:-1\n$alice@");
+      expect(secondaryKeyStore.isKeyExists(privateKeyName), false);
+    });
+
+    test(
+        'keys verb with an emoji Atsign - put private key and check getKeyName, delete',
+        () async {
+      inboundConnection.metadata.isAuthenticated =
+          true; // owner connection, authenticated
+      AtSecondaryServerImpl.getInstance().currentAtSign = '@alice🛠';
+      var enrollId = Uuid().v4();
+      inboundConnection.metadata.enrollmentId = enrollId;
+      final enrollJson = {
+        'sessionId': '123',
+        'appName': 'wavi',
+        'deviceName': 'pixel',
+        'namespaces': {'name': 'wavi', 'access': 'rw'},
+        'apkamPublicKey': 'testPublicKeyValue',
+        'requestType': 'newEnrollment',
+        'approval': {'state': 'approved'}
+      };
+      var keyName = '$enrollId.new.enrollments.__manage@alice🛠';
+      await secondaryKeyStore.put(
+          keyName, AtData()..data = jsonEncode(enrollJson));
+
+      var keysCommand =
+          'keys:put:private:namespace:__global:appName:wavi:deviceName:pixel:keyType:aes256:encryptionKeyName:mykey:keyName:secretKey abcd1234';
+
+      await keysVerbHandler.process(keysCommand, inboundConnection);
+
+      expect(inboundConnection.lastWrittenData, "data:-1\n$aliceEmoji@");
+      expect(secondaryKeyStore.isKeyExists(keyName), true);
+      expect(
+          secondaryKeyStore.isKeyExists(
+              'private:wavi.pixel.secretKey.__private_keys.__global@alice🛠'),
+          true);
+      var privateKeyName =
+          'private:wavi.pixel.secretKey.__private_keys.__global@alice🛠';
+      var keysGetCommand = 'keys:get:keyName:$privateKeyName';
+      await keysVerbHandler.process(keysGetCommand, inboundConnection);
+      var getKeysResponse = decodeResponse(inboundConnection.lastWrittenData!);
+      expect(getKeysResponse['value'], 'abcd1234');
+      expect(getKeysResponse['enrollmentId'], enrollId);
+      expect(getKeysResponse['keyType'], 'aes256');
+      expect(getKeysResponse['encryptionKeyName'], 'mykey');
+      var deleteKeyCommand = 'keys:delete:keyName:$privateKeyName';
+      await keysVerbHandler.process(deleteKeyCommand, inboundConnection);
+      expect(inboundConnection.lastWrittenData, "data:-1\n$aliceEmoji@");
+      expect(secondaryKeyStore.isKeyExists(privateKeyName), false);
+    });
+
+    test(
+        'keys verb with an emoji Atsign - put private key and check getKeyName, delete',
+        () async {
+      inboundConnection.metadata.isAuthenticated =
+          true; // owner connection, authenticated
+      AtSecondaryServerImpl.getInstance().currentAtSign = '@alice🛠';
+      var enrollId = Uuid().v4();
+      inboundConnection.metadata.enrollmentId = enrollId;
+      final enrollJson = {
+        'sessionId': '123',
+        'appName': 'wavi',
+        'deviceName': 'pixel',
+        'namespaces': {'name': 'wavi', 'access': 'rw'},
+        'apkamPublicKey': 'testPublicKeyValue',
+        'requestType': 'newEnrollment',
+        'approval': {'state': 'approved'}
+      };
+      var keyName = '$enrollId.new.enrollments.__manage@alice🛠';
+      await secondaryKeyStore.put(
+          keyName, AtData()..data = jsonEncode(enrollJson));
+
+      var keysCommand =
+          'keys:put:private:namespace:__global:appName:wavi:deviceName:pixel:keyType:aes256:encryptionKeyName:mykey:keyName:secretKey abcd1234';
+
+      await keysVerbHandler.process(keysCommand, inboundConnection);
+
+      expect(inboundConnection.lastWrittenData, "data:-1\n$aliceEmoji@");
+      expect(secondaryKeyStore.isKeyExists(keyName), true);
+      expect(
+          secondaryKeyStore.isKeyExists(
+              'private:wavi.pixel.secretKey.__private_keys.__global@alice🛠'),
+          true);
+      var privateKeyName =
+          'private:wavi.pixel.secretKey.__private_keys.__global@alice🛠';
+      var keysGetCommand = 'keys:get:keyName:$privateKeyName';
+      await keysVerbHandler.process(keysGetCommand, inboundConnection);
+      var getKeysResponse = decodeResponse(inboundConnection.lastWrittenData!);
+      expect(getKeysResponse['value'], 'abcd1234');
+      expect(getKeysResponse['enrollmentId'], enrollId);
+      expect(getKeysResponse['keyType'], 'aes256');
+      expect(getKeysResponse['encryptionKeyName'], 'mykey');
+      var deleteKeyCommand = 'keys:delete:keyName:$privateKeyName';
+      await keysVerbHandler.process(deleteKeyCommand, inboundConnection);
+      expect(inboundConnection.lastWrittenData, "data:-1\n$aliceEmoji@");
+      expect(secondaryKeyStore.isKeyExists(privateKeyName), false);
+    });
+
+    test(
+        'keys verb - keys:get non-existent key should throw an key not found exception',
+        () async {
+      inboundConnection.metadata.isAuthenticated =
+          true; // owner connection, authenticated
+      var enrollId = Uuid().v4();
+      inboundConnection.metadata.enrollmentId = enrollId;
+      final enrollJson = {
+        'sessionId': '123',
+        'appName': 'wavi',
+        'deviceName': 'pixel',
+        'namespaces': {'name': 'wavi', 'access': 'rw'},
+        'apkamPublicKey': 'testPublicKeyValue',
+        'requestType': 'newEnrollment',
+        'approval': {'state': 'approved'}
+      };
+      var keyName = '$enrollId.new.enrollments.__manage@alice';
+      await secondaryKeyStore.put(
+          keyName, AtData()..data = jsonEncode(enrollJson));
+
+      var privateKeyName =
+          'private:wavi.pixel.secretKey123.__private_keys.__global@alice';
+      var keysGetCommand = 'keys:get:keyName:$privateKeyName';
+      expect(
+          () async =>
+              await keysVerbHandler.process(keysGetCommand, inboundConnection),
+          throwsA(predicate((dynamic e) =>
+              e is KeyNotFoundException &&
+              e.message == 'key $privateKeyName not found in keystore')));
+    });
+
+    test('keys verb invalid syntax - invalid operation', () {
+      var verb = Keys();
+      var command = 'keys:update:hello';
+      var regex = verb.syntax();
+      expect(
+          () => getVerbParam(regex, command),
+          throwsA(predicate((dynamic e) =>
+              e is InvalidSyntaxException && e.message == 'Syntax Exception')));
+    });
+
+    test(
+        'keys verb without specifying the operation invalid syntax - invalid operation',
+        () {
+      var verb = Keys();
+      var command =
+          'keys:public:namespace:__global:keyType:rsa2048:keyName:encryption_1278383933 testPublicKeyValue';
+      var regex = verb.syntax();
+      expect(
+          () => getVerbParam(regex, command),
+          throwsA(predicate((dynamic e) =>
+              e is InvalidSyntaxException && e.message == 'Syntax Exception')));
+    });
+
+    test('keys:put verb without auth', () {
+      var command =
+          'keys:put:public:namespace:__global:keyType:rsa2048:keyName:encryption_1278383933 testPublicKeyValue';
+      expect(
+          () async => await keysVerbHandler.process(command, inboundConnection),
+          throwsA(predicate((dynamic e) => e is UnAuthenticatedException)));
+    });
+
+    test(
+        'keys:get verb without an authentication - should throw an UnAuthenticatedException',
+        () async {
+      var command = 'keys:get:nonexistentKey';
+      expect(
+          () async => await keysVerbHandler.process(command, inboundConnection),
+          throwsA(predicate((dynamic e) => e is UnAuthenticatedException)));
+    });
+
+    test(
+        'keys:delete verb without an authentication - should throw an UnAuthenticatedException',
+        () async {
+      var command = 'keys:delete:nonexistentKey';
+      expect(
+          () async => await keysVerbHandler.process(command, inboundConnection),
+          throwsA(predicate((dynamic e) => e is UnAuthenticatedException)));
+    });
+  });
+}

--- a/packages/at_secondary_server/test/remove_malformed_keys_test.dart
+++ b/packages/at_secondary_server/test/remove_malformed_keys_test.dart
@@ -14,7 +14,7 @@ class MockHiveKeyStore extends Mock implements HiveKeystore {
   }
 
   @override
-  Future<int?> remove(String key) async {
+  Future<int?> remove(String key, {bool skipCommit = false}) async {
     dummyKeyStore.remove(key);
     return 1;
   }

--- a/packages/at_secondary_server/test/test_utils.dart
+++ b/packages/at_secondary_server/test/test_utils.dart
@@ -236,6 +236,11 @@ Map decodeResponse(String sentToClient) {
       sentToClient.substring('data:'.length, sentToClient.indexOf('\n')));
 }
 
+List decodeResponseAsList(String serverResponse) {
+  return List<String>.from(jsonDecode(
+      serverResponse.substring('data:'.length, serverResponse.indexOf('\n'))));
+}
+
 Future<AtData> createRandomKeyStoreEntry(String owner, String keyName,
     SecondaryKeyStore<String, AtData?, AtMetaData?> secondaryKeyStore,
     {String? data, Metadata? commonsMetadata, DateTime? refreshAt}) async {

--- a/packages/at_secondary_server/test/test_utils.dart
+++ b/packages/at_secondary_server/test/test_utils.dart
@@ -43,6 +43,7 @@ class MockSecureSocket extends Mock implements SecureSocket {}
 class MockStreamSubscription<T> extends Mock implements StreamSubscription<T> {}
 
 String alice = '@alice';
+String aliceEmoji = '@alice🛠';
 String bob = '@bob';
 var bobHost = "domain.testing.bob.bob.bob";
 var bobPort = 12345;
@@ -104,9 +105,8 @@ verbTestsSetUp() async {
 
   mockOutboundConnection = MockOutboundConnection();
   mockOutboundConnectionFactory = MockOutboundConnectionFactory();
-  when(() =>
-      mockOutboundConnectionFactory.createOutboundConnection(
-          bobHost, bobPort, bob)).thenAnswer((invocation) async {
+  when(() => mockOutboundConnectionFactory.createOutboundConnection(
+      bobHost, bobPort, bob)).thenAnswer((invocation) async {
     return mockOutboundConnection;
   });
 
@@ -136,13 +136,13 @@ verbTestsSetUp() async {
     return outboundClientWithHandshake;
   });
   when(() =>
-      mockOutboundClientManager.getClient(bob, any(), isHandShake: false))
+          mockOutboundClientManager.getClient(bob, any(), isHandShake: false))
       .thenAnswer((_) {
     return outboundClientWithoutHandshake;
   });
 
   AtConnectionMetaData outboundConnectionMetadata =
-  OutboundConnectionMetadata();
+      OutboundConnectionMetadata();
   outboundConnectionMetadata.sessionID = 'mock-session-id';
   when(() => mockOutboundConnection.getMetaData())
       .thenReturn(outboundConnectionMetadata);
@@ -154,10 +154,9 @@ verbTestsSetUp() async {
       .thenAnswer((_) => mockSecureSocket);
   when(() => mockOutboundConnection.close()).thenAnswer((_) async => {});
 
-  when(() =>
-      mockSecureSocket.listen(any(),
-          onError: any(named: "onError"),
-          onDone: any(named: "onDone"))).thenAnswer((Invocation invocation) {
+  when(() => mockSecureSocket.listen(any(),
+      onError: any(named: "onError"),
+      onDone: any(named: "onDone"))).thenAnswer((Invocation invocation) {
     socketOnDataFn = invocation.positionalArguments[0];
     socketOnDoneFn = invocation.namedArguments[#onDone];
     socketOnErrorFn = invocation.namedArguments[#onError];
@@ -168,22 +167,12 @@ verbTestsSetUp() async {
   cacheManager =
       AtCacheManager(alice, secondaryKeyStore, mockOutboundClientManager);
 
-  AtSecondaryServerImpl
-      .getInstance()
-      .cacheManager = cacheManager;
-  AtSecondaryServerImpl
-      .getInstance()
-      .secondaryKeyStore = secondaryKeyStore;
-  AtSecondaryServerImpl
-      .getInstance()
-      .outboundClientManager =
+  AtSecondaryServerImpl.getInstance().cacheManager = cacheManager;
+  AtSecondaryServerImpl.getInstance().secondaryKeyStore = secondaryKeyStore;
+  AtSecondaryServerImpl.getInstance().outboundClientManager =
       mockOutboundClientManager;
-  AtSecondaryServerImpl
-      .getInstance()
-      .currentAtSign = alice;
-  AtSecondaryServerImpl
-      .getInstance()
-      .signingKey =
+  AtSecondaryServerImpl.getInstance().currentAtSign = alice;
+  AtSecondaryServerImpl.getInstance().signingKey =
       bobServerSigningKeypair.privateKey.toString();
 
   DateTime now = DateTime.now().toUtcMillisecondsPrecision();
@@ -203,8 +192,8 @@ verbTestsSetUp() async {
   when(() => mockOutboundConnection.write(any()))
       .thenAnswer((Invocation invocation) async {
     socketOnDataFn('error:AT0001-Mock exception : '
-        'No mock response defined for request '
-        '[${invocation.positionalArguments[0]}]\n$alice@'
+            'No mock response defined for request '
+            '[${invocation.positionalArguments[0]}]\n$alice@'
         .codeUnits);
   });
   when(() => mockOutboundConnection.write('from:$alice\n'))
@@ -360,6 +349,6 @@ const String characters =
 String createRandomString(int length) {
   return String.fromCharCodes(Iterable.generate(
       length,
-          (index) =>
+      (index) =>
           characters.codeUnitAt(testUtilsRandom.nextInt(characters.length))));
 }

--- a/tests/at_functional_test/pubspec.yaml
+++ b/tests/at_functional_test/pubspec.yaml
@@ -13,23 +13,12 @@ dependencies:
     git:
       url: https://github.com/atsign-foundation/at_demos.git
       path: at_demo_data
-      ref: add_apkam_symm_keys
+      ref: trunk
   at_chops: ^1.0.1
   at_lookup: ^3.0.32
+  at_commons: ^3.0.53
   uuid: ^3.0.7
   elliptic: ^0.3.8
-
-dependency_overrides: 
-  at_commons:
-    git:
-      url: https://github.com/atsign-foundation/at_libraries
-      path: packages/at_commons
-      ref: apkam_enc_dec_changes
-  at_client:
-    git:
-      url: https://github.com/atsign-foundation/at_client_sdk
-      path: packages/at_client
-      ref: trunk
 
 dev_dependencies:
   lints: ^1.0.1

--- a/tests/at_functional_test/pubspec.yaml
+++ b/tests/at_functional_test/pubspec.yaml
@@ -13,11 +13,23 @@ dependencies:
     git:
       url: https://github.com/atsign-foundation/at_demos.git
       path: at_demo_data
-      ref: trunk
+      ref: add_apkam_symm_keys
   at_chops: ^1.0.1
   at_lookup: ^3.0.32
   uuid: ^3.0.7
   elliptic: ^0.3.8
+
+dependency_overrides: 
+  at_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_libraries
+      path: packages/at_commons
+      ref: apkam_enc_dec_changes
+  at_client:
+    git:
+      url: https://github.com/atsign-foundation/at_client_sdk
+      path: packages/at_client
+      ref: trunk
 
 dev_dependencies:
   lints: ^1.0.1

--- a/tests/at_functional_test/test/encryption_util.dart
+++ b/tests/at_functional_test/test/encryption_util.dart
@@ -1,10 +1,8 @@
 
 import 'package:crypton/crypton.dart';
 import 'package:encrypt/encrypt.dart';
-import 'package:at_utils/at_logger.dart';
 
 class EncryptionUtil {
-  static final _logger = AtSignLogger('EncryptionUtil');
 
   static IV getIV(String? ivBase64) {
     if (ivBase64 == null) {

--- a/tests/at_functional_test/test/encryption_util.dart
+++ b/tests/at_functional_test/test/encryption_util.dart
@@ -1,0 +1,39 @@
+import 'dart:typed_data';
+import 'dart:convert';
+
+import 'package:crypton/crypton.dart';
+import 'package:encrypt/encrypt.dart';
+import 'package:crypto/crypto.dart';
+import 'package:at_utils/at_logger.dart';
+
+class EncryptionUtil {
+  static final _logger = AtSignLogger('EncryptionUtil');
+
+  static IV getIV(String? ivBase64) {
+    if (ivBase64 == null) {
+      return IV.fromLength(16);
+    } else {
+      return IV.fromBase64(ivBase64);
+    }
+  }
+
+  static String generateAESKey() {
+    return AES(Key.fromSecureRandom(32)).key.base64;
+  }
+
+  static String generateIV({int length = 16}) {
+    return IV.fromSecureRandom(length).base64;
+  }
+
+  static String encryptValue(String value, String encryptionKey,
+      {String? ivBase64}) {
+    var aesEncrypter = Encrypter(AES(Key.fromBase64(encryptionKey)));
+    var encryptedValue = aesEncrypter.encrypt(value, iv: getIV(ivBase64));
+    return encryptedValue.base64;
+  }
+
+  static String encryptKey(String aesKey, String publicKey) {
+    var rsaPublicKey = RSAPublicKey.fromString(publicKey);
+    return rsaPublicKey.encrypt(aesKey);
+  }
+}

--- a/tests/at_functional_test/test/encryption_util.dart
+++ b/tests/at_functional_test/test/encryption_util.dart
@@ -1,9 +1,6 @@
-import 'dart:typed_data';
-import 'dart:convert';
 
 import 'package:crypton/crypton.dart';
 import 'package:encrypt/encrypt.dart';
-import 'package:crypto/crypto.dart';
 import 'package:at_utils/at_logger.dart';
 
 class EncryptionUtil {

--- a/tests/at_functional_test/test/enroll_namespace_access_test.dart
+++ b/tests/at_functional_test/test/enroll_namespace_access_test.dart
@@ -43,12 +43,12 @@ void main() {
       var fromResponse = await read();
       print('from verb response : $fromResponse');
       fromResponse = fromResponse.replaceAll('data:', '');
-      var pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
-      await socket_writer(socketConnection1!, 'pkam:$pkamDigest');
-      var pkamResult = await read();
-      expect(pkamResult, 'data:success\n');
+      var cramDigest = getDigest(firstAtsign, fromResponse);
+      await socket_writer(socketConnection1!, 'cram:$cramDigest');
+      var cramResult = await read();
+      expect(cramResult, 'data:success\n');
       var enrollRequest =
-          'enroll:request:appName:wavi:deviceName:pixel:namespaces:[wavi,rw]:apkamPublicKey:${pkamPublicKeyMap[firstAtsign]!}\n';
+          'enroll:request:{"appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw"},"apkamPublicKey":"${pkamPublicKeyMap[firstAtsign]!}"}\n';
       await socket_writer(socketConnection1!, enrollRequest);
       var enrollResponse = await read();
       print(enrollResponse);
@@ -60,8 +60,8 @@ void main() {
       var enrollmentId = enrollJsonMap['enrollmentId'];
 
       // now do the apkam using the enrollment id
-      pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
-      var apkamEnrollId = 'pkam:enrollApprovalId:$enrollmentId:$pkamDigest\n';
+      var pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
+      var apkamEnrollId = 'pkam:enrollmentId:$enrollmentId:$pkamDigest\n';
 
       await socket_writer(socketConnection1!, apkamEnrollId);
       var apkamEnrollIdResponse = await read();
@@ -89,12 +89,12 @@ void main() {
       var fromResponse = await read();
       print('from verb response : $fromResponse');
       fromResponse = fromResponse.replaceAll('data:', '');
-      var pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
-      await socket_writer(socketConnection1!, 'pkam:$pkamDigest');
-      var pkamResult = await read();
-      expect(pkamResult, 'data:success\n');
+      var cramDigest = getDigest(firstAtsign, fromResponse);
+      await socket_writer(socketConnection1!, 'cram:$cramDigest');
+      var cramResult = await read();
+      expect(cramResult, 'data:success\n');
       var enrollRequest =
-          'enroll:request:appName:wavi:deviceName:pixel:namespaces:[wavi,rw]:apkamPublicKey:${pkamPublicKeyMap[firstAtsign]!}\n';
+          'enroll:request:{"appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw"},"apkamPublicKey":"${pkamPublicKeyMap[firstAtsign]!}"}\n';
       await socket_writer(socketConnection1!, enrollRequest);
       var enrollResponse = await read();
       print(enrollResponse);
@@ -106,8 +106,8 @@ void main() {
       var enrollmentId = enrollJsonMap['enrollmentId'];
 
       // now do the apkam using the enrollment id
-      pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
-      var apkamEnrollId = 'pkam:enrollApprovalId:$enrollmentId:$pkamDigest\n';
+      var pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
+      var apkamEnrollId = 'pkam:enrollmentId:$enrollmentId:$pkamDigest\n';
 
       await socket_writer(socketConnection1!, apkamEnrollId);
       var apkamEnrollIdResponse = await read();
@@ -124,17 +124,17 @@ void main() {
     // Prerequisite - create a atmosphere key
     //  1. Authenticate and send the enroll request for wavi namespace
     //  2. pkam using the enroll id
-    //  3. Do a llookup for the atmosphere key
+    //  3. Do a llookup for a self atmosphere key
     //  4. Assert that the llookup throws an exception
     test(
-        'enroll request on authenticated connection for wavi namespace and llookup for a atmosphere key',
+        'enroll request on authenticated connection for wavi namespace and llookup for a self atmosphere key',
         () async {
       await socket_writer(socketConnection1!, 'from:$firstAtsign');
       var fromResponse = await read();
       print('from verb response : $fromResponse');
       fromResponse = fromResponse.replaceAll('data:', '');
-      var pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
-      await socket_writer(socketConnection1!, 'pkam:$pkamDigest');
+      var cramDigest = getDigest(firstAtsign, fromResponse);
+      await socket_writer(socketConnection1!, 'cram:$cramDigest');
       var pkamResult = await read();
       expect(pkamResult, 'data:success\n');
 
@@ -148,7 +148,7 @@ void main() {
           (!updateResponse.contains('null')));
 
       var enrollRequest =
-          'enroll:request:appName:wavi:deviceName:pixel:namespaces:[wavi,rw]:apkamPublicKey:${pkamPublicKeyMap[firstAtsign]!}\n';
+          'enroll:request:{"appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw"},"apkamPublicKey":"${pkamPublicKeyMap[firstAtsign]!}"}\n';
       await socket_writer(socketConnection1!, enrollRequest);
       var enrollResponse = await read();
       print(enrollResponse);
@@ -160,8 +160,8 @@ void main() {
       var enrollmentId = enrollJsonMap['enrollmentId'];
 
       // now do the apkam using the enrollment id
-      pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
-      var apkamEnrollId = 'pkam:enrollApprovalId:$enrollmentId:$pkamDigest\n';
+      var pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
+      var apkamEnrollId = 'pkam:enrollmentId:$enrollmentId:$pkamDigest\n';
 
       await socket_writer(socketConnection1!, apkamEnrollId);
       var apkamEnrollIdResponse = await read();
@@ -177,19 +177,19 @@ void main() {
     // Prerequisite - create a public atmosphere key
     //  1. Authenticate and send the enroll request for wavi namespace
     //  2. pkam using the enroll id
-    //  3. Do a llookup for the atmosphere key
+    //  3. Do a llookup for a public atmosphere key
     //  4. Assert that the llookup returns a value without an exception
     test(
-        'enroll request on authenticated connection for wavi namespace and llookup for a atmosphere key',
+        'enroll request on authenticated connection for wavi namespace and llookup for a public atmosphere key',
         () async {
       await socket_writer(socketConnection1!, 'from:$firstAtsign');
       var fromResponse = await read();
       print('from verb response : $fromResponse');
       fromResponse = fromResponse.replaceAll('data:', '');
-      var pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
-      await socket_writer(socketConnection1!, 'pkam:$pkamDigest');
-      var pkamResult = await read();
-      expect(pkamResult, 'data:success\n');
+      var cramDigest = getDigest(firstAtsign, fromResponse);
+      await socket_writer(socketConnection1!, 'cram:$cramDigest');
+      var cramResult = await read();
+      expect(cramResult, 'data:success\n');
 
       // Before creating a enroll request with wavi namespace
       // create a atmosphere key
@@ -201,7 +201,7 @@ void main() {
           (!updateResponse.contains('null')));
 
       var enrollRequest =
-          'enroll:request:appName:wavi:deviceName:pixel:namespaces:[wavi,rw]:apkamPublicKey:${pkamPublicKeyMap[firstAtsign]!}\n';
+          'enroll:request:{"appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw"},"apkamPublicKey":"${pkamPublicKeyMap[firstAtsign]!}"}\n';
       await socket_writer(socketConnection1!, enrollRequest);
       var enrollResponse = await read();
       print(enrollResponse);
@@ -213,8 +213,8 @@ void main() {
       var enrollmentId = enrollJsonMap['enrollmentId'];
 
       // now do the apkam using the enrollment id
-      pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
-      var apkamEnrollId = 'pkam:enrollApprovalId:$enrollmentId:$pkamDigest\n';
+      var pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
+      var apkamEnrollId = 'pkam:enrollmentId:$enrollmentId:$pkamDigest\n';
 
       await socket_writer(socketConnection1!, apkamEnrollId);
       var apkamEnrollIdResponse = await read();
@@ -238,10 +238,10 @@ void main() {
       var fromResponse = await read();
       print('from verb response : $fromResponse');
       fromResponse = fromResponse.replaceAll('data:', '');
-      var pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
-      await socket_writer(socketConnection1!, 'pkam:$pkamDigest');
-      var pkamResult = await read();
-      expect(pkamResult, 'data:success\n');
+      var cramDigest = getDigest(firstAtsign, fromResponse);
+      await socket_writer(socketConnection1!, 'cram:$cramDigest');
+      var cramResult = await read();
+      expect(cramResult, 'data:success\n');
 
       // Before creating a enroll request with wavi namespace
       // create a atmosphere key
@@ -253,7 +253,7 @@ void main() {
           (!updateResponse.contains('null')));
 
       var enrollRequest =
-          'enroll:request:appName:wavi:deviceName:pixel:namespaces:[wavi,rw]:apkamPublicKey:${pkamPublicKeyMap[firstAtsign]!}\n';
+          'enroll:request:{"appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw"},"apkamPublicKey":"${pkamPublicKeyMap[firstAtsign]!}"}\n';
       await socket_writer(socketConnection1!, enrollRequest);
       var enrollResponse = await read();
       print(enrollResponse);
@@ -265,8 +265,8 @@ void main() {
       var enrollmentId = enrollJsonMap['enrollmentId'];
 
       // now do the apkam using the enrollment id
-      pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
-      var apkamEnrollId = 'pkam:enrollApprovalId:$enrollmentId:$pkamDigest\n';
+      var pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
+      var apkamEnrollId = 'pkam:enrollmentId:$enrollmentId:$pkamDigest\n';
 
       await socket_writer(socketConnection1!, apkamEnrollId);
       var apkamEnrollIdResponse = await read();
@@ -290,10 +290,10 @@ void main() {
       var fromResponse = await read();
       print('from verb response : $fromResponse');
       fromResponse = fromResponse.replaceAll('data:', '');
-      var pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
-      await socket_writer(socketConnection1!, 'pkam:$pkamDigest');
-      var pkamResult = await read();
-      expect(pkamResult, 'data:success\n');
+      var cramDigest = getDigest(firstAtsign, fromResponse);
+      await socket_writer(socketConnection1!, 'cram:$cramDigest');
+      var cramResult = await read();
+      expect(cramResult, 'data:success\n');
 
       // Before creating a enroll request with wavi namespace
       // create a atmosphere key
@@ -306,7 +306,7 @@ void main() {
 
       // enroll request with wavi namespace
       var enrollRequest =
-          'enroll:request:appName:wavi:deviceName:pixel:namespaces:[wavi,rw]:apkamPublicKey:${pkamPublicKeyMap[firstAtsign]!}\n';
+          'enroll:request:{"appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw"},"apkamPublicKey":"${pkamPublicKeyMap[firstAtsign]!}"}\n';
       await socket_writer(socketConnection1!, enrollRequest);
       var enrollResponse = await read();
       print(enrollResponse);
@@ -318,8 +318,8 @@ void main() {
       var enrollmentId = enrollJsonMap['enrollmentId'];
 
       // now do the apkam using the enrollment id
-      pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
-      var apkamEnrollId = 'pkam:enrollApprovalId:$enrollmentId:$pkamDigest\n';
+      var pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
+      var apkamEnrollId = 'pkam:enrollmentId:$enrollmentId:$pkamDigest\n';
 
       await socket_writer(socketConnection1!, apkamEnrollId);
       var apkamEnrollIdResponse = await read();
@@ -343,10 +343,10 @@ void main() {
       var fromResponse = await read();
       print('from verb response : $fromResponse');
       fromResponse = fromResponse.replaceAll('data:', '');
-      var pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
-      await socket_writer(socketConnection1!, 'pkam:$pkamDigest');
-      var pkamResult = await read();
-      expect(pkamResult, 'data:success\n');
+      var cramDigest = getDigest(firstAtsign, fromResponse);
+      await socket_writer(socketConnection1!, 'cram:$cramDigest');
+      var cramResult = await read();
+      expect(cramResult, 'data:success\n');
 
       // Before creating a enroll request with wavi namespace
       // create a atmosphere key
@@ -359,7 +359,7 @@ void main() {
 
       // enroll request with wavi namespace
       var enrollRequest =
-          'enroll:request:appName:wavi:deviceName:pixel:namespaces:[wavi,rw]:apkamPublicKey:${pkamPublicKeyMap[firstAtsign]!}\n';
+          'enroll:request:{"appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw"},"apkamPublicKey":"${pkamPublicKeyMap[firstAtsign]!}"}\n';
       await socket_writer(socketConnection1!, enrollRequest);
       var enrollResponse = await read();
       print(enrollResponse);
@@ -371,8 +371,8 @@ void main() {
       var enrollmentId = enrollJsonMap['enrollmentId'];
 
       // now do the apkam using the enrollment id
-      pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
-      var apkamEnrollId = 'pkam:enrollApprovalId:$enrollmentId:$pkamDigest\n';
+      var pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
+      var apkamEnrollId = 'pkam:enrollmentId:$enrollmentId:$pkamDigest\n';
 
       await socket_writer(socketConnection1!, apkamEnrollId);
       var apkamEnrollIdResponse = await read();
@@ -396,10 +396,10 @@ void main() {
       var fromResponse = await read();
       print('from verb response : $fromResponse');
       fromResponse = fromResponse.replaceAll('data:', '');
-      var pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
-      await socket_writer(socketConnection1!, 'pkam:$pkamDigest');
-      var pkamResult = await read();
-      expect(pkamResult, 'data:success\n');
+      var cramDigest = getDigest(firstAtsign, fromResponse);
+      await socket_writer(socketConnection1!, 'cram:$cramDigest');
+      var cramResult = await read();
+      expect(cramResult, 'data:success\n');
 
       // Before creating a enroll request with wavi namespace
       // create a atmosphere key
@@ -413,7 +413,7 @@ void main() {
 
       // enroll request with wavi namespace
       var enrollRequest =
-          'enroll:request:appName:wavi:deviceName:pixel:namespaces:[wavi,rw]:apkamPublicKey:${pkamPublicKeyMap[firstAtsign]!}\n';
+          'enroll:request:{"appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw"},"apkamPublicKey":"${pkamPublicKeyMap[firstAtsign]!}"}\n';
       await socket_writer(socketConnection1!, enrollRequest);
       var enrollResponse = await read();
       print(enrollResponse);
@@ -425,8 +425,8 @@ void main() {
       var enrollmentId = enrollJsonMap['enrollmentId'];
 
       // now do the apkam using the enrollment id
-      pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
-      var apkamEnrollId = 'pkam:enrollApprovalId:$enrollmentId:$pkamDigest\n';
+      var pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
+      var apkamEnrollId = 'pkam:enrollmentId:$enrollmentId:$pkamDigest\n';
 
       await socket_writer(socketConnection1!, apkamEnrollId);
       var apkamEnrollIdResponse = await read();
@@ -450,10 +450,10 @@ void main() {
       var fromResponse = await read();
       print('from verb response : $fromResponse');
       fromResponse = fromResponse.replaceAll('data:', '');
-      var pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
-      await socket_writer(socketConnection1!, 'pkam:$pkamDigest');
-      var pkamResult = await read();
-      expect(pkamResult, 'data:success\n');
+      var cramDigest = getDigest(firstAtsign, fromResponse);
+      await socket_writer(socketConnection1!, 'cram:$cramDigest');
+      var cramResult = await read();
+      expect(cramResult, 'data:success\n');
 
       // create a wavi key
       String waviKey = 'public:email.wavi$firstAtsign';
@@ -465,7 +465,7 @@ void main() {
 
       // enroll request with wavi namespace
       var enrollRequest =
-          'enroll:request:appName:wavi:deviceName:pixel:namespaces:[wavi,rw]:apkamPublicKey:${pkamPublicKeyMap[firstAtsign]!}\n';
+          'enroll:request:{"appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw"},"apkamPublicKey":"${pkamPublicKeyMap[firstAtsign]!}"}\n';
       await socket_writer(socketConnection1!, enrollRequest);
       var enrollResponse = await read();
       print(enrollResponse);
@@ -477,8 +477,8 @@ void main() {
       var enrollmentId = enrollJsonMap['enrollmentId'];
 
       // now do the apkam using the enrollment id
-      pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
-      var apkamEnrollId = 'pkam:enrollApprovalId:$enrollmentId:$pkamDigest\n';
+      var pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
+      var apkamEnrollId = 'pkam:enrollmentId:$enrollmentId:$pkamDigest\n';
 
       await socket_writer(socketConnection1!, apkamEnrollId);
       var apkamEnrollIdResponse = await read();
@@ -504,10 +504,10 @@ void main() {
       var fromResponse = await read();
       print('from verb response : $fromResponse');
       fromResponse = fromResponse.replaceAll('data:', '');
-      var pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
-      await socket_writer(socketConnection1!, 'pkam:$pkamDigest');
-      var pkamResult = await read();
-      expect(pkamResult, 'data:success\n');
+      var cramDigest = getDigest(firstAtsign, fromResponse);
+      await socket_writer(socketConnection1!, 'cram:$cramDigest');
+      var cramResult = await read();
+      expect(cramResult, 'data:success\n');
 
       // create a wavi key
       String atmosphereKey = 'files.atmosphere$firstAtsign';
@@ -520,7 +520,7 @@ void main() {
 
       // enroll request with wavi namespace
       var enrollRequest =
-          'enroll:request:appName:wavi:deviceName:pixel:namespaces:[wavi,rw]:apkamPublicKey:${pkamPublicKeyMap[firstAtsign]!}\n';
+          'enroll:request:{"appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw"},"apkamPublicKey":"${pkamPublicKeyMap[firstAtsign]!}"}\n';
       await socket_writer(socketConnection1!, enrollRequest);
       var enrollResponse = await read();
       print(enrollResponse);
@@ -532,8 +532,8 @@ void main() {
       var enrollmentId = enrollJsonMap['enrollmentId'];
 
       // now do the apkam using the enrollment id
-      pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
-      var apkamEnrollId = 'pkam:enrollApprovalId:$enrollmentId:$pkamDigest\n';
+      var pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
+      var apkamEnrollId = 'pkam:enrollmentId:$enrollmentId:$pkamDigest\n';
 
       await socket_writer(socketConnection1!, apkamEnrollId);
       var apkamEnrollIdResponse = await read();

--- a/tests/at_functional_test/test/enroll_verb_test.dart
+++ b/tests/at_functional_test/test/enroll_verb_test.dart
@@ -3,12 +3,12 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:at_client/src/util/encryption_util.dart';
 import 'package:at_demo_data/at_demo_data.dart' as at_demos;
 import 'package:at_functional_test/conf/config_util.dart';
 import 'package:test/test.dart';
 
 import 'at_demo_data.dart';
+import 'encryption_util.dart';
 import 'functional_test_commons.dart';
 import 'pkam_utils.dart';
 

--- a/tests/at_functional_test/test/enroll_verb_test.dart
+++ b/tests/at_functional_test/test/enroll_verb_test.dart
@@ -1,6 +1,10 @@
+// ignore_for_file: prefer_typing_uninitialized_variables
+
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:at_client/src/util/encryption_util.dart';
+import 'package:at_demo_data/at_demo_data.dart' as at_demos;
 import 'package:at_functional_test/conf/config_util.dart';
 import 'package:test/test.dart';
 
@@ -10,6 +14,13 @@ import 'pkam_utils.dart';
 
 Socket? socketConnection1;
 Socket? socketConnection2;
+
+var aliceDefaultEncKey;
+var aliceSelfEncKey;
+var aliceApkamSymmetricKey;
+var encryptedDefaultEncPrivateKey;
+var encryptedSelfEncKey;
+
 var firstAtsignServer =
     ConfigUtil.getYaml()!['first_atsign_server']['first_atsign_url'];
 var firstAtsignPort =
@@ -22,12 +33,23 @@ Future<void> _connect() async {
   socket_listener(socketConnection1!);
 }
 
+Future<void> encryptKeys() async {
+  aliceDefaultEncKey = at_demos.encryptionPrivateKeyMap[firstAtsign];
+  aliceSelfEncKey = at_demos.aesKeyMap[firstAtsign];
+  aliceApkamSymmetricKey = at_demos.apkamSymmetricKeyMap[firstAtsign];
+  encryptedDefaultEncPrivateKey =
+      EncryptionUtil.encryptValue(aliceDefaultEncKey!, aliceApkamSymmetricKey!);
+  encryptedSelfEncKey =
+      EncryptionUtil.encryptValue(aliceSelfEncKey!, aliceApkamSymmetricKey);
+}
+
+var firstAtsign =
+    ConfigUtil.getYaml()!['first_atsign_server']['first_atsign_name'];
 void main() {
-  var firstAtsign =
-      ConfigUtil.getYaml()!['first_atsign_server']['first_atsign_name'];
   //Establish the client socket connection
   setUp(() async {
     await _connect();
+    await encryptKeys();
   });
 
   group('A group of tests to verify apkam enroll requests', () {
@@ -39,8 +61,11 @@ void main() {
       await socket_writer(socketConnection1!, 'cram:$cramResponse');
       var cramResult = await read();
       expect(cramResult, 'data:success\n');
+
+      // send an enroll request with the keys from the setEncryptionKeys method
       var enrollRequest =
-          'enroll:request:{"appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw"},"apkamPublicKey":"${pkamPublicKeyMap[firstAtsign]!}"}\n';
+          'enroll:request:{"appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw"},"encryptedDefaultEncryptedPrivateKey":"$encryptedDefaultEncPrivateKey","encryptedDefaultSelfEncryptionKey":"$encryptedSelfEncKey","apkamPublicKey":"${pkamPublicKeyMap[firstAtsign]!}"}\n';
+
       await socket_writer(socketConnection1!, enrollRequest);
       var enrollResponse = await read();
       enrollResponse = enrollResponse.replaceFirst('data:', '');
@@ -90,8 +115,10 @@ void main() {
       await socket_writer(socketConnection1!, 'cram:$cramSecret');
       var cramResponse = await read();
       expect(cramResponse, 'data:success\n');
+
+      // send an enroll request with the keys from the setEncryptionKeys method
       var enrollRequest =
-          'enroll:request:{"appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw"},"apkamPublicKey":"${pkamPublicKeyMap[firstAtsign]!}"}\n';
+          'enroll:request:{"appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw"},"encryptedDefaultEncryptedPrivateKey":"$encryptedDefaultEncPrivateKey","encryptedDefaultSelfEncryptionKey":"$encryptedSelfEncKey","apkamPublicKey":"${pkamPublicKeyMap[firstAtsign]!}"}\n';
       await socket_writer(socketConnection1!, enrollRequest);
       var enrollResponse = await read();
       enrollResponse = enrollResponse.replaceFirst('data:', '');
@@ -141,6 +168,108 @@ void main() {
           'error:AT0401-Exception: enrollment id: $secondEnrollId is not approved\n');
     });
 
+    // enroll request with only first client
+    // Purpose of the test
+    // 1. Do a cram authentication
+    // 2. Encrypt the default encryption private key and self encryption key with the apkam symmetric key
+    // 3. Send an enroll request with above encrypted keys
+    // 4. Assert that the enroll request is successful
+    // 5. Disconnect the first client
+    // 6. Connect to the second client
+    // 7. Send an apkam request with the enrollment id from step 4
+    // 8. Assert that the apkam request is successful
+    // 9. Assert that the scan verb doesn't return the key with __manage namespace
+    // 10. Assert that the enroll:list verb returns the enrollment key
+    // 11. Assert that the llookup verb on the enrollment key fails
+    // 12. Assert that the keys:get:self verb returns the default self encryption key
+    // 13. Assert that the keys:get:private verb returns the default encryption private key
+    // 14. Assert that the keys:get:selfKeyName verb returns the default self encryption key
+    // 15. Assert that the keys:get:privateKeyName verb returns the default encryption private key
+    test('enroll request on CRAM authenticated connection and encryption keys',
+        () async {
+      await socket_writer(socketConnection1!, 'from:$firstAtsign');
+      var fromResponse = await read();
+      fromResponse = fromResponse.replaceAll('data:', '');
+      var cramResponse = getDigest(firstAtsign, fromResponse);
+      await socket_writer(socketConnection1!, 'cram:$cramResponse');
+      var cramResult = await read();
+      expect(cramResult, 'data:success\n');
+
+      // send an enroll request with the keys from the setEncryptionKeys method
+      var enrollRequest =
+          'enroll:request:{"appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw"},"encryptedDefaultEncryptedPrivateKey":"$encryptedDefaultEncPrivateKey","encryptedDefaultSelfEncryptionKey":"$encryptedSelfEncKey","apkamPublicKey":"${pkamPublicKeyMap[firstAtsign]!}"}\n';
+
+      await socket_writer(socketConnection1!, enrollRequest);
+      var enrollResponse = await read();
+      enrollResponse = enrollResponse.replaceFirst('data:', '');
+      var enrollJsonMap = jsonDecode(enrollResponse);
+      var enrollmentId = enrollJsonMap['enrollmentId'];
+      expect(enrollmentId, isNotEmpty);
+      expect(enrollJsonMap['status'], 'success');
+
+      // destroy the first connection
+      socketConnection1!.close();
+
+      // connect to the second client with the above enrollment ID
+      socketConnection2 =
+          await secure_socket_connection(firstAtsignServer, firstAtsignPort);
+      socket_listener(socketConnection2!);
+      await socket_writer(socketConnection2!, 'from:$firstAtsign');
+      fromResponse = await read();
+      fromResponse = fromResponse.replaceAll('data:', '');
+      // now do the apkam using the enrollment id
+      var pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
+      var apkamEnrollId = 'pkam:enrollmentId:$enrollmentId:$pkamDigest\n';
+      await socket_writer(socketConnection2!, apkamEnrollId);
+      var apkamEnrollIdResponse = await read();
+      expect(apkamEnrollIdResponse, 'data:success\n');
+
+      // check if scan verb doesn't return apkam namespace
+      await socket_writer(socketConnection2!, 'scan\n');
+      var scanResponse = await read();
+      // assert that scan doesn't return key with __manage namespace
+      expect(scanResponse.contains('__manage'), false);
+
+      // enroll:list
+      await socket_writer(socketConnection2!, 'enroll:list\n');
+      var enrollListResponse = await read();
+      // enrollment key to be checked
+      var enrollmentKey = '$enrollmentId.new.enrollments.__manage$firstAtsign';
+      expect(enrollListResponse.contains(enrollmentKey), true);
+
+      // llookup of the enrollment key should fail
+      await socket_writer(socketConnection2!, 'llookup:$enrollmentKey\n');
+      var llookupResponse = await read();
+      expect(
+          llookupResponse.contains(
+              'AT0009-UnAuthorized client in request : Enrollment Id: $enrollmentId is not authorized for local lookup operation on the key: $enrollmentKey'),
+          true);
+
+      // keys:get:self should return default self encryption key
+      var selfKey = '$enrollmentId.default_self_enc_key.__manage$firstAtsign';
+      await socket_writer(socketConnection2!, 'keys:get:self\n');
+      var selfKeyResponse = await read();
+      expect(selfKeyResponse.contains(selfKey), true);
+
+      // keys:get:private should return private encryption key
+      var privateKey =
+          '$enrollmentId.default_enc_private_key.__manage$firstAtsign';
+      await socket_writer(socketConnection2!, 'keys:get:private\n');
+      var privateKeyResponse = await read();
+      expect(privateKeyResponse.contains(privateKey), true);
+
+      // keys:get:keyName should return the enrollment key with __manage namespace
+      await socket_writer(socketConnection2!, 'keys:get:keyName:$selfKey\n');
+      var selfKeyGetResponse = await read();
+      expect(selfKeyGetResponse.contains('$encryptedSelfEncKey'), true);
+
+      // keys:get:keyName should return the enrollment key with __manage namespace
+      await socket_writer(socketConnection2!, 'keys:get:keyName:$privateKey\n');
+      var privateKeyGetResponse = await read();
+      expect(privateKeyGetResponse.contains('$encryptedDefaultEncPrivateKey'),
+          true);
+    });
+
     // Purpose of the tests
     // 1. Do a pkam authentication
     // 2. Send an enroll request
@@ -157,8 +286,9 @@ void main() {
       await socket_writer(socketConnection1!, 'cram:$cramSecret');
       var cramResult = await read();
       expect(cramResult, 'data:success\n');
+
       var enrollRequest =
-          'enroll:request:{"appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw"},"apkamPublicKey":"${pkamPublicKeyMap[firstAtsign]!}"}\n';
+          'enroll:request:{"appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw"},"encryptedDefaultEncryptedPrivateKey":"$encryptedDefaultEncPrivateKey","encryptedDefaultSelfEncryptionKey":"$encryptedSelfEncKey","apkamPublicKey":"${pkamPublicKeyMap[firstAtsign]!}"}\n';
       await socket_writer(socketConnection1!, enrollRequest);
       var enrollResponse = await read();
       enrollResponse = enrollResponse.replaceFirst('data:', '');
@@ -171,14 +301,15 @@ void main() {
       var totpResponse = await read();
       totpResponse = totpResponse.replaceFirst('data:', '');
       totpResponse = totpResponse.trim();
+
       // connect to the second client
       socketConnection2 =
           await secure_socket_connection(firstAtsignServer, firstAtsignPort);
       socket_listener(socketConnection2!);
+
       //send second enroll request with totp
-      var apkamPublicKey = pkamPublicKeyMap[firstAtsign];
       var secondEnrollRequest =
-          'enroll:request:{"appName":"buzz","deviceName":"pixel","namespaces":{"buzz":"rw"},"totp":"$totpResponse","apkamPublicKey":"$apkamPublicKey"}\n';
+          'enroll:request:{"appName":"buzz","deviceName":"pixel","namespaces":{"buzz":"rw"},"totp":"$totpResponse","encryptedDefaultEncryptedPrivateKey":"$encryptedDefaultEncPrivateKey","encryptedDefaultSelfEncryptionKey":"$encryptedSelfEncKey","apkamPublicKey":"${pkamPublicKeyMap[firstAtsign]!}"}\n';
       await socket_writer(socketConnection2!, secondEnrollRequest);
       var secondEnrollResponse = await read();
       secondEnrollResponse = secondEnrollResponse.replaceFirst('data:', '');
@@ -186,6 +317,7 @@ void main() {
       expect(enrollJson['enrollmentId'], isNotEmpty);
       expect(enrollJson['status'], 'pending');
       var secondEnrollId = enrollJson['enrollmentId'];
+
       // connect to the first client to approve the enroll request
       await socket_writer(socketConnection1!,
           'enroll:approve:{"enrollmentId":"$secondEnrollId"}\n');
@@ -194,6 +326,10 @@ void main() {
       var approveJson = jsonDecode(approveResponse);
       expect(approveJson['status'], 'approved');
       expect(approveJson['enrollmentId'], secondEnrollId);
+
+      // close the first connection
+      socketConnection1!.close();
+
       // connect to the second client to do an apkam
       await socket_writer(socketConnection2!, 'from:$firstAtsign');
       fromResponse = await read();
@@ -204,6 +340,19 @@ void main() {
       await socket_writer(socketConnection2!, apkamEnrollId);
       var apkamEnrollIdResponse = await read();
       expect(apkamEnrollIdResponse, 'data:success\n');
+
+      // keys:get:self should return default self encryption key
+      var selfKey = '$secondEnrollId.default_self_enc_key.__manage$firstAtsign';
+      await socket_writer(socketConnection2!, 'keys:get:self\n');
+      var selfKeyResponse = await read();
+      expect(selfKeyResponse.contains(selfKey), true);
+
+      // keys:get:private should return private encryption key
+      var privateKey =
+          '$secondEnrollId.default_enc_private_key.__manage$firstAtsign';
+      await socket_writer(socketConnection2!, 'keys:get:private\n');
+      var privateKeyResponse = await read();
+      expect(privateKeyResponse.contains(privateKey), true);
     });
   });
 

--- a/tests/at_functional_test/test/keys_verb_test.dart
+++ b/tests/at_functional_test/test/keys_verb_test.dart
@@ -3,7 +3,6 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:at_client/src/util/encryption_util.dart';
 import 'package:at_demo_data/at_demo_data.dart';
 import 'package:at_demo_data/at_demo_data.dart' as at_demos;
 import 'package:at_functional_test/conf/config_util.dart';
@@ -12,6 +11,7 @@ import 'package:encrypt/encrypt.dart';
 import 'package:test/test.dart';
 
 // import 'at_demo_data.dart' as demo;
+import 'encryption_util.dart';
 import 'functional_test_commons.dart';
 import 'pkam_utils.dart';
 
@@ -367,7 +367,7 @@ void main() {
       await socket_writer(socketConnection1!, 'keys:get:self');
       var getResponse = await read();
       expect(getResponse,
-          'error:AT0401-Exception: Command cannot be executed without auth');
+          'error:AT0401-Exception: Command cannot be executed without auth\n');
     });
 
     test('check keys verb put operation - without authentication', () async {

--- a/tests/at_functional_test/test/keys_verb_test.dart
+++ b/tests/at_functional_test/test/keys_verb_test.dart
@@ -200,7 +200,7 @@ void main() {
       var cramResult = await read();
       expect(cramResult, 'data:success\n');
 
-       var enrollRequest =
+      var enrollRequest =
           'enroll:request:{"appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw"},"encryptedDefaultEncryptedPrivateKey":"$encryptedDefaultEncPrivateKey","encryptedDefaultSelfEncryptionKey":"$encryptedSelfEncKey","apkamPublicKey":"${pkamPublicKeyMap[firstAtsign]!}"}\n';
       await socket_writer(socketConnection1!, enrollRequest);
       var enrollResponse = await read();
@@ -232,8 +232,8 @@ void main() {
       var secondEnrollId = enrollJson['enrollmentId'];
 
       // connect to the first client to approve the enroll request
-      await socket_writer(
-          socketConnection1!, 'enroll:approve:{"enrollmentId":"$secondEnrollId"}\n');
+      await socket_writer(socketConnection1!,
+          'enroll:approve:{"enrollmentId":"$secondEnrollId"}\n');
       var approveResponse = await read();
       approveResponse = approveResponse.replaceFirst('data:', '');
       var approveJson = jsonDecode(approveResponse);
@@ -361,6 +361,22 @@ void main() {
           'keys:delete:keyName:wavi.pixel.myaesKey.__self_keys.__global$firstAtsign');
       var deleteSelfKeyResponse = await read();
       expect(deleteSelfKeyResponse, 'data:-1\n');
+    });
+
+    test('check keys verb get operation - without authentication', () async {
+      await socket_writer(socketConnection1!, 'keys:get:self');
+      var getResponse = await read();
+      expect(getResponse,
+          'error:AT0401-Exception: Command cannot be executed without auth');
+    });
+
+    test('check keys verb put operation - without authentication', () async {
+      var putCommand =
+          'keys:put:public:namespace:__global:keyType:rsa2048:keyName:encryption_12344444 testPublicKeyValue';
+      await socket_writer(socketConnection1!, putCommand);
+      var putResponse = await read();
+      expect(putResponse,
+          'error:AT0401-Exception: Command cannot be executed without auth\n');
     });
   });
 }

--- a/tests/at_functional_test/test/keys_verb_test.dart
+++ b/tests/at_functional_test/test/keys_verb_test.dart
@@ -1,0 +1,366 @@
+// ignore_for_file: prefer_typing_uninitialized_variables
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:at_client/src/util/encryption_util.dart';
+import 'package:at_demo_data/at_demo_data.dart';
+import 'package:at_demo_data/at_demo_data.dart' as at_demos;
+import 'package:at_functional_test/conf/config_util.dart';
+import 'package:crypton/crypton.dart';
+import 'package:encrypt/encrypt.dart';
+import 'package:test/test.dart';
+
+// import 'at_demo_data.dart' as demo;
+import 'functional_test_commons.dart';
+import 'pkam_utils.dart';
+
+Socket? socketConnection1;
+Socket? socketConnection2;
+
+var aliceDefaultEncKey;
+var aliceSelfEncKey;
+var aliceApkamSymmetricKey;
+var encryptedDefaultEncPrivateKey;
+var encryptedSelfEncKey;
+
+var firstAtsignServer =
+    ConfigUtil.getYaml()!['first_atsign_server']['first_atsign_url'];
+var firstAtsignPort =
+    ConfigUtil.getYaml()!['first_atsign_server']['first_atsign_port'];
+var firstAtsign =
+    ConfigUtil.getYaml()!['first_atsign_server']['first_atsign_name'];
+
+Future<void> _connect() async {
+  // socket connection for first atsign
+  socketConnection1 =
+      await secure_socket_connection(firstAtsignServer, firstAtsignPort);
+  socket_listener(socketConnection1!);
+}
+
+Future<void> _encryptKeys() async {
+  aliceDefaultEncKey = at_demos.encryptionPrivateKeyMap[firstAtsign];
+  aliceSelfEncKey = at_demos.aesKeyMap[firstAtsign];
+  aliceApkamSymmetricKey = at_demos.apkamSymmetricKeyMap[firstAtsign];
+  encryptedDefaultEncPrivateKey =
+      EncryptionUtil.encryptValue(aliceDefaultEncKey!, aliceApkamSymmetricKey!);
+  encryptedSelfEncKey =
+      EncryptionUtil.encryptValue(aliceSelfEncKey!, aliceApkamSymmetricKey);
+}
+
+void main() {
+  //Establish the client socket connection
+  setUp(() async {
+    await _connect();
+    await _encryptKeys();
+  });
+
+  group('A group of tests to verify keys verb test', () {
+    test(
+        'check keys verb put operation - enroll request on authenticated connection',
+        () async {
+      await socket_writer(socketConnection1!, 'from:$firstAtsign');
+      var fromResponse = await read();
+      fromResponse = fromResponse.replaceAll('data:', '');
+      var cramResponse = getDigest(firstAtsign, fromResponse);
+      await socket_writer(socketConnection1!, 'cram:$cramResponse');
+      var cramResult = await read();
+      expect(cramResult, 'data:success\n');
+
+      var enrollRequest =
+          'enroll:request:{"appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw"},"encryptedDefaultEncryptedPrivateKey":"$encryptedDefaultEncPrivateKey","encryptedDefaultSelfEncryptionKey":"$encryptedSelfEncKey","apkamPublicKey":"${pkamPublicKeyMap[firstAtsign]!}"}\n';
+
+      await socket_writer(socketConnection1!, enrollRequest);
+      var enrollResponse = await read();
+      print(enrollResponse);
+      enrollResponse = enrollResponse.replaceFirst('data:', '');
+      var enrollJsonMap = jsonDecode(enrollResponse);
+      var enrollmentId = enrollJsonMap['enrollmentId'];
+      expect(enrollmentId, isNotEmpty);
+      expect(enrollJsonMap['status'], 'success');
+      var encryptionPublicKey = encryptionPublicKeyMap[firstAtsign];
+
+      //1. put encryption public key
+      var keysPutPublicEncryptionKeyCommand =
+          'keys:put:public:namespace:__global:keyType:rsa2048:keyName:encryption_$enrollmentId $encryptionPublicKey';
+      await socket_writer(
+          socketConnection1!, keysPutPublicEncryptionKeyCommand);
+      var publicKeyPutResponse = await read();
+      expect(publicKeyPutResponse, 'data:-1\n');
+
+      //2. put self symmetric key which is encrypted with encryption public key
+      var aesKey = AES(Key.fromSecureRandom(32)).key.base64;
+
+      var rsaPublicKey = RSAPublicKey.fromString(encryptionPublicKey!);
+      var encryptedAESKey = rsaPublicKey.encrypt(aesKey);
+      var selfSymmetricKeyCommand =
+          'keys:put:self:namespace:__global:appName:wavi:deviceName:pixel:keyType:aes256:encryptionKeyName:encryption_$enrollmentId:keyName:myAESkey $encryptedAESKey';
+      await socket_writer(socketConnection1!, selfSymmetricKeyCommand);
+      var selfKeyPutResponse = await read();
+      expect(selfKeyPutResponse, 'data:-1\n');
+
+      //3. put encryption private key which is encrypted with self symmetric key
+      var rsaPrivateKey = encryptionPrivateKeyMap[firstAtsign];
+      var encryptedPrivateKey = Encrypter(AES(Key.fromBase64(aesKey)))
+          .encrypt(rsaPrivateKey!, iv: IV.fromLength(16))
+          .base64;
+      var privateKeyCommand =
+          'keys:put:private:namespace:__global:appName:wavi:deviceName:pixel:keyType:aes:encryptionKeyName:myAESkey:keyName:myPrivateKey $encryptedPrivateKey';
+      await socket_writer(socketConnection1!, privateKeyCommand);
+      var privateKeyPutResponse = await read();
+      expect(privateKeyPutResponse, 'data:-1\n');
+
+      //4. test keys:get:public
+      await socket_writer(socketConnection1!, 'keys:get:public');
+      var getPublicKeysResponse = await read();
+      getPublicKeysResponse = getPublicKeysResponse.replaceFirst('data:', '');
+      var getPublicKeysResponseJson = jsonDecode(getPublicKeysResponse);
+      expect(getPublicKeysResponseJson.length, greaterThanOrEqualTo(1));
+
+      // 5. test keys:get:publicKey value
+      var publicKeyGetCommand =
+          'keys:get:keyName:public:encryption_$enrollmentId.__public_keys.__global$firstAtsign';
+      await socket_writer(socketConnection1!, publicKeyGetCommand);
+      var getPublicKeyResponse = await read();
+      getPublicKeyResponse = getPublicKeyResponse.replaceFirst('data:', '');
+      var getPublicKeyResponseJson = jsonDecode(getPublicKeyResponse);
+
+      expect(getPublicKeyResponseJson['value'], encryptionPublicKey);
+      expect(getPublicKeyResponseJson['keyType'], 'rsa2048');
+      expect(getPublicKeyResponseJson['enrollmentId'], enrollmentId);
+
+      //6. test keys:get:self
+      await socket_writer(socketConnection1!, 'keys:get:self');
+      var getSelfKeysResponse = await read();
+      getSelfKeysResponse = getSelfKeysResponse.replaceFirst('data:', '');
+      var getSelfKeysResponseJson = jsonDecode(getSelfKeysResponse);
+      expect(getSelfKeysResponseJson.length, greaterThanOrEqualTo(1));
+
+      // 7. test keys:get:selfKey value
+      var selfKeyGetCommand =
+          'keys:get:keyName:wavi.pixel.myaesKey.__self_keys.__global$firstAtsign';
+      await socket_writer(socketConnection1!, selfKeyGetCommand);
+      var getselfKeyResponse = await read();
+      getselfKeyResponse = getselfKeyResponse.replaceFirst('data:', '');
+      var getselfKeyResponseJson = jsonDecode(getselfKeyResponse);
+
+      expect(getselfKeyResponseJson['value'], encryptedAESKey);
+      expect(getselfKeyResponseJson['keyType'], 'aes256');
+      expect(getselfKeyResponseJson['enrollmentId'], enrollmentId);
+      expect(getselfKeyResponseJson['encryptionKeyName'],
+          'encryption_$enrollmentId');
+
+      //8. test keys:get:private
+      await socket_writer(socketConnection1!, 'keys:get:private');
+      var getPrivateKeysResponse = await read();
+      getPrivateKeysResponse = getPrivateKeysResponse.replaceFirst('data:', '');
+      var getPrivateKeysResponseJson = jsonDecode(getPrivateKeysResponse);
+      expect(getPrivateKeysResponseJson.length, greaterThanOrEqualTo(1));
+
+      // 9. test keys:get:private:key
+      var privateKeyGetCommand =
+          'keys:get:keyName:private:wavi.pixel.myPrivateKey.__private_keys.__global$firstAtsign';
+      await socket_writer(socketConnection1!, privateKeyGetCommand);
+      var getprivateKeyResponse = await read();
+      getprivateKeyResponse = getprivateKeyResponse.replaceFirst('data:', '');
+      var getprivateKeyResponseJson = jsonDecode(getprivateKeyResponse);
+
+      expect(getprivateKeyResponseJson['value'], encryptedPrivateKey);
+      expect(getprivateKeyResponseJson['keyType'], 'aes');
+      expect(getprivateKeyResponseJson['enrollmentId'], enrollmentId);
+      expect(getprivateKeyResponseJson['encryptionKeyName'], 'myAESkey');
+
+      // delete the public key and check if it is deleted
+      await socket_writer(socketConnection1!,
+          'keys:delete:keyName:public:encryption_$enrollmentId.__public_keys.__global$firstAtsign');
+      var deletePublicKeyResponse = await read();
+      expect(deletePublicKeyResponse, 'data:-1\n');
+
+      // delete the private key and check if it is deleted
+      await socket_writer(socketConnection1!,
+          'keys:delete:keyName:private:wavi.pixel.myPrivateKey.__private_keys.__global$firstAtsign');
+      var deletePrivateKeyResponse = await read();
+      expect(deletePrivateKeyResponse, 'data:-1\n');
+
+      // delete the self key and check if it is deleted
+      await socket_writer(socketConnection1!,
+          'keys:delete:keyName:wavi.pixel.myaesKey.__self_keys.__global$firstAtsign');
+      var deleteSelfKeyResponse = await read();
+      expect(deleteSelfKeyResponse, 'data:-1\n');
+    });
+
+    test(
+        'check keys verb put operation - enroll request on a second authenticated connection using otp',
+        () async {
+      await socket_writer(socketConnection1!, 'from:$firstAtsign');
+      var fromResponse = await read();
+      fromResponse = fromResponse.replaceAll('data:', '');
+      var cramResponse = getDigest(firstAtsign, fromResponse);
+      await socket_writer(socketConnection1!, 'cram:$cramResponse');
+      var cramResult = await read();
+      expect(cramResult, 'data:success\n');
+
+       var enrollRequest =
+          'enroll:request:{"appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw"},"encryptedDefaultEncryptedPrivateKey":"$encryptedDefaultEncPrivateKey","encryptedDefaultSelfEncryptionKey":"$encryptedSelfEncKey","apkamPublicKey":"${pkamPublicKeyMap[firstAtsign]!}"}\n';
+      await socket_writer(socketConnection1!, enrollRequest);
+      var enrollResponse = await read();
+      enrollResponse = enrollResponse.replaceFirst('data:', '');
+      var enrollJsonMap = jsonDecode(enrollResponse);
+      expect(enrollJsonMap['enrollmentId'], isNotEmpty);
+      expect(enrollJsonMap['status'], 'success');
+
+      var totpRequest = 'totp:get\n';
+      await socket_writer(socketConnection1!, totpRequest);
+      var totpResponse = await read();
+      totpResponse = totpResponse.replaceFirst('data:', '');
+      totpResponse = totpResponse.trim();
+
+      // connect to the second client
+      socketConnection2 =
+          await secure_socket_connection(firstAtsignServer, firstAtsignPort);
+      socket_listener(socketConnection2!);
+      //send second enroll request with totp
+      var secondEnrollRequest =
+          'enroll:request:{"appName":"buzz","deviceName":"pixel","namespaces":{"buzz":"rw"},"totp":"$totpResponse","encryptedDefaultEncryptedPrivateKey":"$encryptedDefaultEncPrivateKey","encryptedDefaultSelfEncryptionKey":"$encryptedSelfEncKey","apkamPublicKey":"${pkamPublicKeyMap[firstAtsign]!}"}\n';
+      await socket_writer(socketConnection2!, secondEnrollRequest);
+
+      var secondEnrollResponse = await read();
+      secondEnrollResponse = secondEnrollResponse.replaceFirst('data:', '');
+      var enrollJson = jsonDecode(secondEnrollResponse);
+      expect(enrollJson['enrollmentId'], isNotEmpty);
+      expect(enrollJson['status'], 'pending');
+      var secondEnrollId = enrollJson['enrollmentId'];
+
+      // connect to the first client to approve the enroll request
+      await socket_writer(
+          socketConnection1!, 'enroll:approve:{"enrollmentId":"$secondEnrollId"}\n');
+      var approveResponse = await read();
+      approveResponse = approveResponse.replaceFirst('data:', '');
+      var approveJson = jsonDecode(approveResponse);
+      expect(approveJson['status'], 'approved');
+      expect(approveJson['enrollmentId'], secondEnrollId);
+
+      // connect to the second client to do an apkam
+      await socket_writer(socketConnection2!, 'from:$firstAtsign');
+      fromResponse = await read();
+      fromResponse = fromResponse.replaceAll('data:', '');
+      // now do the apkam using the enrollment id
+      var pkamDigest = generatePKAMDigest(firstAtsign, fromResponse);
+      var apkamEnrollId = 'pkam:enrollmentId:$secondEnrollId:$pkamDigest\n';
+
+      await socket_writer(socketConnection2!, apkamEnrollId);
+      var apkamEnrollIdResponse = await read();
+      print(apkamEnrollIdResponse);
+      expect(apkamEnrollIdResponse, 'data:success\n');
+      var encryptionPublicKey = encryptionPublicKeyMap[firstAtsign];
+
+      //1. put encryption public key
+      var keysPutPublicEncryptionKeyCommand =
+          'keys:put:public:namespace:__global:keyType:rsa2048:keyName:encryption_$secondEnrollId $encryptionPublicKey';
+      await socket_writer(
+          socketConnection2!, keysPutPublicEncryptionKeyCommand);
+      var publicKeyPutResponse = await read();
+      expect(publicKeyPutResponse, 'data:-1\n');
+
+      //2. put self symmetric key which is encrypted with encryption public key
+      var aesKey = AES(Key.fromSecureRandom(32)).key.base64;
+
+      var rsaPublicKey = RSAPublicKey.fromString(encryptionPublicKey!);
+      var encryptedAESKey = rsaPublicKey.encrypt(aesKey);
+      var selfSymmetricKeyCommand =
+          'keys:put:self:namespace:__global:appName:wavi:deviceName:pixel:keyType:aes256:encryptionKeyName:encryption_$secondEnrollId:keyName:myAESkey $encryptedAESKey';
+      await socket_writer(socketConnection2!, selfSymmetricKeyCommand);
+      var selfKeyPutResponse = await read();
+      expect(selfKeyPutResponse, 'data:-1\n');
+
+      //3. put encryption private key which is encrypted with self symmetric key
+      var rsaPrivateKey = encryptionPrivateKeyMap[firstAtsign];
+      var encryptedPrivateKey = Encrypter(AES(Key.fromBase64(aesKey)))
+          .encrypt(rsaPrivateKey!, iv: IV.fromLength(16))
+          .base64;
+      var privateKeyCommand =
+          'keys:put:private:namespace:__global:appName:wavi:deviceName:pixel:keyType:aes:encryptionKeyName:myAESkey:keyName:myPrivateKey $encryptedPrivateKey';
+      await socket_writer(socketConnection2!, privateKeyCommand);
+      var privateKeyPutResponse = await read();
+      expect(privateKeyPutResponse, 'data:-1\n');
+
+      //4. test keys:get:public
+      await socket_writer(socketConnection2!, 'keys:get:public');
+      var getPublicKeysResponse = await read();
+      getPublicKeysResponse = getPublicKeysResponse.replaceFirst('data:', '');
+      var getPublicKeysResponseJson = jsonDecode(getPublicKeysResponse);
+      expect(getPublicKeysResponseJson.length, greaterThanOrEqualTo(1));
+
+      // 5. test keys:get:publicKey value
+      var publicKeyGetCommand =
+          'keys:get:keyName:public:encryption_$secondEnrollId.__public_keys.__global$firstAtsign';
+      await socket_writer(socketConnection2!, publicKeyGetCommand);
+      var getPublicKeyResponse = await read();
+      getPublicKeyResponse = getPublicKeyResponse.replaceFirst('data:', '');
+      var getPublicKeyResponseJson = jsonDecode(getPublicKeyResponse);
+
+      expect(getPublicKeyResponseJson['value'], encryptionPublicKey);
+      expect(getPublicKeyResponseJson['keyType'], 'rsa2048');
+      expect(getPublicKeyResponseJson['enrollmentId'], secondEnrollId);
+
+      //6. test keys:get:self
+      await socket_writer(socketConnection2!, 'keys:get:self');
+      var getSelfKeysResponse = await read();
+      getSelfKeysResponse = getSelfKeysResponse.replaceFirst('data:', '');
+      var getSelfKeysResponseJson = jsonDecode(getSelfKeysResponse);
+      expect(getSelfKeysResponseJson.length, greaterThanOrEqualTo(1));
+
+      // 7. test keys:get:selfKey value
+      var selfKeyGetCommand =
+          'keys:get:keyName:wavi.pixel.myaesKey.__self_keys.__global$firstAtsign';
+      await socket_writer(socketConnection2!, selfKeyGetCommand);
+      var getselfKeyResponse = await read();
+      getselfKeyResponse = getselfKeyResponse.replaceFirst('data:', '');
+      var getselfKeyResponseJson = jsonDecode(getselfKeyResponse);
+
+      expect(getselfKeyResponseJson['value'], encryptedAESKey);
+      expect(getselfKeyResponseJson['keyType'], 'aes256');
+      expect(getselfKeyResponseJson['enrollmentId'], secondEnrollId);
+      expect(getselfKeyResponseJson['encryptionKeyName'],
+          'encryption_$secondEnrollId');
+
+      //8. test keys:get:private
+      await socket_writer(socketConnection2!, 'keys:get:private');
+      var getPrivateKeysResponse = await read();
+      getPrivateKeysResponse = getPrivateKeysResponse.replaceFirst('data:', '');
+      var getPrivateKeysResponseJson = jsonDecode(getPrivateKeysResponse);
+      expect(getPrivateKeysResponseJson.length, greaterThanOrEqualTo(1));
+
+      // 9. test keys:get:private key value
+      var privateKeyGetCommand =
+          'keys:get:keyName:private:wavi.pixel.myPrivateKey.__private_keys.__global$firstAtsign';
+      await socket_writer(socketConnection2!, privateKeyGetCommand);
+      var getprivateKeyResponse = await read();
+      getprivateKeyResponse = getprivateKeyResponse.replaceFirst('data:', '');
+      var getprivateKeyResponseJson = jsonDecode(getprivateKeyResponse);
+
+      expect(getprivateKeyResponseJson['value'], encryptedPrivateKey);
+      expect(getprivateKeyResponseJson['keyType'], 'aes');
+      expect(getprivateKeyResponseJson['enrollmentId'], secondEnrollId);
+      expect(getprivateKeyResponseJson['encryptionKeyName'], 'myAESkey');
+
+      // delete the public key and check if it is deleted
+      await socket_writer(socketConnection2!,
+          'keys:delete:keyName:public:encryption_$secondEnrollId.__public_keys.__global$firstAtsign');
+      var deletePublicKeyResponse = await read();
+      expect(deletePublicKeyResponse, 'data:-1\n');
+
+      // delete the private key and check if it is deleted
+      await socket_writer(socketConnection2!,
+          'keys:delete:keyName:private:wavi.pixel.myPrivateKey.__private_keys.__global$firstAtsign');
+      var deletePrivateKeyResponse = await read();
+      expect(deletePrivateKeyResponse, 'data:-1\n');
+
+      // delete the self key and check if it is deleted
+      await socket_writer(socketConnection2!,
+          'keys:delete:keyName:wavi.pixel.myaesKey.__self_keys.__global$firstAtsign');
+      var deleteSelfKeyResponse = await read();
+      expect(deleteSelfKeyResponse, 'data:-1\n');
+    });
+  });
+}


### PR DESCRIPTION
**- What I did**
- Implemented keys verb , changes to apkam spec, refactoring
**- How I did it**
- Renamed enrollApprovalId to enrollmentId for consistency
- Removed EnrollNamespace class and replaced with Map<String,String> (key- namespace, value-access) for ease of retrieval while checking authorisation for enrollments
- Added AtEnrollmentException to GlobalExceptionHandler
- In AbstractVerbHandler, added restriction for __global and __manage namespace. only keys verb will have access to these namespaces
- Changes to EnrollVerbHandler  
    - store encrypted default encryption private and encrypted default self encryption
    - For first client approval, store apkam public key in existing key name -  AT_PKAM_PUBLIC_KEY. For other approvals store apkam public key in __pkams__.public_keys format.
- For approval notification, stored encrypted apkam symmetric key in notification value.
- Implemented KeysVerbHandler with put, get and delete params
- Made changes in scan verb handler to not display __manage keys
- added unit and functional tests for keys verb, namespace access and enroll verb

**- How to verify it**
- run the unit tests enroll_data_store_value_test.dart, keys_verb_test.dart
- run the functional tests enroll_namespace_access_test.dart, enroll_verb_test.dart, keys_verb_test.dart

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->