### PR TITLE
fix: ignore commit log cache update, if existing entry has higher commitId

### DIFF
--- a/packages/at_persistence_secondary_server/CHANGELOG.md
+++ b/packages/at_persistence_secondary_server/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.63
+- fix: Ensure only latest commitEntry for each present in CommitLogCache
 ## 3.0.62
 - fix: Add check for hive key max length (255 chars)
 - build[deps]: Upgraded the following packages:

--- a/packages/at_persistence_secondary_server/lib/src/log/commitlog/commit_log_keystore.dart
+++ b/packages/at_persistence_secondary_server/lib/src/log/commitlog/commit_log_keystore.dart
@@ -185,7 +185,8 @@ class CommitLogKeyStore extends BaseCommitLogKeyStore {
         (_isRegexMatches(atKey, regex) || _isSpecialKey(atKey));
   }
 
-  bool _isNamespaceAuthorised(String atKeyAsString, List<String>? enrolledNamespace) {
+  bool _isNamespaceAuthorised(
+      String atKeyAsString, List<String>? enrolledNamespace) {
     // This is work-around for : https://github.com/atsign-foundation/at_server/issues/1570
     if (atKeyAsString.toLowerCase() == 'configkey') {
       return true;
@@ -558,6 +559,14 @@ class CommitLogCache {
 
   /// Updates cache when a new [CommitEntry] for the [key] is added
   void update(String key, CommitEntry commitEntry) {
+    int? existingCommitId = getEntry(key)?.commitId;
+    // ignore update, if cache has existing commitEntry for current key with a greater commitId
+    if (existingCommitId != null &&
+        commitEntry.commitId != null &&
+        existingCommitId > commitEntry.commitId!) {
+      _logger.shout('Ignoring commit entry update to cache. existingCommitId: $existingCommitId | toUpdateWithCommitId: ${commitEntry.commitId}');
+      return;
+    }
     _updateCacheLog(key, commitEntry);
 
     if (commitEntry.commitId != null &&

--- a/packages/at_persistence_secondary_server/pubspec.yaml
+++ b/packages/at_persistence_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_persistence_secondary_server
 description: A Dart library with the implementation classes for the persistence layer of the secondary server.
-version: 3.0.62
+version: 3.0.63
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://docs.atsign.com/
 

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -34,6 +34,13 @@ dependencies:
   yaml: 3.1.2
   logging: 1.2.0
 
+dependency_overrides:
+  at_persistence_secondary_server:
+    git:
+      url: https://github.com/atsign-foundation/at_server.git
+      path: packages/at_persistence_secondary_server
+      ref: commit_id_inconsistency_fix
+
 dev_dependencies:
   test: ^1.24.4
   coverage: ^1.6.1

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -34,13 +34,6 @@ dependencies:
   yaml: 3.1.2
   logging: 1.2.0
 
-dependency_overrides:
-  at_persistence_secondary_server:
-    git:
-      url: https://github.com/atsign-foundation/at_server.git
-      path: packages/at_persistence_secondary_server
-      ref: commit_id_inconsistency_fix
-
 dev_dependencies:
   test: ^1.24.4
   coverage: ^1.6.1


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
Closes https://github.com/atsign-foundation/at_client_sdk/issues/1291

**- What I did**
- fix: ignore commit log cache update, if the existing entry has a higher commitId

**- How I did it**
- add a check in CommitLogCache.update() that checks if there is already present for the current key, if YES does not add the current entry to the commitLogCache.

**- How to verify it**
- unit test added to validate the changes
- funtional test mentioned in https://github.com/atsign-foundation/at_client_sdk/issues/1291 should consistently pass. Which has been manually verified.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
fix: ignore commit log cache update, if existing entry has higher commitId