### PR TITLE
fix: Add "sharedKeyEnc" to the metadata to propagate from server to client on receiving end

### DIFF
--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -3,7 +3,8 @@
 - fix: respect isEncrypted:false if supplied in the notify: command, and 
   ensure that the correct value is always transmitted onwards
 - fix: info verb no longer lists "beta" features which are now live
-
+- fix: in MonitorVerbHandler, add "sharedKeyEnc" to the metadata to propagate the sharedEncryptedKey in
+  notifications from the server to the client.
 ## 3.0.48
 - feat Add expiresAt and availableAt params to notify:list response
 

--- a/packages/at_secondary_server/lib/src/verb/handler/monitor_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/monitor_verb_handler.dart
@@ -137,6 +137,7 @@ class MonitorVerbHandler extends AbstractVerbHandler {
           "ivNonce": atNotification.atMetadata?.ivNonce,
           "skeEncKeyName": atNotification.atMetadata?.skeEncKeyName,
           "skeEncAlgo": atNotification.atMetadata?.skeEncAlgo,
+          "sharedKeyEnc": atNotification.atMetadata?.sharedKeyEnc,
         };
 
       await _checkAndSend(notification);


### PR DESCRIPTION
Resolves #1364

**- What I did**
- When running no-ports locally, an issue appear where the client waits for the `srvd` response and eventually times out. This occurs because the client receives the notification sent by `srvd` but fails to decrypt the message. The decryption fails because the "sharedEncryptedKey" received from the sender to the receiver is not being propagated from the receiver's server to the receiver's client via the notification.

Adding the log snippet:
```
SEVERE|2024-07-29 11:34:42.853820|NotificationServiceImpl (@alice🛠)|Failed to fetchData caused by
key not found : Exception: @alice🛠:shared_key@sitaram🛠 does not exist in keystore 

INFO|2024-07-29 11:34:44.149909| SrvdChannel |Still waiting for srvd response 
INFO|2024-07-29 11:49:03.865867| SrvdChannel |Still waiting for srvd response 
WARNING|2024-07-29 11:49:04.976872| SrvdChannel |Timed out waiting for srvd response 

Error : TimeoutException: Connection timeout to srvd @sitaram🛠 service

```
**- How I did it**
- Add "sharedEncKey" to the metadata in MonitorVerbHandler.dart

**- How to verify it**
- After the changes, tested no-ports manually and able to run successfully. Adding the log file.
[client-no-ports.log](https://github.com/user-attachments/files/16408450/client-no-ports.log)

**- Description for the changelog**
- In MonitorVerbHandler, add "sharedKeyEnc" to the metadata to propagate the sharedEncryptedKey in
  notifications from the server to the client.

There is a follow-up PR in at_client.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
