### PR TITLE
ci: Don't fail fast on stable/beta unit test matrix

### DIFF
--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -30,6 +30,7 @@ jobs:
   unit_tests:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         dart-channel: [stable,beta]
 


### PR DESCRIPTION
A single failing test on either beta or stable will cause all the unit tests to fail, requiring a rerun against both channels.

This is happening frequently whilst #1799 is addressed

**- What I did**

Set `fail-fast` to false

**- How to verify it**

Future test runs should only fail on one channel (unless the tests flake on both)

**- Description for the changelog**

ci: Don't fail fast on stable/beta unit test matrix