### PR TITLE
fix: Update path to match sec_ops refactor

### DIFF
--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -496,7 +496,7 @@ jobs:
                 exit 1
               fi
             fi
-            sleep 20
+            sleep $((try * 20))
           done
   
       - name: Activating atsign    

--- a/.github/workflows/refreshcerts.yaml
+++ b/.github/workflows/refreshcerts.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Run ACME script
         run: |-
           chmod -R 777 secondaries-scripts
-          cd secondaries-scripts && ./create_cert_workflow.sh vip.ve.atsign.zone
+          cd secondaries-scripts/sec_ops && ./create_cert_workflow.sh vip.ve.atsign.zone
           cp cert.pem ../tools/build_virtual_environment/ve_base/contents/atsign/root/certs/cert.pem
           cp privkey.pem ../tools/build_virtual_environment/ve_base/contents/atsign/root/certs/privkey.pem
           cp fullchain.pem ../tools/build_virtual_environment/ve_base/contents/atsign/root/certs/fullchain.pem


### PR DESCRIPTION
@gkc noticed that the refreshcerts workflow has been failing (after some refactoring in the secondaries_scripts repo)

**- What I did**

* Altered path to match refactoring
* Added exponential backoff for atServer spinup in end2end_staging tests

**- How to verify it**

We'll need to run manually once merged

**- Description for the changelog**

fix: Update path to match sec_ops refactor