### PR TITLE
build(deps): Bump at_lookup to 3.0.41 and at_chops to 1.0.6

### DIFF
--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -21,8 +21,8 @@ dependencies:
   encrypt: 5.0.3
   at_commons: 3.0.57
   at_utils: 3.0.15
-  at_chops: 1.0.5
-  at_lookup: 3.0.40
+  at_chops: 1.0.6
+  at_lookup: 3.0.41
   at_server_spec: 3.0.15
   at_persistence_spec: 2.0.14
   at_persistence_secondary_server: 3.0.59


### PR DESCRIPTION
Dependabot continues to fail at raising PRs for pubspecs :(

```
updater | +-----------------------------------------------+
updater | |      Changes to Dependabot Pull Requests      |
updater | +---------+-------------------------------------+
updater | | created | at_lookup ( from 3.0.40 to 3.0.41 ) |
updater | | created | at_chops ( from 1.0.5 to 1.0.6 )    |
updater | +---------+-------------------------------------+
```

**- What I did**

Manually bumped pubspec.yaml

**- How to verify it**

Automated tests

**- Description for the changelog**

build(deps): Bump at_lookup to 3.0.41 and at_chops to 1.0.6