### PR TITLE
build(deps): args 2.5.0, meta 1.14.0, at_commons 4.0.8, at_server_spec 5.0.1

### DIFF
--- a/packages/at_root_server/pubspec.yaml
+++ b/packages/at_root_server/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   args: 2.5.0
   uuid: 3.0.7
   yaml: 3.1.2
-  at_commons: 4.0.5
+  at_commons: 4.0.8
   at_utils: 3.0.16
   at_server_spec: 4.0.1
   at_persistence_root_server:

--- a/packages/at_root_server/pubspec.yaml
+++ b/packages/at_root_server/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: '>=2.15.0 <4.0.0'
 
 dependencies:
-  args: 2.4.2
+  args: 2.5.0
   uuid: 3.0.7
   yaml: 3.1.2
   at_commons: 4.0.5

--- a/packages/at_root_server/pubspec.yaml
+++ b/packages/at_root_server/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   yaml: 3.1.2
   at_commons: 4.0.8
   at_utils: 3.0.16
-  at_server_spec: 4.0.1
+  at_server_spec: 5.0.1
   at_persistence_root_server:
     git:
       url: https://github.com/atsign-foundation/at_server.git

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   intl: ^0.19.0
   json_annotation: ^4.8.0
   version: 3.0.2
-  meta: 1.12.0
+  meta: 1.14.0
   mutex: 3.1.0
   yaml: 3.1.2
   logging: 1.2.0

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: '>=2.15.0 <4.0.0'
 
 dependencies:
-  args: 2.4.2
+  args: 2.5.0
   uuid: 3.0.7
   convert: 3.1.1
   cron: 0.5.1


### PR DESCRIPTION
Dependabot still fails to raise PRs for pub deps

**- What I did**

Bumped pubspec.yaml dependencies that should have been Dependabot PRs

**- How I did it**

Took updates from logs:

* https://github.com/atsign-foundation/at_server/network/updates/821450925
* https://github.com/atsign-foundation/at_server/network/updates/821431375

**- How to verify it**

Unit tests passed locally
CI will run functional and end2end tests

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
