### PR TITLE
build(deps): Bump at_commons to 3.0.58

### DIFF
--- a/packages/at_root_server/pubspec.yaml
+++ b/packages/at_root_server/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   args: 2.4.2
   uuid: 3.0.7
   yaml: 3.1.2
-  at_commons: 3.0.57
+  at_commons: 3.0.58
   at_utils: 3.0.15
   at_server_spec: 3.0.15
   at_persistence_root_server:


### PR DESCRIPTION
Dependabot still fails to raise PRs for pubspec.yaml

**- What I did**

Bump at_commons to 3.0.58

**- Description for the changelog**

build(deps): Bump at_commons to 3.0.58
