### PR TITLE
build: canary release 3.0.49

### DIFF
--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.49
+- feat: Enforce superset access check for approving apps
+- fix: respect isEncrypted:false if supplied in the notify: command, and 
+  ensure that the correct value is always transmitted onwards
+
 ## 3.0.48
 - feat Add expiresAt and availableAt params to notify:list response
 

--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -2,6 +2,7 @@
 - feat: Enforce superset access check for approving apps
 - fix: respect isEncrypted:false if supplied in the notify: command, and 
   ensure that the correct value is always transmitted onwards
+- fix: info verb no longer lists "beta" features which are now live
 
 ## 3.0.48
 - feat Add expiresAt and availableAt params to notify:list response

--- a/packages/at_secondary_server/lib/src/verb/handler/info_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/info_verb_handler.dart
@@ -55,25 +55,6 @@ class InfoVerbHandler extends AbstractVerbHandler {
           infoMap['apkam_metadata'] = result;
         }
       }
-      infoMap['features'] = [
-        {
-          "name": "noop:",
-          "status": "Beta",
-          "description":
-              "The No-Op verb simply does nothing for the requested number of milliseconds. "
-                  "The requested number of milliseconds may not be greater than 5000. "
-                  "Upon completion, the noop verb sends 'ok' as a response to the client.",
-          "syntax": VerbSyntax.noOp
-        },
-        {
-          "name": "info:",
-          "status": "Beta",
-          "description":
-              "The Info verb returns some information about the server "
-                  "including uptime and some info about available features. ",
-          "syntax": VerbSyntax.info
-        },
-      ];
     } else {
       infoMap['uptimeAsMillis'] = uptime.inMilliseconds;
     }

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_secondary
 description: Implementation of secondary server.
-version: 3.0.48
+version: 3.0.49
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://www.example.com
 publish_to: none


### PR DESCRIPTION
**- What I did**
- Updates for canary 3.0.49

**- How I did it**
- docs: remove the features entry from the info verb response
- docs: add 3.0.49 to changelog
- build: update at_secondary_server version to 3.0.49

**- How to verify it**
Tests pass
