### PR TITLE
build(deps): Bump at_commons 4.09 meta 1.15.0 lints 4.0.0

### DIFF
--- a/packages/at_root_server/pubspec.yaml
+++ b/packages/at_root_server/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   args: 2.5.0
   uuid: 3.0.7
   yaml: 3.1.2
-  at_commons: 4.0.8
+  at_commons: 4.0.9
   at_utils: 3.0.16
   at_server_spec: 5.0.1
   at_persistence_root_server:
@@ -25,6 +25,6 @@ dependencies:
 dev_dependencies:
   # Adding test_cov for generating the test coverage.
   test_cov: ^1.0.1
-  lints: ^3.0.0
+  lints: ^4.0.0
   test: ^1.24.6
   coverage: ^1.6.3

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   intl: ^0.19.0
   json_annotation: ^4.8.0
   version: 3.0.2
-  meta: 1.14.0
+  meta: 1.15.0
   mutex: 3.1.0
   yaml: 3.1.2
   logging: 1.2.0
@@ -37,5 +37,5 @@ dependencies:
 dev_dependencies:
   test: ^1.24.4
   coverage: ^1.6.1
-  lints: ^3.0.0
+  lints: ^4.0.0
   mocktail: ^1.0.3


### PR DESCRIPTION
Dependabot continues to fail to raise PRs

This is a set of manual bumps that should have been done by Dependabot at https://github.com/atsign-foundation/at_server/network/updates/826882873

**- What I did**

Bumped:

* at_commons 4.09
* meta 1.15.0
* lints 4.0.0

**- How I did it**

Took bumps from failed run and applied them manually

**- How to verify it**

CI

**- Description for the changelog**

build(deps): Bump at_commons 4.09 meta 1.15.0 lints 4.0.0
