### PR TITLE
fix: In SyncProgressiveVerbHandler.prepareResponse, gracefully handle any malformed keys which happen to be in the commit log for historical reasons

### DIFF
--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.0.37
+- fix: In the `SyncProgressiveVerbHandler.prepareResponse` method, gracefully 
+  handle any malformed keys which happen to be in the commit log for
+  historical reasons
+- build: Take up at_persistence_secondary_server version 3.0.59 which
+  includes a similar fix when checking namespace authorization in the
+  `CommitLogKeyStore._isNamespaceAuthorised` method
 ## 3.0.36
 - fix: Implement notify ephemeral changes - Send notification with value without caching the key on receiver's secondary server
 - feat: Implement AtRateLimiter to limit the enrollment requests on a particular connection

--- a/packages/at_secondary_server/lib/src/verb/handler/sync_progressive_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/sync_progressive_verb_handler.dart
@@ -25,7 +25,7 @@ class SyncProgressiveVerbHandler extends AbstractVerbHandler {
   @override
   bool accept(String command) =>
       command.startsWith('${getName(VerbEnum.sync)}:') &&
-      command.startsWith('sync:from');
+          command.startsWith('sync:from');
 
   @override
   Verb getVerb() {
@@ -76,11 +76,19 @@ class SyncProgressiveVerbHandler extends AbstractVerbHandler {
           enforceNameSpace: false);
       if (atKeyType == KeyType.invalidKey) {
         logger.warning(
-            '${commitEntryIterator.current.key} is an invalid key. Skipping from adding it to sync response');
+            'prepareResponse | ${commitEntryIterator.current.key} is an invalid key. Skipping.');
+        continue;
+      }
+      late AtKey parsedAtKey;
+      try {
+        parsedAtKey = AtKey.fromString(commitEntryIterator.current.key!);
+      } on InvalidSyntaxException catch (_) {
+        logger.warning(
+            'prepareResponse | found an invalid key "${commitEntryIterator.current.key!}" in the commit log. Skipping.');
         continue;
       }
       String? keyNamespace =
-          AtKey.fromString(commitEntryIterator.current.key!).namespace;
+          parsedAtKey.namespace;
       if ((keyNamespace != null && keyNamespace.isNotEmpty) &&
           enrolledNamespaces.isNotEmpty &&
           (!enrolledNamespaces.containsKey(allNamespaces) &&
@@ -97,7 +105,7 @@ class SyncProgressiveVerbHandler extends AbstractVerbHandler {
         // exist in keystore, skip the key to sync and continue
         if (!keyStore.isKeyExists(commitEntryIterator.current.key)) {
           logger.finer(
-              '${commitEntryIterator.current.key} does not exist in the keystore. skipping the key to sync');
+              'prepareResponse | ${commitEntryIterator.current.key} does not exist in the keystore. Skipping.');
           continue;
         }
 

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_secondary
 description: Implementation of secondary server.
-version: 3.0.36
+version: 3.0.37
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://www.example.com
 publish_to: none
@@ -25,7 +25,7 @@ dependencies:
   at_lookup: 3.0.40
   at_server_spec: 3.0.15
   at_persistence_spec: 2.0.14
-  at_persistence_secondary_server: 3.0.58
+  at_persistence_secondary_server: 3.0.59
   intl: ^0.18.1
   json_annotation: ^4.8.0
   version: 3.0.2


### PR DESCRIPTION
**- What I did**
- fix: In the `SyncProgressiveVerbHandler.prepareResponse` method, gracefully 
  handle any malformed keys which happen to be in the commit log for
  historical reasons
- build: Take up at_persistence_secondary_server version 3.0.59 which
  includes a similar fix when checking namespace authorization in the
  `CommitLogKeyStore._isNamespaceAuthorised` method
- build: updated CHANGELOG and pubspec for atServer version 3.0.37 

**- How I did it**
See commits

**- How to verify it**
Tests pass
