### PR TITLE
feat: introduce a dedicated namespace for OTPs and SPPs

### DIFF
--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 3.0.46
 - fix: Default OTP expiry value remains unchanged for the subsequent "otp:" requests
-
+- feat: OTPs stored with a dedicated namespace
 ## 3.0.45
 - fix: Update the response format of the "enroll:fetch" to match with "enroll:list" for consistency
 - feat: enroll:revoke now has an optional "force" flag to allow current 

--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 3.0.46
 - fix: Default OTP expiry value remains unchanged for the subsequent "otp:" requests
-- feat: OTPs stored with a dedicated namespace
+- feat: Introduced a dedicated namespace for storing OTPs
 ## 3.0.45
 - fix: Update the response format of the "enroll:fetch" to match with "enroll:list" for consistency
 - feat: enroll:revoke now has an optional "force" flag to allow current 

--- a/packages/at_secondary_server/lib/src/verb/handler/abstract_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/abstract_verb_handler.dart
@@ -287,6 +287,10 @@ abstract class AbstractVerbHandler implements VerbHandler {
     }
     try {
       AtData? sppAtData = await keyStore.get(sppKey);
+      // SPP has a special key so we have to check the value that was stored
+      // (which is the actual SPP)
+      // By comparison, OTPs are stored with the key being ${OTP}.__otp@alice
+      // i.e. the OTP is part of the key, and the stored data is irrelevant
       if (sppAtData?.data?.toLowerCase() == otp.toLowerCase()) {
         return true;
       }

--- a/packages/at_secondary_server/lib/src/verb/handler/otp_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/otp_verb_handler.dart
@@ -104,8 +104,7 @@ class OtpVerbHandler extends AbstractVerbHandler {
     await keyStore.put(
         'private:$otp.$otpNamespace${AtSecondaryServerImpl.getInstance().currentAtSign}',
         AtData()
-          ..data =
-              '${DateTime.now().toUtc().add(Duration(milliseconds: otpExpiryInMillis)).millisecondsSinceEpoch}'
+          ..data = otp
           ..metaData = (AtMetaData()..ttl = otpExpiryInMillis));
   }
 

--- a/packages/at_secondary_server/lib/src/verb/handler/otp_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/otp_verb_handler.dart
@@ -27,6 +27,8 @@ class OtpVerbHandler extends AbstractVerbHandler {
   @override
   Verb getVerb() => otpVerb;
 
+  static final otpNamespace = '__otp';
+
   @override
   Future<void> processVerb(
       Response response,
@@ -49,7 +51,7 @@ class OtpVerbHandler extends AbstractVerbHandler {
         // If OTP generated do not have digits, generate again.
         while (RegExp(r'\d').hasMatch(response.data!) == false);
         await keyStore.put(
-            'private:${response.data}${AtSecondaryServerImpl.getInstance().currentAtSign}',
+            'private:${response.data}.$otpNamespace${AtSecondaryServerImpl.getInstance().currentAtSign}',
             AtData()
               ..data =
                   '${DateTime.now().toUtc().add(Duration(milliseconds: otpExpiryInMillis)).millisecondsSinceEpoch}'
@@ -65,7 +67,7 @@ class OtpVerbHandler extends AbstractVerbHandler {
         }
         String? otp = verbParams['otp'];
         await keyStore.put(
-            'private:spp${AtSecondaryServerImpl.getInstance().currentAtSign}',
+            'private:spp.$otpNamespace${AtSecondaryServerImpl.getInstance().currentAtSign}',
             AtData()..data = otp);
         response.data = 'ok';
         break;

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_secondary
 description: Implementation of secondary server.
-version: 3.0.46
+version: 3.0.47
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://www.example.com
 publish_to: none

--- a/packages/at_secondary_server/test/otp_verb_test.dart
+++ b/packages/at_secondary_server/test/otp_verb_test.dart
@@ -203,8 +203,7 @@ void main() {
       String testOtp = 'ABCD12';
       String otpLegacyKey = 'private:${testOtp.toLowerCase()}$atsign';
       AtData value = AtData()
-        ..data =
-            '${DateTime.now().toUtc().add(OtpVerbHandler.defaultOtpExpiry).millisecondsSinceEpoch}'
+        ..data = testOtp
         ..metaData = (AtMetaData()
           ..ttl = OtpVerbHandler.defaultOtpExpiry.inMilliseconds);
       await secondaryKeyStore.put(otpLegacyKey, value);

--- a/packages/at_secondary_server/test/otp_verb_test.dart
+++ b/packages/at_secondary_server/test/otp_verb_test.dart
@@ -164,14 +164,15 @@ void main() {
       inboundConnection.metaData.isAuthenticated = true;
       OtpVerbHandler otpVerbHandler = OtpVerbHandler(secondaryKeyStore);
       await otpVerbHandler.processVerb(response, verbParams, inboundConnection);
-      AtData? atData =
-          await secondaryKeyStore.get('private:${response.data}$atSign');
+      AtData? atData = await secondaryKeyStore.get(
+          'private:${response.data}.${OtpVerbHandler.otpNamespace}$atSign');
       expect(atData?.metaData?.ttl, 1);
 
       verbParams = getVerbParam(VerbSyntax.otp, 'otp:get');
       inboundConnection.metaData.isAuthenticated = true;
       await otpVerbHandler.processVerb(response, verbParams, inboundConnection);
-      atData = await secondaryKeyStore.get('private:${response.data}$atSign');
+      atData = await secondaryKeyStore.get(
+          'private:${response.data}.${OtpVerbHandler.otpNamespace}$atSign');
       expect(atData?.metaData?.ttl,
           OtpVerbHandler.defaultOtpExpiry.inMilliseconds);
     });
@@ -195,6 +196,21 @@ void main() {
       String? otp = response.data;
       expect(await otpVerbHandler.isOTPValid(otp), true);
       expect(await otpVerbHandler.isOTPValid(otp), false);
+    });
+
+    test('validate backwards compatability with legacy otp key', () async {
+      String atsign = '@alice';
+      String testOtp = 'ABCD12';
+      String otpLegacyKey = 'private:${testOtp.toLowerCase()}$atsign';
+      AtData value = AtData()
+        ..data =
+            '${DateTime.now().toUtc().add(OtpVerbHandler.defaultOtpExpiry).millisecondsSinceEpoch}'
+        ..metaData = (AtMetaData()
+          ..ttl = OtpVerbHandler.defaultOtpExpiry.inMilliseconds);
+      await secondaryKeyStore.put(otpLegacyKey, value);
+
+      OtpVerbHandler otpVerbHandler = OtpVerbHandler(secondaryKeyStore);
+      expect(await otpVerbHandler.isOTPValid(testOtp), true);
     });
     tearDown(() async => await verbTestsTearDown());
   });
@@ -247,6 +263,17 @@ void main() {
       otpVerbHandler = OtpVerbHandler(secondaryKeyStore);
       await otpVerbHandler.processVerb(response, verbParams, inboundConnection);
       expect(await otpVerbHandler.isOTPValid(passcode), true);
+    });
+
+    test('validate backwards compatability with legacy ssp key', () async {
+      String atsign = '@alice';
+      String testOtp = 'ABC123';
+      String otpLegacyKey = 'private:spp$atsign';
+      AtData value = AtData()..data = testOtp;
+      await secondaryKeyStore.put(otpLegacyKey, value);
+
+      OtpVerbHandler otpVerbHandler = OtpVerbHandler(secondaryKeyStore);
+      expect(await otpVerbHandler.isOTPValid(testOtp), true);
     });
     tearDown(() async => await verbTestsTearDown());
   });


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- introduce a dedicated namespace for OTPs and SPPs
- Provide backwards compatibility for legacy OTP and SPP keys

**- How I did it**
- Introduced a class variable in OtpVerbHandler called that has a value of '__otp'; which will be the namespace for all OTPs and SPPs
- Allow backward compatibility: check for OTP and SPP without the otp namespace.

**- How to verify it**
- Unit tests added that validate that OTPs and SPPs that use legacy style keys are also considered valid
- functional/e2e tests will be once this PR is merged into https://github.com/atsign-foundation/at_server/pull/1955

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
feat: introduce a dedicated namespace for OTPs and SPPs