### PR TITLE
fix: otp:put requires an authenticated connection

### DIFF
--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.44
+fix: otp authentication check
+
 ## 3.0.43
 - fix: ensure all connection writes are awaited
 

--- a/packages/at_secondary_server/lib/src/verb/handler/otp_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/otp_verb_handler.dart
@@ -35,12 +35,12 @@ class OtpVerbHandler extends AbstractVerbHandler {
         verbParams[AtConstants.ttl]!.isNotEmpty) {
       otpExpiryInMills = int.parse(verbParams[AtConstants.ttl]!);
     }
+    if (!atConnection.metaData.isAuthenticated) {
+      throw UnAuthenticatedException(
+          'otp:get requires authenticated connection');
+    }
     switch (operation) {
       case 'get':
-        if (!atConnection.metaData.isAuthenticated) {
-          throw UnAuthenticatedException(
-              'otp:get requires authenticated connection');
-        }
         do {
           response.data = _generateOTP();
         }

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_secondary
 description: Implementation of secondary server.
-version: 3.0.43
+version: 3.0.44
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://www.example.com
 publish_to: none

--- a/packages/at_secondary_server/test/otp_verb_test.dart
+++ b/packages/at_secondary_server/test/otp_verb_test.dart
@@ -18,6 +18,39 @@ void main() {
       await verbTestsSetUp();
     });
 
+    test('Verify that otp:get requires authentication', () async {
+      Response response = Response();
+      inboundConnection.metaData.isAuthenticated = false;
+      OtpVerbHandler otpVerbHandler = OtpVerbHandler(secondaryKeyStore);
+      expect(
+          otpVerbHandler.processVerb(
+              response,
+              getVerbParam(VerbSyntax.otp, 'otp:get'),
+              inboundConnection),
+          throwsA(predicate((dynamic e) => e is UnAuthenticatedException)));
+    });
+    test('Verify that otp:get with ttl requires authentication', () async {
+      Response response = Response();
+      inboundConnection.metaData.isAuthenticated = false;
+      OtpVerbHandler otpVerbHandler = OtpVerbHandler(secondaryKeyStore);
+      expect(
+          otpVerbHandler.processVerb(
+              response,
+              getVerbParam(VerbSyntax.otp, 'otp:get:ttl:1000'),
+              inboundConnection),
+          throwsA(predicate((dynamic e) => e is UnAuthenticatedException)));
+    });
+    test('Verify that otp:put requires authentication', () async {
+      Response response = Response();
+      inboundConnection.metaData.isAuthenticated = false;
+      OtpVerbHandler otpVerbHandler = OtpVerbHandler(secondaryKeyStore);
+      expect(
+          otpVerbHandler.processVerb(
+              response,
+              getVerbParam(VerbSyntax.otp, 'otp:put:abcdef'),
+              inboundConnection),
+          throwsA(predicate((dynamic e) => e is UnAuthenticatedException)));
+    });
     test('A test to verify OTP generated is 6-character length', () async {
       Response response = Response();
       HashMap<String, String?> verbParams =

--- a/packages/at_server_spec/CHANGELOG.md
+++ b/packages/at_server_spec/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 5.0.1
+- fix: Modify the Otp verb in at_server_spec so that it also returns true from 
+  requiresAuth (for consistency and clarity only, as the otp verb handler 
+  has its own check for authentication)
+
 ## 5.0.0
 
 - fix: BREAKING: Change signature of AtConnection.write

--- a/packages/at_server_spec/lib/src/verb/otp.dart
+++ b/packages/at_server_spec/lib/src/verb/otp.dart
@@ -23,6 +23,6 @@ class Otp extends Verb {
 
   @override
   bool requiresAuth() {
-    return false;
+    return true;
   }
 }

--- a/packages/at_server_spec/pubspec.yaml
+++ b/packages/at_server_spec/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_server_spec
 description: A Dart library containing abstract classes that defines what implementations of the root and secondary servers are responsible for.
-version: 5.0.0
+version: 5.0.1
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://docs.atsign.com
 documentation: https://docs.atsign.com/atplatform/secondaryserver


### PR DESCRIPTION
**- What I did**
- fix: otp:put requires an authenticated connection
- test: addded unit tests for unauthenticated otp: requests

**- How I did it**
- Moved the auth check in the otp verb handler
- Added missing unit tests.
- Modified the Otp verb in at_server_spec so it also returns true from requiresAuth (for consistency and clarity only, as the otp verb handler has its own check for authentication)
  - updated at_server_spec CHANGELOG
  - updated at_server_spec package version

**- How to verify it**
Tests pass