### PR TITLE
fix: Return keys based on enrollmentId and refactor scan_verb_handler…

### DIFF
--- a/packages/at_secondary_server/lib/src/verb/handler/scan_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/scan_verb_handler.dart
@@ -113,20 +113,7 @@ class ScanVerbHandler extends AbstractVerbHandler {
     return scanResult;
   }
 
-  /// Returns a filtered list of the
-  /// keys where the filtering
-  /// depends on the type of authentication
-  /// on the inbound connection
-  ///
-  /// **Parameters**
-  ///
-  /// [atConnectionMetadata] Metadata of the inbound connection.
-  ///
-  /// [keys] List of keys from the secondary persistent store.
-  ///
-  /// **Returns**
-  ///
-  /// Returns the list of keys of current atSign.
+  /// Filter keys based on authentication type of inbound connection
   @visibleForTesting
   Future<List<String>> getLocalKeys(
       InboundConnectionMetadata atConnectionMetadata,
@@ -136,14 +123,12 @@ class ScanVerbHandler extends AbstractVerbHandler {
     List<String> localKeysList =
         keyStore.getKeys(regex: scanRegex) as List<String>;
     if (atConnectionMetadata.isAuthenticated) {
-      // If connection is authenticated, except the private keys, return other keys.
       localKeysList
           .removeWhere((key) => _isPrivateKeyForAtSign(key, showHiddenKeys));
       if (atConnectionMetadata.enrollmentId == null ||
           atConnectionMetadata.enrollmentId!.isEmpty) {
         return localKeysList;
       }
-      // If enrollmentId is populated, filter keys based on enrollmentId
       return await _filterKeysBasedOnEnrollmentId(
           atConnectionMetadata, localKeysList, currentAtSign);
     } else if (atConnectionMetadata.isPolAuthenticated) {
@@ -158,10 +143,8 @@ class ScanVerbHandler extends AbstractVerbHandler {
       }
       return localKeysList;
     } else {
-      // Display only public keys. "public:_" are hidden keys. So remove them from list.
-      // Also, remove all the other keys that do not start with "public:"
-      localKeysList.removeWhere(
-          (key) => key.startsWith('public:_') || key.startsWith('public:') == false);
+      localKeysList.removeWhere((key) =>
+          key.startsWith('public:_') || key.startsWith('public:') == false);
       for (int i = 0; i < localKeysList.length; i++) {
         localKeysList[i] = localKeysList[i].replaceAll('public:', '');
       }
@@ -189,8 +172,7 @@ class ScanVerbHandler extends AbstractVerbHandler {
         key.startsWith('_');
   }
 
-  /// Filter and returns keys whose namespaces are authorized for the given
-  /// enrollmentId.
+  /// Filter keys based on namespace access for the given enrollmentId
   ///
   ///   - If the enrollment namespace contains ".*", returns all the keys.
   ///

--- a/packages/at_secondary_server/lib/src/verb/handler/scan_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/scan_verb_handler.dart
@@ -12,6 +12,7 @@ import 'package:at_secondary/src/verb/handler/abstract_verb_handler.dart';
 import 'package:at_secondary/src/verb/verb_enum.dart';
 import 'package:at_server_spec/at_server_spec.dart';
 import 'package:at_server_spec/at_verb_spec.dart';
+import 'package:meta/meta.dart';
 
 /// ScanVerbHandler class is used to process scan verb
 /// Scan verb will return all the possible keys you can lookup
@@ -75,7 +76,7 @@ class ScanVerbHandler extends AbstractVerbHandler {
         response.data =
             await _getExternalKeys(forAtSign, scanRegex, atConnection);
       } else {
-        response.data = jsonEncode(await _getLocalKeys(
+        response.data = jsonEncode(await getLocalKeys(
             atConnectionMetadata, scanRegex, showHiddenKeys, currentAtSign));
       }
     } on Exception catch (e) {
@@ -126,7 +127,8 @@ class ScanVerbHandler extends AbstractVerbHandler {
   /// **Returns**
   ///
   /// Returns the list of keys of current atSign.
-  Future<List<String>> _getLocalKeys(
+  @visibleForTesting
+  Future<List<String>> getLocalKeys(
       InboundConnectionMetadata atConnectionMetadata,
       String? scanRegex,
       bool showHiddenKeys,
@@ -159,7 +161,7 @@ class ScanVerbHandler extends AbstractVerbHandler {
       // Display only public keys. "public:_" are hidden keys. So remove them from list.
       // Also, remove all the other keys that do not start with "public:"
       localKeysList.removeWhere(
-          (key) => key.startsWith('public:_') || !key.startsWith('public:'));
+          (key) => key.startsWith('public:_') || key.startsWith('public:') == false);
       for (int i = 0; i < localKeysList.length; i++) {
         localKeysList[i] = localKeysList[i].replaceAll('public:', '');
       }

--- a/packages/at_secondary_server/test/scan_verb_test.dart
+++ b/packages/at_secondary_server/test/scan_verb_test.dart
@@ -9,6 +9,7 @@ import 'package:at_secondary/src/connection/inbound/inbound_connection_metadata.
 import 'package:at_secondary/src/connection/outbound/outbound_client_manager.dart';
 import 'package:at_secondary/src/notification/notification_manager_impl.dart';
 import 'package:at_secondary/src/notification/stats_notification_service.dart';
+import 'package:at_secondary/src/server/at_secondary_impl.dart';
 import 'package:at_secondary/src/utils/handler_util.dart';
 import 'package:at_secondary/src/utils/secondary_util.dart';
 import 'package:at_secondary/src/verb/executor/default_verb_executor.dart';
@@ -167,6 +168,7 @@ void main() {
     test(
         'A test to verify public hidden keys are returned when showhidden set to true',
         () async {
+      AtSecondaryServerImpl.getInstance().currentAtSign = alice;
       scanVerbHandler.responseManager = mockResponseHandlerManager;
       await scanVerbHandler.process('scan:showhidden:true', inboundConnection);
       List scanResponseList = jsonDecode(scanResponse);
@@ -177,6 +179,7 @@ void main() {
     test(
         'A test to verify public hidden keys are not returned when showhidden set to false',
         () async {
+      AtSecondaryServerImpl.getInstance().currentAtSign = alice;
       scanVerbHandler.responseManager = mockResponseHandlerManager;
       await scanVerbHandler.process('scan:showhidden:false', inboundConnection);
       List scanResponseList = jsonDecode(scanResponse);

--- a/packages/at_secondary_server/test/scan_verb_test.dart
+++ b/packages/at_secondary_server/test/scan_verb_test.dart
@@ -2,78 +2,31 @@ import 'dart:convert';
 
 import 'package:at_commons/at_commons.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
-import 'package:at_secondary/src/caching/cache_manager.dart';
-import 'package:at_secondary/src/connection/inbound/dummy_inbound_connection.dart';
 import 'package:at_secondary/src/connection/inbound/inbound_connection_impl.dart';
 import 'package:at_secondary/src/connection/inbound/inbound_connection_metadata.dart';
-import 'package:at_secondary/src/connection/outbound/outbound_client_manager.dart';
 import 'package:at_secondary/src/notification/notification_manager_impl.dart';
 import 'package:at_secondary/src/notification/stats_notification_service.dart';
 import 'package:at_secondary/src/server/at_secondary_impl.dart';
 import 'package:at_secondary/src/utils/handler_util.dart';
 import 'package:at_secondary/src/utils/secondary_util.dart';
 import 'package:at_secondary/src/verb/executor/default_verb_executor.dart';
-import 'package:at_secondary/src/verb/handler/response/default_response_handler.dart';
-import 'package:at_secondary/src/verb/handler/response/response_handler.dart';
 import 'package:at_secondary/src/verb/handler/scan_verb_handler.dart';
-import 'package:at_secondary/src/verb/manager/response_handler_manager.dart';
 import 'package:at_secondary/src/verb/manager/verb_handler_manager.dart';
 import 'package:at_server_spec/at_server_spec.dart';
 import 'package:at_server_spec/at_verb_spec.dart';
-import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 import 'package:uuid/uuid.dart';
 
 import 'test_utils.dart';
 
-// Global variable to assert the scan responses from the mock response handlers
-String scanResponse = '';
-
-class MockSecondaryKeyStore extends Mock implements SecondaryKeyStore {
-  @override
-  List<String> getKeys({String? regex}) {
-    return [
-      'public:location.wavi@alice',
-      'public:__phone.wavi@alice',
-      '_mobile.wavi@alice'
-    ];
-  }
-}
-
-class MockResponseHandlerManager extends Mock
-    implements ResponseHandlerManager {
-  @override
-  ResponseHandler getResponseHandler(Verb verb) {
-    return MockResponseHandler();
-  }
-}
-
-class MockResponseHandler extends Mock implements DefaultResponseHandler {
-  // Assigning the response the global variable 'scanResponse'.
-  @override
-  Future<void> process(AtConnection connection, Response response) async {
-    scanResponse = getResponseMessage(response.data, '@');
-  }
-
-  @override
-  String getResponseMessage(String? verbResult, String promptKey) {
-    return verbResult!;
-  }
-}
-
-class MockOutboundClientManager extends Mock implements OutboundClientManager {}
-
-class MockAtCacheManager extends Mock implements AtCacheManager {}
-
 void main() {
-  SecondaryKeyStore mockKeyStore = MockSecondaryKeyStore();
-  OutboundClientManager mockOutboundClientManager = MockOutboundClientManager();
-  AtCacheManager mockAtCacheManager = MockAtCacheManager();
-
   group('A group of scan verb tests', () {
+    setUpAll(() async {
+      await verbTestsSetUp();
+    });
     test('test scan getVerb', () {
       var handler = ScanVerbHandler(
-          mockKeyStore, mockOutboundClientManager, mockAtCacheManager);
+          secondaryKeyStore, mockOutboundClientManager, cacheManager);
       var verb = handler.getVerb();
       expect(verb is Scan, true);
     });
@@ -81,9 +34,8 @@ void main() {
     test('test scan command accept test', () {
       var command = 'scan';
       var handler = ScanVerbHandler(
-          mockKeyStore, mockOutboundClientManager, mockAtCacheManager);
+          secondaryKeyStore, mockOutboundClientManager, cacheManager);
       var result = handler.accept(command);
-      print('result : $result');
       expect(result, true);
     });
 
@@ -101,9 +53,8 @@ void main() {
       var command = 'SCAN';
       command = SecondaryUtil.convertCommand(command);
       var handler = ScanVerbHandler(
-          mockKeyStore, mockOutboundClientManager, mockAtCacheManager);
+          secondaryKeyStore, mockOutboundClientManager, cacheManager);
       var result = handler.accept(command);
-      print('result : $result');
       expect(result, true);
     });
 
@@ -123,9 +74,9 @@ void main() {
       var inbound = InboundConnectionImpl(null, null);
       var defaultVerbExecutor = DefaultVerbExecutor();
       var defaultVerbHandlerManager = DefaultVerbHandlerManager(
-          mockKeyStore,
+          secondaryKeyStore,
           mockOutboundClientManager,
-          mockAtCacheManager,
+          cacheManager,
           StatsNotificationService.getInstance(),
           NotificationManager.getInstance());
 
@@ -152,45 +103,215 @@ void main() {
       expect(paramsMap[FOR_AT_SIGN], '@🐼');
       expect(paramsMap[AT_REGEX], '^@kevin');
     });
+    tearDownAll(() async {
+      await verbTestsTearDown();
+    });
   });
 
-  group('A group of mock tests to verify scan verb', () {
+  group('A group of mock tests to verify scan verb on authenticated connection',
+      () {
     late ScanVerbHandler scanVerbHandler;
-    late ResponseHandlerManager mockResponseHandlerManager;
-    late InboundConnection inboundConnection;
-    setUp(() {
+    setUp(() async {
+      await verbTestsSetUp();
       scanVerbHandler = ScanVerbHandler(
-          mockKeyStore, mockOutboundClientManager, mockAtCacheManager);
-      mockResponseHandlerManager = MockResponseHandlerManager();
-      inboundConnection = DummyInboundConnection()
-        ..metadata = (InboundConnectionMetadata()..isAuthenticated = true);
+          secondaryKeyStore, mockOutboundClientManager, cacheManager);
     });
+    test('A test to verify all keys are returned for a simple scan', () async {
+      AtSecondaryServerImpl.getInstance().currentAtSign = alice;
+      inboundConnection.getMetaData().isAuthenticated = true;
+      await secondaryKeyStore.put(
+          'public:location.wavi@alice', AtData()..data = 'dummy_value');
+      await secondaryKeyStore.put(
+          '@bob:phone.buzz@alice', AtData()..data = 'dummy_value');
+      await secondaryKeyStore.put(
+          '@alice:mobile.wavi@alice', AtData()..data = 'dummy_value');
+      await secondaryKeyStore.put(
+          'selfkey.atmosphere@alice', AtData()..data = 'dummy_value');
+      await scanVerbHandler.process('scan', inboundConnection);
+      inboundConnection.lastWrittenData = inboundConnection.lastWrittenData!
+          .split('\n')[0]
+          .replaceAll('data:', '');
+      List scanResponse = jsonDecode(inboundConnection.lastWrittenData!);
+      expect(scanResponse.length, 4);
+      expect(scanResponse.contains('@alice:mobile.wavi@alice'), true);
+      expect(scanResponse.contains('@bob:phone.buzz@alice'), true);
+      expect(scanResponse.contains('public:location.wavi@alice'), true);
+      expect(scanResponse.contains('selfkey.atmosphere@alice'), true);
+    });
+
+    test(
+        'A test to verify only keys matching the regex are returned when regex is supplied to scan',
+        () async {
+      AtSecondaryServerImpl.getInstance().currentAtSign = alice;
+      inboundConnection.getMetaData().isAuthenticated = true;
+      await secondaryKeyStore.put(
+          'public:location.wavi@alice', AtData()..data = 'dummy_value');
+      await secondaryKeyStore.put(
+          '@bob:phone.buzz@alice', AtData()..data = 'dummy_value');
+      await secondaryKeyStore.put(
+          '@alice:mobile.wavi@alice', AtData()..data = 'dummy_value');
+      await secondaryKeyStore.put(
+          'selfkey.atmosphere@alice', AtData()..data = 'dummy_value');
+      await scanVerbHandler.process('scan wavi', inboundConnection);
+      inboundConnection.lastWrittenData = inboundConnection.lastWrittenData!
+          .split('\n')[0]
+          .replaceAll('data:', '');
+      List scanResponse = jsonDecode(inboundConnection.lastWrittenData!);
+      expect(scanResponse.length, 2);
+      expect(scanResponse.contains('@alice:mobile.wavi@alice'), true);
+      expect(scanResponse.contains('public:location.wavi@alice'), true);
+    });
+
     test(
         'A test to verify public hidden keys are returned when showhidden set to true',
         () async {
       AtSecondaryServerImpl.getInstance().currentAtSign = alice;
-      scanVerbHandler.responseManager = mockResponseHandlerManager;
+      inboundConnection.getMetaData().isAuthenticated = true;
+      await secondaryKeyStore.put(
+          'public:__phone.wavi@alice', AtData()..data = 'dummy_value');
+      await secondaryKeyStore.put(
+          '_mobile.wavi@alice', AtData()..data = 'dummy_value');
       await scanVerbHandler.process('scan:showhidden:true', inboundConnection);
-      List scanResponseList = jsonDecode(scanResponse);
-      expect(scanResponseList.contains('public:__phone.wavi@alice'), true);
-      expect(scanResponseList.contains('_mobile.wavi@alice'), true);
+      inboundConnection.lastWrittenData = inboundConnection.lastWrittenData!
+          .split('\n')[0]
+          .replaceAll('data:', '');
+      List scanResponse = jsonDecode(inboundConnection.lastWrittenData!);
+      expect(scanResponse.length, 2);
+      expect(scanResponse.contains('public:__phone.wavi@alice'), true);
+      expect(scanResponse.contains('_mobile.wavi@alice'), true);
     });
 
     test(
         'A test to verify public hidden keys are not returned when showhidden set to false',
         () async {
       AtSecondaryServerImpl.getInstance().currentAtSign = alice;
-      scanVerbHandler.responseManager = mockResponseHandlerManager;
+      inboundConnection.getMetaData().isAuthenticated = true;
+      await secondaryKeyStore.put(
+          'public:__phone.wavi@alice', AtData()..data = 'dummy_value');
+      await secondaryKeyStore.put(
+          '_mobile.wavi@alice', AtData()..data = 'dummy_value');
       await scanVerbHandler.process('scan:showhidden:false', inboundConnection);
-      List scanResponseList = jsonDecode(scanResponse);
-      expect(scanResponseList.contains('public:__phone.wavi@alice'), false);
-      expect(scanResponseList.contains('_mobile.wavi@alice'), false);
+      inboundConnection.lastWrittenData = inboundConnection.lastWrittenData!
+          .split('\n')[0]
+          .replaceAll('data:', '');
+      List scanResponse = jsonDecode(inboundConnection.lastWrittenData!);
+      expect(scanResponse.length, 0);
+    });
+    tearDown(() async {
+      await verbTestsTearDown();
+    });
+  });
+
+  group('A group of tests related to pol authenticated connection', () {
+    late ScanVerbHandler scanVerbHandler;
+    setUp(() async {
+      await verbTestsSetUp();
+      scanVerbHandler = ScanVerbHandler(
+          secondaryKeyStore, mockOutboundClientManager, cacheManager);
+    });
+
+    test(
+        'A test to verify keys specific to forAtSign are returned on pol authenticated connection',
+        () async {
+      inboundConnection.getMetaData().isPolAuthenticated = true;
+      (inboundConnection.getMetaData() as InboundConnectionMetadata)
+          .fromAtSign = '@bob';
+
+      await secondaryKeyStore.put(
+          '@bob:phone.wavi@alice', AtData()..data = 'dummy-value');
+      await secondaryKeyStore.put(
+          '@kevin:location.wavi@alice', AtData()..data = 'dummy-value');
+      await secondaryKeyStore.put(
+          '@random:coutry.wavi@alice', AtData()..data = 'dummy-value');
+      await secondaryKeyStore.put(
+          'public:mobile.wavi@alice', AtData()..data = 'dummy-value');
+      await secondaryKeyStore.put(
+          'city.wavi@alice', AtData()..data = 'dummy-value');
+
+      List<String> scanResponseKeys = await scanVerbHandler.getLocalKeys(
+          inboundConnection.getMetaData() as InboundConnectionMetadata,
+          '.*',
+          false,
+          alice);
+      expect(scanResponseKeys.length, 1);
+      expect(scanResponseKeys[0], 'phone.wavi@alice');
+    });
+
+    test(
+        'A test to verify regex applied on pol authenticated connection returns only keys specific to forAtSign that matches the regex',
+        () async {
+      inboundConnection.getMetaData().isPolAuthenticated = true;
+      (inboundConnection.getMetaData() as InboundConnectionMetadata)
+          .fromAtSign = '@bob';
+
+      await secondaryKeyStore.put(
+          '@bob:phone.wavi@alice', AtData()..data = 'dummy-value');
+      await secondaryKeyStore.put(
+          '@bob:firstname.buzz@alice', AtData()..data = 'dummy-value');
+      await secondaryKeyStore.put(
+          '@kevin:location.wavi@alice', AtData()..data = 'dummy-value');
+      await secondaryKeyStore.put(
+          '@random:coutry.wavi@alice', AtData()..data = 'dummy-value');
+      await secondaryKeyStore.put(
+          'public:mobile.wavi@alice', AtData()..data = 'dummy-value');
+      await secondaryKeyStore.put(
+          'city.wavi@alice', AtData()..data = 'dummy-value');
+
+      List<String> scanResponseKeys = await scanVerbHandler.getLocalKeys(
+          inboundConnection.getMetaData() as InboundConnectionMetadata,
+          'wavi',
+          false,
+          alice);
+      expect(scanResponseKeys.length, 1);
+      expect(scanResponseKeys[0], 'phone.wavi@alice');
+    });
+    tearDown(() async {
+      await verbTestsTearDown();
+    });
+  });
+
+  group('A group of tests related to unauthenticated connection', () {
+    late ScanVerbHandler scanVerbHandler;
+    setUp(() async {
+      await verbTestsSetUp();
+      scanVerbHandler = ScanVerbHandler(
+          secondaryKeyStore, mockOutboundClientManager, cacheManager);
+    });
+    test(
+        'A test to verify scan to forAtSign cannot be executed on unauthenticated connection',
+        () {
+      expect(
+          () => scanVerbHandler.process('scan:@bob', inboundConnection),
+          throwsA(predicate((dynamic e) =>
+              e is UnAuthenticatedException &&
+              e.message ==
+                  'Scan to another atSign cannot be performed without auth')));
+    });
+    test(
+        'A test to verify scan on unauthenticated connection returns only public keys',
+        () async {
+      await secondaryKeyStore.put(
+          '@bob:phone.wavi@alice', AtData()..data = 'dummy-value');
+      await secondaryKeyStore.put(
+          'public:firstname.buzz@alice', AtData()..data = 'dummy-value');
+      await secondaryKeyStore.put(
+          'city.wavi@alice', AtData()..data = 'dummy-value');
+      await scanVerbHandler.process('scan', inboundConnection);
+
+      inboundConnection.lastWrittenData = inboundConnection.lastWrittenData!
+          .split('\n')[0]
+          .replaceAll('data:', '');
+      List scanResponseKeys = jsonDecode(inboundConnection.lastWrittenData!);
+      expect(scanResponseKeys.length, 1);
+      expect(scanResponseKeys[0], 'firstname.buzz@alice');
+    });
+    tearDown(() async {
+      await verbTestsTearDown();
     });
   });
 
   group('A group of APKAM enrollment tests', () {
     late ScanVerbHandler scanVerbHandler;
-    late ResponseHandlerManager mockResponseHandlerManager;
     setUp(() async {
       await verbTestsSetUp();
     });
@@ -218,13 +339,14 @@ void main() {
 
       scanVerbHandler = ScanVerbHandler(
           secondaryKeyStore, mockOutboundClientManager, cacheManager);
-      mockResponseHandlerManager = MockResponseHandlerManager();
       // Set enrollmentId to the inboundConnection to mimic the APKAM auth
       (inboundConnection.getMetaData() as InboundConnectionMetadata)
           .enrollmentId = enrollmentId;
-      scanVerbHandler.responseManager = mockResponseHandlerManager;
       await scanVerbHandler.process('scan', inboundConnection);
-      List scanResponseList = jsonDecode(scanResponse);
+      inboundConnection.lastWrittenData = inboundConnection.lastWrittenData!
+          .split('\n')[0]
+          .replaceAll('data:', '');
+      List scanResponseList = jsonDecode(inboundConnection.lastWrittenData!);
       expect(scanResponseList, isNotEmpty);
       expect(
           scanResponseList
@@ -258,13 +380,14 @@ void main() {
 
       scanVerbHandler = ScanVerbHandler(
           secondaryKeyStore, mockOutboundClientManager, cacheManager);
-      mockResponseHandlerManager = MockResponseHandlerManager();
       // Set enrollmentId to the inboundConnection to mimic the APKAM auth
       (inboundConnection.getMetaData() as InboundConnectionMetadata)
           .enrollmentId = enrollmentId;
-      scanVerbHandler.responseManager = mockResponseHandlerManager;
       await scanVerbHandler.process('scan', inboundConnection);
-      List scanResponseList = jsonDecode(scanResponse);
+      inboundConnection.lastWrittenData = inboundConnection.lastWrittenData!
+          .split('\n')[0]
+          .replaceAll('data:', '');
+      List scanResponseList = jsonDecode(inboundConnection.lastWrittenData!);
       expect(scanResponseList.length, 1);
       expect(scanResponseList[0], 'firstname.wavi$alice');
     });
@@ -291,10 +414,11 @@ void main() {
 
       scanVerbHandler = ScanVerbHandler(
           secondaryKeyStore, mockOutboundClientManager, cacheManager);
-      mockResponseHandlerManager = MockResponseHandlerManager();
-      scanVerbHandler.responseManager = mockResponseHandlerManager;
       await scanVerbHandler.process('scan', inboundConnection);
-      List scanResponseList = jsonDecode(scanResponse);
+      inboundConnection.lastWrittenData = inboundConnection.lastWrittenData!
+          .split('\n')[0]
+          .replaceAll('data:', '');
+      List scanResponseList = jsonDecode(inboundConnection.lastWrittenData!);
       expect(scanResponseList.length, 1);
       expect(
           scanResponseList[0], '$enrollmentId.new.enrollments.__manage$alice');
@@ -322,10 +446,11 @@ void main() {
 
       scanVerbHandler = ScanVerbHandler(
           secondaryKeyStore, mockOutboundClientManager, cacheManager);
-      mockResponseHandlerManager = MockResponseHandlerManager();
-      scanVerbHandler.responseManager = mockResponseHandlerManager;
       await scanVerbHandler.process('scan', inboundConnection);
-      List scanResponseList = jsonDecode(scanResponse);
+      inboundConnection.lastWrittenData = inboundConnection.lastWrittenData!
+          .split('\n')[0]
+          .replaceAll('data:', '');
+      List scanResponseList = jsonDecode(inboundConnection.lastWrittenData!);
       expect(scanResponseList[0].toString().startsWith(enrollmentId), true);
     });
 
@@ -360,10 +485,11 @@ void main() {
 
       scanVerbHandler = ScanVerbHandler(
           secondaryKeyStore, mockOutboundClientManager, cacheManager);
-      mockResponseHandlerManager = MockResponseHandlerManager();
-      scanVerbHandler.responseManager = mockResponseHandlerManager;
       await scanVerbHandler.process('scan', inboundConnection);
-      List scanResponseList = jsonDecode(scanResponse);
+      inboundConnection.lastWrittenData = inboundConnection.lastWrittenData!
+          .split('\n')[0]
+          .replaceAll('data:', '');
+      List scanResponseList = jsonDecode(inboundConnection.lastWrittenData!);
       expect(
           scanResponseList
               .contains('$enrollmentId.new.enrollments.__manage@alice'),
@@ -408,13 +534,55 @@ void main() {
 
       scanVerbHandler = ScanVerbHandler(
           secondaryKeyStore, mockOutboundClientManager, cacheManager);
-      mockResponseHandlerManager = MockResponseHandlerManager();
-      scanVerbHandler.responseManager = mockResponseHandlerManager;
       await scanVerbHandler.process('scan', inboundConnection);
-      List scanResponseList = jsonDecode(scanResponse);
+      inboundConnection.lastWrittenData = inboundConnection.lastWrittenData!
+          .split('\n')[0]
+          .replaceAll('data:', '');
+      List scanResponseList = jsonDecode(inboundConnection.lastWrittenData!);
       expect(scanResponseList[0], 'firstname.atmosphere$alice');
       expect(scanResponseList[1], 'mobile.buzz$alice');
       expect(scanResponseList[2], 'phone.wavi$alice');
+    });
+
+    test(
+        'A test to verify keys without namespace are not returned when enrollmentId is supplied',
+        () async {
+      inboundConnection.getMetaData().isAuthenticated = true;
+      inboundConnection.getMetaData().sessionID = 'dummy_session';
+      var enrollmentId = Uuid().v4();
+      final enrollJson = {
+        'sessionId': '123',
+        'appName': 'wavi',
+        'deviceName': 'pixel',
+        'namespaces': {'__manage': 'r', 'wavi': 'r'},
+        'apkamPublicKey': 'testPublicKeyValue',
+        'requestType': 'newEnrollment',
+        'approval': {'state': 'approved'}
+      };
+      var keyName = '$enrollmentId.new.enrollments.__manage@alice';
+      await secondaryKeyStore.put(
+          keyName, AtData()..data = jsonEncode(enrollJson));
+      // Insert key with wavi and buzz namespace
+      await secondaryKeyStore.put('firstName$alice', AtData()..data = 'alice');
+      await secondaryKeyStore.put(
+          'mobilenumber.wavi$alice', AtData()..data = '+1 434 543 3232');
+      await secondaryKeyStore.put(
+          'public:country.wavi$alice', AtData()..data = 'India');
+      await secondaryKeyStore.put('city.buzz$alice', AtData()..data = 'India');
+
+      scanVerbHandler = ScanVerbHandler(
+          secondaryKeyStore, mockOutboundClientManager, cacheManager);
+      // Set enrollmentId to the inboundConnection to mimic the APKAM auth
+      (inboundConnection.getMetaData() as InboundConnectionMetadata)
+          .enrollmentId = enrollmentId;
+      await scanVerbHandler.process('scan', inboundConnection);
+      inboundConnection.lastWrittenData = inboundConnection.lastWrittenData!
+          .split('\n')[0]
+          .replaceAll('data:', '');
+      List scanResponseList = jsonDecode(inboundConnection.lastWrittenData!);
+      expect(scanResponseList.length, 2);
+      expect(scanResponseList[0], 'mobilenumber.wavi$alice');
+      expect(scanResponseList[1], 'public:country.wavi$alice');
     });
     tearDown(() async => await verbTestsTearDown());
   });


### PR DESCRIPTION
….dart

<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Fix the issue, when connection is authenticated via APKAM, and if enrollment have ".*" namespace, all the keys should be returned.
- Refactored the code the optimize the memory usage by removing the temporary list to filter keys. Instead iterate though the index and update the keys in the list.

**- How I did it**
- 1. To fix the issue related to keys not being returned when enrollment has ".*", add a check  in `_filterKeysBasedOnEnrollmentId` where if enrollment namespace have ".*" return all the keys 
- 2. In `_getLocalKeys` method, remove the temporary list to modify the key. Instead use index to fetch the data and iterate through the list and modify the key.

**- How to verify it**
- All test should pass.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->