### PR TITLE
feat: add enrollment details to public hidden key

### DIFF
--- a/packages/at_secondary_server/lib/src/constants/enroll_constants.dart
+++ b/packages/at_secondary_server/lib/src/constants/enroll_constants.dart
@@ -3,3 +3,4 @@ const String newEnrollmentKeyPattern = 'new.enrollments';
 const String pkamNamespace = '__pkams';
 const String globalNamespace = '__global';
 const String allNamespaces = '*';
+const String enrollmentPublicHiddenKey = '_enrollments';

--- a/packages/at_secondary_server/test/enroll_verb_test.dart
+++ b/packages/at_secondary_server/test/enroll_verb_test.dart
@@ -60,7 +60,7 @@ void main() {
     });
 
     test(
-        'A test to verify enrollment of CRAM auth connection have __manage and * namespaces added to enrollment value',
+        'A test to verify enrollment of CRAM auth connection have __manage and * namespaces added to enrollment value and enrollment info is added to public hidden key',
         () async {
       String enrollmentRequest =
           'enroll:request:{"appName":"wavi","deviceName":"mydevice","namespaces":{"wavi":"r"},"apkamPublicKey":"dummy_apkam_public_key"}';
@@ -81,6 +81,15 @@ void main() {
           await enrollVerbHandler.getEnrollDataStoreValue(enrollmentKey);
       expect(enrollmentValue.namespaces.containsKey('__manage'), true);
       expect(enrollmentValue.namespaces.containsKey('*'), true);
+      var enrollmentAtData = await secondaryKeyStore
+          .get('public:$enrollmentPublicHiddenKey$alice');
+      expect(enrollmentAtData, isNotNull);
+      var enrollmentInfoJson = jsonDecode(enrollmentAtData!.data!);
+      var firstEnrollmentInfo = jsonDecode(enrollmentInfoJson[0]);
+      expect(firstEnrollmentInfo['enrollmentId'], enrollmentId);
+      expect(firstEnrollmentInfo['appName'], "wavi");
+      expect(firstEnrollmentInfo['deviceName'], "mydevice");
+      expect(firstEnrollmentInfo['namespaces']['wavi'], "r");
     });
 
     test(
@@ -708,7 +717,9 @@ void main() {
       expect(response.errorCode, 'AT0028');
     });
 
-    test('A test to verify TTL on approved enrollment is reset', () async {
+    test(
+        'A test to verify TTL on approved enrollment is reset and enrollment info is added to public hidden key',
+        () async {
       Response response = Response();
       // Enroll a request on an unauthenticated connection which will expire in 1 minute
       EnrollVerbHandler enrollVerbHandler =
@@ -744,6 +755,15 @@ void main() {
       enrollmentData = await secondaryKeyStore.get(enrollmentKey);
       expect(enrollmentData!.metaData!.expiresAt, null);
       expect(enrollmentData.metaData!.ttl, 0);
+      var enrollmentAtData = await secondaryKeyStore
+          .get('public:$enrollmentPublicHiddenKey$alice');
+      expect(enrollmentAtData, isNotNull);
+      var enrollmentInfoJson = jsonDecode(enrollmentAtData!.data!);
+      var secondEnrollmentInfo = jsonDecode(enrollmentInfoJson[0]);
+      expect(secondEnrollmentInfo['enrollmentId'], enrollmentId);
+      expect(secondEnrollmentInfo['appName'], "wavi");
+      expect(secondEnrollmentInfo['deviceName'], "mydevice");
+      expect(secondEnrollmentInfo['namespaces']['wavi'], "r");
     });
 
     test(
@@ -847,6 +867,14 @@ void main() {
           response, approveEnrollVerbParams, inboundConnection);
       expect(jsonDecode(response.data!)['enrollmentId'], enrollmentId);
       expect(jsonDecode(response.data!)['status'], 'approved');
+      // verify enrollmentId is present in hidden public key before enroll:revoke
+      var enrollmentAtData = await secondaryKeyStore
+          .get('public:$enrollmentPublicHiddenKey$alice');
+      expect(enrollmentAtData, isNotNull);
+      var enrollmentInfoJson = jsonDecode(enrollmentAtData!.data!);
+      var enrollmentInfo = jsonDecode(enrollmentInfoJson[0]);
+      expect(enrollmentInfo['enrollmentId'], enrollmentId);
+
       //revoke enrollment
       String revokeEnrollmentCommand =
           'enroll:revoke:{"enrollmentId":"$enrollmentId"}';
@@ -856,6 +884,12 @@ void main() {
           response, enrollVerbParams, inboundConnection);
       expect(jsonDecode(response.data!)['enrollmentId'], enrollmentId);
       expect(jsonDecode(response.data!)['status'], 'revoked');
+      // verify enrollmentId is removed from hidden public key after enroll:revoke
+      enrollmentAtData = await secondaryKeyStore
+          .get('public:$enrollmentPublicHiddenKey$alice');
+      var enrollmentInfoJsonAfterRevoke =
+          jsonDecode(enrollmentAtData!.data!) as List;
+      expect(enrollmentInfoJsonAfterRevoke.length, 0);
     });
 
     test('A test to verify revoke enrollment with force flag', () async {


### PR DESCRIPTION
**- What I did**
- added enrollment details to public hidden key which can be used in enrollment widget to fetch list of apps that are eligible to approve enrollment request
**- How I did it**
- on enrollment approval,  add enrollment info (enrollmentid, app name,device name, namespaces) to a public key public:_enrollments<atsign>
- on enrollment revoke, remove the enrollment info from the public hidden key
**- How to verify it**
- added checks to existing unit tests
