### PR TITLE
build(deps): Add groups to dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
   - package-ecosystem: "docker"
     directories:
       - "/tools/build_secondary"
@@ -14,13 +18,25 @@ updates:
       - "/packages/at_root_server"
     schedule:
       interval: "daily"
+    groups:
+      docker:
+        patterns:
+          - "*"
   - package-ecosystem: "pub"
     directories:
       - "/packages/at_root_server"
       - "/packages/at_secondary_server"
     schedule:
       interval: "daily"
+    groups:
+      pub:
+        patterns:
+          - "*"
   - package-ecosystem: "pip"
     directory: "/tools" # Location of package manifests
     schedule:
       interval: "daily"
+    groups:
+      pip:
+        patterns:
+          - "*"


### PR DESCRIPTION
Dependabot is presently creating individual PRs for each change it finds. This config change should group them together, which should also (hopefully) deal with the issue that individual directories get a single PR (per scan) for a given change.

**- What I did**

Added groups to each package manager

**- How I did it**

Same process as https://github.com/atsign-foundation/noports/pull/1036

**- How to verify it**

Will have to wait for some deps to be bumped and see which PRs are created.

**- Description for the changelog**

build(deps): Add groups to dependabot.yml