### PR TITLE
fix: Improve socket handling for better server resilience

### DIFF
--- a/packages/at_secondary_server/lib/src/connection/inbound/inbound_connection_impl.dart
+++ b/packages/at_secondary_server/lib/src/connection/inbound/inbound_connection_impl.dart
@@ -226,13 +226,11 @@ class InboundConnectionImpl<T extends Socket> extends BaseSocketConnection
       underlying.destroy();
       logger.finer(logger.getAtConnectionLogMessage(
           metaData, '$address:$port Disconnected'));
-      metaData.isClosed = true;
-    } on Exception {
-      metaData.isStale = true;
+    } catch (_) {
       // Ignore exception on a connection close
-    } on Error {
       metaData.isStale = true;
-      // Ignore error on a connection close
+    } finally {
+      metaData.isClosed = true;
     }
   }
 

--- a/packages/at_secondary_server/lib/src/connection/outbound/outbound_connection_impl.dart
+++ b/packages/at_secondary_server/lib/src/connection/outbound/outbound_connection_impl.dart
@@ -51,13 +51,11 @@ class OutboundConnectionImpl<T extends Socket>
       var port = socket.remotePort;
       socket.destroy();
       logger.finer('$address:$port Disconnected');
-      metaData.isClosed = true;
-    } on Exception {
-      metaData.isStale = true;
+    } catch (_) {
       // Ignore exception on a connection close
-    } on Error {
       metaData.isStale = true;
-      // Ignore error on a connection close
+    } finally {
+      metaData.isClosed = true;
     }
   }
 

--- a/packages/at_secondary_server/lib/src/server/bootstrapper.dart
+++ b/packages/at_secondary_server/lib/src/server/bootstrapper.dart
@@ -54,7 +54,7 @@ class SecondaryServerBootStrapper {
       //prevents secondary from terminating due to uncaught non-fatal errors
       unawaited(runZonedGuarded(() async {
         await secondaryServerInstance.start();
-      }, (error, stackTrace) {
+      }, (error, StackTrace stackTrace) {
         logger.severe('Uncaught error: $error \n StackTrace: $stackTrace');
         handleTerminateSignal(ProcessSignal.sigstop);
       }));


### PR DESCRIPTION
**- What I did**
- Try to ensure that any async errors from sockets are not left unhandled (which will cause the server to exit). Similar changes have been made during the past year in the at_lookup and at_client packages
- Partially addresses #1689 

**- How I did it**
- inbound_message_listener.dart: wrap call to 'listen' in runZonedGuarded; add StackTrace parameter to _errorHandler
- outbound_message_listener.dart: wrap call to 'listen' in runZonedGuarded; add StackTrace parameter to _errorHandler
- inbound_connection_impl.dart: simplify 'close' method and ensure that it always sets isClosed to true
- outbound_connection_impl.dart: simplify 'close' method and ensure that it always sets isClosed to true

**- How to verify it**
Tests pass

