### PR TITLE
ci: Don't fail fast on functional test matrix

### DIFF
--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -124,6 +124,7 @@ jobs:
   functional_tests:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         dart-channel: [stable,beta]
 


### PR DESCRIPTION
Same as #1808 but for functional tests

**- What I did**

Added `fail-fast: false` to strategy

**- How to verify it**

Single failures will be tolerated

**- Description for the changelog**

ci: Don't fail fast on functional test matrix