### PR TITLE
build(deps): Fix location of refactored at_demo_data

### DIFF
--- a/tests/at_end2end_test/pubspec.yaml
+++ b/tests/at_end2end_test/pubspec.yaml
@@ -8,11 +8,7 @@ environment:
 
 dependencies:
   encrypt: 5.0.3
-  at_demo_data:
-    git:
-      url: https://github.com/atsign-foundation/at_demos.git
-      path: packages/at_demo_data
-      ref: trunk
+  at_demo_data: ^1.0.3
   at_lookup: ^3.0.45
 
 dev_dependencies:

--- a/tests/at_end2end_test/pubspec.yaml
+++ b/tests/at_end2end_test/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   at_demo_data:
     git:
       url: https://github.com/atsign-foundation/at_demos.git
-      path: at_demo_data
+      path: packages/at_demo_data
       ref: trunk
   at_lookup: ^3.0.45
 

--- a/tests/at_functional_test/pubspec.yaml
+++ b/tests/at_functional_test/pubspec.yaml
@@ -8,11 +8,7 @@ environment:
 
 dependencies:
   hex: ^0.2.0
-  at_demo_data:
-    git:
-      url: https://github.com/atsign-foundation/at_demos.git
-      path: packages/at_demo_data
-      ref: trunk
+  at_demo_data: ^1.0.3
   at_chops: ^2.0.0
   at_lookup: ^3.0.45
   at_commons: ^4.0.9

--- a/tests/at_functional_test/pubspec.yaml
+++ b/tests/at_functional_test/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   at_demo_data:
     git:
       url: https://github.com/atsign-foundation/at_demos.git
-      path: at_demo_data
+      path: packages/at_demo_data
       ref: trunk
   at_chops: ^2.0.0
   at_lookup: ^3.0.45

--- a/tests/at_functional_test/pubspec.yaml
+++ b/tests/at_functional_test/pubspec.yaml
@@ -15,6 +15,14 @@ dependencies:
   uuid: ^3.0.7
   elliptic: ^0.3.8
 
+dependency_overrides:
+  # 20240812 apkam changes to at_demo_data haven't been published yet
+  at_demo_data:
+      git:
+        url: https://github.com/atsign-foundation/at_demos.git
+        path: packages/at_demo_data
+        ref: trunk
+
 dev_dependencies:
   lints: ^1.0.1
   test: ^1.24.3


### PR DESCRIPTION
@XavierChanth recently refactored the at_demos repo, which involved moving the at_demo_data package into the packages directory with https://github.com/atsign-foundation/at_demos/pull/216

**- What I did**

Updated reference in pubspec.yaml

**- How to verify it**

CI for this PR should correctly run functional tests and Melos bootstrap

**- Description for the changelog**

build(deps): Fix location of refactored at_demo_data
