### PR TITLE
fix: add encryptedAPKAMSymmetricKey to enrollment notification

### DIFF
--- a/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
@@ -479,6 +479,10 @@ class EnrollVerbHandler extends AbstractVerbHandler {
       var notificationValue = {};
       notificationValue[AtConstants.apkamEncryptedSymmetricKey] =
           enrollParams.encryptedAPKAMSymmetricKey;
+      // send both encryptedAPKAMSymmetricKey and encryptedApkamSymmetricKey in notification
+      // after the server is released, use encryptedAPKAMSymmetricKey. Modify the constant name in at_commons and client side code.
+      notificationValue['encryptedAPKAMSymmetricKey'] =
+          enrollParams.encryptedAPKAMSymmetricKey;
       notificationValue[AtConstants.appName] = enrollParams.appName;
       notificationValue[AtConstants.deviceName] = enrollParams.deviceName;
       notificationValue[AtConstants.namespace] = enrollParams.namespaces;

--- a/packages/at_secondary_server/test/monitor_verb_test.dart
+++ b/packages/at_secondary_server/test/monitor_verb_test.dart
@@ -11,6 +11,7 @@ import 'package:at_secondary/src/verb/handler/enroll_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/monitor_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/otp_verb_handler.dart';
 import 'package:at_server_spec/at_server_spec.dart';
+import 'package:test/expect.dart';
 import 'package:test/test.dart';
 import 'package:uuid/uuid.dart';
 
@@ -360,6 +361,7 @@ void main() {
           ',"deviceName":"$deviceName"'
           ',"namespaces":${jsonEncode(namespaces)}'
           ',"apkamPublicKey":"dummy_apkam_public_key"'
+          ',"encryptedAPKAMSymmetricKey":"dummy_encrypted_apkam_symm_key"'
           '}';
       HashMap<String, String?> enrollmentRequestVerbParams =
           getVerbParam(VerbSyntax.enroll, enrollmentRequest);
@@ -415,10 +417,15 @@ void main() {
 
       // Verify that the monitor connection receives the
       //    enrollment request notification
+      var notificationJson = jsonDecode(
+          pkamMC.lastWrittenData!.replaceAll('notification:', '').trim());
+      expect(notificationJson['value'], isNotNull);
+      final valueJson = jsonDecode(notificationJson['value']);
+      expect(valueJson['appName'], 'mvt_app_2');
+      expect(valueJson['deviceName'], 'mvt_dev_2');
+      expect(valueJson['namespace'], equals({'app_2_namespace': 'rw'}));
       expect(
-          jsonDecode(pkamMC.lastWrittenData!
-              .replaceAll('notification:', '')
-              .trim())['key'],
+          notificationJson['key'],
           '$nextEnrollmentId'
           '.new.enrollments.__manage'
           '@alice');
@@ -467,10 +474,20 @@ void main() {
 
       // Verify that the APKAM monitor connection receives the
       //    enrollment request notification
+      var notificationJson = jsonDecode(
+          apkamMC.lastWrittenData!.replaceAll('notification:', '').trim());
+      expect(notificationJson['value'], isNotNull);
+      final valueJson = jsonDecode(notificationJson['value']);
+      //TODO remove encryptedApkamSymmetricKey in the future
+      expect(valueJson['encryptedApkamSymmetricKey'],
+          'dummy_encrypted_apkam_symm_key');
+      expect(valueJson['encryptedAPKAMSymmetricKey'],
+          'dummy_encrypted_apkam_symm_key');
+      expect(valueJson['appName'], 'mvt_app_2');
+      expect(valueJson['deviceName'], 'mvt_dev_2');
+      expect(valueJson['namespace'], equals({'app_2_namespace': 'rw'}));
       expect(
-          jsonDecode(apkamMC.lastWrittenData!
-              .replaceAll('notification:', '')
-              .trim())['key'],
+          notificationJson['key'],
           '$nextEnrollmentId'
           '.new.enrollments.__manage'
           '@alice');

--- a/tests/at_functional_test/test/enroll_verb_test.dart
+++ b/tests/at_functional_test/test/enroll_verb_test.dart
@@ -464,7 +464,10 @@ void main() {
           expect(notificationValue['appName'], 'buzz');
           expect(notificationValue['deviceName'], deviceName);
           expect(notificationValue['namespace'], {'buzz': 'rw'});
+          // TODO remove encryptedApkamSymmetricKey and use encryptedAPKAMSymmetricKey constant name in future
           expect(notificationValue['encryptedApkamSymmetricKey'],
+              apkamEncryptedKeysMap['encryptedApkamSymmetricKey']);
+          expect(notificationValue['encryptedAPKAMSymmetricKey'],
               apkamEncryptedKeysMap['encryptedApkamSymmetricKey']);
           monitorSocket.close();
         }


### PR DESCRIPTION
**- What I did**
- in enrollment notification encryptedApkamSymmetricKey is sent in json. encryptedAPKAMSymmetricKey is used in other places in server code. Temporarily send both encryptedApkamSymmetricKey,encryptedAPKAMSymmetricKey in the notification. Once server is released to prod, use encryptedAPKAMSymmetricKey for consistency
**- How I did it**
- added encryptedAPKAMSymmetricKey in enrollment notification json
- added a check in functional test
**- How to verify it**
- tests should pass
