### PR TITLE
fix: Remove skip tag in commit_log_test.dart

### DIFF
--- a/packages/at_persistence_secondary_server/test/commit_log_test.dart
+++ b/packages/at_persistence_secondary_server/test/commit_log_test.dart
@@ -97,25 +97,24 @@ void main() async {
       expect(commitLogInstance?.lastCommittedSequenceNumber(), -1);
     });
 
-    test('test to verify commitId does not increment for signing public key',
-        () async {
+    test('test to verify commitId increments for signing public key', () async {
       var commitLogInstance =
           await (AtCommitLogManagerImpl.getInstance().getCommitLog('@alice'));
       var commitId = await commitLogInstance?.commit(
           'public:signing_publickey@alice', CommitOp.UPDATE);
-      expect(commitId, -1);
-      expect(commitLogInstance?.lastCommittedSequenceNumber(), -1);
-    }, skip: 'Reverting the changes temporarily. Hence skipping the test');
+      expect(commitId, 0);
+      expect(commitLogInstance?.lastCommittedSequenceNumber(), 0);
+    });
 
-    test('test to verify commitId does not increment for signing private key',
+    test('test to verify commitId increments for signing private key',
         () async {
       var commitLogInstance =
           await (AtCommitLogManagerImpl.getInstance().getCommitLog('@alice'));
       var commitId = await commitLogInstance?.commit(
           '@alice:signing_privatekey@alice', CommitOp.UPDATE);
-      expect(commitId, -1);
-      expect(commitLogInstance?.lastCommittedSequenceNumber(), -1);
-    }, skip: 'Reverting the changes temporarily. Hence skipping the test');
+      expect(commitId, 0);
+      expect(commitLogInstance?.lastCommittedSequenceNumber(), 0);
+    });
 
     test(
         'test to verify commitId does not increment for key starting with private:',


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- The two tests which have "skip" tag are a part of the following PR: https://github.com/atsign-foundation/at_server/pull/893, in which we refactored to avoid sync of `signing private key` and `signing public key`. However, this leads to perpetual sync imbalance between the client and server and hence the changes are reverted.
- Please refer to https://github.com/atsign-foundation/at_widgets/issues/546#issuecomment-1271850615 on reverting the changes related to skip sync of signing private/public keys.

- Refactored the tests to assert the current behaviour which is to increment the commit id on creation of `signing_private_key` and `signing_public_key`
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->