### PR TITLE
fix: ensure all connection writes are awaited

### DIFF
--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.43
+- fix: ensure all connection writes are awaited
+
 ## 3.0.42
 - feat: allow filtering of requests in EnrollVerbHandler using enrollment
   approval status

--- a/packages/at_secondary_server/lib/src/connection/inbound/inbound_connection_impl.dart
+++ b/packages/at_secondary_server/lib/src/connection/inbound/inbound_connection_impl.dart
@@ -88,13 +88,15 @@ class InboundConnectionImpl<T extends Socket> extends BaseSocketConnection
     requestTimestampQueue = Queue();
 
     logger.info(logger.getAtConnectionLogMessage(
-        metaData, 'New connection ('
+        metaData,
+        'New connection ('
         'this side: ${underlying.address}:${underlying.port}'
         ' remote side: ${underlying.remoteAddress}:${underlying.remotePort}'
         ')'));
 
     socket.done.onError((error, stackTrace) {
-      logger.info('socket.done.onError called with $error. Calling this.close()');
+      logger
+          .info('socket.done.onError called with $error. Calling this.close()');
       this.close();
     });
   }
@@ -233,7 +235,8 @@ class InboundConnectionImpl<T extends Socket> extends BaseSocketConnection
 
     try {
       logger.info(logger.getAtConnectionLogMessage(
-          metaData, 'destroying socket ('
+          metaData,
+          'destroying socket ('
           'this side: ${underlying.address}:${underlying.port}'
           ' remote side: ${underlying.remoteAddress}:${underlying.remotePort}'
           ')'));

--- a/packages/at_secondary_server/lib/src/connection/outbound/outbound_connection_impl.dart
+++ b/packages/at_secondary_server/lib/src/connection/outbound/outbound_connection_impl.dart
@@ -19,13 +19,15 @@ class OutboundConnectionImpl<T extends Socket>
       ..isCreated = true;
 
     logger.info(logger.getAtConnectionLogMessage(
-        metaData, 'New connection ('
+        metaData,
+        'New connection ('
         'this side: ${underlying.address}:${underlying.port}'
         ' remote side: ${underlying.remoteAddress}:${underlying.remotePort}'
         ')'));
 
     socket.done.onError((error, stackTrace) {
-      logger.info('socket.done.onError called with $error. Calling this.close()');
+      logger
+          .info('socket.done.onError called with $error. Calling this.close()');
       this.close();
     });
   }
@@ -59,7 +61,8 @@ class OutboundConnectionImpl<T extends Socket>
     try {
       var socket = underlying;
       logger.info(logger.getAtConnectionLogMessage(
-          metaData, 'destroying socket ('
+          metaData,
+          'destroying socket ('
           'this side: ${underlying.address}:${underlying.port}'
           ' remote side: ${underlying.remoteAddress}:${underlying.remotePort}'
           ')'));

--- a/packages/at_secondary_server/lib/src/exception/global_exception_handler.dart
+++ b/packages/at_secondary_server/lib/src/exception/global_exception_handler.dart
@@ -130,7 +130,7 @@ class GlobalExceptionHandler {
         } else {
           errorDescription = exception.toString();
         }
-        _writeToSocket(atConnection, prompt, errorCode, errorDescription);
+        await _writeToSocket(atConnection, prompt, errorCode, errorDescription);
       }
     }
   }
@@ -150,11 +150,11 @@ class GlobalExceptionHandler {
     return error_description[errorCode];
   }
 
-  void _writeToSocket(AtConnection atConnection, String prompt,
-      String? errorCode, String errorDescription) {
+  Future<void> _writeToSocket(AtConnection atConnection, String prompt,
+      String? errorCode, String errorDescription) async {
     if (atConnection.metaData.clientVersion ==
         AtConnectionMetaData.clientVersionNotAvailable) {
-      atConnection.write('error:$errorCode-$errorDescription\n$prompt');
+      await atConnection.write('error:$errorCode-$errorDescription\n$prompt');
       return;
     }
     // The JSON encoding of error message is supported by the client versions greater than 3.0.37
@@ -166,10 +166,10 @@ class GlobalExceptionHandler {
         'errorCode': errorCode,
         'errorDescription': errorDescription
       };
-      atConnection.write('error:${jsonEncode(errorJsonMap)}\n$prompt');
+      await atConnection.write('error:${jsonEncode(errorJsonMap)}\n$prompt');
       return;
     }
     // Defaults to return the error message in string format if all the conditions fails
-    atConnection.write('error:$errorCode-$errorDescription\n$prompt');
+    await atConnection.write('error:$errorCode-$errorDescription\n$prompt');
   }
 }

--- a/packages/at_secondary_server/lib/src/notification/stats_notification_service.dart
+++ b/packages/at_secondary_server/lib/src/notification/stats_notification_service.dart
@@ -133,7 +133,7 @@ class StatsNotificationService {
   }
 
   /// Writes the lastCommitID to all Monitor connections
-  void writeStatsToMonitor({String? latestCommitID, String? operationType}) {
+  Future<void> writeStatsToMonitor({String? latestCommitID, String? operationType}) async {
     try {
       latestCommitID ??= atCommitLog!.lastCommittedSequenceNumber().toString();
       // Gets the list of active connections.
@@ -156,8 +156,8 @@ class StatsNotificationService {
             ..messageType = MessageType.key.toString()
             ..isTextMessageEncrypted = false;
           // Convert notification object to JSON and write to connection
-          connection
-              .write('notification: ${jsonEncode(notification.toJson())}\n');
+          await connection.write('notification:'
+              ' ${jsonEncode(notification.toJson())}\n');
         }
       }
       if (numOfMonitorConn == 0) {

--- a/packages/at_secondary_server/lib/src/notification/stats_notification_service.dart
+++ b/packages/at_secondary_server/lib/src/notification/stats_notification_service.dart
@@ -133,7 +133,8 @@ class StatsNotificationService {
   }
 
   /// Writes the lastCommitID to all Monitor connections
-  Future<void> writeStatsToMonitor({String? latestCommitID, String? operationType}) async {
+  Future<void> writeStatsToMonitor(
+      {String? latestCommitID, String? operationType}) async {
     try {
       latestCommitID ??= atCommitLog!.lastCommittedSequenceNumber().toString();
       // Gets the list of active connections.

--- a/packages/at_secondary_server/lib/src/server/at_secondary_impl.dart
+++ b/packages/at_secondary_server/lib/src/server/at_secondary_impl.dart
@@ -443,7 +443,7 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
   /// @param - ServerSocket
   void _listen(var serverSocket) {
     logger.info('serverSocket _listen : ${serverSocket.runtimeType}');
-    serverSocket.listen(((clientSocket) {
+    serverSocket.listen(((clientSocket) async {
       var sessionID = '_${Uuid().v4()}';
       InboundConnection? connection;
       try {
@@ -453,9 +453,9 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
         connection = inBoundConnectionManager
             .createSocketConnection(clientSocket, sessionId: sessionID);
         connection.acceptRequests(_executeVerbCallBack, _streamCallBack);
-        connection.write('@');
+        await connection.write('@');
       } on InboundConnectionLimitException catch (e) {
-        GlobalExceptionHandler.getInstance()
+        await GlobalExceptionHandler.getInstance()
             .handle(e, atConnection: connection, clientSocket: clientSocket);
       }
     }), onError: (error) {

--- a/packages/at_secondary_server/lib/src/verb/handler/change_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/change_verb_handler.dart
@@ -23,7 +23,7 @@ abstract class ChangeVerbHandler extends AbstractVerbHandler {
     if (_responseInternal != null &&
         _responseInternal!.isError == false &&
         _responseInternal!.data != null) {
-      statsNotificationService.writeStatsToMonitor(
+      await statsNotificationService.writeStatsToMonitor(
           latestCommitID: _responseInternal!.data,
           operationType: getVerb().name());
     }

--- a/packages/at_secondary_server/lib/src/verb/handler/monitor_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/monitor_verb_handler.dart
@@ -90,7 +90,7 @@ class MonitorVerbHandler extends AbstractVerbHandler {
     // If enrollmentId is null, then connection is authenticated via PKAM
     if ((atConnection.metaData as InboundConnectionMetadata).enrollmentId ==
         null) {
-      _sendLegacyNotification(notification);
+      await _sendLegacyNotification(notification);
     } else {
       // If enrollmentId is populated, then connection is authenticated via APKAM
       await _sendNotificationByEnrollmentNamespaceAccess(notification);
@@ -101,7 +101,7 @@ class MonitorVerbHandler extends AbstractVerbHandler {
   ///    - Writes all the notifications on the connection.
   ///    - Optionally, if regex is supplied, write only the notifications that
   ///      matches the pattern.
-  void _sendLegacyNotification(Notification notification) {
+  Future<void> _sendLegacyNotification(Notification notification) async {
     var fromAtSign = notification.fromAtSign;
     if (fromAtSign != null) {
       fromAtSign = fromAtSign.replaceAll('@', '');
@@ -110,8 +110,8 @@ class MonitorVerbHandler extends AbstractVerbHandler {
       // If the user does not provide regex, defaults to ".*" to match all notifications.
       if (notification.notification!.contains(RegExp(regex)) ||
           (fromAtSign != null && fromAtSign.contains(RegExp(regex)))) {
-        atConnection
-            .write('notification: ${jsonEncode(notification.toJson())}\n');
+        await atConnection.write('notification:'
+            ' ${jsonEncode(notification.toJson())}\n');
       }
     } on FormatException {
       logger.severe('Invalid regular expression : $regex');

--- a/packages/at_secondary_server/lib/src/verb/handler/stream_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/stream_verb_handler.dart
@@ -59,8 +59,8 @@ class StreamVerbHandler extends AbstractVerbHandler {
           logger.severe('sender connection is null for stream id:$streamId');
           throw UnAuthenticatedException('Invalid stream id');
         }
-        await StreamManager.senderSocketMap[streamId]!
-            .write('stream:done $streamId\n');
+        await StreamManager.senderSocketMap[streamId]!.write('stream:done'
+            ' $streamId\n');
         _cleanUp(streamId);
         break;
       case 'init':

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_secondary
 description: Implementation of secondary server.
-version: 3.0.42
+version: 3.0.43
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://www.example.com
 publish_to: none

--- a/packages/at_secondary_server/test/delete_verb_test.dart
+++ b/packages/at_secondary_server/test/delete_verb_test.dart
@@ -162,7 +162,8 @@ void main() {
 
     test('verify deletion of cached signing private key', () async {
       inboundConnection.metadata.isAuthenticated = true;
-      var command = 'delete:cached:@alice:${AtConstants.atSigningPrivateKey}@alice';
+      var command =
+          'delete:cached:@alice:${AtConstants.atSigningPrivateKey}@alice';
       Response response =
           await handler.processInternal(command, inboundConnection);
       expect(int.parse(response.data!).runtimeType, int);

--- a/packages/at_secondary_server/test/inbound_connection_pool_test.dart
+++ b/packages/at_secondary_server/test/inbound_connection_pool_test.dart
@@ -113,7 +113,8 @@ void main() async {
     });
 
     /// Verify that, at lowWaterMark, allowable idle time is still as configured by inboundIdleTimeMillis
-    test('test connection pool - at lowWaterMark - clear idle connection', () async {
+    test('test connection pool - at lowWaterMark - clear idle connection',
+        () async {
       int maxPoolSize = 10;
 
       var poolInstance = InboundConnectionPool.getInstance();
@@ -158,7 +159,8 @@ void main() async {
     /// - Wait until we pass the currently allowable idle time for 'authenticated'
     /// - Verify that the number of connections in the pool is now 3, since only
     ///   the 3 that we wrote to earlier are still not 'idle'
-    test('test connection pool - 90% capacity - clear idle connection', () async {
+    test('test connection pool - 90% capacity - clear idle connection',
+        () async {
       int maxPoolSize = 100; // Please don't change this
 
       var poolInstance = InboundConnectionPool.getInstance();
@@ -211,7 +213,8 @@ void main() async {
         await connections[i * 2].write('test data'); // evens are authenticated
       }
       for (int i = 0; i < numUnAuthToWriteTo; i++) {
-        await connections[i * 2 + 1].write('test data'); // odds are not authenticated
+        await connections[i * 2 + 1]
+            .write('test data'); // odds are not authenticated
       }
 
       expect(poolInstance.getCurrentSize(), desiredPoolSize);

--- a/packages/at_secondary_server/test/test_utils.dart
+++ b/packages/at_secondary_server/test/test_utils.dart
@@ -26,7 +26,11 @@ class MockOutboundClientManager extends Mock implements OutboundClientManager {}
 class MockNotificationManager extends Mock implements NotificationManager {}
 
 class MockStatsNotificationService extends Mock
-    implements StatsNotificationService {}
+    implements StatsNotificationService {
+  @override
+  Future<void> writeStatsToMonitor(
+      {String? latestCommitID, String? operationType}) async {}
+}
 
 class MockAtCacheManager extends Mock implements AtCacheManager {}
 
@@ -234,8 +238,6 @@ verbTestsSetUp() async {
       .thenAnswer((invocation) async => 'some-notification-id');
 
   statsNotificationService = MockStatsNotificationService();
-  when(() => statsNotificationService.writeStatsToMonitor())
-      .thenAnswer((invocation) {});
 }
 
 Future<void> verbTestsTearDown() async {

--- a/tests/at_end2end_test/test/e2e_test_utils.dart
+++ b/tests/at_end2end_test/test/e2e_test_utils.dart
@@ -110,36 +110,53 @@ class SimpleOutboundSocketHandler {
     // queue.clear();
   }
 
+  final int newLineCodeUnit = 10;
+  final int atCharCodeUnit = 64;
+
   /// Handles responses from the remote secondary, adds to [_queue] for processing in [read] method
   /// Throws a [BufferOverFlowException] if buffer is unable to hold incoming data
   Future<void> _messageHandler(data) async {
-    String result;
-    if (!_buffer.isOverFlow(data)) {
-      // skip @ prompt. byte code for @ is 64
-      if (data.length == 1 && data.first == 64) {
-        return;
-      }
-      //ignore prompt(@ or @<atSign>@) after '\n'. byte code for \n is 10
-      if (data.last == 64 && data.contains(10)) {
-        data = data.sublist(0, data.lastIndexOf(10) + 1);
-        _buffer.append(data);
-      } else if (data.length > 1 && data.first == 64 && data.last == 64) {
-        // pol responses do not end with '\n'. Add \n for buffer completion
-        _buffer.append(data);
-        _buffer.addByte(10);
+    // check buffer overflow
+    _checkBufferOverFlow(data);
+
+    // Loop from last index to until the end of data.
+    // If a new line character is found, then it is end
+    // of server response. process the data.
+    // Else add the byte to buffer.
+    for (int element = 0; element < data.length; element++) {
+      // If it's a '\n' then complete data has been received. process it.
+      if (data[element] == newLineCodeUnit) {
+        String result = utf8.decode(_buffer.getData().toList());
+        result = _stripPrompt(result);
+        _buffer.clear();
+        _queue.add(result);
       } else {
-        _buffer.append(data);
+        _buffer.addByte(data[element]);
       }
-    } else {
-      _buffer.clear();
-      throw BufferOverFlowException('Buffer overflow on outbound connection');
     }
-    if (_buffer.isEnd()) {
-      result = utf8.decode(_buffer.getData());
-      result = result.trim();
+  }
+
+  _checkBufferOverFlow(data) {
+    if (_buffer.isOverFlow(data)) {
+      int bufferLength = (_buffer.length() + data.length) as int;
       _buffer.clear();
-      _queue.add(result);
+      throw BufferOverFlowException(
+          'data length exceeded the buffer limit. Data length : $bufferLength and Buffer capacity ${_buffer.capacity}');
     }
+  }
+
+  String _stripPrompt(String result) {
+    var colonIndex = result.indexOf(':');
+    if (colonIndex == -1) {
+      return result;
+    }
+    var responsePrefix = result.substring(0, colonIndex);
+    var response = result.substring(colonIndex);
+    if (responsePrefix.contains('@')) {
+      responsePrefix =
+          responsePrefix.substring(responsePrefix.lastIndexOf('@') + 1);
+    }
+    return '$responsePrefix$response';
   }
 
   /// A message which is returned from [read] if throwTimeoutException is set to false
@@ -151,10 +168,14 @@ class SimpleOutboundSocketHandler {
     // Wait this many milliseconds between checks on the queue
     var loopDelay=250;
 
+    bool first = true;
     // Check every loopDelay milliseconds until we get a response or timeoutMillis have passed.
     var loopCount = (timeoutMillis / loopDelay).round();
     for (var i = 0; i < loopCount; i++) {
-      await Future.delayed(Duration(milliseconds: loopDelay));
+      if (!first) {
+        await Future.delayed(Duration(milliseconds: loopDelay));
+      }
+      first = false;
       var queueLength = _queue.length;
       if (queueLength > 0) {
         result = _queue.removeFirst();

--- a/tests/at_end2end_test/test/notify_verb_test.dart
+++ b/tests/at_end2end_test/test/notify_verb_test.dart
@@ -51,7 +51,7 @@ void main() {
     monitorSH = await e2e.getSocketHandler(atSign_2);
 
     try {
-      var atServerVersion = Version.parse(await sh1.getVersion());
+      var atServerVersion = Version.parse(await monitorSH.getVersion());
       if (atServerVersion < Version(3, 0, 43)) {
         print ('\n\nNOT running monitor test as atServer is running version $atServerVersion\n\n');
         return;

--- a/tests/at_end2end_test/test/notify_verb_test.dart
+++ b/tests/at_end2end_test/test/notify_verb_test.dart
@@ -89,7 +89,7 @@ void main() {
     for (int i = 1; i <= numNotifications; i++) {
       print ('/nWaiting for notification $i');
       String subsequentNotification = await monitorSH.read(
-          log: true, timeoutMillis: 10000, throwTimeoutException: true);
+          log: true, timeoutMillis: 1000, throwTimeoutException: true);
       print('Notification number $i: $subsequentNotification');
       final notifJson = jsonDecode(
           subsequentNotification.replaceFirst('notification: ', ''));

--- a/tests/at_end2end_test/test/notify_verb_test.dart
+++ b/tests/at_end2end_test/test/notify_verb_test.dart
@@ -90,7 +90,6 @@ void main() {
       // Wait for a second
       await Future.delayed(Duration(seconds: 1));
 
-      List<String> receivedNotificationIds = [];
       // verify atsign2 receives all notifications ~immediately
       for (int i = 1; i <= numNotifications; i++) {
         print('/nWaiting for notification $i');
@@ -99,10 +98,10 @@ void main() {
         print('Notification number $i: $subsequentNotification');
         final notifJson = jsonDecode(
             subsequentNotification.replaceFirst('notification: ', ''));
-        receivedNotificationIds.add(notifJson['id']);
-      }
 
-      expect(receivedNotificationIds.length, sentNotificationIds.length);
+        expect(sentNotificationIds, contains(notifJson['id']));
+        sentNotificationIds.remove(notifJson['id']);
+      }
     } finally {
       notifySH.close();
       monitorSH.close();

--- a/tests/at_end2end_test/test/notify_verb_test.dart
+++ b/tests/at_end2end_test/test/notify_verb_test.dart
@@ -89,7 +89,7 @@ void main() {
     for (int i = 1; i <= numNotifications; i++) {
       print ('/nWaiting for notification $i');
       String subsequentNotification = await monitorSH.read(
-          log: true, timeoutMillis: 1000, throwTimeoutException: true);
+          log: true, timeoutMillis: 10000, throwTimeoutException: true);
       print('Notification number $i: $subsequentNotification');
       final notifJson = jsonDecode(
           subsequentNotification.replaceFirst('notification: ', ''));

--- a/tests/at_end2end_test/test/notify_verb_test.dart
+++ b/tests/at_end2end_test/test/notify_verb_test.dart
@@ -41,6 +41,64 @@ void main() {
     sh2.clear();
   });
 
+  // atsign1 send 5 notifications to atsign2 in some specific namespace
+  // atsign1 wait for all 5 notifications to be delivered
+  // atsign2 create connection, issue monitor command for that namespace
+  // verify atsign2 receives all 5 notifications immediately
+  test('monitor receives multiple pending notifications immediately', () async {
+    e2e.SimpleOutboundSocketHandler notifySH, monitorSH;
+    notifySH = await e2e.getSocketHandler(atSign_1);
+    monitorSH = await e2e.getSocketHandler(atSign_2);
+
+    List<String> sentNotificationIds = [];
+
+    int startTime=DateTime.now().millisecondsSinceEpoch;
+
+    // Wait for a couple of seconds in case of time drift
+    // between client and server
+    await Future.delayed(Duration(seconds:2));
+
+    int numNotifications = 5;
+    // atsign1 send N notifications to atsign2 in some specific namespace
+    for (int i = 1; i <= numNotifications; i++) {
+      await notifySH.writeCommand('notify:update'
+          ':messageType:key:$atSign_2:monitor.e2etest$atSign_1'
+          ':message_$i');
+      String response = await notifySH.read();
+      print('notify verb response : $response');
+      assert(
+      (!response.contains('Invalid syntax')) && (!response.contains('null')));
+      String notificationId = response.replaceAll('data:', '');
+      sentNotificationIds.add(notificationId);
+    }
+    // atsign1 wait for all 5 notifications to be delivered
+    for (String notificationId in sentNotificationIds) {
+      String response = await getNotifyStatus(notifySH, notificationId,
+          returnWhenStatusIn: ['delivered'], timeOutMillis: 15000);
+      print('notify status response : $response');
+      expect(response, contains('data:delivered'));
+    }
+
+    // atsign2 issue monitor command for that namespace since $startTime
+    await monitorSH.writeCommand('monitor:strict:$startTime monitor.e2etest');
+    // Wait for a second
+    await Future.delayed(Duration(seconds:1));
+
+    List<String> receivedNotificationIds = [];
+    // verify atsign2 receives all notifications ~immediately
+    for (int i = 1; i <= numNotifications; i++) {
+      print ('/nWaiting for notification $i');
+      String subsequentNotification = await monitorSH.read(
+          log: true, timeoutMillis: 1000, throwTimeoutException: true);
+      print('Notification number $i: $subsequentNotification');
+      final notifJson = jsonDecode(
+          subsequentNotification.replaceFirst('notification: ', ''));
+      receivedNotificationIds.add(notifJson['id']);
+    }
+
+    expect(receivedNotificationIds.length, sentNotificationIds.length);
+  });
+
   test('notify verb for notifying a key update to the atsign', () async {
     /// NOTIFY VERB
     var value = 'alice$lastValue@yahoo.com';
@@ -789,9 +847,13 @@ Future<String> getNotifyStatus(
   String response = 'NO_RESPONSE';
 
   bool readTimedOut = false;
+  bool first = true;
   int endTime = DateTime.now().millisecondsSinceEpoch + timeOutMillis;
   while (DateTime.now().millisecondsSinceEpoch < endTime) {
+    if (!first) {
     await Future.delayed(Duration(milliseconds: loopDelay));
+    }
+    first = false;
 
     if (!readTimedOut) {
       await sh.writeCommand('notify:status:$notificationId', log: true);

--- a/tests/at_functional_test/test/enroll_verb_test.dart
+++ b/tests/at_functional_test/test/enroll_verb_test.dart
@@ -460,7 +460,7 @@ void main() {
       3. On sending a cram request, server returns "data:success"
       4. On sending monitor request, server returns enrollment request
         */
-      }, count: 5));
+      }, count: 4));
       monitorSocket.write('from:${firstAtSign.toString().trim()}\n');
     });
 

--- a/tools/run_locally/scripts/macos/at_server
+++ b/tools/run_locally/scripts/macos/at_server
@@ -62,7 +62,7 @@ export accessLogPath="$storageDir/accessLog"
 export notificationStoragePath="$storageDir/notificationLog.v1"
 export inbound_max_limit=200
 
-export logLevel="WARNING"
+export logLevel="INFO"
 
 export testingMode="true"
 


### PR DESCRIPTION
**- What I did**
- fix: ensure all connection writes are awaited
- test: added new e2e test to verify that a client, having issued a monitor command, receives all pending notifications
  ~immediately. This also demonstrates that the socket handling on the server is working properly for multiple writes
  in rapid succession. The new test is in `tests/at_end2end_test/test/notify_verb_test.dart` and is called _"monitor receives multiple pending notifications immediately"_
- build: updated version to 3.0.43

**- How I did it**
- Find all usages of `AtConnection.write`, ensure those calls are `await`ed
- Modify signatures of calling functions to mark them as async
- Modify code which calls those calling functions and `await` those calls

**- How to verify it**
- Tests pass
- Note (1) : New end-to-end test will only work where the 'second' server is running this version or later, as demonstrated by [this test run](https://github.com/atsign-foundation/at_server/actions/runs/8801289393/job/24154366034?pr=1910) where it succeeds when the 'second' server is cicd2 / cicd6 (which run trunk) but  fails when the 'second' server is cicd4 (which runs prod)
- Note (2) : New test now does an atServer version check and will run it only when the atServer for the monitor is running 3.0.43 or higher
- Note (3) : If you are looking at test logs, the new test is named `monitor receives multiple pending notifications immediately` 