### PR TITLE
feat: enroll revoke with force flag

### DIFF
--- a/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
@@ -99,7 +99,7 @@ class EnrollVerbHandler extends AbstractVerbHandler {
           if (enrollmentIdFromParams ==
                   inboundConnectionMetaData.enrollmentId &&
               forceFlag == null) {
-            throw AtEnrollmentException(
+            throw AtEnrollmentRevokeException(
                 'Current client cannot revoke its own enrollment');
           }
           await _handleEnrollmentPermissions(enrollVerbParams, currentAtSign,

--- a/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
@@ -88,8 +88,21 @@ class EnrollVerbHandler extends AbstractVerbHandler {
 
         case 'approve':
         case 'deny':
-        case 'revoke':
           await _handleEnrollmentPermissions(enrollVerbParams!, currentAtSign,
+              operation, responseJson, response);
+          break;
+        case 'revoke':
+          var forceFlag = verbParams['force'];
+          final enrollmentIdFromParams = enrollVerbParams!.enrollmentId;
+          var inboundConnectionMetaData =
+              atConnection.metaData as InboundConnectionMetadata;
+          if (enrollmentIdFromParams ==
+                  inboundConnectionMetaData.enrollmentId &&
+              forceFlag == null) {
+            throw AtEnrollmentException(
+                'Current client cannot revoke its own enrollment');
+          }
+          await _handleEnrollmentPermissions(enrollVerbParams, currentAtSign,
               operation, responseJson, response);
           break;
 

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -34,6 +34,14 @@ dependencies:
   yaml: 3.1.2
   logging: 1.2.0
 
+# TODO replace with published version
+dependency_overrides:
+  at_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_libraries
+      path: packages/at_commons
+      ref: trunk
+
 dev_dependencies:
   test: ^1.24.4
   coverage: ^1.6.1

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   basic_utils: 5.7.0
   ecdsa: 0.1.0
   encrypt: 5.0.3
-  at_commons: 4.0.8
+  at_commons: 4.0.9
   at_utils: 3.0.16
   at_chops: 2.0.0
   at_lookup: 3.0.47
@@ -33,14 +33,6 @@ dependencies:
   mutex: 3.1.0
   yaml: 3.1.2
   logging: 1.2.0
-
-# TODO replace with published version
-dependency_overrides:
-  at_commons:
-    git:
-      url: https://github.com/atsign-foundation/at_libraries
-      path: packages/at_commons
-      ref: trunk
 
 dev_dependencies:
   test: ^1.24.4

--- a/packages/at_secondary_server/test/enroll_verb_test.dart
+++ b/packages/at_secondary_server/test/enroll_verb_test.dart
@@ -508,7 +508,7 @@ void main() {
       inboundConnection.metaData.isAuthenticated = true;
       inboundConnection.metaData.sessionID = 'dummy_session';
       (inboundConnection.metaData as InboundConnectionMetadata).enrollmentId =
-          '123';
+          '456'; // a client cannot revoke its own enrollment. Set a different enrollmentId in inbound
       Response response = Response();
       EnrollVerbHandler enrollVerbHandler =
           EnrollVerbHandler(secondaryKeyStore);

--- a/packages/at_secondary_server/test/enroll_verb_test.dart
+++ b/packages/at_secondary_server/test/enroll_verb_test.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 
 import 'package:at_commons/at_commons.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
-import 'package:at_secondary/src/connection/inbound/dummy_inbound_connection.dart';
 import 'package:at_secondary/src/connection/inbound/inbound_connection_metadata.dart';
 import 'package:at_secondary/src/constants/enroll_constants.dart';
 import 'package:at_secondary/src/enroll/enroll_datastore_value.dart';

--- a/tests/at_end2end_test/pubspec.yaml
+++ b/tests/at_end2end_test/pubspec.yaml
@@ -15,6 +15,14 @@ dependencies:
       ref: trunk
   at_lookup: ^3.0.45
 
+# TODO replace with published version
+dependency_overrides:
+  at_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_libraries
+      path: packages/at_commons
+      ref: trunk
+
 dev_dependencies:
   lints: ^1.0.1
   test: ^1.14.4

--- a/tests/at_end2end_test/pubspec.yaml
+++ b/tests/at_end2end_test/pubspec.yaml
@@ -15,14 +15,6 @@ dependencies:
       ref: trunk
   at_lookup: ^3.0.45
 
-# TODO replace with published version
-dependency_overrides:
-  at_commons:
-    git:
-      url: https://github.com/atsign-foundation/at_libraries
-      path: packages/at_commons
-      ref: trunk
-
 dev_dependencies:
   lints: ^1.0.1
   test: ^1.14.4

--- a/tests/at_functional_test/pubspec.yaml
+++ b/tests/at_functional_test/pubspec.yaml
@@ -19,6 +19,14 @@ dependencies:
   uuid: ^3.0.7
   elliptic: ^0.3.8
 
+# TODO replace with published version
+dependency_overrides:
+  at_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_libraries
+      path: packages/at_commons
+      ref: trunk
+
 dev_dependencies:
   lints: ^1.0.1
   test: ^1.24.3

--- a/tests/at_functional_test/pubspec.yaml
+++ b/tests/at_functional_test/pubspec.yaml
@@ -15,17 +15,9 @@ dependencies:
       ref: trunk
   at_chops: ^2.0.0
   at_lookup: ^3.0.45
-  at_commons: ^4.0.7
+  at_commons: ^4.0.9
   uuid: ^3.0.7
   elliptic: ^0.3.8
-
-# TODO replace with published version
-dependency_overrides:
-  at_commons:
-    git:
-      url: https://github.com/atsign-foundation/at_libraries
-      path: packages/at_commons
-      ref: trunk
 
 dev_dependencies:
   lints: ^1.0.1

--- a/tests/at_functional_test/test/enroll_verb_test.dart
+++ b/tests/at_functional_test/test/enroll_verb_test.dart
@@ -598,8 +598,9 @@ void main() {
             .sendRequestToServer(revokeEnrollmentCommand);
         var revokeEnrollmentMap =
             jsonDecode(revokeEnrollmentResponse.replaceAll('error:', ''));
-        print(revokeEnrollmentMap);
         expect(revokeEnrollmentMap['errorCode'], 'AT0031');
+        expect(revokeEnrollmentMap['errorDescription'],
+            'Cannot revoke self enrollment : Current client cannot revoke its own enrollment');
       });
 
       test(


### PR DESCRIPTION
fixes https://github.com/atsign-foundation/at_server/issues/1926

**- What I did**
- changes to enroll revoke logic to introduce force flag and check for preventing revoke of self enrollment
**- How I did it**
- if force flag is not set and if enroll revoke is sent on own client connection then throw AtEnrollmentRevokeException
- allow enroll:revoke in other scenarios listed in
https://github.com/atsign-foundation/at_server/issues/1926#issuecomment-2084511276
- added unit and functional tests
**- How to verify it**
- unit and functional tests should pass
--------
TODO: Change dependency overrides to at_commons published version before merging