### PR TITLE
fix: Notifications not being delivered to APKAM Monitors

### DIFF
--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 3.0.45
-- fix: Update the response format of the "enroll:fetch" to match with "enroll:list" for consistency.
+- fix: Update the response format of the "enroll:fetch" to match with "enroll:list" for consistency
+- feat: enroll:revoke now has an optional "force" flag to allow current 
+  connection to revoke its own enrollment
+- fix: Fixed bug in delivery of notifications to APKAM Monitors
 
 ## 3.0.44
 - fix: otp authentication check

--- a/packages/at_secondary_server/lib/src/verb/handler/abstract_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/abstract_verb_handler.dart
@@ -132,6 +132,13 @@ abstract class AbstractVerbHandler implements VerbHandler {
   /// Use [namespace] if passed, otherwise retrieve namespace from [atKey]. Return false if no [namespace] or [atKey] is set.
   Future<bool> isAuthorized(InboundConnectionMetadata connectionMetadata,
       {String? atKey, String? namespace}) async {
+    bool retVal = await _isAuthorized(connectionMetadata, atKey: atKey, namespace: namespace);
+    logger.finer('_isAuthorized returned $retVal');
+    return retVal;
+  }
+
+  Future<bool> _isAuthorized(InboundConnectionMetadata connectionMetadata,
+      {String? atKey, String? namespace}) async {
     final Verb verb = getVerb();
 
     final enrollmentId = connectionMetadata.enrollmentId;
@@ -177,14 +184,17 @@ abstract class AbstractVerbHandler implements VerbHandler {
       return false;
     }
 
-    logger.finer('enrollNamespaces:$enrollNamespaces');
-    logger.finer('keyNamespace:$keyNamespace');
     final access = enrollNamespaces.containsKey(allNamespaces)
         ? enrollNamespaces[allNamespaces]
         : enrollNamespaces[keyNamespace];
-    logger.finer('access:$access');
 
-    logger.shout('Verb: $verb, keyNamespace: $keyNamespace, access: $access');
+    logger.finer('_isAuthorized check for'
+        ' app: [${enrollDataStoreValue.appName}]'
+        ' device: [${enrollDataStoreValue.deviceName}]'
+        ' verb: [${verb.runtimeType}]'
+        ' enrollNamespaces: [$enrollNamespaces]'
+        ' keyNamespace: $keyNamespace'
+        ' access: $access');
 
     if (access == null) {
       return false;
@@ -213,7 +223,8 @@ abstract class AbstractVerbHandler implements VerbHandler {
             verb is Lookup ||
             verb is NotifyFetch ||
             verb is NotifyStatus ||
-            verb is NotifyList) &&
+            verb is NotifyList ||
+            verb is Monitor) &&
         (access == 'r' || access == 'rw');
   }
 
@@ -222,7 +233,8 @@ abstract class AbstractVerbHandler implements VerbHandler {
             verb is Delete ||
             verb is Notify ||
             verb is NotifyAll ||
-            verb is NotifyRemove) &&
+            verb is NotifyRemove ||
+            verb is Monitor) &&
         access == 'rw';
   }
 

--- a/packages/at_secondary_server/test/monitor_verb_test.dart
+++ b/packages/at_secondary_server/test/monitor_verb_test.dart
@@ -135,7 +135,7 @@ void main() {
             ..fromAtSign = '@bob'
             ..notificationDateTime = DateTime.now()
             ..toAtSign = alice
-            ..notification = 'phone.buzz'
+            ..notification = '@alice:phone.buzz@bob'
             ..type = NotificationType.received
             ..opType = OperationType.update
             ..messageType = MessageType.key)
@@ -148,7 +148,7 @@ void main() {
             ..fromAtSign = '@bob'
             ..notificationDateTime = DateTime.now()
             ..toAtSign = alice
-            ..notification = 'phone.wavi'
+            ..notification = '@alice:phone.wavi@bob'
             ..type = NotificationType.received
             ..opType = OperationType.update
             ..messageType = MessageType.key)
@@ -162,7 +162,7 @@ void main() {
       expect(notificationMap['id'], 'abc');
       expect(notificationMap['from'], '@bob');
       expect(notificationMap['to'], '@alice');
-      expect(notificationMap['key'], 'phone.wavi');
+      expect(notificationMap['key'], '@alice:phone.wavi@bob');
       expect(notificationMap['messageType'], 'MessageType.key');
       expect(notificationMap['operation'], 'update');
     });
@@ -184,7 +184,7 @@ void main() {
             ..fromAtSign = '@bob'
             ..notificationDateTime = DateTime.now()
             ..toAtSign = alice
-            ..notification = 'phone.buzz'
+            ..notification = '@alice:phone.buzz@bob'
             ..type = NotificationType.received
             ..opType = OperationType.update
             ..messageType = MessageType.key)
@@ -197,7 +197,7 @@ void main() {
       expect(notificationMap['id'], 'abc');
       expect(notificationMap['from'], '@bob');
       expect(notificationMap['to'], '@alice');
-      expect(notificationMap['key'], 'phone.buzz');
+      expect(notificationMap['key'], '@alice:phone.buzz@bob');
       expect(notificationMap['messageType'], 'MessageType.key');
       expect(notificationMap['operation'], 'update');
 
@@ -206,7 +206,7 @@ void main() {
             ..fromAtSign = '@bob'
             ..notificationDateTime = DateTime.now()
             ..toAtSign = alice
-            ..notification = 'phone.wavi'
+            ..notification = '@alice:phone.wavi@bob'
             ..type = NotificationType.received
             ..opType = OperationType.update
             ..messageType = MessageType.key)
@@ -220,7 +220,7 @@ void main() {
       expect(notificationMap['id'], 'abc');
       expect(notificationMap['from'], '@bob');
       expect(notificationMap['to'], '@alice');
-      expect(notificationMap['key'], 'phone.wavi');
+      expect(notificationMap['key'], '@alice:phone.wavi@bob');
       expect(notificationMap['messageType'], 'MessageType.key');
       expect(notificationMap['operation'], 'update');
     });
@@ -243,7 +243,7 @@ void main() {
             ..fromAtSign = '@bob'
             ..notificationDateTime = DateTime.now()
             ..toAtSign = alice
-            ..notification = 'phone.buzz'
+            ..notification = '@alice:phone.buzz@bob'
             ..type = NotificationType.received
             ..opType = OperationType.update
             ..messageType = MessageType.key)
@@ -256,7 +256,7 @@ void main() {
             ..fromAtSign = '@bob'
             ..notificationDateTime = DateTime.now()
             ..toAtSign = alice
-            ..notification = 'phone.wavi'
+            ..notification = '@alice:phone.wavi@bob'
             ..type = NotificationType.received
             ..opType = OperationType.update
             ..messageType = MessageType.key)
@@ -269,7 +269,7 @@ void main() {
       expect(notificationMap['id'], 'abc');
       expect(notificationMap['from'], '@bob');
       expect(notificationMap['to'], '@alice');
-      expect(notificationMap['key'], 'phone.wavi');
+      expect(notificationMap['key'], '@alice:phone.wavi@bob');
       expect(notificationMap['messageType'], 'MessageType.key');
       expect(notificationMap['operation'], 'update');
     });
@@ -304,7 +304,7 @@ void main() {
             ..fromAtSign = '@bob'
             ..notificationDateTime = DateTime.now()
             ..toAtSign = alice
-            ..notification = 'phone.wavi'
+            ..notification = '@alice:phone.wavi@bob'
             ..type = NotificationType.received
             ..opType = OperationType.update
             ..messageType = MessageType.key)
@@ -317,7 +317,7 @@ void main() {
       expect(notificationMap['id'], 'abc');
       expect(notificationMap['from'], '@bob');
       expect(notificationMap['to'], '@alice');
-      expect(notificationMap['key'], 'phone.wavi');
+      expect(notificationMap['key'], '@alice:phone.wavi@bob');
       expect(notificationMap['messageType'], 'MessageType.key');
       expect(notificationMap['operation'], 'update');
       // Notification with buzz namespace
@@ -326,7 +326,7 @@ void main() {
             ..fromAtSign = '@bob'
             ..notificationDateTime = DateTime.now()
             ..toAtSign = alice
-            ..notification = 'phone.buzz'
+            ..notification = '@alice:phone.buzz@bob'
             ..type = NotificationType.received
             ..opType = OperationType.update
             ..messageType = MessageType.key)
@@ -339,7 +339,7 @@ void main() {
       expect(notificationMap['id'], 'abc');
       expect(notificationMap['from'], '@bob');
       expect(notificationMap['to'], '@alice');
-      expect(notificationMap['key'], 'phone.buzz');
+      expect(notificationMap['key'], '@alice:phone.buzz@bob');
       expect(notificationMap['messageType'], 'MessageType.key');
       expect(notificationMap['operation'], 'update');
     });
@@ -372,7 +372,7 @@ void main() {
             ..fromAtSign = '@bob'
             ..notificationDateTime = DateTime.now()
             ..toAtSign = alice
-            ..notification = 'phone.wavi'
+            ..notification = '@alice:phone.wavi@bob'
             ..type = NotificationType.received
             ..opType = OperationType.update
             ..messageType = MessageType.key)
@@ -386,7 +386,7 @@ void main() {
       expect(notificationMap['id'], 'abc');
       expect(notificationMap['from'], '@bob');
       expect(notificationMap['to'], '@alice');
-      expect(notificationMap['key'], 'phone.wavi');
+      expect(notificationMap['key'], '@alice:phone.wavi@bob');
       expect(notificationMap['messageType'], 'MessageType.key');
       expect(notificationMap['operation'], 'update');
       // Set to empty string to remove the previous data
@@ -408,7 +408,7 @@ void main() {
             ..fromAtSign = '@bob'
             ..notificationDateTime = DateTime.now()
             ..toAtSign = alice
-            ..notification = 'phone.wavi'
+            ..notification = '@alice:phone.wavi@bob'
             ..type = NotificationType.received
             ..opType = OperationType.update
             ..messageType = MessageType.key)
@@ -488,7 +488,7 @@ void main() {
             ..fromAtSign = '@bob'
             ..notificationDateTime = DateTime.now()
             ..toAtSign = alice
-            ..notification = 'phone.wavi'
+            ..notification = '@alice:phone.wavi@bob'
             ..type = NotificationType.received
             ..opType = OperationType.update
             ..messageType = MessageType.key)


### PR DESCRIPTION
**- What I did**
- Ensured that properly-formed notifications are delivered to APKAM monitors

**- How I did it**
- MonitorVerbHandler now uses the standard AbstractVerbHandler.isAuthorized check instead of its own custom code which was not working correctly for properly-formed notifications
- Modified relevant monitor-plus-apkam unit tests so they create properly-formed notification objects for testing

**- How to verify it**
Tests pass
