### PR TITLE
fix: Fix the handling of enrollment self-notifications

### DIFF
--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.0.46
 - fix: Default OTP expiry value remains unchanged for the subsequent "otp:" requests
+- fix: Fix the handling of enrollment self-notifications
 
 ## 3.0.45
 - fix: Update the response format of the "enroll:fetch" to match with "enroll:list" for consistency

--- a/packages/at_secondary_server/lib/src/verb/executor/default_verb_executor.dart
+++ b/packages/at_secondary_server/lib/src/verb/executor/default_verb_executor.dart
@@ -27,8 +27,8 @@ class DefaultVerbExecutor implements VerbExecutor {
       await handler.process(utf8EncodedCommand, fromConnection);
     } on AtConnectException {
       rethrow;
-    } on Exception catch (e) {
-      logger.severe(
+    } catch (e) {
+      logger.finer(
           'exception in processing command :$utf8EncodedCommand: ${e.toString()}');
       rethrow;
     }

--- a/packages/at_secondary_server/lib/src/verb/handler/abstract_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/abstract_verb_handler.dart
@@ -132,7 +132,8 @@ abstract class AbstractVerbHandler implements VerbHandler {
   /// Use [namespace] if passed, otherwise retrieve namespace from [atKey]. Return false if no [namespace] or [atKey] is set.
   Future<bool> isAuthorized(InboundConnectionMetadata connectionMetadata,
       {String? atKey, String? namespace}) async {
-    bool retVal = await _isAuthorized(connectionMetadata, atKey: atKey, namespace: namespace);
+    bool retVal = await _isAuthorized(connectionMetadata,
+        atKey: atKey, namespace: namespace);
     logger.finer('_isAuthorized returned $retVal');
     return retVal;
   }

--- a/packages/at_secondary_server/lib/src/verb/handler/abstract_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/abstract_verb_handler.dart
@@ -203,7 +203,7 @@ abstract class AbstractVerbHandler implements VerbHandler {
     // Only spp and enroll operations are allowed to access
     // the enrollManageNamespace
     if (keyNamespace == enrollManageNamespace) {
-      return (verb is Otp || verb is Enroll)
+      return (verb is Otp || verb is Enroll || verb is Monitor)
           ? (access == 'r' || access == 'rw')
           : false;
     }

--- a/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
@@ -97,14 +97,13 @@ class EnrollVerbHandler extends AbstractVerbHandler {
         final enrollmentIdFromParams = enrollVerbParams!.enrollmentId;
         var inboundConnectionMetaData =
             atConnection.metaData as InboundConnectionMetadata;
-        if (enrollmentIdFromParams ==
-                inboundConnectionMetaData.enrollmentId &&
+        if (enrollmentIdFromParams == inboundConnectionMetaData.enrollmentId &&
             forceFlag == null) {
           throw AtEnrollmentRevokeException(
               'Current client cannot revoke its own enrollment');
         }
-        await _handleEnrollmentPermissions(enrollVerbParams, currentAtSign,
-            operation, responseJson, response);
+        await _handleEnrollmentPermissions(
+            enrollVerbParams, currentAtSign, operation, responseJson, response);
         if (responseJson['status'] == EnrollmentStatus.revoked.name) {
           logger.finer(
               'Dropping connection for enrollmentId: $enrollmentIdFromParams');

--- a/packages/at_secondary_server/lib/src/verb/handler/monitor_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/monitor_verb_handler.dart
@@ -90,9 +90,11 @@ class MonitorVerbHandler extends AbstractVerbHandler {
       fromAtSign = fromAtSign.replaceAll('@', '');
     }
     try {
+      logger.finest('Checking $notification against $regex');
       // If the user does not provide regex, defaults to ".*" to match all notifications.
       if (notification.notification!.contains(RegExp(regex)) ||
           (fromAtSign != null && fromAtSign.contains(RegExp(regex)))) {
+        logger.finest('Matched regex - sending');
         await atConnection.write('notification:'
             ' ${jsonEncode(notification.toJson())}\n');
       }

--- a/packages/at_secondary_server/test/lookup_verb_test.dart
+++ b/packages/at_secondary_server/test/lookup_verb_test.dart
@@ -876,7 +876,8 @@ void main() {
                   'Connection with enrollment ID $enrollmentId is not authorized to lookup key: @alice:some_key.buzz@bob')));
     });
 
-    test('A test to verify read access is allowed if key is @alice:shared_key@bob',
+    test(
+        'A test to verify read access is allowed if key is @alice:shared_key@bob',
         () async {
       inboundConnection.metadata.isAuthenticated = true;
       String sharedKeyForThem = 'shared_key$bob';
@@ -904,7 +905,8 @@ void main() {
           jsonDecode(verbResponse.data!);
       expect(jsonDecodedResponseData['data'], bobAtData.data);
     });
-    test('A test to verify read access is allowed if key is shared_key.alice@bob',
+    test(
+        'A test to verify read access is allowed if key is shared_key.alice@bob',
         () async {
       inboundConnection.metadata.isAuthenticated = true;
       String sharedKeyForMe = 'shared_key.alice$bob';

--- a/tools/run_locally/scripts/macos/at_server
+++ b/tools/run_locally/scripts/macos/at_server
@@ -62,7 +62,7 @@ export accessLogPath="$storageDir/accessLog"
 export notificationStoragePath="$storageDir/notificationLog.v1"
 export inbound_max_limit=200
 
-export logLevel="INFO"
+export logLevel="WARNING"
 
 export testingMode="true"
 


### PR DESCRIPTION
**- What I did**
fix: Fix the handling of enrollment self-notifications

**- How I did it**
fix: Fix the handling of self-notifications which are generated at enrollment time
- add Monitor to list of verbs which AbstractVerbHandler.isAuthorized allows to access the enrollManageNamespace
- in EnrollVerbHandler, append the atSign to the notification key
refactor: Got rid of some unnecessary try-catch clauses where the catches were just logging and re-throwing

**- How to verify it**
- Tests pass

