### PR TITLE
fix: at_server_spec: BREAKING: Change signature of AtConnection.write

### DIFF
--- a/packages/at_server_spec/CHANGELOG.md
+++ b/packages/at_server_spec/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 5.0.0
 
 - fix: BREAKING: Change signature of AtConnection.write
-  from `void write(String data)` to `Future<void> write(String data);`
+  from `void write(String data)` to `Future<void> write(String data)`
 
 ## 4.0.1
 

--- a/packages/at_server_spec/CHANGELOG.md
+++ b/packages/at_server_spec/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 5.0.0
+
+- fix: BREAKING: Change signature of AtConnection.write
+  from `void write(String data)` to `Future<void> write(String data);`
+
 ## 4.0.1
 
 - docs: updated CHANGELOG

--- a/packages/at_server_spec/lib/src/connection/at_connection.dart
+++ b/packages/at_server_spec/lib/src/connection/at_connection.dart
@@ -5,9 +5,10 @@ abstract class AtConnection<T> {
   /// Gets the connection metadata
   AtConnectionMetaData get metaData;
 
-  /// Write some [data] to the [underlying] connection.
-  /// Throws [AtIOException] for any exception during the operation
-  void write(String data);
+  /// Write some [data] to the [underlying] connection,
+  /// and call underlying.flush or equivalent to ensure that
+  /// exceptions can be thrown directly to the calling code
+  Future<void> write(String data);
 
   /// closes the underlying connection
   Future<void> close();

--- a/packages/at_server_spec/pubspec.yaml
+++ b/packages/at_server_spec/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_server_spec
 description: A Dart library containing abstract classes that defines what implementations of the root and secondary servers are responsible for.
-version: 4.0.1
+version: 5.0.0
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://docs.atsign.com
 documentation: https://docs.atsign.com/atplatform/secondaryserver


### PR DESCRIPTION
**- What I did**
- fix: BREAKING: Change signature of AtConnection.write from `void write(String data)` to `Future<void> write(String data);`
- Updating at_server_spec package's major version to 5.0.0 as is a breaking change
- Required by #1871 which resolves #1689

**- How to verify it**
- Covered by #1871 
