### PR TITLE
fix: gracefully handle malformed keys in CommitLogKeystore._isNamespaceAuthorised method

### DIFF
--- a/packages/at_persistence_secondary_server/CHANGELOG.md
+++ b/packages/at_persistence_secondary_server/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.59
+- fix: When checking namespace authorization, gracefully handle any malformed 
+  keys which happen to be in the commit log for historical reasons
 ## 3.0.58
 - fix: Modify "lastCommittedSequenceNumberWithRegex" to return highest commitId among enrolled namespaces
 ## 3.0.57

--- a/packages/at_persistence_secondary_server/pubspec.yaml
+++ b/packages/at_persistence_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_persistence_secondary_server
 description: A Dart library with the implementation classes for the persistence layer of the secondary server.
-version: 3.0.58
+version: 3.0.59
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://docs.atsign.com/
 

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -8,10 +8,6 @@ publish_to: none
 environment:
   sdk: '>=2.15.0 <4.0.0'
 
-dependency_overrides:
-  at_persistence_secondary_server:
-    path: ../at_persistence_secondary_server
-
 dependencies:
   args: 2.4.2
   uuid: 3.0.7

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -8,6 +8,10 @@ publish_to: none
 environment:
   sdk: '>=2.15.0 <4.0.0'
 
+dependency_overrides:
+  at_persistence_secondary_server:
+    path: ../at_persistence_secondary_server
+
 dependencies:
   args: 2.4.2
   uuid: 3.0.7


### PR DESCRIPTION
**- What I did**
fix: When checking namespace authorization in the `CommitLogKeystore._isNamespaceAuthorised` method, gracefully handle any malformed keys which happen to be in the commit log for historical reasons

**- How I did it**
See commit diffs

**- How to verify it**
Tests pass

