### PR TITLE
fix: take up at_commons 4.0.8

### DIFF
--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,8 +1,9 @@
 ## 3.0.44
 - fix: otp authentication check
 - build[deps]: Upgraded the following packages:
-  - at_commons to v4.0.7
+  - at_commons to v4.0.8
   - at_server_spec to v5.0.1
+  - at_lookup to v3.0.47
 - feat: Add enroll:fetch to fetch the enrollment details.
 - fix: Added validation to ensure a new enrollment request does not contain a duplicate combination of appName and
   deviceName.

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -19,10 +19,10 @@ dependencies:
   basic_utils: 5.7.0
   ecdsa: 0.1.0
   encrypt: 5.0.3
-  at_commons: 4.0.7
+  at_commons: 4.0.8
   at_utils: 3.0.16
   at_chops: 2.0.0
-  at_lookup: 3.0.46
+  at_lookup: 3.0.47
   at_server_spec: 5.0.1
   at_persistence_spec: 2.0.14
   at_persistence_secondary_server: 3.0.62


### PR DESCRIPTION
**- What I did**
- fixes a problem where enrollments with limited namespace access were unable to access `shared_key.bob@alice`
- added unit test verifying access

**- How I did it**
- use at_commons 4.0.8

**- How to verify it**
Tests pass

**- Additional context**
This PR also takes up at_lookup 3.0.47 but nothing has changed in there that at_server uses
