### PR TITLE
fix: fix otp put

### DIFF
--- a/packages/at_secondary_server/lib/src/verb/handler/abstract_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/abstract_verb_handler.dart
@@ -140,22 +140,23 @@ abstract class AbstractVerbHandler implements VerbHandler {
       return true;
     }
 
+    final enrollmentKey =
+        '$enrollmentId.$newEnrollmentKeyPattern.$enrollManageNamespace';
+    final fullKey =
+        '$enrollmentKey${AtSecondaryServerImpl.getInstance().currentAtSign}';
+
     final EnrollDataStoreValue enrollDataStoreValue;
     try {
-      final enrollmentKey =
-          '$enrollmentId.$newEnrollmentKeyPattern.$enrollManageNamespace';
-      final fullKey =
-          '$enrollmentKey${AtSecondaryServerImpl.getInstance().currentAtSign}';
-
       enrollDataStoreValue = await getEnrollDataStoreValue(fullKey);
     } on KeyNotFoundException {
-      logger.shout('Could not retrieve enrollment data');
+      logger.shout('Could not retrieve enrollment data for $fullKey');
       return false;
     }
 
     if (enrollDataStoreValue.approval?.state !=
         EnrollmentStatus.approved.name) {
-      logger.shout('Enrollment state is ${enrollDataStoreValue.approval?.state}');
+      logger.warning('Enrollment state for $fullKey'
+          ' is ${enrollDataStoreValue.approval?.state}');
       return false;
     }
 

--- a/packages/at_secondary_server/lib/src/verb/handler/delete_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/delete_verb_handler.dart
@@ -93,15 +93,19 @@ class DeleteVerbHandler extends ChangeVerbHandler {
       await keyStore.put(
           AtConstants.atCramSecretDeleted, AtData()..data = 'true');
     }
-    final enrollApprovalId =
-        (atConnection.metaData as InboundConnectionMetadata).enrollmentId;
-    bool isAuthorized = true; // for legacy clients allow access by default
-    if (enrollApprovalId != null) {
-      isAuthorized = await super.isAuthorized(enrollApprovalId, keyNamespace);
-    }
+
+    InboundConnectionMetadata inboundConnectionMetadata =
+        atConnection.metaData as InboundConnectionMetadata;
+
+    bool isAuthorized = await super.isAuthorized(
+      inboundConnectionMetadata,
+      keyNamespace,
+    );
+
     if (!isAuthorized) {
       throw UnAuthorizedException(
-          'Enrollment Id: $enrollApprovalId is not authorized for delete operation on the key: $deleteKey');
+          'Connection with enrollment ID ${inboundConnectionMetadata.enrollmentId}'
+              ' is not authorized to delete key: $deleteKey');
     }
     try {
       var result = await keyStore.remove(deleteKey);

--- a/packages/at_secondary_server/lib/src/verb/handler/local_lookup_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/local_lookup_verb_handler.dart
@@ -60,15 +60,20 @@ class LocalLookupVerbHandler extends AbstractVerbHandler {
     if (verbParams.containsKey('isCached')) {
       key = 'cached:$key';
     }
-    final enrollmentId =
-        (atConnection.metaData as InboundConnectionMetadata).enrollmentId;
+
+    InboundConnectionMetadata inboundConnectionMetadata =
+        atConnection.metaData as InboundConnectionMetadata;
+
     bool isAuthorized = true; // for legacy clients allow access by default
-    if (!isPublic && enrollmentId != null && keyNamespace != null) {
-      isAuthorized = await super.isAuthorized(enrollmentId, keyNamespace);
+
+    if (!isPublic && keyNamespace != null) {
+      isAuthorized = await super.isAuthorized(inboundConnectionMetadata, keyNamespace);
     }
+
     if (!isAuthorized) {
       throw UnAuthorizedException(
-          'Enrollment Id: $enrollmentId is not authorized for local lookup operation on the key: $key');
+          'Connection with enrollment ID ${inboundConnectionMetadata.enrollmentId}'
+              ' is not authorized to llookup key: $key');
     }
     AtData? atData = await keyStore.get(key);
     var isActive = false;

--- a/packages/at_secondary_server/lib/src/verb/handler/lookup_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/lookup_verb_handler.dart
@@ -99,7 +99,8 @@ class LookupVerbHandler extends AbstractVerbHandler {
     bool isAuthorized = await _isAuthorizedToViewData(atConnection, lookupKey);
     if (!isAuthorized) {
       throw UnAuthorizedException(
-          'Enrollment Id: ${(atConnection.metaData as InboundConnectionMetadata).enrollmentId} is not authorized for lookup operation on the key: $lookupKey');
+          'Connection with enrollment ID ${(atConnection.metaData as InboundConnectionMetadata).enrollmentId}'
+              ' is not authorized to lookup key: $lookupKey');
     }
     if (keyOwnersAtSign == thisServersAtSign) {
       // We're looking up data owned by this server's atSign
@@ -271,17 +272,13 @@ class LookupVerbHandler extends AbstractVerbHandler {
     if (!lookupKey.contains('.')) {
       return true;
     }
-    final enrollmentId =
-        (atConnection.metaData as InboundConnectionMetadata).enrollmentId;
-    bool isAuthorized = true; // for legacy clients allow access by default
-    if (enrollmentId != null) {
-      // Extract namespace from the key - 'some_key.wavi@alice' where "wavi" is
-      // is the namespace.
-      String keyNamespace = lookupKey.substring(
-          lookupKey.lastIndexOf('.') + 1, lookupKey.lastIndexOf('@'));
-      isAuthorized = await super.isAuthorized(enrollmentId, keyNamespace);
-    }
-    return isAuthorized;
+
+    // Extract namespace from the key - 'some_key.wavi@alice' where "wavi" is
+    // is the namespace.
+    String keyNamespace = lookupKey.substring(
+        lookupKey.lastIndexOf('.') + 1, lookupKey.lastIndexOf('@'));
+
+    return await super.isAuthorized(atConnection.metaData as InboundConnectionMetadata, keyNamespace);
   }
 
   /// Resolves the value references and returns correct value if value is resolved with in depth of resolution.

--- a/packages/at_secondary_server/lib/src/verb/handler/otp_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/otp_verb_handler.dart
@@ -125,21 +125,6 @@ class OtpVerbHandler extends AbstractVerbHandler {
   Future<bool> _isClientAuthorizedToStoreSPP(
       InboundConnectionMetadata atConnectionMetadata,
       String currentAtSign) async {
-    var enrollmentKey =
-        '${atConnectionMetadata.enrollmentId}.$newEnrollmentKeyPattern.$enrollManageNamespace$currentAtSign';
-    var enrollNamespaces =
-        (await getEnrollDataStoreValue(enrollmentKey)).namespaces;
-
-    if (enrollNamespaces.isEmpty) {
-      logger.finer(
-          'For the enrollmentId ${atConnectionMetadata.enrollmentId} no namespaces are enrolled. Returning empty list');
-      return false;
-    }
-    // If enrollment namespace contains ".*" return all keys.
-    if (enrollNamespaces.containsKey(enrollManageNamespace) ||
-        enrollNamespaces.containsKey(allNamespaces)) {
-      return true;
-    }
-    return false;
+    return super.isAuthorized(atConnectionMetadata, enrollManageNamespace);
   }
 }

--- a/packages/at_secondary_server/test/delete_verb_test.dart
+++ b/packages/at_secondary_server/test/delete_verb_test.dart
@@ -265,7 +265,7 @@ void main() {
           throwsA(predicate((dynamic e) =>
               e is UnAuthorizedException &&
               e.message ==
-                  'Enrollment Id: $enrollmentId is not authorized for delete operation on the key: dummykey.wavi@alice')));
+                  'Connection with enrollment ID $enrollmentId is not authorized to delete key: dummykey.wavi@alice')));
     });
 
     test('A test to verify keys with unauthorized namespace are not deleted',
@@ -304,7 +304,7 @@ void main() {
           throwsA(predicate((dynamic e) =>
               e is UnAuthorizedException &&
               e.message ==
-                  'Enrollment Id: $enrollmentId is not authorized for delete operation on the key: dummykey.buzz@alice')));
+                  'Connection with enrollment ID $enrollmentId is not authorized to delete key: dummykey.buzz@alice')));
     });
     tearDown(() async => await verbTestsTearDown());
   });
@@ -350,7 +350,7 @@ void main() {
             throwsA(predicate((dynamic e) =>
                 e is UnAuthorizedException &&
                 e.message ==
-                    'Enrollment Id: $enrollmentId is not authorized for delete operation on the key: @alice:dummykey.wavi@alice')));
+                    'Connection with enrollment ID $enrollmentId is not authorized to delete key: @alice:dummykey.wavi@alice')));
       });
     }
     tearDown(() async => await verbTestsTearDown());

--- a/packages/at_secondary_server/test/enroll_verb_test.dart
+++ b/packages/at_secondary_server/test/enroll_verb_test.dart
@@ -568,10 +568,10 @@ void main() {
       expect(status, 'pending');
       //Deny enrollment
       await Future.delayed(Duration(milliseconds: 1));
-      String approveEnrollmentCommand =
+      String denyEnrollmentCommand =
           'enroll:deny:{"enrollmentId":"$enrollmentId"}';
       enrollVerbParams =
-          getVerbParam(VerbSyntax.enroll, approveEnrollmentCommand);
+          getVerbParam(VerbSyntax.enroll, denyEnrollmentCommand);
       inboundConnection.metaData.isAuthenticated = true;
       inboundConnection.metaData.sessionID = 'dummy_session_id';
       await enrollVerbHandler.processVerb(

--- a/packages/at_secondary_server/test/local_lookup_verb_test.dart
+++ b/packages/at_secondary_server/test/local_lookup_verb_test.dart
@@ -356,7 +356,7 @@ void main() {
           throwsA(predicate((dynamic e) =>
               e is UnAuthorizedException &&
               e.message ==
-                  'Enrollment Id: $enrollmentId is not authorized for local lookup operation on the key: $alice:mobile.buzz$alice')));
+                  'Connection with enrollment ID $enrollmentId is not authorized to llookup key: $alice:mobile.buzz$alice')));
     });
   });
 
@@ -401,7 +401,7 @@ void main() {
             throwsA(predicate((dynamic e) =>
                 e is UnAuthorizedException &&
                 e.message ==
-                    'Enrollment Id: $enrollmentId is not authorized for local lookup operation on the key: @alice:dummykey.wavi@alice')));
+                    'Connection with enrollment ID $enrollmentId is not authorized to llookup key: @alice:dummykey.wavi@alice')));
       });
     }
   });

--- a/packages/at_secondary_server/test/lookup_verb_test.dart
+++ b/packages/at_secondary_server/test/lookup_verb_test.dart
@@ -842,7 +842,7 @@ void main() {
           throwsA(predicate((e) =>
               e is UnAuthorizedException &&
               e.message ==
-                  'Enrollment Id: $enrollmentId is not authorized for lookup operation on the key: @alice:some_key.buzz@alice')));
+                  'Connection with enrollment ID $enrollmentId is not authorized to lookup key: @alice:some_key.buzz@alice')));
     });
 
     test(
@@ -875,7 +875,7 @@ void main() {
           throwsA(predicate((e) =>
               e is UnAuthorizedException &&
               e.message ==
-                  'Enrollment Id: $enrollmentId is not authorized for lookup operation on the key: @alice:some_key.buzz@bob')));
+                  'Connection with enrollment ID $enrollmentId is not authorized to lookup key: @alice:some_key.buzz@bob')));
     });
     tearDown(() async => await verbTestsTearDown());
   });
@@ -924,7 +924,7 @@ void main() {
             throwsA(predicate((dynamic e) =>
                 e is UnAuthorizedException &&
                 e.message ==
-                    'Enrollment Id: $enrollmentId is not authorized for lookup operation on the key: @alice:dummykey.wavi@bob')));
+                    'Connection with enrollment ID $enrollmentId is not authorized to lookup key: @alice:dummykey.wavi@bob')));
       });
     }
   });

--- a/packages/at_secondary_server/test/otp_verb_test.dart
+++ b/packages/at_secondary_server/test/otp_verb_test.dart
@@ -157,7 +157,8 @@ void main() {
           '$enrollmentId.$newEnrollmentKeyPattern.$enrollManageNamespace$alice';
       EnrollDataStoreValue enrollDataStoreValue = EnrollDataStoreValue(
           'dummy_session_id', 'dummy-app', 'dummy-device', 'dummy-apkam-key')
-        ..namespaces = {enrollManageNamespace: 'rw'};
+        ..namespaces = {enrollManageNamespace: 'rw'}
+        ..approval = EnrollApproval(EnrollmentStatus.approved.name);
       await secondaryKeyStore.put(
           enrollmentKey, AtData()..data = jsonEncode(enrollDataStoreValue));
     });

--- a/packages/at_secondary_server/test/test_utils.dart
+++ b/packages/at_secondary_server/test/test_utils.dart
@@ -99,6 +99,10 @@ verbTestsSetUp() async {
 
   secondaryKeyStore = secondaryPersistenceStore!.getSecondaryKeyStore()!;
 
+  var notificationKeystore = AtNotificationKeystore.getInstance();
+  notificationKeystore.currentAtSign = alice;
+  await notificationKeystore.init(storageDir);
+
   mockSecondaryAddressFinder = MockSecondaryAddressFinder();
   when(() => mockSecondaryAddressFinder.findSecondary(bob))
       .thenAnswer((_) async {

--- a/packages/at_secondary_server/test/update_verb_test.dart
+++ b/packages/at_secondary_server/test/update_verb_test.dart
@@ -1071,7 +1071,7 @@ void main() {
           throwsA(predicate((dynamic e) =>
               e is UnAuthorizedException &&
               e.message ==
-                  'Enrollment Id: $enrollmentId is not authorized for update operation on the key: @alice:phone.buzz@alice')));
+                  'Connection with enrollment ID $enrollmentId is not authorized to update key: @alice:phone.buzz@alice')));
     });
 
     group('A group of tests when "*" namespace have only read access', () {
@@ -1110,7 +1110,7 @@ void main() {
             throwsA(predicate((dynamic e) =>
                 e is UnAuthorizedException &&
                 e.message ==
-                    'Enrollment Id: $enrollmentId is not authorized for update operation on the key: @alice:dummykey.wavi@alice')));
+                    'Connection with enrollment ID $enrollmentId is not authorized to update key: @alice:dummykey.wavi@alice')));
       });
 
       test(
@@ -1131,7 +1131,7 @@ void main() {
             throwsA(predicate((dynamic e) =>
                 e is UnAuthorizedException &&
                 e.message ==
-                    'Enrollment Id: $enrollmentId is not authorized for update operation on the key: @alice:dummykey.wavi@alice')));
+                    'Connection with enrollment ID $enrollmentId is not authorized to update key: @alice:dummykey.wavi@alice')));
       });
       tearDown(() async => await verbTestsTearDown());
     });
@@ -1174,7 +1174,7 @@ void main() {
               throwsA(predicate((dynamic e) =>
                   e is UnAuthorizedException &&
                   e.message ==
-                      'Enrollment Id: $enrollmentId is not authorized for update operation on the key: @alice:dummykey.wavi@alice')));
+                      'Connection with enrollment ID $enrollmentId is not authorized to update key: @alice:dummykey.wavi@alice')));
         });
       }
       tearDown(() async => await verbTestsTearDown());

--- a/tests/at_functional_test/test/enroll_namespace_access_test.dart
+++ b/tests/at_functional_test/test/enroll_namespace_access_test.dart
@@ -346,7 +346,7 @@ void main() {
       Map deleteResponseMap = jsonDecode(deleteResponse);
       expect(deleteResponseMap['errorCode'], 'AT0009');
       expect(deleteResponseMap['errorDescription'],
-          'UnAuthorized client in request : Enrollment Id: $secondEnrollmentId is not authorized for delete operation on the key: $waviKey');
+          'UnAuthorized client in request : Connection with enrollment ID $secondEnrollmentId is not authorized to delete key: $waviKey');
 
       // llookup on buzz key should succeed
       llookupResponse =

--- a/tests/at_functional_test/test/enroll_namespace_access_test.dart
+++ b/tests/at_functional_test/test/enroll_namespace_access_test.dart
@@ -337,7 +337,7 @@ void main() {
       Map llookupResponseMap = jsonDecode(llookupResponse);
       expect(llookupResponseMap['errorCode'], 'AT0009');
       expect(llookupResponseMap['errorDescription'],
-          'UnAuthorized client in request : Enrollment Id: $secondEnrollmentId is not authorized for local lookup operation on the key: $waviKey');
+          'UnAuthorized client in request : Connection with enrollment ID $secondEnrollmentId is not authorized to llookup key: $waviKey');
 
       // delete on wavi key should fail
       String deleteResponse =

--- a/tests/at_functional_test/test/enroll_verb_test.dart
+++ b/tests/at_functional_test/test/enroll_verb_test.dart
@@ -254,7 +254,7 @@ void main() {
       Map llookupResponseMap = jsonDecode(llookupResponse);
       expect(llookupResponseMap['errorCode'], 'AT0009');
       expect(llookupResponseMap['errorDescription'],
-          'UnAuthorized client in request : Enrollment Id: $enrollmentId is not authorized for local lookup operation on the key: $enrollmentKey');
+          'UnAuthorized client in request : Connection with enrollment ID $enrollmentId is not authorized to llookup key: $enrollmentKey');
 
       // keys:get:self should return default self encryption key
       var selfKey = '$enrollmentId.default_self_enc_key.__manage$firstAtSign';


### PR DESCRIPTION
**- What I did**
Fixed otp:put so it works for connections from the "first" app (which don't have an enrollment ID)


**- How I did it**
- fix: Have OtpVerbHandler use the same `AbstractVerbHandler isAuthorized` method as other verb handlers
- refactor: clean up usages of isAuthorized
- refactor: tidy up isAuthorized
- docs: improve docs of isAuthorized

**NB** isAuthorized doesn't appear to have any specific handling of keys which don't have a namespace ... this needs to be addressed ASAP. [Update: @murali-shris created this [ticket](https://github.com/atsign-foundation/at_server/issues/1830)]

**- How to verify it**
Tests pass

