### PR TITLE
ci: Tag prod images as latest

### DIFF
--- a/.github/workflows/promote_canary.yaml
+++ b/.github/workflows/promote_canary.yaml
@@ -43,8 +43,9 @@ jobs:
           file: tools/build_secondary/Dockerfile.canary_to_prod
           context: .
           tags: |
-            atsigncompany/secondary:prod
             atsigncompany/secondary:dess
+            atsigncompany/secondary:latest
+            atsigncompany/secondary:prod
             atsigncompany/secondary:prod-${{ env.VERSION }}
           platforms: |
             linux/amd64
@@ -83,6 +84,7 @@ jobs:
           file: tools/build_virtual_environment/ve/Dockerfile.canary_to_vip
           context: .
           tags: |
+            atsigncompany/virtualenv:latest
             atsigncompany/virtualenv:vip
             atsigncompany/virtualenv:vip-${{ env.VERSION }}
           platforms: |


### PR DESCRIPTION
The `latest` tags for [atsigncompany/secondary](https://hub.docker.com/layers/atsigncompany/secondary/latest/images/sha256-916749ae4929653b3f6d8ec5d1de9dec724b95741f7f9e346ac252ca158d5de5?context=explore) and [atsigncompany/virtualenv](https://hub.docker.com/layers/atsigncompany/virtualenv/latest/images/sha256-e1864fc31cbb83e5eece4a360a9364ccc7989307ece5b883d49048ba229a0ec9?context=explore) haven't been updated for 3y, because we don't use them.

This could cause problems for anybody who does choose to try to use a `latest` image, and also that's the default for any security scanning tools etc.

e.g. if I use [syft](https://github.com/anchore/syft) to scan atsigncompany/secondary then it finds a whole bunch of (dated) deb packages :(

`syft atsigncompany/secondary`

```
 ✔ Pulled image
 ✔ Loaded image                                                                         atsigncompany/secondary:latest
 ✔ Parsed image                                sha256:f48026b4cc10e01378019293ff7ebf652e35ba610b3c5a63a7d1d8e27e506fb4
 ✔ Cataloged contents                                 072a1104a981d9096e86a9a676d33456d9e71255041a3e776c078ca2b968650f
   ├── ✔ Packages                        [93 packages]
   ├── ✔ File digests                    [1,972 files]
   ├── ✔ File metadata                   [1,972 locations]
   └── ✔ Executables                     [725 executables]
NAME                 VERSION                       TYPE
adduser              3.118ubuntu2                  deb
apt                  2.0.5                         deb
base-files           11ubuntu5.3                   deb
base-passwd          3.5.47                        deb
bash                 5.0-6ubuntu1.1                deb
bash                 5.0.17                        binary
bsdutils             1:2.34-0.1ubuntu9.1           deb
bzip2                1.0.8-2                       deb
coreutils            8.30-3ubuntu2                 deb
dash                 0.5.10.2-6                    deb
debconf              1.5.73                        deb
debianutils          4.9.1                         deb
diffutils            1:3.7-3                       deb
dpkg                 1.19.7ubuntu3                 deb
e2fsprogs            1.45.5-2ubuntu1               deb
fdisk                2.34-0.1ubuntu9.1             deb
findutils            4.7.0-1ubuntu1                deb
gcc-10-base          10.2.0-5ubuntu1~20.04         deb
gpgv                 2.2.19-3ubuntu2.1             deb
grep                 3.4-1                         deb
gzip                 1.10-0ubuntu4                 deb
hostname             3.23                          deb
init-system-helpers  1.57                          deb
libacl1              2.2.53-6                      deb
libapt-pkg6.0        2.0.5                         deb
libattr1             1:2.4.48-5                    deb
libaudit-common      1:2.8.5-2ubuntu6              deb
libaudit1            1:2.8.5-2ubuntu6              deb
libblkid1            2.34-0.1ubuntu9.1             deb
libbz2-1.0           1.0.8-2                       deb
libc-bin             2.31-0ubuntu9.2               deb
libc6                2.31-0ubuntu9.2               deb
libcap-ng0           0.7.9-2.1build1               deb
libcom-err2          1.45.5-2ubuntu1               deb
libcrypt1            1:4.4.10-10ubuntu4            deb
libdb5.3             5.3.28+dfsg1-0.6ubuntu2       deb
libdebconfclient0    0.251ubuntu1                  deb
libext2fs2           1.45.5-2ubuntu1               deb
libfdisk1            2.34-0.1ubuntu9.1             deb
libffi7              3.3-4                         deb
libgcc-s1            10.2.0-5ubuntu1~20.04         deb
libgcrypt20          1.8.5-5ubuntu1                deb
libgmp10             2:6.2.0+dfsg-4                deb
libgnutls30          3.6.13-2ubuntu1.3             deb
libgpg-error0        1.37-1                        deb
libhogweed5          3.5.1+really3.5.1-2ubuntu0.1  deb
libidn2-0            2.2.0-2                       deb
liblz4-1             1.9.2-2                       deb
liblzma5             5.2.4-1ubuntu1                deb
libmount1            2.34-0.1ubuntu9.1             deb
libncurses6          6.2-0ubuntu2                  deb
libncursesw6         6.2-0ubuntu2                  deb
libnettle7           3.5.1+really3.5.1-2ubuntu0.1  deb
libp11-kit0          0.23.20-1ubuntu0.1            deb
libpam-modules       1.3.1-5ubuntu4.1              deb
libpam-modules-bin   1.3.1-5ubuntu4.1              deb
libpam-runtime       1.3.1-5ubuntu4.1              deb
libpam0g             1.3.1-5ubuntu4.1              deb
libpcre2-8-0         10.34-7                       deb
libpcre3             2:8.39-12build1               deb
libprocps8           2:3.3.16-1ubuntu2.1           deb
libseccomp2          2.5.1-1ubuntu1~20.04.1        deb
libselinux1          3.0-1build2                   deb
libsemanage-common   3.0-1build2                   deb
libsemanage1         3.0-1build2                   deb
libsepol1            3.0-1                         deb
libsmartcols1        2.34-0.1ubuntu9.1             deb
libss2               1.45.5-2ubuntu1               deb
libstdc++6           10.2.0-5ubuntu1~20.04         deb
libsystemd0          245.4-4ubuntu3.6              deb
libtasn1-6           4.16.0-2                      deb
libtinfo6            6.2-0ubuntu2                  deb
libudev1             245.4-4ubuntu3.6              deb
libunistring2        0.9.10-2                      deb
libuuid1             2.34-0.1ubuntu9.1             deb
libzstd1             1.4.4+dfsg-3ubuntu0.1         deb
login                1:4.8.1-1ubuntu5.20.04        deb
logsave              1.45.5-2ubuntu1               deb
lsb-base             11.1.0ubuntu2                 deb
mawk                 1.3.4.20200120-2              deb
mount                2.34-0.1ubuntu9.1             deb
ncurses-base         6.2-0ubuntu2                  deb
ncurses-bin          6.2-0ubuntu2                  deb
passwd               1:4.8.1-1ubuntu5.20.04        deb
perl-base            5.30.0-9ubuntu0.2             deb
procps               2:3.3.16-1ubuntu2.1           deb
sed                  4.7-1                         deb
sensible-utils       0.0.12+nmu1                   deb
sysvinit-utils       2.96-2.1ubuntu1               deb
tar                  1.30+dfsg-7ubuntu0.20.04.1    deb
ubuntu-keyring       2020.02.11.4                  deb
util-linux           2.34-0.1ubuntu9.1             deb
zlib1g               1:1.2.11.dfsg-2ubuntu1.2      deb
```

**- What I did**

Added latest tag for those images, which will take effect next time we promote a canary to prod.

**- How to verify it**

Inspect Dockerhub after next promotion

**- Description for the changelog**

ci: Tag prod images as latest