### PR TITLE
build(deps): Bump meta to 1.10.0

### DIFF
--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   intl: ^0.18.1
   json_annotation: ^4.8.0
   version: 3.0.2
-  meta: 1.9.1
+  meta: 1.10.0
   mutex: 3.0.1
   yaml: 3.1.2
   logging: 1.2.0


### PR DESCRIPTION
Dependabot continues to fail in raising pub PRs :(

**- What I did**

Took a look at https://github.com/atsign-foundation/at_server/network/updates/719448299 and saw that meta needed to be updated to 1.10.0

**- How to verify it**

Automated tests

**- Description for the changelog**

build(deps): Bump meta to 1.10.0