### PR TITLE
fix: In enrollment notification notify only enrollmentId instead of e…

### DIFF
--- a/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
@@ -196,7 +196,7 @@ class EnrollVerbHandler extends AbstractVerbHandler {
       enrollmentValue.encryptedAPKAMSymmetricKey =
           enrollParams.encryptedAPKAMSymmetricKey;
       enrollmentValue.approval = EnrollApproval(EnrollmentStatus.pending.name);
-      await _storeNotification(key, enrollParams, currentAtSign);
+      await _storeNotification(newEnrollmentId, enrollParams, currentAtSign);
       responseJson['status'] = 'pending';
       enrollData = AtData()
         ..data = jsonEncode(enrollmentValue.toJson())

--- a/tests/at_functional_test/test/enroll_verb_test.dart
+++ b/tests/at_functional_test/test/enroll_verb_test.dart
@@ -318,8 +318,8 @@ void main() {
           'pixel-$randomNumber');
       expect(
           enrollListResponseMap[
-          '$enrollmentId.new.enrollments.__manage$firstAtSign']
-          ['namespace']['wavi'],
+                  '$enrollmentId.new.enrollments.__manage$firstAtSign']
+              ['namespace']['wavi'],
           'rw');
       expect(
           enrollListResponseMap[
@@ -442,9 +442,7 @@ void main() {
         // Response on monitor starts with "notification:"
         else if (serverResponse.startsWith('notification:')) {
           expect(
-              serverResponse.contains(
-                  '${enrollJson['enrollmentId']}.new.enrollments.__manage'),
-              true);
+              serverResponse.contains('${enrollJson['enrollmentId']}'), true);
           Map notificationValue = jsonDecode(jsonDecode(
               serverResponse.replaceAll('notification: ', ''))['value']);
           expect(notificationValue['appName'], 'buzz');


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- When an enrollment request is submitted, the notification that is sent to the approving apps contains the entire enrollment key. For example "123..new.enrollments.__manage" where 123 is enrollment id. When an app wants to approve or deny an enrollment, the apps have to do a substring to get the enrollment id -123. 
To remove the overhead on apps, send only the enrollment id in the notification instead of sending the entire enrollment key.

**- How to verify it**
- Updated the unit and functional tests

**- Description for the changelog**
- Send enrollment id instead of enrollment key in notification
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
