### PR TITLE
fix: Hive max length check

### DIFF
--- a/packages/at_secondary_server/lib/src/verb/handler/abstract_update_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/abstract_update_verb_handler.dart
@@ -18,6 +18,7 @@ import 'package:at_utils/at_utils.dart';
 abstract class AbstractUpdateVerbHandler extends ChangeVerbHandler {
   static bool _autoNotify = AtSecondaryConfig.autoNotify;
   late final NotificationManager notificationManager;
+  final int maxKeyLength = 255;
 
   AbstractUpdateVerbHandler(
       SecondaryKeyStore keyStore,
@@ -117,6 +118,11 @@ abstract class AbstractUpdateVerbHandler extends ChangeVerbHandler {
         sharedBy != null &&
         sharedBy != AtSecondaryServerImpl.getInstance().currentAtSign) {
       atKey = 'cached:$atKey';
+    }
+
+    if (atKey.length > maxKeyLength) {
+      throw InvalidAtKeyException(
+          'key length ${atKey.length} is greater than $maxKeyLength chars');
     }
 
     atData.metaData = AtMetaData.fromCommonsMetadata(updateParams.metadata!);

--- a/packages/at_secondary_server/lib/src/verb/handler/notify_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/notify_verb_handler.dart
@@ -21,7 +21,7 @@ enum Type { sent, received }
 
 class NotifyVerbHandler extends AbstractVerbHandler {
   static Notify notify = Notify();
-  final int maxKeyLength = 255;
+  final int _maxKeyLength = 255;
 
   NotifyVerbHandler(SecondaryKeyStore keyStore) : super(keyStore);
 
@@ -135,9 +135,9 @@ class NotifyVerbHandler extends AbstractVerbHandler {
     // form a cached key
     String cachedNotificationKey =
         '${AtConstants.cached}:${atNotificationBuilder.notification}';
-    if (cachedNotificationKey.length > maxKeyLength) {
+    if (cachedNotificationKey.length > _maxKeyLength) {
       throw InvalidAtKeyException(
-          'notification key length ${cachedNotificationKey.length} is greater than $maxKeyLength chars');
+          'notification key length ${cachedNotificationKey.length} is greater than $_maxKeyLength chars');
     }
     // If operationType is delete, remove the cached key only
     // when cascade delete is set to true

--- a/packages/at_secondary_server/lib/src/verb/handler/notify_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/notify_verb_handler.dart
@@ -21,6 +21,7 @@ enum Type { sent, received }
 
 class NotifyVerbHandler extends AbstractVerbHandler {
   static Notify notify = Notify();
+  final int maxKeyLength = 255;
 
   NotifyVerbHandler(SecondaryKeyStore keyStore) : super(keyStore);
 
@@ -134,6 +135,10 @@ class NotifyVerbHandler extends AbstractVerbHandler {
     // form a cached key
     String cachedNotificationKey =
         '${AtConstants.cached}:${atNotificationBuilder.notification}';
+    if (cachedNotificationKey.length > maxKeyLength) {
+      throw InvalidAtKeyException(
+          'notification key length ${cachedNotificationKey.length} is greater than $maxKeyLength chars');
+    }
     // If operationType is delete, remove the cached key only
     // when cascade delete is set to true
     int? cachedKeyCommitId;

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -34,12 +34,13 @@ dependencies:
   yaml: 3.1.2
   logging: 1.2.0
 
+#TODO replace with published version
 dependency_overrides:
   at_persistence_secondary_server:
     git:
       url: https://github.com/atsign-foundation/at_server
       path: packages/at_persistence_secondary_server
-      ref: hive_max_length_bug
+      ref: trunk
 
 dev_dependencies:
   test: ^1.24.4

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -34,6 +34,13 @@ dependencies:
   yaml: 3.1.2
   logging: 1.2.0
 
+dependency_overrides:
+  at_persistence_secondary_server:
+    git:
+      url: https://github.com/atsign-foundation/at_server
+      path: packages/at_persistence_secondary_server
+      ref: hive_max_length_bug
+
 dev_dependencies:
   test: ^1.24.4
   coverage: ^1.6.1

--- a/packages/at_secondary_server/test/notify_verb_test.dart
+++ b/packages/at_secondary_server/test/notify_verb_test.dart
@@ -459,7 +459,7 @@ void main() {
       expect(atNotification?.notification, '@bob:hello');
       expect(atNotification?.type, NotificationType.sent);
     });
-    test('test for max key length check', () async {
+    test('test for max key length check for cached key', () async {
       SecondaryKeyStore keyStore = keyStoreManager.getKeyStore();
       AtSecondaryServerImpl.getInstance().currentAtSign = '@alice';
       var notifyVerb = NotifyVerbHandler(keyStore);
@@ -470,8 +470,7 @@ void main() {
       var notifyResponse = Response();
       var notifyVerbParams = HashMap<String, String>();
       notifyVerbParams.putIfAbsent(AtConstants.forAtSign, () => '@alice');
-      var key =
-          'iujpsefqvdzmtqthrqbaxqszxokaiutvpnbcphcjvjghpdxzdwywfsaowruwafmcudeoarfhuncezjkwbdvprcbujeptisxkjtztxogqqrrnjpqrdsjmcrpmpusrkzaksdfleyzsuarjhsqvxwicxulzqjzcwwjaupxzoqfwenkfonwhxtmwamiyzqqoesnreknrzwxazvykbybafrlwgqsyreudprnakoioqiwoqiwqdebbeeeeddddddd';
+      var key = createRandomString(250);
       notifyVerbParams.putIfAbsent(AtConstants.atKey, () => key);
       notifyVerbParams.putIfAbsent(AtConstants.atSign, () => '@bob');
       notifyVerbParams.putIfAbsent(AtConstants.ttr, () => '100');

--- a/packages/at_secondary_server/test/notify_verb_test.dart
+++ b/packages/at_secondary_server/test/notify_verb_test.dart
@@ -459,6 +459,30 @@ void main() {
       expect(atNotification?.notification, '@bob:hello');
       expect(atNotification?.type, NotificationType.sent);
     });
+    test('test for max key length check', () async {
+      SecondaryKeyStore keyStore = keyStoreManager.getKeyStore();
+      AtSecondaryServerImpl.getInstance().currentAtSign = '@alice';
+      var notifyVerb = NotifyVerbHandler(keyStore);
+      var inboundConnection = InboundConnectionImpl(mockSocket, '123');
+      inboundConnection.metaData = InboundConnectionMetadata()
+        ..isPolAuthenticated = true
+        ..fromAtSign = '@bob';
+      var notifyResponse = Response();
+      var notifyVerbParams = HashMap<String, String>();
+      notifyVerbParams.putIfAbsent(AtConstants.forAtSign, () => '@alice');
+      var key =
+          'iujpsefqvdzmtqthrqbaxqszxokaiutvpnbcphcjvjghpdxzdwywfsaowruwafmcudeoarfhuncezjkwbdvprcbujeptisxkjtztxogqqrrnjpqrdsjmcrpmpusrkzaksdfleyzsuarjhsqvxwicxulzqjzcwwjaupxzoqfwenkfonwhxtmwamiyzqqoesnreknrzwxazvykbybafrlwgqsyreudprnakoioqiwoqiwqdebbeeeeddddddd';
+      notifyVerbParams.putIfAbsent(AtConstants.atKey, () => key);
+      notifyVerbParams.putIfAbsent(AtConstants.atSign, () => '@bob');
+      notifyVerbParams.putIfAbsent(AtConstants.ttr, () => '100');
+      expect(
+          () async => await notifyVerb.processVerb(
+              notifyResponse, notifyVerbParams, inboundConnection),
+          throwsA(predicate((dynamic e) =>
+              e is InvalidAtKeyException &&
+              e.message ==
+                  'notification key length ${'cached:'.length + '@bob:'.length + key.length + '@alice'.length} is greater than 255 chars')));
+    });
     tearDown(() async => await tearDownFunc());
   });
 

--- a/packages/at_secondary_server/test/update_verb_test.dart
+++ b/packages/at_secondary_server/test/update_verb_test.dart
@@ -775,8 +775,7 @@ void main() {
       var updateResponse = Response();
       var updateVerbParams = HashMap<String, String>();
       updateVerbParams.putIfAbsent('atSign', () => '@alice');
-      var key =
-          'iujpsefqvdzmtqthrqbaxqszxokaiutvpnbcphcjvjghpdxzdwywfsaowruwafmcudeoarfhuncezjkwbdvprcbujeptisxkjtztxogqqrrnjpqrdsjmcrpmpusrkzaksdfleyzsuarjhsqvxwicxulzqjzcwwjaupxzoqfwenkfonwhxtmwamiyzqqoesnreknrzwxazvykbybafrlwgqsyreudprnakoioqiwoqiwqdebbeeeeddddddd';
+      var key = createRandomString(250);
       updateVerbParams.putIfAbsent('atKey', () => key);
       updateVerbParams.putIfAbsent('value', () => 'hyderabad');
       expect(
@@ -785,7 +784,7 @@ void main() {
           throwsA(predicate((dynamic e) =>
               e is InvalidAtKeyException &&
               e.message ==
-                  'key length ${key.length + '@alice'.length} is greater than 255 chars')));
+                  'key length ${key.length + '@alice'.length} is greater than max allowed ${AbstractUpdateVerbHandler.maxKeyLengthWithoutCached} chars')));
     });
   });
 

--- a/packages/at_secondary_server/test/update_verb_test.dart
+++ b/packages/at_secondary_server/test/update_verb_test.dart
@@ -765,6 +765,28 @@ void main() {
       expect(autoNotification.expiresAt!.millisecondsSinceEpoch,
           closeTo(notifExpiresAt.millisecondsSinceEpoch, 3000));
     });
+
+    test('test max key length check', () async {
+      var inBoundSessionId = 'testsessionid';
+      var atConnection = InboundConnectionImpl(mockSocket, inBoundSessionId);
+      var updateVerbHandler = UpdateVerbHandler(
+          secondaryKeyStore, statsNotificationService, notificationManager);
+      atConnection.metaData.isAuthenticated = true;
+      var updateResponse = Response();
+      var updateVerbParams = HashMap<String, String>();
+      updateVerbParams.putIfAbsent('atSign', () => '@alice');
+      var key =
+          'iujpsefqvdzmtqthrqbaxqszxokaiutvpnbcphcjvjghpdxzdwywfsaowruwafmcudeoarfhuncezjkwbdvprcbujeptisxkjtztxogqqrrnjpqrdsjmcrpmpusrkzaksdfleyzsuarjhsqvxwicxulzqjzcwwjaupxzoqfwenkfonwhxtmwamiyzqqoesnreknrzwxazvykbybafrlwgqsyreudprnakoioqiwoqiwqdebbeeeeddddddd';
+      updateVerbParams.putIfAbsent('atKey', () => key);
+      updateVerbParams.putIfAbsent('value', () => 'hyderabad');
+      expect(
+          () async => await updateVerbHandler.processVerb(
+              updateResponse, updateVerbParams, atConnection),
+          throwsA(predicate((dynamic e) =>
+              e is InvalidAtKeyException &&
+              e.message ==
+                  'key length ${key.length + '@alice'.length} is greater than 255 chars')));
+    });
   });
 
   group('update verb tests with metadata', () {


### PR DESCRIPTION
**- What I did**
- implemented hive max length check
**- How I did it**
- modified AbstractUpdateVerbHandler and NotifyVerbHandler to check for key length before persisting to keystore. InvalidAtKeyException will be thrown and handled by GlobalExceptionHandler(no changes here)
- added unit tests
**- How to verify it**
- unit tests and functional/end2end tests should pass
