### PR TITLE
feat: allow a ttl to be set for a semi-permanent passcode (spp)

### DIFF
--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.0.47
 - feat: Introduced a dedicated namespace for storing OTPs
+- feat: allow a ttl to be set for a semi-permanent passcode (spp)
 
 ## 3.0.46
 - fix: Default OTP expiry value remains unchanged for the subsequent "otp:" requests

--- a/packages/at_secondary_server/lib/src/verb/handler/abstract_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/abstract_verb_handler.dart
@@ -270,14 +270,14 @@ abstract class AbstractVerbHandler implements VerbHandler {
   ///
   /// Additionally, this function removes the OTP from the keystore to prevent
   /// its reuse.
-  Future<bool> isOTPValid(String? otp) async {
-    if (otp == null) {
+  Future<bool> isPasscodeValid(String? passcode) async {
+    if (passcode == null) {
       return false;
     }
     // 1. Check if user has configured an SPP(Semi-Permanent Pass-code).
     // If SPP key is available, check if the otp sent is a valid pass code.
     // If yes, return true, else check it is a valid OTP.
-    String passcodeKey = OtpVerbHandler.passcodeKey(otp, isSpp: true);
+    String passcodeKey = OtpVerbHandler.passcodeKey(passcode, isSpp: true);
     if (!keyStore.isKeyExists(passcodeKey)) {
       // if new SPPKey does not exist in keystore, check for SPP data against legacy SPP key
       // New SPP key has __otp namespace, legacy key does NOT have any namespace
@@ -290,7 +290,7 @@ abstract class AbstractVerbHandler implements VerbHandler {
       // (which is the actual SPP)
       // By comparison, OTPs are stored with the key being ${OTP}.__otp@alice
       // i.e. the OTP is part of the key, and the stored data is irrelevant
-      if (sppAtData?.data?.toLowerCase() == otp.toLowerCase()) {
+      if (sppAtData?.data?.toLowerCase() == passcode.toLowerCase()) {
         if (SecondaryUtil.isActiveKey(sppAtData)) {
           return true;
         } else {
@@ -303,12 +303,12 @@ abstract class AbstractVerbHandler implements VerbHandler {
     }
 
     // 2. If not a valid SPP, then check against OTP keys
-    String otpKey = OtpVerbHandler.passcodeKey(otp, isSpp: false);
+    String otpKey = OtpVerbHandler.passcodeKey(passcode, isSpp: false);
     if (!keyStore.isKeyExists(otpKey)) {
       // if new OTPKey does not exist in keystore, check for OTP data against legacy OTPKey
       // New OTP key has __otp namespace, legacy key does not have namespace
       otpKey =
-          'private:${otp.toLowerCase()}${AtSecondaryServerImpl.getInstance().currentAtSign}';
+          'private:${passcode.toLowerCase()}${AtSecondaryServerImpl.getInstance().currentAtSign}';
     }
 
     AtData? otpAtData;

--- a/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
@@ -191,7 +191,7 @@ class EnrollVerbHandler extends AbstractVerbHandler {
     // OTP is sent only in enrollment request which is submitted on
     // unauthenticated connection.
     if (atConnection.metaData.isAuthenticated == false) {
-      var isValid = await isOTPValid(enrollParams.otp);
+      var isValid = await isPasscodeValid(enrollParams.otp);
       if (!isValid) {
         _lastInvalidOtpReceivedInMills =
             DateTime.now().toUtc().millisecondsSinceEpoch;

--- a/packages/at_secondary_server/lib/src/verb/handler/otp_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/otp_verb_handler.dart
@@ -36,17 +36,15 @@ class OtpVerbHandler extends AbstractVerbHandler {
       InboundConnection atConnection) async {
     final operation = verbParams['operation'];
     if (!atConnection.metaData.isAuthenticated) {
-      throw UnAuthenticatedException(
-          'otp:get requires authenticated connection');
+      throw UnAuthenticatedException('otp: requires authenticated connection');
     }
     switch (operation) {
       case 'get':
         String otp = generateOTP();
         // Extract the ttl from the verb parameters if supplied, or use the default value.
-        int otpExpiryInMillis =
-            int.tryParse(verbParams[AtConstants.ttl] ?? '') ??
-                defaultOtpExpiry.inMilliseconds;
-        await saveOTP(otp, otpExpiryInMillis);
+        int otpTtl = int.tryParse(verbParams[AtConstants.ttl] ?? '') ??
+            defaultOtpExpiry.inMilliseconds;
+        await savePasscode(otp, ttl: otpTtl, isSpp: false);
         response.data = otp;
         break;
       case 'put':
@@ -57,10 +55,12 @@ class OtpVerbHandler extends AbstractVerbHandler {
           throw InvalidRequestException(
               'Client not allowed to not store semi permanent pass code');
         }
-        String? otp = verbParams['otp'];
-        await keyStore.put(
-            'private:spp.$otpNamespace${AtSecondaryServerImpl.getInstance().currentAtSign}',
-            AtData()..data = otp);
+        int sppTtl = int.tryParse(verbParams[AtConstants.ttl] ?? '') ?? -1;
+        String? spp = verbParams['otp'];
+        if (spp == null) {
+          throw InvalidRequestException('otp:put requires a passcode');
+        }
+        await savePasscode(spp, ttl: sppTtl, isSpp: true);
         response.data = 'ok';
         break;
       default:
@@ -100,12 +100,21 @@ class OtpVerbHandler extends AbstractVerbHandler {
     return otp;
   }
 
-  Future<void> saveOTP(String otp, int otpExpiryInMillis) async {
+  static String passcodeKey(String passcode, {required bool isSpp}) {
+    return isSpp
+        ? 'private:spp.$otpNamespace'
+            '${AtSecondaryServerImpl.getInstance().currentAtSign}'
+        : 'private:${passcode.toLowerCase()}.$otpNamespace'
+            '${AtSecondaryServerImpl.getInstance().currentAtSign}';
+  }
+
+  Future<void> savePasscode(String passcode,
+      {required int ttl, required bool isSpp}) async {
     await keyStore.put(
-        'private:$otp.$otpNamespace${AtSecondaryServerImpl.getInstance().currentAtSign}',
+        passcodeKey(passcode, isSpp: isSpp),
         AtData()
-          ..data = otp
-          ..metaData = (AtMetaData()..ttl = otpExpiryInMillis));
+          ..data = passcode
+          ..metaData = (AtMetaData()..ttl = ttl));
   }
 
   String _generateRandomAlphabet() {

--- a/packages/at_secondary_server/test/abstract_verb_handler_test.dart
+++ b/packages/at_secondary_server/test/abstract_verb_handler_test.dart
@@ -97,7 +97,7 @@ class TestUpdateVerbHandler extends AbstractVerbHandler {
   }
 
   @override
-  Future<bool> isOTPValid(String? otp) {
+  Future<bool> isPasscodeValid(String? otp) {
     // TODO: implement isOTPValid
     throw UnimplementedError();
   }

--- a/packages/at_secondary_server/test/enroll_verb_test.dart
+++ b/packages/at_secondary_server/test/enroll_verb_test.dart
@@ -108,7 +108,7 @@ void main() {
           response, enrollmentRequestVerbParams, inboundConnection);
       String enrollmentId = jsonDecode(response.data!)['enrollmentId'];
       expect(enrollmentId, isNotNull);
-      expect(await enrollVerbHandler.isOTPValid(otp), false);
+      expect(await enrollVerbHandler.isPasscodeValid(otp), false);
     });
     tearDown(() async => await verbTestsTearDown());
   });

--- a/packages/at_secondary_server/test/monitor_verb_test.dart
+++ b/packages/at_secondary_server/test/monitor_verb_test.dart
@@ -11,7 +11,6 @@ import 'package:at_secondary/src/verb/handler/enroll_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/monitor_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/otp_verb_handler.dart';
 import 'package:at_server_spec/at_server_spec.dart';
-import 'package:test/expect.dart';
 import 'package:test/test.dart';
 import 'package:uuid/uuid.dart';
 
@@ -351,7 +350,7 @@ void main() {
         {required bool autoApprove}) async {
       OtpVerbHandler otpVH = OtpVerbHandler(secondaryKeyStore);
       String otp = otpVH.generateOTP();
-      await otpVH.saveOTP(otp, 5000);
+      await otpVH.savePasscode(otp, ttl: 5000, isSpp: false);
 
       EnrollVerbHandler enrollVerbHandler =
           EnrollVerbHandler(secondaryKeyStore);
@@ -361,7 +360,7 @@ void main() {
           ',"deviceName":"$deviceName"'
           ',"namespaces":${jsonEncode(namespaces)}'
           ',"apkamPublicKey":"dummy_apkam_public_key"'
-          ',"encryptedAPKAMSymmetricKey":"dummy_encrypted_apkam_symm_key"'
+          ',"encryptedAPKAMSymmetricKey":"dummy_encrypted_apkam_symmetric_key"'
           '}';
       HashMap<String, String?> enrollmentRequestVerbParams =
           getVerbParam(VerbSyntax.enroll, enrollmentRequest);
@@ -480,9 +479,9 @@ void main() {
       final valueJson = jsonDecode(notificationJson['value']);
       //TODO remove encryptedApkamSymmetricKey in the future
       expect(valueJson['encryptedApkamSymmetricKey'],
-          'dummy_encrypted_apkam_symm_key');
+          'dummy_encrypted_apkam_symmetric_key');
       expect(valueJson['encryptedAPKAMSymmetricKey'],
-          'dummy_encrypted_apkam_symm_key');
+          'dummy_encrypted_apkam_symmetric_key');
       expect(valueJson['appName'], 'mvt_app_2');
       expect(valueJson['deviceName'], 'mvt_dev_2');
       expect(valueJson['namespace'], equals({'app_2_namespace': 'rw'}));


### PR DESCRIPTION
**- What I did**
feat: allow a ttl to be set for a semi-permanent passcode (spp)

**- How I did it**
- feat: have AbstractVerbHandler.isOTPValid do an 'isActiveKey' check after fetching the SPP
- feat: in the OtpVerbHandler 'put' block, use the ttl from the verb parameters if supplied, otherwise use -1
- test: added unit tests covering the new behaviour

other changes
- refactor: add a `passcodeKey` function to remove some code duplication
- fix: change the UnauthenticatedException message in OtpVerbHandler from `otp:get [...]` to `otp: [...]` 
- refactor: change some variable names across 'put' and 'get' blocks in OtpVerbHandler for readability
- refactor: add `isSpp` parameter to `savePasscode` and use `savePasscode` in OtpVerbHandler's 'put' block
- refactor: rename `isOTPValid` to `isPasscodeValid`

**- How to verify it**
Tests pass
