### PR TITLE
build(deps): Bump certifi to 2024.7.4 and urllib3 to 2.2.2

### DIFF
--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,6 +1,6 @@
-certifi==2024.2.2 ; python_version >= "3.8" and python_version < "4.0" \
-    --hash=sha256:0569859f95fc761b18b45ef421b1290a0f65f147e92a1e5eb3e635f9a5e4e66f \
-    --hash=sha256:dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1
+certifi==2024.7.4 ; python_version >= "3.8" and python_version < "4.0" \
+    --hash=sha256:5a1e7645bc0ec61a09e26c36f6106dd4cf40c6db3a1fb6352b0244e7fb057c7b \
+    --hash=sha256:c198e21b1289c2ab85ee4e67bb4b4ef3ead0892059901a8d5b622f24a1101e90
 charset-normalizer==3.3.2 ; python_version >= "3.8" and python_version < "4.0" \
     --hash=sha256:06435b539f889b1f6f4ac1758871aae42dc3a8c0e24ac9e60c2384973ad73027 \
     --hash=sha256:06a81e93cd441c56a9b65d8e1d043daeb97a3d0856d177d5c90ba85acb3db087 \
@@ -101,6 +101,6 @@ idna==3.7 ; python_version >= "3.8" and python_version < "4.0" \
 requests==2.32.3 ; python_version >= "3.8" and python_version < "4.0" \
     --hash=sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760 \
     --hash=sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6
-urllib3==2.2.1 ; python_version >= "3.8" and python_version < "4.0" \
-    --hash=sha256:450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d \
-    --hash=sha256:d0570876c61ab9e520d776c38acbbb5b05a776d3f9ff98a5c8fd5162a444cf19
+urllib3==2.2.2 ; python_version >= "3.8" and python_version < "4.0" \
+    --hash=sha256:a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472 \
+    --hash=sha256:dd505485549a7a552833da5e6063639d0d177c04f23bc3864e41e5dc5f612168


### PR DESCRIPTION
Fixes https://github.com/atsign-foundation/at_server/security/dependabot/12 and https://github.com/atsign-foundation/at_server/security/dependabot/13

**- What I did**

Bumped certifi and urllib3

**- How I did it**

```
cd tools
./update_requirements.sh
```

**- How to verify it**

Dependabot alerts will clear when merged

**- Description for the changelog**

build(deps): Bump certifi to 2024.7.4 and urllib3 to 2.2.2
