### PR TITLE
fix: Add scan regex for failing functional tests

### DIFF
--- a/tests/at_functional_test/test/all_verbs_test.dart
+++ b/tests/at_functional_test/test/all_verbs_test.dart
@@ -46,7 +46,7 @@ void main() async {
   });
 
   test('scan verb test $firstAtsign', () async {
-    await socket_writer(socketFirstAtsign!, 'scan');
+    await socket_writer(socketFirstAtsign!, 'scan mobile');
     var response = await read();
     print('scan verb response $response');
     expect(response, contains('"public:mobile$firstAtsign"'));

--- a/tests/at_functional_test/test/enroll_namespace_access_test.dart
+++ b/tests/at_functional_test/test/enroll_namespace_access_test.dart
@@ -347,7 +347,7 @@ void main() {
       var apkamEnrollIdResponse = await read();
       expect(apkamEnrollIdResponse, 'data:success\n');
 
-      await socket_writer(socketConnection1!, 'scan');
+      await socket_writer(socketConnection1!, 'scan filename.atmosphere');
       var scanResponse = await read();
       expect(scanResponse.contains(atmosphereKey), true);
     });
@@ -507,7 +507,7 @@ void main() {
       var apkamEnrollIdResponse = await read();
       expect(apkamEnrollIdResponse, 'data:success\n');
 
-      await socket_writer(socketConnection1!, 'scan');
+      await socket_writer(socketConnection1!, 'scan lastname.wavi');
       var scanResponse = await read();
       print(scanResponse);
       expect((scanResponse.contains(waviKey)), true);


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Add a work around to fix the failing functional tests in the following  link https://github.com/atsign-foundation/at_server/actions/runs/6650002663/job/18069387859

The server response is sent in two packets where as below
```
Server Response: data:["00478077-0cac-48eb-aa4b-cc43de28a82f.default_enc_private_key.__manage@sitaram"<trimmed>"bce50954-ff3a-47dc-9216-6f368205dd3d.default_self_e

Server Response: nc_key.__manage@sitaram",<trimmed>"lastname.wavi@sitaram"worknumber-267927159.wavi@sitaram"]
```
In test, socket messageHandler method has following condition to add response to the queue: 
`if (data.last == 64 && data.contains(10))` which looks for the "@" and "\n". So the response received in the first packet (which starts with "data:" is not added to queue) 

In the second packet, though there is a key, since it does not start with "data:", the read assumes that it is not a valid a response and ignores it.

As a work around, add regex to the scan verb to reduce the number of keys in the scan response.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->