### PR TITLE
fix: Hash for deabian:stable-20240612-slim

### DIFF
--- a/tools/build_virtual_environment/ve_base/Dockerfile
+++ b/tools/build_virtual_environment/ve_base/Dockerfile
@@ -17,7 +17,7 @@ RUN \
   dart pub update ; \
   dart compile exe bin/install_PKAM_Keys.dart -o install_PKAM_Keys
 
-FROM debian:stable-20240612-slim@sha256:eb37f58646a901dc7727cf448cae36daaefaba79de33b5058dab79aa4c04aefb
+FROM debian:stable-20240612-slim@sha256:0200978f5b28cc795ec1699254fd789263193af9ab650bd2e4ef2bedf6cbd1c2
 # was debian:stable-20221114-slim
 USER root
 


### PR DESCRIPTION
#1986 introduced a hash for an image that seems to have been removed from Docker Hub

**- What I did**

Found the hash and added it

**- How I did it**

`docker buildx imagetools inspect debian:stable-20240612-slim --format "{{json .Manifest}}" | jq -r .digest`

**- How to verify it**

Manual run against this branch worked - https://github.com/atsign-foundation/at_server/actions/runs/9497828837/job/26175276385

**- Description for the changelog**

fix: Hash for deabian:stable-20240612-slim
