### PR TITLE
fix: Add enroll param values to notification value and update the functional test to verify new fields in the notification value

### DIFF
--- a/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
@@ -376,6 +376,9 @@ class EnrollVerbHandler extends AbstractVerbHandler {
       var notificationValue = {};
       notificationValue[AtConstants.apkamEncryptedSymmetricKey] =
           enrollParams.encryptedAPKAMSymmetricKey;
+      notificationValue[AtConstants.appName] = enrollParams.appName;
+      notificationValue[AtConstants.deviceName] = enrollParams.deviceName;
+      notificationValue[AtConstants.namespace] = enrollParams.namespaces;
       logger.finer('notificationValue:$notificationValue');
       final atNotification = (AtNotificationBuilder()
             ..notification = key

--- a/tests/at_functional_test/test/enroll_verb_test.dart
+++ b/tests/at_functional_test/test/enroll_verb_test.dart
@@ -28,6 +28,9 @@ void main() {
         at_demos.apkamSymmetricKeyMap[firstAtSign]!),
     'encryptedSelfEncKey': EncryptionUtil.encryptValue(
         at_demos.aesKeyMap[firstAtSign]!,
+        at_demos.apkamSymmetricKeyMap[firstAtSign]!),
+    'encryptedApkamSymmetricKey': EncryptionUtil.encryptValue(
+        at_demos.aesKeyMap[firstAtSign]!,
         at_demos.apkamSymmetricKeyMap[firstAtSign]!)
   };
 
@@ -44,7 +47,7 @@ void main() {
           authType: AuthType.cram);
       // send an enroll request with the keys from the setEncryptionKeys method
       String enrollRequest =
-          'enroll:request:{"appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw"},"encryptedDefaultEncryptedPrivateKey":"${apkamEncryptedKeysMap['encryptedDefaultEncPrivateKey']}","encryptedDefaultSelfEncryptionKey":"${apkamEncryptedKeysMap['encryptedSelfEncKey']}","apkamPublicKey":"${pkamPublicKeyMap[firstAtSign]!}"}\n';
+          'enroll:request:{"appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw"},"encryptedDefaultEncryptionPrivateKey":"${apkamEncryptedKeysMap['encryptedDefaultEncPrivateKey']}","encryptedDefaultSelfEncryptionKey":"${apkamEncryptedKeysMap['encryptedSelfEncKey']}","apkamPublicKey":"${pkamPublicKeyMap[firstAtSign]!}"}\n';
       String enrollResponse =
           (await firstAtSignConnection.sendRequestToServer(enrollRequest))
               .replaceAll('data:', '');
@@ -148,7 +151,7 @@ void main() {
           authType: AuthType.cram);
       // send an enroll request with the keys from the setEncryptionKeys method
       var enrollRequest =
-          'enroll:request:{"appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw"},"encryptedDefaultEncryptedPrivateKey":"${apkamEncryptedKeysMap['encryptedDefaultEncPrivateKey']}","encryptedDefaultSelfEncryptionKey":"${apkamEncryptedKeysMap['encryptedSelfEncKey']}","apkamPublicKey":"${pkamPublicKeyMap[firstAtSign]!}"}';
+          'enroll:request:{"appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw"},"encryptedDefaultEncryptionPrivateKey":"${apkamEncryptedKeysMap['encryptedDefaultEncPrivateKey']}","encryptedDefaultSelfEncryptionKey":"${apkamEncryptedKeysMap['encryptedSelfEncKey']}","apkamPublicKey":"${pkamPublicKeyMap[firstAtSign]!}"}';
       String enrollResponse =
           await firstAtSignConnection.sendRequestToServer(enrollRequest);
       enrollResponse = enrollResponse.replaceFirst('data:', '');
@@ -295,7 +298,7 @@ void main() {
       await firstAtSignConnection.authenticateConnection(
           authType: AuthType.cram);
       var enrollRequest =
-          'enroll:request:{"appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw"},"encryptedDefaultEncryptedPrivateKey":"${apkamEncryptedKeysMap['encryptedDefaultEncPrivateKey']}","encryptedDefaultSelfEncryptionKey":"${apkamEncryptedKeysMap['encryptedSelfEncKey']}","apkamPublicKey":"${pkamPublicKeyMap[firstAtSign]!}"}';
+          'enroll:request:{"appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw"},"encryptedDefaultEncryptionPrivateKey":"${apkamEncryptedKeysMap['encryptedDefaultEncPrivateKey']}","encryptedDefaultSelfEncryptionKey":"${apkamEncryptedKeysMap['encryptedSelfEncKey']}","apkamPublicKey":"${pkamPublicKeyMap[firstAtSign]!}"}';
       String enrollResponse =
           (await firstAtSignConnection.sendRequestToServer(enrollRequest))
               .replaceFirst('data:', '');
@@ -313,7 +316,7 @@ void main() {
               firstAtSign, firstAtSignHost, firstAtSignPort);
       //send second enroll request with otp
       String secondEnrollRequest =
-          'enroll:request:{"appName":"buzz","deviceName":"pixel","namespaces":{"buzz":"rw"},"otp":"$otpResponse","encryptedDefaultEncryptedPrivateKey":"${apkamEncryptedKeysMap['encryptedDefaultEncPrivateKey']}","encryptedDefaultSelfEncryptionKey":"${apkamEncryptedKeysMap['encryptedSelfEncKey']}","apkamPublicKey":"${apkamPublicKeyMap[firstAtSign]!}"}';
+          'enroll:request:{"appName":"buzz","deviceName":"pixel","namespaces":{"buzz":"rw"},"otp":"$otpResponse","encryptedDefaultEncryptionPrivateKey":"${apkamEncryptedKeysMap['encryptedDefaultEncPrivateKey']}","encryptedDefaultSelfEncryptionKey":"${apkamEncryptedKeysMap['encryptedSelfEncKey']}","apkamPublicKey":"${apkamPublicKeyMap[firstAtSign]!}"}';
       String secondEnrollResponse =
           (await socketConnection2.sendRequestToServer(secondEnrollRequest))
               .replaceFirst('data:', '');
@@ -362,13 +365,13 @@ void main() {
           await firstAtSignConnection.sendRequestToServer('otp:get');
       otpResponse = otpResponse.replaceFirst('data:', '');
       otpResponse = otpResponse.trim();
-      firstAtSignConnection.close();
+      await firstAtSignConnection.close();
       // Connect to unauthenticated socket to send an enrollment request
       firstAtSignConnection = await OutboundConnectionFactory()
           .initiateConnectionWithListener(
               firstAtSign, firstAtSignHost, firstAtSignPort);
       var secondEnrollRequest =
-          'enroll:request:{"appName":"buzz","deviceName":"pixel","namespaces":{"buzz":"rw"},"otp":"$otpResponse","encryptedDefaultEncryptedPrivateKey":"${apkamEncryptedKeysMap['encryptedDefaultEncPrivateKey']}","encryptedDefaultSelfEncryptionKey":"${apkamEncryptedKeysMap['encryptedSelfEncKey']}","apkamPublicKey":"${apkamPublicKeyMap[firstAtSign]!}"}';
+          'enroll:request:{"appName":"buzz","deviceName":"pixel","namespaces":{"buzz":"rw"},"otp":"$otpResponse","encryptedDefaultEncryptionPrivateKey":"${apkamEncryptedKeysMap['encryptedDefaultEncPrivateKey']}","encryptedDefaultSelfEncryptionKey":"${apkamEncryptedKeysMap['encryptedSelfEncKey']}","apkamPublicKey":"${apkamPublicKeyMap[firstAtSign]!}","encryptedAPKAMSymmetricKey":"${apkamEncryptedKeysMap['encryptedApkamSymmetricKey']}"}';
       var secondEnrollResponse =
           await firstAtSignConnection.sendRequestToServer(secondEnrollRequest);
       secondEnrollResponse = secondEnrollResponse.replaceFirst('data:', '');
@@ -400,6 +403,11 @@ void main() {
               serverResponse.contains(
                   '${enrollJson['enrollmentId']}.new.enrollments.__manage'),
               true);
+          Map notificationValue = jsonDecode(jsonDecode(serverResponse.replaceAll('notification: ',''))['value']);
+          expect(notificationValue['appName'], 'buzz');
+          expect(notificationValue['deviceName'], 'pixel');
+          expect(notificationValue['namespace'], {'buzz':'rw'});
+          expect(notificationValue['encryptedApkamSymmetricKey'], apkamEncryptedKeysMap['encryptedApkamSymmetricKey']);
           monitorSocket.close();
         }
         /* Setting count to 4 to wait until server returns 4 responses
@@ -417,7 +425,7 @@ void main() {
           authType: AuthType.cram);
       // send an enroll request with the keys from the setEncryptionKeys method
       String enrollRequest =
-          'enroll:request:{"appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw"},"encryptedDefaultEncryptedPrivateKey":"${apkamEncryptedKeysMap['encryptedDefaultEncPrivateKey']}","encryptedDefaultSelfEncryptionKey":"${apkamEncryptedKeysMap['encryptedSelfEncKey']}","apkamPublicKey":"${pkamPublicKeyMap[firstAtSign]!}"}';
+          'enroll:request:{"appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw"},"encryptedDefaultEncryptionPrivateKey":"${apkamEncryptedKeysMap['encryptedDefaultEncPrivateKey']}","encryptedDefaultSelfEncryptionKey":"${apkamEncryptedKeysMap['encryptedSelfEncKey']}","apkamPublicKey":"${pkamPublicKeyMap[firstAtSign]!}"}';
       String enrollResponse =
           (await firstAtSignConnection.sendRequestToServer(enrollRequest))
               .replaceFirst('data:', '');
@@ -474,7 +482,7 @@ void main() {
         await firstAtSignConnection.authenticateConnection(
             authType: AuthType.cram);
         String enrollRequest =
-            'enroll:request:{"appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw"},"apkamPublicKey":"${pkamPublicKeyMap[firstAtSign]!}"}';
+            'enroll:request:{"appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw"},"apkamPublicKey":"${apkamPublicKeyMap[firstAtSign]!}"}';
         String enrollmentResponse =
             await firstAtSignConnection.sendRequestToServer(enrollRequest);
         String enrollmentId = jsonDecode(
@@ -484,9 +492,10 @@ void main() {
         OutboundConnectionFactory socketConnection2 =
             await OutboundConnectionFactory().initiateConnectionWithListener(
                 firstAtSign, firstAtSignHost, firstAtSignPort);
-        socketConnection2.authenticateConnection(
+        String authResponse = await socketConnection2.authenticateConnection(
             authType: AuthType.apkam, enrollmentId: enrollmentId);
-        socketConnection2.close();
+        expect(authResponse.trim(), 'data:success');
+        await socketConnection2.close();
 
         // Revoke the enrollment
         String revokeEnrollmentCommand =
@@ -524,7 +533,7 @@ void main() {
             await OutboundConnectionFactory().initiateConnectionWithListener(
                 firstAtSign, firstAtSignHost, firstAtSignPort);
         String revokeEnrollmentCommand =
-            'enroll:revoke:enrollmentid:$enrollmentId';
+            'enroll:revoke:{"enrollmentid":"$enrollmentId"}';
         String revokeEnrollmentResponse = await socketConnection2
             .sendRequestToServer(revokeEnrollmentCommand);
         expect(revokeEnrollmentResponse.trim(),


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Currently, the enrollment request that is sent to the approving app does not contain the information about the enrollment, such as the which app has requested for access and what namespaces is the app requesting for? So, to enable the approving app to get this information, send "appName", "deviceName" and "namespace" to the approving app.
- Update the functional tests with use "encryptedDefaultEncryptedPrivateKey" to "encryptedDefaultEncryptionPrivateKey".

**- How I did it**
- When notifying the enrollment request from the server to the approving app via the monitor connection, add the necessary information to the notification value. 
- Currently only encryptedAPKAMSymmetric key is being notified. Add "appName", "deviceName" and "namespaces" to the notification value.

**- How to verify it**
- Extended the functional tests to verify the notification value in the monitor connection contains appName, deviceName and namespaces.

**- Description for the changelog**
- Add enroll param values to notification value
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
