### PR TITLE
chore: Use new directories functionality to consolodate updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,27 +7,17 @@ updates:
     schedule:
       interval: "daily"
   - package-ecosystem: "docker"
-    directory: "/tools/build_secondary"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "docker"
-    directory: "/tools/build_virtual_environment/ve"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "docker"
-    directory: "/tools/build_virtual_environment/ve_base"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "docker"
-    directory: "/packages/at_root_server"
+    directories:
+      - "/tools/build_secondary"
+      - "/tools/build_virtual_environment/ve"
+      - "/tools/build_virtual_environment/ve_base"
+      - "/packages/at_root_server"
     schedule:
       interval: "daily"
   - package-ecosystem: "pub"
-    directory: "/packages/at_root_server"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "pub"
-    directory: "/packages/at_secondary_server"
+    directories:
+      - "/packages/at_root_server"
+      - "/packages/at_secondary_server"
     schedule:
       interval: "daily"
   - package-ecosystem: "pip"


### PR DESCRIPTION
The present config results in individual Dependabot PRs for each directory where we have Dockerfiles (and other dependencies).

[Dependabot multi-directory configuration public beta now available](https://github.blog/changelog/2024-04-29-dependabot-multi-directory-configuration-public-beta-now-available/) should reduce the number of PRs and save us from having to do rollups quite so often.

**- What I did**

Took each `directory:` entry and put it into `directories:`

**- How to verify it**

Insights - Dependency Graph - Dependabot should highlight that the new YAML is valid.

**- Description for the changelog**

chore: Use new directories functionality to consolodate updates
