### PR TITLE
fix: Return encryptedAPKAMSymmetricKey in enroll list

### DIFF
--- a/packages/at_secondary_server/lib/src/enroll/enroll_datastore_value.dart
+++ b/packages/at_secondary_server/lib/src/enroll/enroll_datastore_value.dart
@@ -15,6 +15,7 @@ class EnrollDataStoreValue {
   late String apkamPublicKey;
   EnrollRequestType? requestType;
   EnrollApproval? approval;
+  String? encryptedAPKAMSymmetricKey;
 
   EnrollDataStoreValue(
       this.sessionId, this.appName, this.deviceName, this.apkamPublicKey);

--- a/packages/at_secondary_server/lib/src/enroll/enroll_datastore_value.g.dart
+++ b/packages/at_secondary_server/lib/src/enroll/enroll_datastore_value.g.dart
@@ -1,5 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// dart run build_runner build to generate this file
+
 part of 'enroll_datastore_value.dart';
 
 // **************************************************************************
@@ -19,7 +19,9 @@ EnrollDataStoreValue _$EnrollDataStoreValueFromJson(
           $enumDecodeNullable(_$EnrollRequestTypeEnumMap, json['requestType'])
       ..approval = json['approval'] == null
           ? null
-          : EnrollApproval.fromJson(json['approval'] as Map<String, dynamic>);
+          : EnrollApproval.fromJson(json['approval'] as Map<String, dynamic>)
+      ..encryptedAPKAMSymmetricKey =
+          json['encryptedAPKAMSymmetricKey'] as String?;
 
 Map<String, dynamic> _$EnrollDataStoreValueToJson(
         EnrollDataStoreValue instance) =>
@@ -31,6 +33,7 @@ Map<String, dynamic> _$EnrollDataStoreValueToJson(
       'apkamPublicKey': instance.apkamPublicKey,
       'requestType': _$EnrollRequestTypeEnumMap[instance.requestType],
       'approval': instance.approval,
+      'encryptedAPKAMSymmetricKey': instance.encryptedAPKAMSymmetricKey,
     };
 
 const _$EnrollRequestTypeEnumMap = {

--- a/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
@@ -193,6 +193,7 @@ class EnrollVerbHandler extends AbstractVerbHandler {
           AtData()..data = enrollParams.apkamPublicKey!);
       enrollData = AtData()..data = jsonEncode(enrollmentValue.toJson());
     } else {
+      enrollmentValue.encryptedAPKAMSymmetricKey = enrollParams.encryptedAPKAMSymmetricKey;
       enrollmentValue.approval = EnrollApproval(EnrollmentStatus.pending.name);
       await _storeNotification(key, enrollParams, currentAtSign);
       responseJson['status'] = 'pending';
@@ -340,7 +341,8 @@ class EnrollVerbHandler extends AbstractVerbHandler {
         enrollmentRequestsMap[enrollmentKey] = {
           'appName': enrollDataStoreValue.appName,
           'deviceName': enrollDataStoreValue.deviceName,
-          'namespace': enrollDataStoreValue.namespaces
+          'namespace': enrollDataStoreValue.namespaces,
+          'encryptedAPKAMSymmetricKey' : enrollDataStoreValue.encryptedAPKAMSymmetricKey
         };
       }
     }
@@ -357,7 +359,8 @@ class EnrollVerbHandler extends AbstractVerbHandler {
         enrollmentRequestsMap[enrollmentKey] = {
           'appName': enrollDataStoreValue.appName,
           'deviceName': enrollDataStoreValue.deviceName,
-          'namespace': enrollDataStoreValue.namespaces
+          'namespace': enrollDataStoreValue.namespaces,
+          'encryptedAPKAMSymmetricKey' : enrollDataStoreValue.encryptedAPKAMSymmetricKey
         };
       }
     }

--- a/packages/at_secondary_server/test/enroll_verb_test.dart
+++ b/packages/at_secondary_server/test/enroll_verb_test.dart
@@ -117,7 +117,7 @@ void main() {
 
     test('A test to verify enrollment list', () async {
       String enrollmentRequest =
-          'enroll:request:{"appName":"wavi","deviceName":"mydevice","namespaces":{"wavi":"r"},"apkamPublicKey":"dummy_apkam_public_key"}';
+          'enroll:request:{"appName":"wavi","deviceName":"mydevice","namespaces":{"wavi":"r"},"apkamPublicKey":"dummy_apkam_public_key","encryptedAPKAMSymmetricKey":"dummy_encrypted_apkam_key"}';
       HashMap<String, String?> verbParams =
           getVerbParam(VerbSyntax.enroll, enrollmentRequest);
       inboundConnection.metaData.isAuthenticated = true;
@@ -134,7 +134,11 @@ void main() {
       verbParams = getVerbParam(VerbSyntax.enroll, enrollmentList);
       await enrollVerbHandler.processVerb(
           response, verbParams, inboundConnection);
+      var responseMap = jsonDecode(response.data!);
       expect(response.data?.contains(enrollmentId), true);
+      expect(responseMap['$enrollmentId.new.enrollments.__manage@alice']['appName'],'wavi');
+      expect(responseMap['$enrollmentId.new.enrollments.__manage@alice']['deviceName'],'mydevice');
+      expect(responseMap['$enrollmentId.new.enrollments.__manage@alice']['namespace']['wavi'],'r');
     });
 
     test('A test to verify enrollment list with enrollmentId is populated',
@@ -187,7 +191,7 @@ void main() {
       print('OTP: ${response.data}');
       // Enroll request
       enrollmentRequest =
-          'enroll:request:{"appName":"wavi","deviceName":"mydevice","namespaces":{"wavi":"r"},"otp":"${response.data}","apkamPublicKey":"dummy_apkam_public_key"}';
+          'enroll:request:{"appName":"wavi","deviceName":"mydevice","namespaces":{"wavi":"r"},"otp":"${response.data}","apkamPublicKey":"dummy_apkam_public_key","encryptedAPKAMSymmetricKey":"default_apkam_symmetric_key"}';
       enrollmentRequestVerbParams =
           getVerbParam(VerbSyntax.enroll, enrollmentRequest);
       inboundConnection.metaData.isAuthenticated = false;
@@ -218,6 +222,7 @@ void main() {
       expect(responseTest['appName'], 'wavi');
       expect(responseTest['deviceName'], 'mydevice');
       expect(responseTest['namespace']['wavi'], 'r');
+      expect(responseTest['encryptedAPKAMSymmetricKey'],'default_apkam_symmetric_key');
       expect(
           enrollListResponse.containsKey(
               '$enrollmentIdOne.$newEnrollmentKeyPattern.$enrollManageNamespace$alice'),

--- a/tests/at_functional_test/test/enroll_verb_test.dart
+++ b/tests/at_functional_test/test/enroll_verb_test.dart
@@ -286,6 +286,48 @@ void main() {
           true);
     });
 
+    test(
+        'enroll request on APKAM authenticated connection and verify enroll:list',
+        () async {
+      int randomNumber = Uuid().v4().hashCode;
+      await firstAtSignConnection.authenticateConnection(
+          authType: AuthType.pkam);
+      // send an enroll request with the keys from the setEncryptionKeys method
+      String enrollRequest =
+          'enroll:request:{"appName":"atmosphere-$randomNumber","deviceName":"pixel-$randomNumber","namespaces":{"wavi":"rw"},"encryptedDefaultEncryptionPrivateKey":"${apkamEncryptedKeysMap['encryptedDefaultEncPrivateKey']}","encryptedDefaultSelfEncryptionKey":"${apkamEncryptedKeysMap['encryptedSelfEncKey']}","apkamPublicKey":"${pkamPublicKeyMap[firstAtSign]!}","encryptedAPKAMSymmetricKey":"dummy_apkam_$randomNumber"}';
+      String enrollResponse =
+          (await firstAtSignConnection.sendRequestToServer(enrollRequest))
+              .replaceFirst('data:', '');
+      var enrollJsonMap = jsonDecode(enrollResponse);
+      var enrollmentId = enrollJsonMap['enrollmentId'];
+      expect(enrollmentId, isNotEmpty);
+      expect(enrollJsonMap['status'], 'pending');
+      // enroll:list
+      String enrollListResponse =
+          await firstAtSignConnection.sendRequestToServer('enroll:list');
+      enrollListResponse = enrollListResponse.replaceAll('data:', '');
+      var enrollListResponseMap = jsonDecode(enrollListResponse);
+      expect(
+          enrollListResponseMap[
+              '$enrollmentId.new.enrollments.__manage$firstAtSign']['appName'],
+          'atmosphere-$randomNumber');
+      expect(
+          enrollListResponseMap[
+                  '$enrollmentId.new.enrollments.__manage$firstAtSign']
+              ['deviceName'],
+          'pixel-$randomNumber');
+      expect(
+          enrollListResponseMap[
+          '$enrollmentId.new.enrollments.__manage$firstAtSign']
+          ['namespace']['wavi'],
+          'rw');
+      expect(
+          enrollListResponseMap[
+                  '$enrollmentId.new.enrollments.__manage$firstAtSign']
+              ['encryptedAPKAMSymmetricKey'],
+          'dummy_apkam_$randomNumber');
+    });
+
     // Purpose of the tests
     // 1. Do a pkam authentication
     // 2. Send an enroll request
@@ -403,11 +445,13 @@ void main() {
               serverResponse.contains(
                   '${enrollJson['enrollmentId']}.new.enrollments.__manage'),
               true);
-          Map notificationValue = jsonDecode(jsonDecode(serverResponse.replaceAll('notification: ',''))['value']);
+          Map notificationValue = jsonDecode(jsonDecode(
+              serverResponse.replaceAll('notification: ', ''))['value']);
           expect(notificationValue['appName'], 'buzz');
           expect(notificationValue['deviceName'], 'pixel');
-          expect(notificationValue['namespace'], {'buzz':'rw'});
-          expect(notificationValue['encryptedApkamSymmetricKey'], apkamEncryptedKeysMap['encryptedApkamSymmetricKey']);
+          expect(notificationValue['namespace'], {'buzz': 'rw'});
+          expect(notificationValue['encryptedApkamSymmetricKey'],
+              apkamEncryptedKeysMap['encryptedApkamSymmetricKey']);
           monitorSocket.close();
         }
         /* Setting count to 4 to wait until server returns 4 responses


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Fixes the issue https://github.com/atsign-foundation/at_server/issues/1821

**- How I did it**
- Add encryptedAPKAMSymmetricKey in the EnrollDataStoreValue and store encryptedAPKAMSymmetricKey.
- When enroll:list is executed, fetch the EnrollDataStoreValue of each enrollment which contains the encryptedAPKAMSymmetricKey

**- How to verify it**
- Added unit and functional test to verify enroll:list contains encryptedAPKAMSymmetricKey

**- Description for the changelog**
- Return encryptedAPKAMSymmetricKey in enroll list
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
