### PR TITLE
fix: New link for best practices badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://github.com/atsign-foundation/at_server/actions/workflows/at_server.yaml/badge.svg?branch=trunk)](https://github.com/atsign-foundation/at_server/actions/workflows/at_server.yaml)
 [![GitHub License](https://img.shields.io/badge/license-BSD3-blue.svg)](./LICENSE)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_server/badge)](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_server)
-[![OpenSSF Best Practices](https://bestpractices.coreinfrastructure.org/projects/6713/badge)](https://bestpractices.coreinfrastructure.org/projects/6713)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/6713/badge)](https://www.bestpractices.dev/projects/6713)
 
 # at_server
 This repo contains the core software implementation of the atProtocol:


### PR DESCRIPTION
Badge was not updating to reflect that best practices are now passing

**- What I did**

Updated link

**- How I did it**

Copy/pasted from https://www.bestpractices.dev/en/projects/6713

**- How to verify it**

Badge should show 
![image](https://github.com/atsign-foundation/at_server/assets/478926/3ebbf559-7859-4560-939b-5dd41a01397f)

Though that might require some CDN object expiry.

**- Description for the changelog**

fix: New link for best practices badge