### PR TITLE
ci: Add SLSA provenance to releases

### DIFF
--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -728,7 +728,11 @@ jobs:
     needs: [ unit_tests, functional_tests, end2end_test_12, end2end_test_34, end2end_test_56 ]
     if: ${{ github.repository == 'atsign-foundation/at_server' && github.event_name == 'push' && contains(github.ref, 'refs/tags/c') }}
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      digest: ${{ steps.docker_build_secondary.outputs.digest }}
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
@@ -771,10 +775,30 @@ jobs:
             linux/arm64/v8
             linux/arm/v7
 
+  provenance_canary_secondary_image:
+    needs: [push_canary_secondary_image]
+    permissions:
+      actions: read # for detecting the Github Actions environment.
+      id-token: write # for creating OIDC tokens for signing.
+      packages: write # for uploading attestations.
+    if: startsWith(github.ref, 'refs/tags/')
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0
+    with:
+      image: "atsigncompany/secondary"
+      digest: ${{ needs.push_canary_secondary_image.outputs.digest }}
+    secrets:
+      registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
+      registry-password: ${{ secrets.DOCKERHUB_TOKEN }}
+
   push_canary_virtualenv_image:
     needs: [ unit_tests, functional_tests, end2end_test_12, end2end_test_34, end2end_test_56 ]
     if: ${{ github.repository == 'atsign-foundation/at_server' && github.event_name == 'push' && contains(github.ref, 'refs/tags/c') }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      digest: ${{ steps.docker_build.outputs.digest }}
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
@@ -817,6 +841,21 @@ jobs:
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
 
+  provenance_canary_virtualenv_image:
+    needs: [push_canary_virtualenv_image]
+    permissions:
+      actions: read # for detecting the Github Actions environment.
+      id-token: write # for creating OIDC tokens for signing.
+      packages: write # for uploading attestations.
+    if: startsWith(github.ref, 'refs/tags/')
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0
+    with:
+      image: "atsigncompany/virtualenv"
+      digest: ${{ needs.push_canary_virtualenv_image.outputs.digest }}
+    secrets:
+      registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
+      registry-password: ${{ secrets.DOCKERHUB_TOKEN }}
+
   # The below jobs run's on completion of 'run_end2end_tests' job.
   # This job run's on trigger event 'push' and when a release is tagged.
   # The job builds the production version of secondary server docker image and pushes to docker hub.
@@ -825,7 +864,11 @@ jobs:
     needs: [ unit_tests, functional_tests, end2end_test_12, end2end_test_34, end2end_test_56 ]
     if: ${{ github.repository == 'atsign-foundation/at_server' && github.event_name == 'push' && contains(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      digest: ${{ steps.docker_build_secondary.outputs.digest }}
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
@@ -863,10 +906,30 @@ jobs:
             linux/arm64/v8
             linux/arm/v7
 
+  provenance_prod_secondary_image:
+    needs: [push_prod_secondary_image]
+    permissions:
+      actions: read # for detecting the Github Actions environment.
+      id-token: write # for creating OIDC tokens for signing.
+      packages: write # for uploading attestations.
+    if: startsWith(github.ref, 'refs/tags/')
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0
+    with:
+      image: "atsigncompany/secondary"
+      digest: ${{ needs.push_prod_secondary_image.outputs.digest }}
+    secrets:
+      registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
+      registry-password: ${{ secrets.DOCKERHUB_TOKEN }}
+
   push_prod_virtualenv_image:
     needs: [ unit_tests, functional_tests, end2end_test_12, end2end_test_34, end2end_test_56 ]
     if: ${{ github.repository == 'atsign-foundation/at_server' && github.event_name == 'push' && contains(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      digest: ${{ steps.docker_build.outputs.digest }}
     steps:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
@@ -904,3 +967,18 @@ jobs:
           name: New Docker image for atsigncompany/virtualenv:vip
           url: ${{ secrets.GOOGLE_CHAT_WEBHOOK }}
           status: ${{ job.status }}
+
+  provenance_prod_virtualenv_image:
+    needs: [push_prod_virtualenv_image]
+    permissions:
+      actions: read # for detecting the Github Actions environment.
+      id-token: write # for creating OIDC tokens for signing.
+      packages: write # for uploading attestations.
+    if: startsWith(github.ref, 'refs/tags/')
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0
+    with:
+      image: "atsigncompany/virtualenv"
+      digest: ${{ needs.push_prod_virtualenv_image.outputs.digest }}
+    secrets:
+      registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
+      registry-password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/at_server_prod_deploy.yaml
+++ b/.github/workflows/at_server_prod_deploy.yaml
@@ -12,6 +12,11 @@ permissions:  # added using https://github.com/step-security/secure-workflows
 jobs:
   Docker_Build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      digest: ${{ steps.docker_build.outputs.digest }}
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -31,6 +36,7 @@ jobs:
 
       # Build the Docker image for Dev
       - name: Build and push
+        id: docker_build
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           file: packages/at_root_server/Dockerfile
@@ -40,6 +46,21 @@ jobs:
             atsigncompany/root:prod
             atsigncompany/root:prod-gha${{ github.run_number }}
             atsigncompany/root:prod-${{ env.BRANCH }}-gha${{ github.run_number }}
+
+  provenance:
+    needs: [Docker_Build]
+    permissions:
+      actions: read # for detecting the Github Actions environment.
+      id-token: write # for creating OIDC tokens for signing.
+      packages: write # for uploading attestations.
+    if: startsWith(github.ref, 'refs/tags/')
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0
+    with:
+      image: "atsigncompany/root"
+      digest: ${{ needs.Docker_Build.outputs.digest }}
+    secrets:
+      registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
+      registry-password: ${{ secrets.DOCKERHUB_TOKEN }}
 
   Deploy_On_Prod_K8:
     needs: Docker_Build

--- a/.github/workflows/promote_canary.yaml
+++ b/.github/workflows/promote_canary.yaml
@@ -13,7 +13,11 @@ jobs:
   # Add layer to canary secondary image with prod pubspec.yaml
   deploy_canary_secondary_to_prod_image:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      digest: ${{ steps.docker_build_canary_to_prod.outputs.digest }}
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
@@ -52,10 +56,29 @@ jobs:
             linux/arm64/v8
             linux/arm/v7
 
+  prod_secondary_provenance:
+    needs: [deploy_canary_secondary_to_prod_image]
+    permissions:
+      actions: read # for detecting the Github Actions environment.
+      id-token: write # for creating OIDC tokens for signing.
+      packages: write # for uploading attestations.
+    if: startsWith(github.ref, 'refs/tags/')
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0
+    with:
+      image: "atsigncompany/secondary"
+      digest: ${{ needs.deploy_canary_secondary_to_prod_image.outputs.digest }}
+    secrets:
+      registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
+      registry-password: ${{ secrets.DOCKERHUB_TOKEN }}
+
   # Add layer to canary virtualenv image with prod pubspec.yaml
   deploy_canary_virtualenv_to_prod_image:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      digest: ${{ steps.docker_build_canary_to_vip.outputs.digest }}
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
 
@@ -90,3 +113,18 @@ jobs:
           platforms: |
             linux/amd64
             linux/arm64/v8
+
+  prod_virtualenv_provenance:
+    needs: [deploy_canary_virtualenv_to_prod_image]
+    permissions:
+      actions: read # for detecting the Github Actions environment.
+      id-token: write # for creating OIDC tokens for signing.
+      packages: write # for uploading attestations.
+    if: startsWith(github.ref, 'refs/tags/')
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0
+    with:
+      image: "atsigncompany/virtualenv"
+      digest: ${{ needs.deploy_canary_virtualenv_to_prod_image.outputs.digest }}
+    secrets:
+      registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
+      registry-password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
Progresses https://github.com/atsign-foundation/operations/issues/133

**- What I did**

Added workflow jobs to create SLSA attestations for canary and prod images for secondary, virtualenv and root

**- How I did it**

First tested in https://github.com/cpswan/release_automation and transferred config fragments

**- How to verify it**

If (say) we do a c3.0.47b release, then using the [slsa-verifier](https://github.com/slsa-framework/slsa-verifier):

```
TAG="c3.0.47b"
IMAGE="atsigncompany/secondary"
SHA=$(docker buildx imagetools inspect ${IMAGE}:canary-${TAG} --format "{{json .Manifest}}" | jq -r .digest)
slsa-verifier verify-image ${IMAGE}@${SHA} --source-uri github.com/atsign-foundation/at_server --source-tag $
{TAG}
```

**- Description for the changelog**

ci: Add SLSA provenance to releases