### PR TITLE
build(deps): Bump at_commons at 4.0.1 - repoint to trunk

### DIFF
--- a/packages/at_root_server/pubspec.yaml
+++ b/packages/at_root_server/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
     git:
       url: https://github.com/atsign-foundation/at_server.git
       path: packages/at_persistence_root_server
-      ref: cpswan-root-bump-at_commons-4.0.1
+      ref: trunk
       version: ^2.0.6
 
 dev_dependencies:


### PR DESCRIPTION
Completes #1791 

**- What I did**

Moved git ref back to trunk

**- How to verify it**

CI will now pass without the branch ref

**- Description for the changelog**

build(deps): Bump at_commons at 4.0.1 - repoint to trunk
