### PR TITLE
fix: OTP default expiry duration remain constant

### DIFF
--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.46
+- fix: Default OTP expiry value remains unchanged for the subsequent "otp:" requests
+
 ## 3.0.45
 - fix: Update the response format of the "enroll:fetch" to match with "enroll:list" for consistency
 - feat: enroll:revoke now has an optional "force" flag to allow current 

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_secondary
 description: Implementation of secondary server.
-version: 3.0.45
+version: 3.0.46
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://www.example.com
 publish_to: none

--- a/packages/at_secondary_server/test/otp_verb_test.dart
+++ b/packages/at_secondary_server/test/otp_verb_test.dart
@@ -10,6 +10,7 @@ import 'package:at_secondary/src/utils/handler_util.dart';
 import 'package:at_secondary/src/verb/handler/otp_verb_handler.dart';
 import 'package:test/test.dart';
 
+import 'sync_unit_test.dart';
 import 'test_utils.dart';
 
 void main() {
@@ -23,10 +24,8 @@ void main() {
       inboundConnection.metaData.isAuthenticated = false;
       OtpVerbHandler otpVerbHandler = OtpVerbHandler(secondaryKeyStore);
       expect(
-          otpVerbHandler.processVerb(
-              response,
-              getVerbParam(VerbSyntax.otp, 'otp:get'),
-              inboundConnection),
+          otpVerbHandler.processVerb(response,
+              getVerbParam(VerbSyntax.otp, 'otp:get'), inboundConnection),
           throwsA(predicate((dynamic e) => e is UnAuthenticatedException)));
     });
     test('Verify that otp:get with ttl requires authentication', () async {
@@ -149,14 +148,31 @@ void main() {
         () async {
       Response response = Response();
       HashMap<String, String?> verbParams =
-          getVerbParam(VerbSyntax.otp, 'otp:get');
+          getVerbParam(VerbSyntax.otp, 'otp:get:ttl:1');
       inboundConnection.metaData.isAuthenticated = true;
       OtpVerbHandler otpVerbHandler = OtpVerbHandler(secondaryKeyStore);
-      otpVerbHandler.otpExpiryInMills = 1;
       await otpVerbHandler.processVerb(response, verbParams, inboundConnection);
       String? otp = response.data;
       await Future.delayed(Duration(milliseconds: 2));
       expect(await otpVerbHandler.isOTPValid(otp), false);
+    });
+
+    test('A test to verify default otp expiry not overwritten', () async {
+      Response response = Response();
+      HashMap<String, String?> verbParams =
+          getVerbParam(VerbSyntax.otp, 'otp:get:ttl:1');
+      inboundConnection.metaData.isAuthenticated = true;
+      OtpVerbHandler otpVerbHandler = OtpVerbHandler(secondaryKeyStore);
+      await otpVerbHandler.processVerb(response, verbParams, inboundConnection);
+      AtData? atData =
+          await secondaryKeyStore.get('private:${response.data}$atSign');
+      expect(atData?.metaData?.ttl, 1);
+
+      verbParams = getVerbParam(VerbSyntax.otp, 'otp:get');
+      inboundConnection.metaData.isAuthenticated = true;
+      await otpVerbHandler.processVerb(response, verbParams, inboundConnection);
+      atData = await secondaryKeyStore.get('private:${response.data}$atSign');
+      expect(atData?.metaData?.ttl, 300000);
     });
 
     test(

--- a/packages/at_secondary_server/test/otp_verb_test.dart
+++ b/packages/at_secondary_server/test/otp_verb_test.dart
@@ -172,7 +172,8 @@ void main() {
       inboundConnection.metaData.isAuthenticated = true;
       await otpVerbHandler.processVerb(response, verbParams, inboundConnection);
       atData = await secondaryKeyStore.get('private:${response.data}$atSign');
-      expect(atData?.metaData?.ttl, 300000);
+      expect(atData?.metaData?.ttl,
+          OtpVerbHandler.defaultOtpExpiry.inMilliseconds);
     });
 
     test(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Fix the following issue - "otpExpiryInMillis" is an instance variable and hence if the TTL is set, then the value remains for all the subsequent otp: verbs instead of the default expiry value.

**- How I did it**
- Add "_defaultOtpExpiryInMills" and mark it as final to ensure its value is not changed.
- Add the following logic - If TTL value is set, then set "otpExpiryInMills" to the value of TTL, else set to "_defaultOtpExpiryInMills".

**- How to verify it**
- Added a unit test to ensure the default expiry of the OTP value not changed for the subsequent requests of the OTP.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
