### PR TITLE
fix: outbound listener handle error response string

### DIFF
--- a/packages/at_secondary_server/lib/src/connection/outbound/outbound_message_listener.dart
+++ b/packages/at_secondary_server/lib/src/connection/outbound/outbound_message_listener.dart
@@ -98,17 +98,8 @@ class OutboundMessageListener {
           // Right now, all callers of this method only expect there ever to be a 'data:' response.
           // So right now, the right thing to do here is to throw an exception.
           // We can leave the connection open since an 'error:' response indicates normal functioning on the other end
-          try {
-            result = result.toString().replaceFirst('error:', '');
-            var errorMap = jsonDecode(result);
-            throw AtExceptionUtils.get(
-                errorMap['errorCode'], errorMap['errorDescription']);
-          } on FormatException {
-            // Catching the FormatException to preserve backward compatibility - responses without jsonEncoding.
-            // TODO: Can remove the catch block in the next release (once all the existing servers are migrated to new version).
-            throw AtConnectException(
-                "Request to remote secondary ${outboundClient.toAtSign} at ${outboundClient.toHost}:${outboundClient.toPort} received error response '$result'");
-          }
+          result = result.toString().replaceFirst('error:', '');
+          _throwAtExceptionFromErrorResponse(result);
         } else {
           // any other response is unexpected and bad, so close the connection and throw an exception
           _closeOutboundClient();
@@ -122,6 +113,36 @@ class OutboundMessageListener {
     _closeOutboundClient();
     throw AtTimeoutException(
         "No response after $maxWaitMilliSeconds millis from remote secondary ${outboundClient.toAtSign} at ${outboundClient.toHost}:${outboundClient.toPort}");
+  }
+
+  AtException _throwAtExceptionFromErrorResponse(String errorResponse) {
+    try {
+      var errorMap = jsonDecode(errorResponse);
+      throw AtExceptionUtils.get(
+          errorMap['errorCode'], errorMap['errorDescription']);
+    } on FormatException {
+      // Catching the FormatException to preserve backward compatibility - responses without jsonEncoding.
+      // TODO: Can remove the catch block in the next release (once all the existing servers are migrated to new version).
+      // get error code and description from error response
+      String? errorCode;
+      try {
+        errorCode = errorResponse.substring(
+            errorResponse.indexOf('AT'), errorResponse.indexOf('-'));
+        logger.finer('errorCode: $errorCode');
+      } on Exception {
+        logger.warning(
+            'Unable to extract error code from errorResponse: $errorResponse');
+        // if we are unable to get errorCode from error response, do nothing
+      }
+      if (errorCode != null && errorCode.isNotEmpty) {
+        var errorDescription = errorResponse
+            .substring(errorResponse.indexOf(errorCode) + errorCode.length + 1);
+        throw AtExceptionUtils.get(errorCode, errorDescription);
+      } else {
+        throw AtConnectException(
+            "Request to remote secondary ${outboundClient.toAtSign} at ${outboundClient.toHost}:${outboundClient.toPort} received error response '$errorResponse'");
+      }
+    }
   }
 
   /// Logs the error and closes the [OutboundClient]

--- a/packages/at_secondary_server/test/outbound_message_listener_test.dart
+++ b/packages/at_secondary_server/test/outbound_message_listener_test.dart
@@ -1,0 +1,112 @@
+import 'package:at_commons/at_commons.dart';
+import 'package:at_secondary/src/connection/outbound/outbound_client.dart';
+import 'package:at_secondary/src/connection/outbound/outbound_connection.dart';
+import 'package:at_secondary/src/connection/outbound/outbound_connection_impl.dart';
+import 'package:at_secondary/src/connection/outbound/outbound_message_listener.dart';
+import 'package:at_server_spec/at_server_spec.dart';
+import 'package:test/test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockOutboundClient extends Mock implements OutboundClient {}
+
+class MockOutboundConnectionImpl extends Mock
+    implements OutboundConnectionImpl {}
+
+class MockAtConnectionMetaData extends Mock implements AtConnectionMetaData {}
+
+void main() async {
+  // mock object for outbound client
+  OutboundClient mockOutboundClient = MockOutboundClient();
+  OutboundSocketConnection mockOutboundConnection =
+      MockOutboundConnectionImpl();
+  AtConnectionMetaData mockAtConnectionMetaData = MockAtConnectionMetaData();
+  setUp(() {
+    reset(mockOutboundClient);
+    when(() => mockOutboundClient.toAtSign).thenReturn('@alice');
+    when(() => mockOutboundClient.toPort).thenReturn('25000');
+    when(() => mockOutboundClient.toHost).thenReturn('localhost');
+    when(() => mockOutboundClient.outboundConnection)
+        .thenReturn(mockOutboundConnection);
+    when(() => mockOutboundConnection.metaData)
+        .thenReturn(mockAtConnectionMetaData);
+    when(() => mockAtConnectionMetaData.isStale).thenReturn(false);
+    when(() => mockAtConnectionMetaData.isClosed).thenReturn(false);
+  });
+
+  group('A group of tests for outbound message listener read', () {
+    test('A test to verify valid response', () async {
+      OutboundMessageListener outboundMessageListener =
+          OutboundMessageListener(mockOutboundClient);
+      await outboundMessageListener
+          .messageHandler('data:phone@alice\n@alice@'.codeUnits);
+      var response = await outboundMessageListener.read();
+      expect(response, 'data:phone@alice');
+    });
+
+    test('A test to validate timeout exception when there is no data to read',
+        () async {
+      OutboundMessageListener outboundMessageListener =
+          OutboundMessageListener(mockOutboundClient);
+      expect(
+          () async =>
+              await outboundMessageListener.read(maxWaitMilliSeconds: 500),
+          throwsA(predicate((dynamic e) => e is AtTimeoutException)));
+    });
+
+    test('A test to validate error response string throws KeyNotFoundException',
+        () async {
+      OutboundMessageListener outboundMessageListener =
+          OutboundMessageListener(mockOutboundClient);
+      await outboundMessageListener.messageHandler(
+          'error:AT0015-Exception.key not found : phone@alice does not exist in keystore\n@alice@'
+              .codeUnits);
+
+      expect(
+          () async => await outboundMessageListener.read(),
+          throwsA(predicate((dynamic e) =>
+              e is KeyNotFoundException &&
+              e.message ==
+                  'Exception.key not found : phone@alice does not exist in keystore')));
+    });
+    test('A test to validate error response json throws KeyNotFoundException',
+        () async {
+      OutboundMessageListener outboundMessageListener =
+          OutboundMessageListener(mockOutboundClient);
+      await outboundMessageListener.messageHandler(
+          'error:{"errorCode":"AT0015","errorDescription":"key not found: public:no-key@alice does not exist in keystore"}\n@alice@'
+              .codeUnits);
+
+      expect(
+          () async => await outboundMessageListener.read(),
+          throwsA(predicate((dynamic e) =>
+              e is KeyNotFoundException &&
+              e.message ==
+                  'key not found: public:no-key@alice does not exist in keystore')));
+    });
+
+    test('A test to invalid response throws AtConnectException', () async {
+      OutboundMessageListener outboundMessageListener =
+          OutboundMessageListener(mockOutboundClient);
+      await outboundMessageListener
+          .messageHandler('test:invalid response\n@alice@'.codeUnits);
+
+      expect(() async => await outboundMessageListener.read(),
+          throwsA(predicate((dynamic e) => e is AtConnectException)));
+    });
+
+    test('A test to validate error response string without error code',
+        () async {
+      OutboundMessageListener outboundMessageListener =
+          OutboundMessageListener(mockOutboundClient);
+      await outboundMessageListener.messageHandler(
+          'error: key not found : phone@alice does not exist in keystore\n@alice@'
+              .codeUnits);
+      expect(
+          () async => await outboundMessageListener.read(),
+          throwsA(predicate((dynamic e) =>
+              e is AtConnectException &&
+              e.message ==
+                  'Request to remote secondary @alice at localhost:25000 received error response \' key not found : phone@alice does not exist in keystore\'')));
+    });
+  });
+}

--- a/tests/at_end2end_test/test/plookup_verb_test.dart
+++ b/tests/at_end2end_test/test/plookup_verb_test.dart
@@ -73,7 +73,7 @@ void main() {
     print(version);
     var serverVersion = Version.parse(version);
     if (serverVersion > Version(3, 0, 46)) {
-      //3.0.46 contains fix to properly parse error for non existent key
+      //3.0.47 contains fix to properly parse error for non existent key.
       response = response.replaceFirst('error:', '');
       var errorMap = jsonDecode(response);
       expect(errorMap['errorCode'], 'AT0015');

--- a/tests/at_end2end_test/test/plookup_verb_test.dart
+++ b/tests/at_end2end_test/test/plookup_verb_test.dart
@@ -71,11 +71,18 @@ void main() {
     print('plookup verb response $response');
     var version = await sh1.getVersion();
     print(version);
-    var serverResponse = Version.parse(await sh1.getVersion());
-    if (serverResponse > Version(3, 0, 24)) {
+    var serverVersion = Version.parse(version);
+    if (serverVersion > Version(3, 0, 45)) {
+      //3.0.46 contains fix to properly parse error for non existent key
       response = response.replaceFirst('error:', '');
       var errorMap = jsonDecode(response);
       expect(errorMap['errorCode'], 'AT0015');
+      expect(errorMap['errorDescription'],
+          contains('public:no-key$atSign_1 does not exist in keystore'));
+    } else if (serverVersion > Version(3, 0, 24)) {
+      response = response.replaceFirst('error:', '');
+      var errorMap = jsonDecode(response);
+      expect(errorMap['errorCode'], 'AT0011');
       expect(errorMap['errorDescription'],
           contains('public:no-key$atSign_1 does not exist in keystore'));
     } else {

--- a/tests/at_end2end_test/test/plookup_verb_test.dart
+++ b/tests/at_end2end_test/test/plookup_verb_test.dart
@@ -72,7 +72,7 @@ void main() {
     var version = await sh1.getVersion();
     print(version);
     var serverVersion = Version.parse(version);
-    if (serverVersion > Version(3, 0, 45)) {
+    if (serverVersion > Version(3, 0, 46)) {
       //3.0.46 contains fix to properly parse error for non existent key
       response = response.replaceFirst('error:', '');
       var errorMap = jsonDecode(response);

--- a/tests/at_end2end_test/test/plookup_verb_test.dart
+++ b/tests/at_end2end_test/test/plookup_verb_test.dart
@@ -82,7 +82,6 @@ void main() {
     } else if (serverVersion > Version(3, 0, 24)) {
       response = response.replaceFirst('error:', '');
       var errorMap = jsonDecode(response);
-      expect(errorMap['errorCode'], 'AT0011');
       expect(errorMap['errorDescription'],
           contains('public:no-key$atSign_1 does not exist in keystore'));
     } else {

--- a/tests/at_end2end_test/test/plookup_verb_test.dart
+++ b/tests/at_end2end_test/test/plookup_verb_test.dart
@@ -75,7 +75,7 @@ void main() {
     if (serverResponse > Version(3, 0, 24)) {
       response = response.replaceFirst('error:', '');
       var errorMap = jsonDecode(response);
-      expect(errorMap['errorCode'], 'AT0011');
+      expect(errorMap['errorCode'], 'AT0015');
       expect(errorMap['errorDescription'],
           contains('public:no-key$atSign_1 does not exist in keystore'));
     } else {


### PR DESCRIPTION
**- What I did**
- fixed the error response from plookup for non existent key
**- How I did it**
- When error response is returned as string for non existent key, error code and error message is not parsed from the error response string. Incorrect AT0011 internal server error was returned to the client.
Implemented a method _throwAtExceptionFromErrorResponse which takes care of handling error code and error message from both json and string error response. Instead of AT0011 (internal server error), AT0015 (key not found) error will be returned as error response to the client
- added unit test for outbound message listener
**- How to verify it**
- plookup end2end tests should pass
- unit tests should pass 
