### PR TITLE
fix: Invalid AtKey causes exception in notify list during authorizati…

### DIFF
--- a/packages/at_secondary_server/lib/src/verb/handler/abstract_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/abstract_verb_handler.dart
@@ -1,5 +1,6 @@
 import 'dart:collection';
 import 'dart:convert';
+
 import 'package:at_commons/at_commons.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:at_secondary/src/connection/inbound/inbound_connection_metadata.dart';
@@ -7,12 +8,12 @@ import 'package:at_secondary/src/constants/enroll_constants.dart';
 import 'package:at_secondary/src/enroll/enroll_datastore_value.dart';
 import 'package:at_secondary/src/server/at_secondary_impl.dart';
 import 'package:at_secondary/src/utils/handler_util.dart' as handler_util;
+import 'package:at_secondary/src/utils/secondary_util.dart';
 import 'package:at_secondary/src/verb/handler/sync_progressive_verb_handler.dart';
 import 'package:at_secondary/src/verb/manager/response_handler_manager.dart';
 import 'package:at_server_spec/at_server_spec.dart';
 import 'package:at_server_spec/at_verb_spec.dart';
 import 'package:at_utils/at_logger.dart';
-import 'package:at_secondary/src/utils/secondary_util.dart';
 
 final String paramFullCommandAsReceived = 'FullCommandAsReceived';
 
@@ -190,8 +191,13 @@ abstract class AbstractVerbHandler implements VerbHandler {
       }
     }
     // set passed namespace. If passed namespace is null, get namespace from atKey
-    final keyNamespace =
-        namespace ?? (atKey != null ? AtKey.fromString(atKey).namespace : null);
+    String? keyNamespace;
+    try {
+      keyNamespace = namespace ??
+          (atKey != null ? AtKey.fromString(atKey).namespace : null);
+    } catch (e) {
+      throw AtEnrollmentException('AtKey.toString($atKey) failed: $e');
+    }
     if (keyNamespace == null && atKey == null) {
       logger.shout('Both AtKey and namespace are null');
       return false;

--- a/packages/at_secondary_server/lib/src/verb/handler/notify_list_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/notify_list_verb_handler.dart
@@ -63,9 +63,14 @@ class NotifyListVerbHandler extends AbstractVerbHandler {
       var filteredResponseList = [];
       for (Notification notification in responseList) {
         var notificationKey = notification.notification;
-        if (await super
-            .isAuthorized(atConnectionMetadata, atKey: notificationKey!)) {
-          filteredResponseList.add(notification);
+        try {
+          if (await super
+              .isAuthorized(atConnectionMetadata, atKey: notificationKey!)) {
+            filteredResponseList.add(notification);
+          }
+        } on AtEnrollmentException catch (e) {
+          logger.finer(
+              'Failed to authorize the key with enrollment ID ${atConnectionMetadata.enrollmentId} caused by ${e.toString()}');
         }
       }
       responseList.clear();


### PR DESCRIPTION
…on check

<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix the below error in at_client_sdk - E2E tests.

```
❌ test/notify_test.dart: Notify a key with value to sharedWith atSign and listen for notification from sharedWith atSign (failed)
  Exception: Invalid syntax : @ce2e4:Hello How are you is not well-formed key
  package:at_client/src/client/remote_secondary.dart 100:7  RemoteSecondary.executeVerb
  ===== asynchronous gap ===========================
  package:at_client/src/client/at_client_impl.dart 582:24   AtClientImpl.notifyList
  ===== asynchronous gap ===========================
  test/notify_test.dart 58:34                               main.<fn>
```
When a connection is authenticated through APKAM and the "notify list" command is executed, the fetched notifications undergo namespace authorization check where `Atkey.fromString(key)` is invoked. If an invalid key is detected within the notification, it leads to above mentioned issue.

**- How I did it**
- In AbstractVerbHandler._isAuthorized method, wrap the `AtKey.fromString` inside try-catch block and throw `AtEnrollmentException` for the invalid keys
- In NotifyListVerbHandler, catch the AtEnrollmentException and log the error and continue to the next notification.

**- How to verify it**
- Performed a manual testing with @ce2e4 data dump and able to run notify list command successfully.

```
@from:@ce2e4
data:_f6d82602-2ba4-4381-8e0f-aa3fe5756f6d@ce2e4:4ed33128-ea07-4fb2-9962-cbc22aa4caaf
@pkam:enrollmentid:2f09d06d-5dc3-4ecf-87bf-7a9daadb215e:Kxa5tLnJrfLOwzTP8YNVbju7IzFicpp0hWxdG97Xqygdy92JDghLObvbHw21weZ5lTUAkExwUN1IVPAKc141flUurLC58I9dZAtuJay8CUW7c9wgb9kSVjEvLOvp0sVZSUl0RgRPvDQHHi3DNGBCAM1vY92oOXsJzCrfWweV0YfdBpVrvLtkGGqi3FwqpHyjt32Eq0YaPXvatJbCQ1mu2UpcxS1CUa8O5zXHXc2UEfP2fziOZxcZlC//XqrWmcqDAy4PwP2AL1jKh3/Mec9OArCAeYtR/3rWXynxrP5tXQ28JlH/nVyKqkB/k47pIxS/gK9utoqhjTwwrEn5jjuv/w==
data:success
@ce2e4@notify:list:phone
data:[{"id":"07ee6ced-758c-4e88-9e8b-3412171dc810","from":"@ce2e1","to":"@ce2e4","key":"@ce2e4:phone844a2fba-4c15-44d6-a7fd-2afcb9289273.wavi@ce2e1","value":"AKBIKLZ7jO/gOI/iRR1fJA==","operation":"update","epochMillis":1716306388878,"messageType":"MessageType.key","isEncrypted":true,"metadata":{"encKeyName":null,"encAlgo":null,"ivNonce":null,"skeEncKeyName":null,"skeEncAlgo":null}},{"id":"136dd666-0289-4b05-9557-55eef42c52ce","from":"@ce2e1","to":"@ce2e4","key":"@ce2e4:phone204e38db-41d2-4bc7-be8d-96a573b9d740.wavi@ce2e1",
```

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
