### PR TITLE
fix: Wait untill the root server is fully initialized

### DIFF
--- a/tests/at_functional_test/test/check_docker_readiness.dart
+++ b/tests/at_functional_test/test/check_docker_readiness.dart
@@ -16,15 +16,19 @@ void main() {
 
   test('checking for test environment readiness', () async {
     _secureSocket = await secure_socket_connection(rootServer, atsignPort);
-    print('connection established');
     socket_listener(_secureSocket);
     String response = '';
-    while (response.isEmpty || response == 'data:null\n') {
+    while ((retryCount < maxRetryCount) &&
+        (response.isEmpty || response == 'data:null\n')) {
       _secureSocket.write('lookup:signing_publickey$atsign\n');
       response = await read();
       print('waiting for signing public key response : $response');
       await Future.delayed(Duration(milliseconds: 100));
+      if (response.startsWith('data:')) {
+        break;
+      }
     }
     await _secureSocket.close();
-  }, timeout: Timeout(Duration(minutes: 1)));
+    expect(response.startsWith('data:'), true);
+  });
 }

--- a/tests/at_functional_test/test/check_root_server_readiness.dart
+++ b/tests/at_functional_test/test/check_root_server_readiness.dart
@@ -15,6 +15,8 @@ void main() {
 
   late SecureSocket _secureSocket;
 
+  bool isRootServerStarted = false;
+
   test('checking for root server readiness', () async {
     while (retryCount < maxRetryCount) {
       try {
@@ -25,16 +27,17 @@ void main() {
         if (response == '@') {
           print('Secure Socket is open for Root Server');
         }
-        var isRootServerStarted =
-        await _lookupForSecondaryAddress(_secureSocket, atSign, rootServer);
+        isRootServerStarted =
+            await _lookupForSecondaryAddress(_secureSocket, atSign, rootServer);
         if (isRootServerStarted) {
-          print('Closing socket connection');
+          print('Root server started successfully');
           _secureSocket.close();
           break;
         } else {
-          print('Failed to start root server');
+          print('Root server is not completely initialized');
           _secureSocket.close();
-          break;
+          retryCount = retryCount + 1;
+          await Future.delayed(Duration(seconds: 5));
         }
       } on SocketException {
         print('Waiting for the root server to start: RetryCount: $retryCount');
@@ -46,6 +49,7 @@ void main() {
         retryCount = retryCount + 1;
       }
     }
+    expect(isRootServerStarted, true, reason: 'Failed to start root server successfully');
   }, timeout: Timeout(Duration(minutes: 1)));
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Changes in "tests/at_functional_test/test/check_root_server_readiness.dart"
   -  Wait until the root server is completely loaded with secondary server address before loading the PKAM keys.
   - Modify the code to mark the test as "fail" if the secondary is not in the intended state.

- Modify code in "check_docker_readiness.dart" and "check_test_env.dart" to "fail" if the intended response is not received before the time-out.

**- How to verify it**
- The functional tests should pass.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->