### PR TITLE
fix: Refactor to two sequential jobs

### DIFF
--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -879,7 +879,7 @@ jobs:
           provenance: false
           tags: |
             atsigncompany/virtualenv:vip
-            atsigncompany/virtualenv:GHA${{ github.run_number }}
+            atsigncompany/virtualenv:at_server-gha${{ github.run_number }}
           platforms: |
             linux/amd64
             linux/arm64/v8

--- a/.github/workflows/ve_base.yaml
+++ b/.github/workflows/ve_base.yaml
@@ -31,7 +31,7 @@ jobs:
           push: true
           tags: |
             atsigncompany/vebase:latest
-            atsigncompany/vebase:GHA${{ github.run_number }}
+            atsigncompany/vebase:ve_base-gha${{ github.run_number }}
           platforms: |
             linux/amd64
             linux/arm64/v8

--- a/.github/workflows/ve_base.yaml
+++ b/.github/workflows/ve_base.yaml
@@ -8,7 +8,7 @@ permissions:  # added using https://github.com/step-security/secure-workflows
   contents: read
 
 jobs:
-  docker:
+  ve_base:
     runs-on: ubuntu-latest
     steps:
       - name: Set up QEMU

--- a/.github/workflows/vip_rebuild.yaml
+++ b/.github/workflows/vip_rebuild.yaml
@@ -26,6 +26,7 @@ jobs:
       - name: Checkout latest production tag
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
+          fetch-depth: 0
           ref: ${{ steps.prod_tag.outputs.prod_tag}}
 
       - name: Copy latest certs from trunk

--- a/.github/workflows/vip_rebuild.yaml
+++ b/.github/workflows/vip_rebuild.yaml
@@ -13,36 +13,11 @@ permissions:  # added using https://github.com/step-security/secure-workflows
   contents: read
 
 jobs:
-  push_prod_virtualenv_image:
+  ve_base:
     runs-on: ubuntu-latest
     steps:
-      - name: Get latest production tag
-        id: prod_tag
-        run: |
-          REPO="https://api.github.com/repos/atsign-foundation/at_server/releases/latest"
-          PROD_TAG=$(curl -s ${REPO} | jq -r .tag_name)
-          echo "prod_tag=${PROD_TAG}" >> $GITHUB_OUTPUT
-
-      - name: Checkout latest production tag
+      - name: Checkout trunk
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          fetch-depth: 0
-          ref: ${{ steps.prod_tag.outputs.prod_tag}}
-
-      - name: Copy latest certs from trunk
-        run: |
-          git checkout trunk \
-            tools/build_virtual_environment/ve_base/contents/atsign/root/certs/cert.pem
-          git checkout trunk \
-            tools/build_virtual_environment/ve_base/contents/atsign/root/certs/fullchain.pem
-          git checkout trunk \
-            tools/build_virtual_environment/ve_base/contents/atsign/root/certs/privkey.pem
-          git checkout trunk \
-            tools/build_virtual_environment/ve_base/contents/atsign/secondary/base/certs/cert.pem
-          git checkout trunk \
-            tools/build_virtual_environment/ve_base/contents/atsign/secondary/base/certs/fullchain.pem
-          git checkout trunk \
-            tools/build_virtual_environment/ve_base/contents/atsign/secondary/base/certs/privkey.pem
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
@@ -78,6 +53,34 @@ jobs:
           name: New Docker base image for vebase:latest
           url: ${{ secrets.GOOGLE_CHAT_WEBHOOK }}
           status: ${{ job.status }}
+
+  push_prod_virtualenv_image:
+    needs: [ ve_base ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get latest production tag
+        id: prod_tag
+        run: |
+          REPO="https://api.github.com/repos/atsign-foundation/at_server/releases/latest"
+          PROD_TAG=$(curl -s ${REPO} | jq -r .tag_name)
+          echo "prod_tag=${PROD_TAG}" >> $GITHUB_OUTPUT
+
+      - name: Checkout latest production tag
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          ref: ${{ steps.prod_tag.outputs.prod_tag}}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+
+      - name: Login to DockerHub
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push vip
         id: docker_build_vip

--- a/.github/workflows/vip_rebuild.yaml
+++ b/.github/workflows/vip_rebuild.yaml
@@ -39,7 +39,7 @@ jobs:
           push: true
           tags: |
             atsigncompany/vebase:latest
-            atsigncompany/vebase:GHA${{ github.run_number }}
+            atsigncompany/vebase:vip_rebuild-gha${{ github.run_number }}
           platforms: |
             linux/amd64
             linux/arm64/v8
@@ -92,7 +92,7 @@ jobs:
           provenance: false
           tags: |
             atsigncompany/virtualenv:vip
-            atsigncompany/virtualenv:GHA${{ github.run_number }}
+            atsigncompany/virtualenv:vip_rebuild-gha${{ github.run_number }}
           platforms: |
             linux/amd64
             linux/arm64/v8


### PR DESCRIPTION
First attempt at workflow is failing as the trunk branch isn't available to copy from

**- What I did**

Tried setting fetch-depth to 0 so that all branches are available but that still didn't work so refactored into two jobs, the first building a base image from trunk and the second building the prod binaries from the latest release tag

**- How to verify it**

Successful test run against this branch at https://github.com/atsign-foundation/at_server/actions/runs/7540549186

**- Description for the changelog**

fix: Refactor to two sequential jobs
