### PR TITLE
fix: Modify enroll:fetch response similar to enroll:list to be consistent

### DIFF
--- a/packages/at_secondary_server/test/enroll_verb_test.dart
+++ b/packages/at_secondary_server/test/enroll_verb_test.dart
@@ -1147,6 +1147,7 @@ void main() {
       enrollDataStoreValue.namespaces = {'wavi': 'rw'};
       enrollDataStoreValue.approval =
           EnrollApproval(EnrollmentStatus.approved.name);
+      enrollDataStoreValue.encryptedAPKAMSymmetricKey = 'dummy_apkam_key';
       AtData atData = AtData()..data = jsonEncode(enrollDataStoreValue);
       await secondaryKeyStore.put(key, atData);
 
@@ -1161,13 +1162,15 @@ void main() {
           getVerbParam(VerbSyntax.enroll, enrollmentRequest);
       await enrollVerbHandler.processVerb(
           response, enrollmentRequestVerbParams, inboundConnection);
-      EnrollDataStoreValue enrollmentResponse =
-          EnrollDataStoreValue.fromJson(jsonDecode(response.data!));
+      Map enrollmentResponse = jsonDecode(response.data!);
 
-      expect(enrollmentResponse.appName, enrollDataStoreValue.appName);
-      expect(enrollmentResponse.deviceName, enrollDataStoreValue.deviceName);
-      expect(enrollmentResponse.sessionId, enrollDataStoreValue.sessionId);
-      expect(enrollmentResponse.namespaces, enrollDataStoreValue.namespaces);
+      expect(enrollmentResponse['appName'], enrollDataStoreValue.appName);
+      expect(enrollmentResponse['deviceName'], enrollDataStoreValue.deviceName);
+      expect(enrollmentResponse['namespace'], enrollDataStoreValue.namespaces);
+      expect(
+          enrollmentResponse['status'], enrollDataStoreValue.approval?.state);
+      expect(enrollmentResponse['encryptedAPKAMSymmetricKey'],
+          enrollDataStoreValue.encryptedAPKAMSymmetricKey);
     });
 
     tearDown(() async => await verbTestsTearDown());

--- a/tests/at_functional_test/test/enroll_verb_test.dart
+++ b/tests/at_functional_test/test/enroll_verb_test.dart
@@ -62,10 +62,11 @@ void main() {
           (await firstAtSignConnection.sendRequestToServer(enrollFetch))
               .replaceAll('data:', '');
       Map<dynamic, dynamic> enrollMap = jsonDecode(enrollFetchResponse);
+      print(enrollMap);
       expect(enrollMap['appName'], 'wavi');
       expect(enrollMap['deviceName'], deviceName);
       expect(
-          enrollMap['namespaces'], {'wavi': 'rw', '__manage': 'rw', '*': 'rw'});
+          enrollMap['namespace'], {'wavi': 'rw', '__manage': 'rw', '*': 'rw'});
     });
 
     test(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- The response of enroll:fetch and enroll:list are different. Ensure the responses are consistent. Hence modified the enroll:fetch response to be similar to enroll:list command.

**- How I did it**
- Fetch the enrollment details from the keystore and construct a map with the fields that are to be sent to client. Convert the response to jsonEncoded string and return it back to the clients.

**- How to verify it**
- Updated the unit and functional tests.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
