### PR TITLE
feat: Return latestCommitId among enrolled namespaces

### DIFF
--- a/packages/at_persistence_secondary_server/CHANGELOG.md
+++ b/packages/at_persistence_secondary_server/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.58
+- fix: Modify "lastCommittedSequenceNumberWithRegex" to return highest commitId among enrolled namespaces
 ## 3.0.57
 - fix: Refactor commit log keystore to optimize memory usage
 ## 3.0.56

--- a/packages/at_persistence_secondary_server/lib/src/log/commitlog/at_commit_log.dart
+++ b/packages/at_persistence_secondary_server/lib/src/log/commitlog/at_commit_log.dart
@@ -87,8 +87,8 @@ class AtCommitLog extends BaseAtCommitLog {
 
   /// Returns the latest committed sequence number with regex
   @server
-  Future<int?> lastCommittedSequenceNumberWithRegex(String regex) async {
-    return await _commitLogKeyStore.lastCommittedSequenceNumberWithRegex(regex);
+  Future<int?> lastCommittedSequenceNumberWithRegex(String regex,{List<String>? enrolledNamespace}) async {
+    return await _commitLogKeyStore.lastCommittedSequenceNumberWithRegex(regex, enrolledNamespace: enrolledNamespace);
   }
 
   /// Returns the first committed sequence number

--- a/packages/at_persistence_secondary_server/pubspec.yaml
+++ b/packages/at_persistence_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_persistence_secondary_server
 description: A Dart library with the implementation classes for the persistence layer of the secondary server.
-version: 3.0.57
+version: 3.0.58
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://docs.atsign.com/
 

--- a/packages/at_persistence_secondary_server/test/commit_log_test.dart
+++ b/packages/at_persistence_secondary_server/test/commit_log_test.dart
@@ -133,10 +133,10 @@ void main() async {
         for (int i = 0; i < 10; i++) {
           if (i % 2 == 0) {
             await commitLogKeystore.getBox().add(CommitEntry(
-                'test_key_false_$i', CommitOp.UPDATE, DateTime.now()));
+                'test_key_false_$i.wavi@alice', CommitOp.UPDATE, DateTime.now()));
           } else {
             await commitLogKeystore.getBox().add(CommitEntry(
-                'test_key_false_$i', CommitOp.UPDATE, DateTime.now())
+                'test_key_false_$i.wavi@alice', CommitOp.UPDATE, DateTime.now())
               ..commitId = i);
           }
         }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- With reference to the PR: https://github.com/atsign-foundation/at_server/pull/1569, moved at_persistence_secondary_server changes into this branch.
- Updated the pubspec.yaml and CHANGELOG.md of at_persistence_secondary_server

**- How I did it**
- In "at_commit_log.dart"-> "lastCommittedSequenceNumberWithRegex", added an optional parameter to pass the enrolled namespaces.
- In the CommitLogKeyStore.dart file, include a new method named isNamespaceAuthorized to validate whether the key's namespace is authorized and return the latestCommitId among enrolled namespaces.

**- How to verify it**
- The unit and functional tests in the PR mentioned above should pass.
