### PR TITLE
feat: <breaking change> Persistence impl changes for replacing optional params in keystore put/create with metadata object

### DIFF
--- a/packages/at_persistence_secondary_server/CHANGELOG.md
+++ b/packages/at_persistence_secondary_server/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 4.0.0
+- [Breaking Change] feat: Implement changes for keystore put/create method signature change to replace optional metadata params 
 ## 3.0.60
 - build[deps]: Upgraded the following packages:
     - at_commons to v4.0.0

--- a/packages/at_persistence_secondary_server/lib/src/config/at_config.dart
+++ b/packages/at_persistence_secondary_server/lib/src/config/at_config.dart
@@ -26,7 +26,8 @@ class AtConfig {
     persistenceManager = SecondaryPersistenceStoreFactory.getInstance()
         .getSecondaryPersistenceStore(_atSign)!
         .getHivePersistenceManager()!;
-    configKey = HiveKeyStoreHelper.getInstance().prepareKey('private:blocklist$_atSign');
+    configKey = HiveKeyStoreHelper.getInstance()
+        .prepareKey('private:blocklist$_atSign');
   }
 
   ///Returns 'success' on adding unique [blockList] into blocklist.
@@ -132,8 +133,9 @@ class AtConfig {
     var newData = AtData();
     newData.data = jsonEncode(config);
 
-    newData = HiveKeyStoreHelper.getInstance()
-        .prepareDataForKeystoreOperation(newData, existingAtData: existingData);
+    newData = HiveKeyStoreHelper.getInstance().prepareDataForKeystoreOperation(
+        newData,
+        existingMetaData: existingData?.metdata);
 
     logger.finest('Storing the config key:$configKey | Value: $newData');
     await persistenceManager.getBox().put(configKey, newData);
@@ -167,7 +169,7 @@ class AtConfig {
           AtData newAtData = AtData()..data = existingData.data;
           HiveKeyStoreHelper.getInstance().prepareDataForKeystoreOperation(
               newAtData,
-              existingAtData: existingData);
+              existingMetaData: existingData.metaData);
           // store the existing data with the new key
           await persistenceManager.getBox().put(configKey, newAtData);
           logger.info('Successfully migrated configKey data to new key format');

--- a/packages/at_persistence_secondary_server/lib/src/config/at_config.dart
+++ b/packages/at_persistence_secondary_server/lib/src/config/at_config.dart
@@ -135,7 +135,7 @@ class AtConfig {
 
     newData = HiveKeyStoreHelper.getInstance().prepareDataForKeystoreOperation(
         newData,
-        existingMetaData: existingData?.metdata);
+        existingMetaData: existingData?.metaData);
 
     logger.finest('Storing the config key:$configKey | Value: $newData');
     await persistenceManager.getBox().put(configKey, newData);

--- a/packages/at_persistence_secondary_server/lib/src/keystore/hive_keystore_helper.dart
+++ b/packages/at_persistence_secondary_server/lib/src/keystore/hive_keystore_helper.dart
@@ -1,3 +1,4 @@
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:at_persistence_secondary_server/src/model/at_data.dart';
 import 'package:at_persistence_secondary_server/src/model/at_metadata_builder.dart';
 import 'package:at_utf7/at_utf7.dart';
@@ -17,44 +18,13 @@ class HiveKeyStoreHelper {
   }
 
   AtData prepareDataForKeystoreOperation(AtData newAtData,
-      {AtData? existingAtData,
-      int? ttl,
-      int? ttb,
-      int? ttr,
-      bool? isCascade,
-      bool? isBinary,
-      bool? isEncrypted,
-      String? dataSignature,
-      String? sharedKeyEncrypted,
-      String? publicKeyChecksum,
-      String? encoding,
-      String? encKeyName,
-      String? encAlgo,
-      String? ivNonce,
-      String? skeEncKeyName,
-      String? skeEncAlgo,
-      String? atSign}) {
+      {AtMetaData? existingMetaData, AtMetaData? newMetaData, String? atSign}) {
     var atData = AtData();
     atData.data = newAtData.data;
     atData.metaData = AtMetadataBuilder(
             atSign: atSign,
-            newAtMetaData: newAtData.metaData,
-            existingMetaData: existingAtData?.metaData,
-            ttl: ttl,
-            ttb: ttb,
-            ttr: ttr,
-            ccd: isCascade,
-            isBinary: isBinary,
-            isEncrypted: isEncrypted,
-            dataSignature: dataSignature,
-            sharedKeyEncrypted: sharedKeyEncrypted,
-            publicKeyChecksum: publicKeyChecksum,
-            encoding: encoding,
-            encKeyName: encKeyName,
-            encAlgo: encAlgo,
-            ivNonce: ivNonce,
-            skeEncKeyName: skeEncKeyName,
-            skeEncAlgo: skeEncAlgo)
+            newMetaData: newMetaData,
+            existingMetaData: existingMetaData)
         .build();
     return atData;
   }

--- a/packages/at_persistence_secondary_server/lib/src/keystore/secondary_keystore_manager.dart
+++ b/packages/at_persistence_secondary_server/lib/src/keystore/secondary_keystore_manager.dart
@@ -16,6 +16,6 @@ class SecondaryKeyStoreManager implements KeystoreManager<String, AtData?> {
 
   @override
   StoreType getStoreType() {
-    return StoreType.SECONDARY;
+    return StoreType.secondary;
   }
 }

--- a/packages/at_persistence_secondary_server/lib/src/log/commitlog/commit_log_keystore.dart
+++ b/packages/at_persistence_secondary_server/lib/src/log/commitlog/commit_log_keystore.dart
@@ -185,7 +185,8 @@ class CommitLogKeyStore extends BaseCommitLogKeyStore {
         (_isRegexMatches(atKey, regex) || _isSpecialKey(atKey));
   }
 
-  bool _isNamespaceAuthorised(String atKeyAsString, List<String>? enrolledNamespace) {
+  bool _isNamespaceAuthorised(
+      String atKeyAsString, List<String>? enrolledNamespace) {
     // This is work-around for : https://github.com/atsign-foundation/at_server/issues/1570
     if (atKeyAsString.toLowerCase() == 'configkey') {
       return true;

--- a/packages/at_persistence_secondary_server/lib/src/model/at_meta_data.dart
+++ b/packages/at_persistence_secondary_server/lib/src/model/at_meta_data.dart
@@ -173,11 +173,10 @@ class AtMetaData extends HiveObject {
         ? null
         : DateTime.parse(json['availableAt']);
     status = json['status'];
+    // convert to int for non-null value.
     version = (json['version'] is String)
         ? int.parse(json['version'])
-        : (json['version'] == null)
-            ? 0
-            : json['version'];
+        : json['version'];
     ttl = (json[AtConstants.ttl] is String)
         ? int.parse(json[AtConstants.ttl])
         : (json[AtConstants.ttl] == null)

--- a/packages/at_persistence_secondary_server/lib/src/model/at_meta_data.dart
+++ b/packages/at_persistence_secondary_server/lib/src/model/at_meta_data.dart
@@ -121,7 +121,7 @@ class AtMetaData extends HiveObject {
       ..ivNonce = metadata.ivNonce
       ..skeEncKeyName = metadata.skeEncKeyName
       ..skeEncAlgo = metadata.skeEncAlgo;
-    return AtMetadataBuilder(newAtMetaData: atMetadata).build();
+    return AtMetadataBuilder(newMetaData: atMetadata).build();
   }
 
   Map toJson() {

--- a/packages/at_persistence_secondary_server/lib/src/model/at_metadata_builder.dart
+++ b/packages/at_persistence_secondary_server/lib/src/model/at_metadata_builder.dart
@@ -3,94 +3,139 @@ import 'package:at_utils/at_logger.dart';
 
 /// Builder class to build [AtMetaData] object.
 class AtMetadataBuilder {
-  late final AtMetaData atMetaData;
+  late AtMetaData atMetaData;
 
   /// We will constrain to millisecond precision because Hive only stores
   /// [DateTime]s to millisecond precision - see https://github.com/hivedb/hive/issues/474
   /// for details.
-  final DateTime currentUtcTimeToMillisecondPrecision =
+  var currentUtcTimeToMillisecondPrecision =
       DateTime.now().toUtcMillisecondsPrecision();
 
   static final AtSignLogger logger = AtSignLogger('AtMetadataBuilder');
 
   AtMetadataBuilder(
-      {String? atSign, AtMetaData? newMetaData, AtMetaData? existingMetaData})
-      : atMetaData = newMetaData ?? AtMetaData() {
+      {String? atSign, AtMetaData? newMetaData, AtMetaData? existingMetaData}) {
+    newMetaData ??= AtMetaData();
+    atMetaData = newMetaData;
     // createdAt indicates the date and time of the key created.
     // For a new key, the currentDateTime is set and remains unchanged
     // on an update event.
-    atMetaData.createdAt =
-        existingMetaData?.createdAt ?? currentUtcTimeToMillisecondPrecision;
+    (existingMetaData?.createdAt == null)
+        ? atMetaData.createdAt = currentUtcTimeToMillisecondPrecision
+        : atMetaData.createdAt = existingMetaData?.createdAt;
     atMetaData.createdBy ??= atSign;
     atMetaData.updatedBy = atSign;
-
     // updatedAt indicates the date and time of the key updated.
     // For a new key, the updatedAt is same as createdAt and on key
     // update, set the updatedAt to the currentDateTime.
     atMetaData.updatedAt = currentUtcTimeToMillisecondPrecision;
     atMetaData.status = 'active';
+    // // The version indicates the number of updates a key has received.
+    // // Version is set to 0 for a new key and for each update the key receives,
+    // // the version increases by 1
+    // (existingMetaData?.version == null)
+    //     ? atMetaData.version = 0
+    //     : atMetaData.version = (existingMetaData!.version! + 1);
 
-    // sets newAtMetaData attributes if set. Otherwise fallback to existingMetaData attributes.
-    _copyMetadata(existingMetaData, newMetaData);
+    //If new metadata is available, consider new metadata, else if existing metadata is available consider it.
+    int? ttl;
+    ttl ??= newMetaData.ttl;
+    if (ttl == null && existingMetaData != null) ttl = existingMetaData.ttl;
 
-    if (atMetaData.ttl != null && atMetaData.ttl! >= 0) {
-      setTTL(atMetaData.ttl, ttb: atMetaData.ttb);
+    int? ttb;
+    ttb ??= newMetaData.ttb;
+    if (ttb == null && existingMetaData != null) ttb = existingMetaData.ttb;
+
+    int? ttr;
+    ttr ??= newMetaData.ttr;
+    if (ttr == null && existingMetaData != null) ttr = existingMetaData.ttr;
+
+    bool? ccd;
+    ccd ??= newMetaData.isCascade;
+    if (ccd == null && existingMetaData != null) {
+      ccd = existingMetaData.isCascade;
     }
-    if (atMetaData.ttb != null && atMetaData.ttb! >= 0) {
-      setTTB(atMetaData.ttb);
+    bool? isBinary;
+    isBinary ??= newMetaData.isBinary;
+    if (isBinary == null && existingMetaData != null) {
+      isBinary = existingMetaData.isBinary;
+    }
+    bool? isEncrypted;
+    isEncrypted ??= newMetaData.isEncrypted;
+    if (isEncrypted == null && existingMetaData != null) {
+      isEncrypted = existingMetaData.isEncrypted;
+    }
+    String? dataSignature;
+    dataSignature ??= newMetaData.dataSignature;
+    if (dataSignature == null && existingMetaData != null) {
+      dataSignature = existingMetaData.dataSignature;
+    }
+    String? sharedKeyEncrypted;
+    sharedKeyEncrypted ??= newMetaData.sharedKeyEnc;
+    if (sharedKeyEncrypted == null && existingMetaData != null) {
+      sharedKeyEncrypted = existingMetaData.sharedKeyEnc;
+    }
+    String? publicKeyChecksum;
+    publicKeyChecksum ??= newMetaData.pubKeyCS;
+    if (publicKeyChecksum == null && existingMetaData != null) {
+      publicKeyChecksum = existingMetaData.pubKeyCS;
+    }
+    String? encoding;
+    encoding ??= newMetaData.encoding;
+    if (encoding == null && existingMetaData != null) {
+      encoding = existingMetaData.encoding;
+    }
+    String? encKeyName;
+    encKeyName ??= newMetaData.encKeyName;
+    if (encKeyName == null && existingMetaData != null) {
+      encKeyName = existingMetaData.encKeyName;
+    }
+    String? encAlgo;
+    encAlgo ??= newMetaData.encAlgo;
+    if (encAlgo == null && existingMetaData != null) {
+      encAlgo = existingMetaData.encAlgo;
+    }
+    String? ivNonce;
+    ivNonce ??= newMetaData.ivNonce;
+    if (ivNonce == null && existingMetaData != null) {
+      ivNonce = existingMetaData.ivNonce;
+    }
+    String? skeEncKeyName;
+    skeEncKeyName ??= newMetaData.skeEncKeyName;
+
+    if (skeEncKeyName == null && existingMetaData != null) {
+      skeEncKeyName = existingMetaData.skeEncKeyName;
+    }
+    String? skeEncAlgo;
+    skeEncAlgo ??= newMetaData.skeEncAlgo;
+    if (skeEncAlgo == null && existingMetaData != null) {
+      skeEncAlgo = existingMetaData.skeEncAlgo;
+    }
+    if (ttl != null && ttl >= 0) {
+      setTTL(ttl, ttb: ttb);
+    }
+    if (ttb != null && ttb >= 0) {
+      setTTB(ttb);
     }
     // If TTR is -1, cache the key forever.
-    if (atMetaData.ttr != null && atMetaData.ttr! > 0 || atMetaData.ttr == -1) {
-      setTTR(atMetaData.ttr);
+    if (ttr != null && ttr > 0 || ttr == -1) {
+      setTTR(ttr);
     }
+    if (ccd != null) {
+      setCCD(ccd);
+    }
+    atMetaData.isBinary = isBinary;
+    atMetaData.isEncrypted = isEncrypted;
+    atMetaData.dataSignature = dataSignature;
+    atMetaData.sharedKeyEnc = sharedKeyEncrypted;
+    atMetaData.pubKeyCS = publicKeyChecksum;
+    atMetaData.encoding = encoding;
+    atMetaData.encKeyName = encKeyName;
+    atMetaData.encAlgo = encAlgo;
+    atMetaData.ivNonce = ivNonce;
+    atMetaData.skeEncKeyName = skeEncKeyName;
+    atMetaData.skeEncAlgo = skeEncAlgo;
   }
-
-  // if existing metadata field is NOT null and new metadata field is null object, then set existing metadata field
-  // if existing metadata field is NOT null and new metadata field is not null object, then set new metadata field
-  // if existing metadata field is null and new metadata field is NOT null, then set new metadata field
-  // if existing metadata field is NOT null and new metadata field is null string, then set new metadata field (unset scenario)
-  void _copyMetadata(AtMetaData? existingMetaData, AtMetaData? newAtMetaData) {
-    atMetaData.ttl = _getOrDefault(newAtMetaData?.ttl, existingMetaData?.ttl);
-    atMetaData.ttb = newAtMetaData?.ttb ?? existingMetaData?.ttb;
-    atMetaData.ttr = newAtMetaData?.ttr ?? existingMetaData?.ttr;
-    atMetaData.isCascade =
-        newAtMetaData?.isCascade ?? existingMetaData?.isCascade;
-    atMetaData.isBinary = newAtMetaData?.isBinary ?? existingMetaData?.isBinary;
-    atMetaData.isEncrypted =
-        newAtMetaData?.isEncrypted ?? existingMetaData?.isEncrypted;
-    atMetaData.dataSignature = newAtMetaData?.dataSignature == "null"
-        ? null
-        : newAtMetaData?.dataSignature ?? existingMetaData?.dataSignature;
-    atMetaData.sharedKeyEnc = newAtMetaData?.sharedKeyEnc == "null"
-        ? null
-        : newAtMetaData?.sharedKeyEnc ?? existingMetaData?.sharedKeyEnc;
-    atMetaData.pubKeyCS = newAtMetaData?.pubKeyCS == "null"
-        ? null
-        : newAtMetaData?.pubKeyCS ?? existingMetaData?.pubKeyCS;
-
-    atMetaData.encoding = newAtMetaData?.encoding == "null"
-        ? null
-        : newAtMetaData?.encoding ?? existingMetaData?.encoding;
-    atMetaData.encKeyName = newAtMetaData?.encKeyName == "null"
-        ? null
-        : newAtMetaData?.encKeyName ?? existingMetaData?.encKeyName;
-    atMetaData.encAlgo = newAtMetaData?.encAlgo == "null"
-        ? null
-        : newAtMetaData?.encAlgo ?? existingMetaData?.encAlgo;
-    atMetaData.ivNonce = newAtMetaData?.ivNonce == "null"
-        ? null
-        : newAtMetaData?.ivNonce ?? existingMetaData?.ivNonce;
-    atMetaData.skeEncKeyName = newAtMetaData?.skeEncKeyName == "null"
-        ? null
-        : newAtMetaData?.skeEncKeyName ?? existingMetaData?.skeEncKeyName;
-    atMetaData.skeEncAlgo = newAtMetaData?.skeEncAlgo == "null"
-        ? null
-        : newAtMetaData?.skeEncAlgo ?? existingMetaData?.skeEncAlgo;
-    atMetaData.version = newAtMetaData?.version ?? existingMetaData?.version;
-  }
-
-  int? _getOrDefault(int? newValue, int? existingValue) =>
-      newValue ?? existingValue;
 
   void setTTL(int? ttl, {int? ttb}) {
     if (ttl != null) {
@@ -123,17 +168,32 @@ class AtMetadataBuilder {
     atMetaData.isCascade = ccd;
   }
 
-  DateTime? _getAvailableAt(int epochNow, int ttb) =>
-      DateTime.fromMillisecondsSinceEpoch(epochNow + ttb).toUtc();
+  DateTime? _getAvailableAt(int epochNow, int ttb) {
+    var availableAt = epochNow + ttb;
+    return DateTime.fromMillisecondsSinceEpoch(availableAt).toUtc();
+  }
 
   DateTime? _getExpiresAt(int epochNow, int ttl, {int? ttb}) {
-    if (ttl == 0) return null; // Key will not expire if TTL is 0
-    var expiresAt = epochNow + ttl + (ttb ?? 0);
+    //if ttl is zero, reset expires at. The key will not expire
+    if (ttl == 0) {
+      return null;
+    }
+    var expiresAt = epochNow + ttl;
+    if (ttb != null) {
+      expiresAt = expiresAt + ttb;
+    }
     return DateTime.fromMillisecondsSinceEpoch(expiresAt).toUtc();
   }
 
-  DateTime? _getRefreshAt(DateTime today, int ttr) =>
-      ttr == -1 ? null : today.add(Duration(seconds: ttr));
+  DateTime? _getRefreshAt(DateTime today, int ttr) {
+    if (ttr == -1) {
+      return null;
+    }
 
-  AtMetaData build() => atMetaData;
+    return today.add(Duration(seconds: ttr));
+  }
+
+  AtMetaData build() {
+    return atMetaData;
+  }
 }

--- a/packages/at_persistence_secondary_server/lib/src/model/at_metadata_builder.dart
+++ b/packages/at_persistence_secondary_server/lib/src/model/at_metadata_builder.dart
@@ -54,20 +54,34 @@ class AtMetadataBuilder {
     atMetaData.isBinary = newAtMetaData?.isBinary ?? existingMetaData?.isBinary;
     atMetaData.isEncrypted =
         newAtMetaData?.isEncrypted ?? existingMetaData?.isEncrypted;
-    atMetaData.dataSignature =
-        newAtMetaData?.dataSignature ?? existingMetaData?.dataSignature;
-    atMetaData.sharedKeyEnc =
-        newAtMetaData?.sharedKeyEnc ?? existingMetaData?.sharedKeyEnc;
-    atMetaData.pubKeyCS = newAtMetaData?.pubKeyCS ?? existingMetaData?.pubKeyCS;
-    atMetaData.encoding = newAtMetaData?.encoding ?? existingMetaData?.encoding;
-    atMetaData.encKeyName =
-        newAtMetaData?.encKeyName ?? existingMetaData?.encKeyName;
-    atMetaData.encAlgo = newAtMetaData?.encAlgo ?? existingMetaData?.encAlgo;
-    atMetaData.ivNonce = newAtMetaData?.ivNonce ?? existingMetaData?.ivNonce;
-    atMetaData.skeEncKeyName =
-        newAtMetaData?.skeEncKeyName ?? existingMetaData?.skeEncKeyName;
-    atMetaData.skeEncAlgo =
-        newAtMetaData?.skeEncAlgo ?? existingMetaData?.skeEncAlgo;
+    atMetaData.dataSignature = newAtMetaData?.dataSignature == "null"
+        ? null
+        : newAtMetaData?.dataSignature ?? existingMetaData?.dataSignature;
+    atMetaData.sharedKeyEnc = newAtMetaData?.sharedKeyEnc == "null"
+        ? null
+        : newAtMetaData?.sharedKeyEnc ?? existingMetaData?.sharedKeyEnc;
+    atMetaData.pubKeyCS = newAtMetaData?.pubKeyCS == "null"
+        ? null
+        : newAtMetaData?.pubKeyCS ?? existingMetaData?.pubKeyCS;
+
+    atMetaData.encoding = newAtMetaData?.encoding == "null"
+        ? null
+        : newAtMetaData?.encoding ?? existingMetaData?.encoding;
+    atMetaData.encKeyName = newAtMetaData?.encKeyName == "null"
+        ? null
+        : newAtMetaData?.encKeyName ?? existingMetaData?.encKeyName;
+    atMetaData.encAlgo = newAtMetaData?.encAlgo == "null"
+        ? null
+        : newAtMetaData?.encAlgo ?? existingMetaData?.encAlgo;
+    atMetaData.ivNonce = newAtMetaData?.ivNonce == "null"
+        ? null
+        : newAtMetaData?.ivNonce ?? existingMetaData?.ivNonce;
+    atMetaData.skeEncKeyName = newAtMetaData?.skeEncKeyName == "null"
+        ? null
+        : newAtMetaData?.skeEncKeyName ?? existingMetaData?.skeEncKeyName;
+    atMetaData.skeEncAlgo = newAtMetaData?.skeEncAlgo == "null"
+        ? null
+        : newAtMetaData?.skeEncAlgo ?? existingMetaData?.skeEncAlgo;
     atMetaData.version = newAtMetaData?.version ?? existingMetaData?.version;
   }
 

--- a/packages/at_persistence_secondary_server/lib/src/model/at_metadata_builder.dart
+++ b/packages/at_persistence_secondary_server/lib/src/model/at_metadata_builder.dart
@@ -3,106 +3,76 @@ import 'package:at_utils/at_logger.dart';
 
 /// Builder class to build [AtMetaData] object.
 class AtMetadataBuilder {
-  late AtMetaData atMetaData;
+  late final AtMetaData atMetaData;
 
   /// We will constrain to millisecond precision because Hive only stores
   /// [DateTime]s to millisecond precision - see https://github.com/hivedb/hive/issues/474
   /// for details.
-  var currentUtcTimeToMillisecondPrecision =
+  final DateTime currentUtcTimeToMillisecondPrecision =
       DateTime.now().toUtcMillisecondsPrecision();
 
   static final AtSignLogger logger = AtSignLogger('AtMetadataBuilder');
 
   AtMetadataBuilder(
-      {String? atSign, AtMetaData? newMetaData, AtMetaData? existingMetaData}) {
-    newMetaData ??= AtMetaData();
-    atMetaData = newMetaData;
+      {String? atSign, AtMetaData? newMetaData, AtMetaData? existingMetaData})
+      : atMetaData = newMetaData ?? AtMetaData() {
     // createdAt indicates the date and time of the key created.
     // For a new key, the currentDateTime is set and remains unchanged
     // on an update event.
-    (existingMetaData?.createdAt == null)
-        ? atMetaData.createdAt = currentUtcTimeToMillisecondPrecision
-        : atMetaData.createdAt = existingMetaData?.createdAt;
+    atMetaData.createdAt =
+        existingMetaData?.createdAt ?? currentUtcTimeToMillisecondPrecision;
     atMetaData.createdBy ??= atSign;
     atMetaData.updatedBy = atSign;
+
     // updatedAt indicates the date and time of the key updated.
     // For a new key, the updatedAt is same as createdAt and on key
     // update, set the updatedAt to the currentDateTime.
     atMetaData.updatedAt = currentUtcTimeToMillisecondPrecision;
     atMetaData.status = 'active';
-    // The version indicates the number of updates a key has received.
-    // Version is set to 0 for a new key and for each update the key receives,
-    // the version increases by 1
-    (existingMetaData?.version == null)
-        ? atMetaData.version = 0
-        : atMetaData.version = (existingMetaData!.version! + 1);
 
-    //If new metadata is available, consider new metadata, else if existing metadata is available consider it.
-    int? ttl;
-    ttl ??= newMetaData.ttl;
-    if (ttl == null && existingMetaData != null) ttl = existingMetaData.ttl;
+    // sets newAtMetaData attributes if set. Otherwise fallback to existingMetaData attributes.
+    _copyMetadata(existingMetaData, newMetaData);
 
-    int? ttb;
-    ttb ??= newMetaData.ttb;
-    if (ttb == null && existingMetaData != null) ttb = existingMetaData.ttb;
-
-    int? ttr;
-    ttr ??= newMetaData.ttr;
-    if (ttr == null && existingMetaData != null) ttr = existingMetaData.ttr;
-
-    bool? ccd;
-    ccd ??= newMetaData.isCascade;
-    if (ccd == null && existingMetaData != null) {
-      ccd = existingMetaData.isCascade;
+    if (atMetaData.ttl != null && atMetaData.ttl! >= 0) {
+      setTTL(atMetaData.ttl, ttb: atMetaData.ttb);
     }
-    bool? isBinary;
-    isBinary ??= newMetaData.isBinary;
-    bool? isEncrypted;
-    isEncrypted ??= newMetaData.isEncrypted;
-    String? dataSignature;
-    dataSignature ??= newMetaData.dataSignature;
-    String? sharedKeyEncrypted;
-    sharedKeyEncrypted ??= newMetaData.sharedKeyEnc;
-    String? publicKeyChecksum;
-    publicKeyChecksum ??= newMetaData.pubKeyCS;
-    String? encoding;
-    encoding ??= newMetaData.encoding;
-    String? encKeyName;
-    encKeyName ??= newMetaData.encKeyName;
-    String? encAlgo;
-    encAlgo ??= newMetaData.encAlgo;
-    String? ivNonce;
-    ivNonce ??= newMetaData.ivNonce;
-    String? skeEncKeyName;
-    skeEncKeyName ??= newMetaData.skeEncKeyName;
-    String? skeEncAlgo;
-    skeEncAlgo ??= newMetaData.skeEncAlgo;
-
-    if (ttl != null && ttl >= 0) {
-      setTTL(ttl, ttb: ttb);
-    }
-    if (ttb != null && ttb >= 0) {
-      setTTB(ttb);
+    if (atMetaData.ttb != null && atMetaData.ttb! >= 0) {
+      setTTB(atMetaData.ttb);
     }
     // If TTR is -1, cache the key forever.
-    if (ttr != null && ttr > 0 || ttr == -1) {
-      setTTR(ttr);
+    if (atMetaData.ttr != null && atMetaData.ttr! > 0 || atMetaData.ttr == -1) {
+      setTTR(atMetaData.ttr);
     }
-    if (ccd != null) {
-      setCCD(ccd);
-    }
-    atMetaData.isBinary = isBinary;
-    atMetaData.isEncrypted = isEncrypted;
-    atMetaData.dataSignature = dataSignature;
-    atMetaData.sharedKeyEnc = sharedKeyEncrypted;
-    atMetaData.pubKeyCS = publicKeyChecksum;
-    atMetaData.encoding = encoding;
-    atMetaData.encKeyName = encKeyName;
-    atMetaData.encAlgo = encAlgo;
-    atMetaData.ivNonce = ivNonce;
-    atMetaData.skeEncKeyName = skeEncKeyName;
-    atMetaData.skeEncAlgo = skeEncAlgo;
   }
+
+  void _copyMetadata(AtMetaData? existingMetaData, AtMetaData? newAtMetaData) {
+    atMetaData.ttl = _getOrDefault(newAtMetaData?.ttl, existingMetaData?.ttl);
+    atMetaData.ttb = newAtMetaData?.ttb ?? existingMetaData?.ttb;
+    atMetaData.ttr = newAtMetaData?.ttr ?? existingMetaData?.ttr;
+    atMetaData.isCascade =
+        newAtMetaData?.isCascade ?? existingMetaData?.isCascade;
+    atMetaData.isBinary = newAtMetaData?.isBinary ?? existingMetaData?.isBinary;
+    atMetaData.isEncrypted =
+        newAtMetaData?.isEncrypted ?? existingMetaData?.isEncrypted;
+    atMetaData.dataSignature =
+        newAtMetaData?.dataSignature ?? existingMetaData?.dataSignature;
+    atMetaData.sharedKeyEnc =
+        newAtMetaData?.sharedKeyEnc ?? existingMetaData?.sharedKeyEnc;
+    atMetaData.pubKeyCS = newAtMetaData?.pubKeyCS ?? existingMetaData?.pubKeyCS;
+    atMetaData.encoding = newAtMetaData?.encoding ?? existingMetaData?.encoding;
+    atMetaData.encKeyName =
+        newAtMetaData?.encKeyName ?? existingMetaData?.encKeyName;
+    atMetaData.encAlgo = newAtMetaData?.encAlgo ?? existingMetaData?.encAlgo;
+    atMetaData.ivNonce = newAtMetaData?.ivNonce ?? existingMetaData?.ivNonce;
+    atMetaData.skeEncKeyName =
+        newAtMetaData?.skeEncKeyName ?? existingMetaData?.skeEncKeyName;
+    atMetaData.skeEncAlgo =
+        newAtMetaData?.skeEncAlgo ?? existingMetaData?.skeEncAlgo;
+    atMetaData.version = newAtMetaData?.version ?? existingMetaData?.version;
+  }
+
+  int? _getOrDefault(int? newValue, int? existingValue) =>
+      newValue ?? existingValue;
 
   void setTTL(int? ttl, {int? ttb}) {
     if (ttl != null) {
@@ -135,32 +105,17 @@ class AtMetadataBuilder {
     atMetaData.isCascade = ccd;
   }
 
-  DateTime? _getAvailableAt(int epochNow, int ttb) {
-    var availableAt = epochNow + ttb;
-    return DateTime.fromMillisecondsSinceEpoch(availableAt).toUtc();
-  }
+  DateTime? _getAvailableAt(int epochNow, int ttb) =>
+      DateTime.fromMillisecondsSinceEpoch(epochNow + ttb).toUtc();
 
   DateTime? _getExpiresAt(int epochNow, int ttl, {int? ttb}) {
-    //if ttl is zero, reset expires at. The key will not expire
-    if (ttl == 0) {
-      return null;
-    }
-    var expiresAt = epochNow + ttl;
-    if (ttb != null) {
-      expiresAt = expiresAt + ttb;
-    }
+    if (ttl == 0) return null; // Key will not expire if TTL is 0
+    var expiresAt = epochNow + ttl + (ttb ?? 0);
     return DateTime.fromMillisecondsSinceEpoch(expiresAt).toUtc();
   }
 
-  DateTime? _getRefreshAt(DateTime today, int ttr) {
-    if (ttr == -1) {
-      return null;
-    }
+  DateTime? _getRefreshAt(DateTime today, int ttr) =>
+      ttr == -1 ? null : today.add(Duration(seconds: ttr));
 
-    return today.add(Duration(seconds: ttr));
-  }
-
-  AtMetaData build() {
-    return atMetaData;
-  }
+  AtMetaData build() => atMetaData;
 }

--- a/packages/at_persistence_secondary_server/lib/src/model/at_metadata_builder.dart
+++ b/packages/at_persistence_secondary_server/lib/src/model/at_metadata_builder.dart
@@ -45,6 +45,10 @@ class AtMetadataBuilder {
     }
   }
 
+  // if existing metadata field is NOT null and new metadata field is null object, then set existing metadata field
+  // if existing metadata field is NOT null and new metadata field is not null object, then set new metadata field
+  // if existing metadata field is null and new metadata field is NOT null, then set new metadata field
+  // if existing metadata field is NOT null and new metadata field is null string, then set new metadata field (unset scenario)
   void _copyMetadata(AtMetaData? existingMetaData, AtMetaData? newAtMetaData) {
     atMetaData.ttl = _getOrDefault(newAtMetaData?.ttl, existingMetaData?.ttl);
     atMetaData.ttb = newAtMetaData?.ttb ?? existingMetaData?.ttb;

--- a/packages/at_persistence_secondary_server/lib/src/model/at_metadata_builder.dart
+++ b/packages/at_persistence_secondary_server/lib/src/model/at_metadata_builder.dart
@@ -13,33 +13,10 @@ class AtMetadataBuilder {
 
   static final AtSignLogger logger = AtSignLogger('AtMetadataBuilder');
 
-  /// AtMetadata Object : Optional parameter, If atMetadata object is null a new AtMetadata object is created.
-  /// ttl : Time to live of the key. If ttl is null, atMetadata's ttl is assigned to ttl.
-  /// ttb : Time to birth of the key. If ttb is null, atMetadata's ttb is assigned to ttb.
-  /// ttr : Time to refresh of the key. If ttr is null, atMetadata's ttr is assigned to ttr.
-  /// ccd : Cascade delete. If ccd is null, atMetadata's ccd is assigned to ccd.
-  AtMetadataBuilder({
-    String? atSign,
-    AtMetaData? newAtMetaData,
-    AtMetaData? existingMetaData,
-    int? ttl,
-    int? ttb,
-    int? ttr,
-    bool? ccd,
-    bool? isBinary,
-    bool? isEncrypted,
-    String? dataSignature,
-    String? sharedKeyEncrypted,
-    String? publicKeyChecksum,
-    String? encoding,
-    String? encKeyName,
-    String? encAlgo,
-    String? ivNonce,
-    String? skeEncKeyName,
-    String? skeEncAlgo,
-  }) {
-    newAtMetaData ??= AtMetaData();
-    atMetaData = newAtMetaData;
+  AtMetadataBuilder(
+      {String? atSign, AtMetaData? newMetaData, AtMetaData? existingMetaData}) {
+    newMetaData ??= AtMetaData();
+    atMetaData = newMetaData;
     // createdAt indicates the date and time of the key created.
     // For a new key, the currentDateTime is set and remains unchanged
     // on an update event.
@@ -61,30 +38,45 @@ class AtMetadataBuilder {
         : atMetaData.version = (existingMetaData!.version! + 1);
 
     //If new metadata is available, consider new metadata, else if existing metadata is available consider it.
-    ttl ??= newAtMetaData.ttl;
+    int? ttl;
+    ttl ??= newMetaData.ttl;
     if (ttl == null && existingMetaData != null) ttl = existingMetaData.ttl;
 
-    ttb ??= newAtMetaData.ttb;
+    int? ttb;
+    ttb ??= newMetaData.ttb;
     if (ttb == null && existingMetaData != null) ttb = existingMetaData.ttb;
 
-    ttr ??= newAtMetaData.ttr;
+    int? ttr;
+    ttr ??= newMetaData.ttr;
     if (ttr == null && existingMetaData != null) ttr = existingMetaData.ttr;
 
-    ccd ??= newAtMetaData.isCascade;
+    bool? ccd;
+    ccd ??= newMetaData.isCascade;
     if (ccd == null && existingMetaData != null) {
       ccd = existingMetaData.isCascade;
     }
-    isBinary ??= newAtMetaData.isBinary;
-    isEncrypted ??= newAtMetaData.isEncrypted;
-    dataSignature ??= newAtMetaData.dataSignature;
-    sharedKeyEncrypted ??= newAtMetaData.sharedKeyEnc;
-    publicKeyChecksum ??= newAtMetaData.pubKeyCS;
-    encoding ??= newAtMetaData.encoding;
-    encKeyName ??= newAtMetaData.encKeyName;
-    encAlgo ??= newAtMetaData.encAlgo;
-    ivNonce ??= newAtMetaData.ivNonce;
-    skeEncKeyName ??= newAtMetaData.skeEncKeyName;
-    skeEncAlgo ??= newAtMetaData.skeEncAlgo;
+    bool? isBinary;
+    isBinary ??= newMetaData.isBinary;
+    bool? isEncrypted;
+    isEncrypted ??= newMetaData.isEncrypted;
+    String? dataSignature;
+    dataSignature ??= newMetaData.dataSignature;
+    String? sharedKeyEncrypted;
+    sharedKeyEncrypted ??= newMetaData.sharedKeyEnc;
+    String? publicKeyChecksum;
+    publicKeyChecksum ??= newMetaData.pubKeyCS;
+    String? encoding;
+    encoding ??= newMetaData.encoding;
+    String? encKeyName;
+    encKeyName ??= newMetaData.encKeyName;
+    String? encAlgo;
+    encAlgo ??= newMetaData.encAlgo;
+    String? ivNonce;
+    ivNonce ??= newMetaData.ivNonce;
+    String? skeEncKeyName;
+    skeEncKeyName ??= newMetaData.skeEncKeyName;
+    String? skeEncAlgo;
+    skeEncAlgo ??= newMetaData.skeEncAlgo;
 
     if (ttl != null && ttl >= 0) {
       setTTL(ttl, ttb: ttb);

--- a/packages/at_persistence_secondary_server/lib/src/notification/at_notification_keystore.dart
+++ b/packages/at_persistence_secondary_server/lib/src/notification/at_notification_keystore.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: non_constant_identifier_names
 
+import 'package:at_commons/at_commons.dart';
 import 'package:at_utf7/at_utf7.dart';
 import 'package:at_utils/at_utils.dart';
 import 'package:hive/hive.dart';
@@ -67,44 +68,14 @@ class AtNotificationKeystore
 
   @override
   Future<dynamic> put(key, value,
-      {int? time_to_live,
-      int? time_to_born,
-      int? time_to_refresh,
-      bool? isCascade,
-      bool? isBinary,
-      bool? isEncrypted,
-      String? dataSignature,
-      String? sharedKeyEncrypted,
-      String? publicKeyChecksum,
-      String? encoding,
-      String? encKeyName,
-      String? encAlgo,
-      String? ivNonce,
-      String? skeEncKeyName,
-      String? skeEncAlgo,
-      bool skipCommit = false}) async {
+      {Metadata? metadata, bool skipCommit = false}) async {
     AtNotificationCallback.getInstance().invokeCallbacks(value);
     await _getBox().put(key, value);
   }
 
   @override
   Future<dynamic> create(key, value,
-      {int? time_to_live,
-      int? time_to_born,
-      int? time_to_refresh,
-      bool? isCascade,
-      bool? isBinary,
-      bool? isEncrypted,
-      String? dataSignature,
-      String? sharedKeyEncrypted,
-      String? publicKeyChecksum,
-      String? encoding,
-      String? encKeyName,
-      String? encAlgo,
-      String? ivNonce,
-      String? skeEncKeyName,
-      String? skeEncAlgo,
-      bool skipCommit = false}) async {
+      {Metadata? metadata, bool skipCommit = false}) async {
     throw UnimplementedError();
   }
 
@@ -172,7 +143,7 @@ class AtNotificationKeystore
                 ..atMetaData = value.atMetadata
                 ..ttl = value.ttl)
               .build();
-          put(key, newNotification);
+          put(key, newNotification, metadata: Metadata());
         }
       });
 

--- a/packages/at_persistence_secondary_server/pubspec.yaml
+++ b/packages/at_persistence_secondary_server/pubspec.yaml
@@ -19,6 +19,20 @@ dependencies:
   at_persistence_spec: ^2.0.14
   meta: ^1.8.0
 
+dependency_overrides:
+  at_persistence_spec:
+    git:
+      url: https://github.com/atsign-foundation/at_server/
+      path: packages/at_persistence_spec
+      ref: persistence_spec_refactoring
+
+  at_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_libraries/
+      path: packages/at_commons
+      ref: trunk
+
+
 dev_dependencies:
   lints: ^2.0.1
   test: ^1.22.1

--- a/packages/at_persistence_secondary_server/pubspec.yaml
+++ b/packages/at_persistence_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_persistence_secondary_server
 description: A Dart library with the implementation classes for the persistence layer of the secondary server.
-version: 3.0.60
+version: 4.0.0
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://docs.atsign.com/
 
@@ -14,24 +14,18 @@ dependencies:
   crypto: ^3.0.2
   uuid: ^3.0.6
   at_utf7: ^1.0.0
-  at_commons: ^4.0.0
+  at_commons: ^4.0.2
   at_utils: ^3.0.16
   at_persistence_spec: ^2.0.14
   meta: ^1.8.0
 
+# TODO replace with published version
 dependency_overrides:
   at_persistence_spec:
     git:
       url: https://github.com/atsign-foundation/at_server/
       path: packages/at_persistence_spec
       ref: persistence_spec_refactoring
-
-  at_commons:
-    git:
-      url: https://github.com/atsign-foundation/at_libraries/
-      path: packages/at_commons
-      ref: trunk
-
 
 dev_dependencies:
   lints: ^2.0.1

--- a/packages/at_persistence_secondary_server/pubspec.yaml
+++ b/packages/at_persistence_secondary_server/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   crypto: ^3.0.2
   uuid: ^3.0.6
   at_utf7: ^1.0.0
-  at_commons: ^4.0.2
+  at_commons: ^4.0.1
   at_utils: ^3.0.16
   at_persistence_spec: ^2.0.14
   meta: ^1.8.0

--- a/packages/at_persistence_secondary_server/test/at_config_test.dart
+++ b/packages/at_persistence_secondary_server/test/at_config_test.dart
@@ -137,7 +137,8 @@ Future<void> tearDownFunc() async {
   // closes the instance of hive keystore
   await SecondaryPersistenceStoreFactory.getInstance()
       .getSecondaryPersistenceStore('@test_user_1')!
-      .getHivePersistenceManager()?.close();
+      .getHivePersistenceManager()
+      ?.close();
 
   var isExists = await Directory('test/hive/').exists();
   if (isExists) {

--- a/packages/at_persistence_secondary_server/test/at_metadata_builder_test.dart
+++ b/packages/at_persistence_secondary_server/test/at_metadata_builder_test.dart
@@ -1,5 +1,4 @@
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
-import 'package:hive/hive.dart';
 import 'package:test/test.dart';
 
 void main() async {
@@ -9,7 +8,10 @@ void main() async {
       var existingMetadata = AtMetaData()
         ..isEncrypted = true
         ..encAlgo = 'rsa'
-        ..encKeyName = 'rsa2048';
+        ..encKeyName = 'rsa2048'
+        ..ttl = 10000
+        ..ttb = 5000
+        ..ttr = 65000;
       var atMetaData = AtMetadataBuilder(
               atSign: '@alice', existingMetaData: existingMetadata)
           .build();
@@ -17,19 +19,28 @@ void main() async {
       expect(atMetaData.isEncrypted, true);
       expect(atMetaData.encAlgo, 'rsa');
       expect(atMetaData.encKeyName, 'rsa2048');
+      expect(atMetaData.ttl, 10000);
+      expect(atMetaData.ttb, 5000);
+      expect(atMetaData.ttr, 65000);
     });
     test('test existing metadata is null and new metadata has few fields set',
         () async {
       var newMetadata = AtMetaData()
         ..isEncrypted = true
         ..encAlgo = 'rsa'
-        ..encKeyName = 'rsa2048';
+        ..encKeyName = 'rsa2048'
+        ..ttl = 9000
+        ..ttb = 2000
+        ..ttr = 1200;
       var atMetaData =
           AtMetadataBuilder(atSign: '@alice', newMetaData: newMetadata).build();
       expect(atMetaData, isNotNull);
       expect(atMetaData.isEncrypted, true);
       expect(atMetaData.encAlgo, 'rsa');
       expect(atMetaData.encKeyName, 'rsa2048');
+      expect(atMetaData.ttl, 9000);
+      expect(atMetaData.ttb, 2000);
+      expect(atMetaData.ttr, 1200);
     });
     test('test existing metadata and new metadata have distinct fields set ',
         () async {
@@ -78,6 +89,66 @@ void main() async {
       expect(atMetadata.isEncrypted, true);
       expect(atMetadata.encAlgo, 'rsa');
       expect(atMetadata.encKeyName, 'rsa2048');
+    });
+
+    test(
+        'test existing metadata and new metadata has a different ttl value set ',
+        () async {
+      var existingMetadata = AtMetaData()
+        ..isCascade = false
+        ..ttl = 10000;
+      var newMetadata = AtMetaData()
+        ..isCascade = false
+        ..ttl = 5555;
+      var atMetadata = AtMetadataBuilder(
+              atSign: '@alice',
+              existingMetaData: existingMetadata,
+              newMetaData: newMetadata)
+          .build();
+      //resulting metadata should have values set from newMetadata
+      expect(atMetadata, isNotNull);
+      expect(atMetadata.isCascade, false);
+      expect(atMetadata.ttl, 5555);
+    });
+
+    test(
+        'test existing metadata and new metadata has a different ttb value set',
+        () async {
+      var existingMetadata = AtMetaData()
+        ..isCascade = false
+        ..ttb = 9000;
+      var newMetadata = AtMetaData()
+        ..isCascade = false
+        ..ttb = 20000;
+      var atMetadata = AtMetadataBuilder(
+              atSign: '@alice',
+              existingMetaData: existingMetadata,
+              newMetaData: newMetadata)
+          .build();
+      //resulting metadata should have ttb value set from newMetadata
+      expect(atMetadata, isNotNull);
+      expect(atMetadata.isCascade, false);
+      expect(atMetadata.ttb, 20000);
+    });
+
+    test(
+        'test existing metadata and new metadata has a different ttr value set ',
+        () async {
+      var existingMetadata = AtMetaData()
+        ..isCascade = true
+        ..ttr = 1000;
+      var newMetadata = AtMetaData()
+        ..isCascade = true
+        ..ttr = 12340;
+      var atMetadata = AtMetadataBuilder(
+              atSign: '@alice',
+              existingMetaData: existingMetadata,
+              newMetaData: newMetadata)
+          .build();
+      //resulting metadata should have values set from newMetadata
+      expect(atMetadata, isNotNull);
+      expect(atMetadata.isCascade, true);
+      expect(atMetadata.ttr, 12340);
     });
   });
 }

--- a/packages/at_persistence_secondary_server/test/at_metadata_builder_test.dart
+++ b/packages/at_persistence_secondary_server/test/at_metadata_builder_test.dart
@@ -1,0 +1,83 @@
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:hive/hive.dart';
+import 'package:test/test.dart';
+
+void main() async {
+  group('A group of metadata builder tests', () {
+    test('test existing metadata has few fields set and new metadata is null',
+        () async {
+      var existingMetadata = AtMetaData()
+        ..isEncrypted = true
+        ..encAlgo = 'rsa'
+        ..encKeyName = 'rsa2048';
+      var atMetaData = AtMetadataBuilder(
+              atSign: '@alice', existingMetaData: existingMetadata)
+          .build();
+      expect(atMetaData, isNotNull);
+      expect(atMetaData.isEncrypted, true);
+      expect(atMetaData.encAlgo, 'rsa');
+      expect(atMetaData.encKeyName, 'rsa2048');
+    });
+    test('test existing metadata is null and new metadata has few fields set',
+        () async {
+      var newMetadata = AtMetaData()
+        ..isEncrypted = true
+        ..encAlgo = 'rsa'
+        ..encKeyName = 'rsa2048';
+      var atMetaData =
+          AtMetadataBuilder(atSign: '@alice', newMetaData: newMetadata).build();
+      expect(atMetaData, isNotNull);
+      expect(atMetaData.isEncrypted, true);
+      expect(atMetaData.encAlgo, 'rsa');
+      expect(atMetaData.encKeyName, 'rsa2048');
+    });
+    test('test existing metadata and new metadata have distinct fields set ',
+        () async {
+      var existingMetadata = AtMetaData()
+        ..isEncrypted = true
+        ..encAlgo = 'rsa'
+        ..encKeyName = 'rsa2048';
+      var newMetadata = AtMetaData()
+        ..dataSignature = 'test_signature'
+        ..isCascade = true
+        ..ivNonce = 'test_nonce';
+      var atMetadata = AtMetadataBuilder(
+              atSign: '@alice',
+              newMetaData: newMetadata,
+              existingMetaData: existingMetadata)
+          .build();
+      //resulting metadata should have all fields set from newMetadata and existingMetadata
+      expect(atMetadata, isNotNull);
+      expect(atMetadata.isEncrypted, true);
+      expect(atMetadata.encAlgo, 'rsa');
+      expect(atMetadata.encKeyName, 'rsa2048');
+      expect(atMetadata.dataSignature, 'test_signature');
+      expect(atMetadata.isCascade, true);
+      expect(atMetadata.ivNonce, 'test_nonce');
+    });
+    test('test existing metadata and new metadata have some common fields set ',
+        () async {
+      var existingMetadata = AtMetaData()
+        ..isCascade = false
+        ..isEncrypted = true
+        ..encAlgo = 'rsa'
+        ..encKeyName = 'rsa1024';
+      var newMetadata = AtMetaData()
+        ..isCascade = true
+        ..isEncrypted = true
+        ..encAlgo = 'rsa'
+        ..encKeyName = 'rsa2048';
+      var atMetadata = AtMetadataBuilder(
+              atSign: '@alice',
+              newMetaData: newMetadata,
+              existingMetaData: existingMetadata)
+          .build();
+      //resulting metadata should have values set from newMetadata
+      expect(atMetadata, isNotNull);
+      expect(atMetadata.isCascade, true);
+      expect(atMetadata.isEncrypted, true);
+      expect(atMetadata.encAlgo, 'rsa');
+      expect(atMetadata.encKeyName, 'rsa2048');
+    });
+  });
+}

--- a/packages/at_persistence_secondary_server/test/at_metadata_test.dart
+++ b/packages/at_persistence_secondary_server/test/at_metadata_test.dart
@@ -106,35 +106,6 @@ void main() async {
       expect(atData.metaData!.createdBy, atSign);
       expect(atData.metaData!.version, 1);
     });
-
-    test(
-        'A test to verify version field in metadata is set to 1 when using putAll method',
-        () async {
-      var keyCreationDateTime = DateTime.now().toUtcMillisecondsPrecision();
-      var hiveKeyStore = SecondaryPersistenceStoreFactory.getInstance()
-          .getSecondaryPersistenceStore(atSign)!
-          .getSecondaryKeyStore();
-      var key = '@bob:city@alice';
-      await hiveKeyStore?.putAll(
-          key, AtData()..data = '9878123322', AtMetaData());
-      // Update the same key
-      var updateKeyDateTime = DateTime.now().toUtcMillisecondsPrecision();
-      await hiveKeyStore?.putAll(
-          key, AtData()..data = '9878123322', AtMetaData()..ttl = 10000);
-      var atData = await hiveKeyStore?.get(key);
-      expect(atData?.data, '9878123322');
-      expect(
-          atData!.metaData!.createdAt!.millisecondsSinceEpoch >=
-              keyCreationDateTime.millisecondsSinceEpoch,
-          true);
-      expect(
-          atData.metaData!.updatedAt!.millisecondsSinceEpoch >=
-              updateKeyDateTime.millisecondsSinceEpoch,
-          true);
-      expect(atData.metaData!.createdBy, atSign);
-      expect(atData.metaData!.version, 1);
-      expect(atData.metaData!.ttl, 10000);
-    });
     tearDownAll(() async => await tearDownFunc());
   });
   group('A group of tests to verify at_metadata adapter', () {

--- a/packages/at_persistence_secondary_server/test/hive_key_expiry_check.dart
+++ b/packages/at_persistence_secondary_server/test/hive_key_expiry_check.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_commons/at_commons.dart';
 
 void main() async {
   var secondaryPersistenceStore = SecondaryPersistenceStoreFactory.getInstance()
@@ -20,7 +21,7 @@ void main() async {
   atData.data = 'abc';
   await keyStoreManager
       .getKeyStore()
-      .put('123', atData, time_to_live: 30 * 1000);
+      .put('123', atData, metadata: Metadata()..ttl = 30 * 1000);
   print('end');
   var atDataResponse = await keyStoreManager.getKeyStore().get('123');
   print(atDataResponse?.data);

--- a/packages/at_persistence_secondary_server/test/hive_keystore_impl_test.dart
+++ b/packages/at_persistence_secondary_server/test/hive_keystore_impl_test.dart
@@ -210,7 +210,7 @@ void main() async {
       var atData = AtData();
       atData.data = '123';
       await keyStore.create('phone.wavi@test_user_1', atData,
-          time_to_live: 6000);
+          metadata: Metadata()..ttl = 6000);
       var dataFromHive = await (keyStore.get('phone.wavi@test_user_1'));
       expect(dataFromHive?.data, '123');
       expect(dataFromHive?.metaData, isNotNull);
@@ -223,8 +223,11 @@ void main() async {
       var keyStore = keyStoreManager.getSecondaryKeyStore()!;
       var atData = AtData();
       atData.data = '123';
+      var metaData = Metadata()
+        ..sharedKeyEnc = 'abc'
+        ..pubKeyCS = 'xyz';
       await keyStore.create('phone.wavi@test_user_1', atData,
-          sharedKeyEncrypted: 'abc', publicKeyChecksum: 'xyz');
+          metadata: metaData);
       var dataFromHive = await (keyStore.get('phone.wavi@test_user_1'));
       expect(dataFromHive?.data, '123');
       expect(dataFromHive?.metaData, isNotNull);
@@ -601,7 +604,7 @@ void main() async {
           ..ttl = 0
           ..ttr = -1);
       await keystore?.put('dummykey.wavi@test_user_1', updatedAtData,
-          time_to_born: null);
+          metadata: Metadata()..ttb = null);
       AtMetaData? atMetaData =
           await keystore?.getMeta('dummykey.wavi@test_user_1');
       expect(atMetaData?.ttr, -1);
@@ -673,11 +676,13 @@ void main() async {
       //inserting sample keys
       for (int i = 0; i < 30; i++) {
         //inserting random metaData to induce variance in data
+        var newMetadata = Metadata()
+          ..ttl = 12000 + i.toInt()
+          ..ttb = i
+          ..isBinary = true;
         metaData = AtMetadataBuilder(
-                ttl: 12000 + i.toInt(),
-                ttb: i,
-                atSign: '@atsign_$i',
-                isBinary: true)
+                newMetaData: AtMetaData.fromCommonsMetadata(newMetadata),
+                atSign: '@atsign_$i')
             .build();
 
         atData.data = 'value_test_$i';

--- a/packages/at_secondary_server/lib/src/verb/handler/notify_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/notify_verb_handler.dart
@@ -155,7 +155,7 @@ class NotifyVerbHandler extends AbstractVerbHandler {
         atMetadata = await keyStore.getMeta(cachedNotificationKey);
       }
       var metadata = AtMetadataBuilder(
-              newAtMetaData: atNotificationBuilder.atMetaData,
+              newMetaData: atNotificationBuilder.atMetaData,
               existingMetaData: atMetadata)
           .build();
       cachedKeyCommitId = await _storeCachedKeys(


### PR DESCRIPTION
**- What I did**
- persistence secondary impl changes for put/create method signature changes

**- How I did it**
- version increment in metadata was previously in metadata builder. Moved the logic just before updating/create key in hive. 
- removed putAll method from hive keystore
- introduced _copyMetadata method in at_metadata_builder
1. if existing metadata field is NOT null and new metadata field is null object, then set existing metadata field
2. if existing metadata field is NOT null and new metadata field is  not null object, then set new metadata field
3. if existing metadata field is null and new metadata field is NOT null, then set new metadata field
4. f existing metadata field is NOT null and new metadata field is null string, then set new metadata field  (unset scenario)
- added new test at_metadata_builder_test.dart

**- How to verify it**
- unit tests should pass
- update this branch in server with server changes. functional/end2end tests should pass
