### PR TITLE
fix: Enhance namespace authorisation check to verify when namespace has a period in it

### DIFF
--- a/packages/at_secondary_server/test/local_lookup_verb_test.dart
+++ b/packages/at_secondary_server/test/local_lookup_verb_test.dart
@@ -351,6 +351,43 @@ void main() {
     });
 
     test(
+        'A test to verify llookup verb of a at_contact.buzz namespace is allowed when namespace is at_contact.buzz ',
+        () async {
+      final enrollJson = {
+        'sessionId': '123',
+        'appName': 'buzz',
+        'deviceName': 'pixel',
+        'namespaces': {'at_contact.buzz': 'rw'},
+        'apkamPublicKey': 'testPublicKeyValue',
+        'requestType': 'newEnrollment',
+        'approval': {'state': 'approved'}
+      };
+      var keyName = '$enrollmentId.new.enrollments.__manage@alice';
+      await secondaryKeyStore.put(
+          keyName, AtData()..data = jsonEncode(enrollJson));
+      // Update a key with at_contact.buzz namespace
+      String updateCommand =
+          'update:atconnections.bob.alice.at_contact.buzz$alice bob';
+      HashMap<String, String?> updateVerbParams =
+          getVerbParam(VerbSyntax.update, updateCommand);
+      UpdateVerbHandler updateVerbHandler = UpdateVerbHandler(
+          secondaryKeyStore, statsNotificationService, notificationManager);
+      await updateVerbHandler.processVerb(
+          response, updateVerbParams, inboundConnection);
+      expect(response.data, isNotNull);
+      // Local Lookup a key with at_contact.buzz namespace
+      String llookupCommand =
+          'llookup:atconnections.bob.alice.at_contact.buzz$alice';
+      HashMap<String, String?> llookupVerbParams =
+          getVerbParam(VerbSyntax.llookup, llookupCommand);
+      LocalLookupVerbHandler localLookupVerbHandler =
+          LocalLookupVerbHandler(secondaryKeyStore);
+      await localLookupVerbHandler.processVerb(
+          response, llookupVerbParams, inboundConnection);
+      expect(response.data, 'bob');
+    });
+
+    test(
         'A test to verify llookup verb throws exception when namespace is not authorized',
         () async {
       final enrollJson = {

--- a/packages/at_secondary_server/test/update_verb_test.dart
+++ b/packages/at_secondary_server/test/update_verb_test.dart
@@ -1338,6 +1338,71 @@ void main() {
       expect(response.data, isNotNull);
       expect(response.isError, false);
     });
+
+     test(
+        'A test to verify write access is allowed to a key with a at_contact.buzz namespace for an enrollment with at_contact.buzz namespace access',
+        () async {
+      inboundConnection.metadata.isAuthenticated =
+          true; // owner connection, authenticated
+      enrollmentId = Uuid().v4();
+      inboundConnection.metadata.enrollmentId = enrollmentId;
+      final enrollJson = {
+        'sessionId': '123',
+        'appName': 'buzz',
+        'deviceName': 'pixel',
+        'namespaces': {'at_contact.buzz': 'rw'},
+        'apkamPublicKey': 'testPublicKeyValue',
+        'requestType': 'newEnrollment',
+        'approval': {'state': 'approved'}
+      };
+      var keyName = '$enrollmentId.new.enrollments.__manage@alice';
+      await secondaryKeyStore.put(
+          keyName, AtData()..data = jsonEncode(enrollJson));
+      String updateCommand =
+          'update:atconnections.bob.alice.at_contact.buzz$alice bob';
+      HashMap<String, String?> updateVerbParams =
+          getVerbParam(VerbSyntax.update, updateCommand);
+      UpdateVerbHandler updateVerbHandler = UpdateVerbHandler(
+          secondaryKeyStore, statsNotificationService, notificationManager);
+      await updateVerbHandler.processVerb(
+          response, updateVerbParams, inboundConnection);
+      expect(response.data, isNotNull);
+      expect(response.isError, false);
+    });
+
+    test(
+        'A test to verify write access is not allowed to a key with only buzz namespace for an enrollment with at_contact.buzz namespace access',
+        () async {
+      inboundConnection.metadata.isAuthenticated =
+          true; // owner connection, authenticated
+      enrollmentId = Uuid().v4();
+      inboundConnection.metadata.enrollmentId = enrollmentId;
+      final enrollJson = {
+        'sessionId': '123',
+        'appName': 'buzz',
+        'deviceName': 'pixel',
+        'namespaces': {'at_contact.buzz': 'rw'},
+        'apkamPublicKey': 'testPublicKeyValue',
+        'requestType': 'newEnrollment',
+        'approval': {'state': 'approved'}
+      };
+      var keyName = '$enrollmentId.new.enrollments.__manage@alice';
+      await secondaryKeyStore.put(
+          keyName, AtData()..data = jsonEncode(enrollJson));
+      String updateCommand =
+          'update:atconnections.bob.alice.buzz$alice bob';
+      HashMap<String, String?> updateVerbParams =
+          getVerbParam(VerbSyntax.update, updateCommand);
+      UpdateVerbHandler updateVerbHandler = UpdateVerbHandler(
+          secondaryKeyStore, statsNotificationService, notificationManager);
+      expect(
+          () async => await updateVerbHandler.processVerb(
+              response, updateVerbParams, inboundConnection),
+          throwsA(predicate((dynamic e) =>
+              e is UnAuthorizedException &&
+              e.message ==
+                  'Connection with enrollment ID $enrollmentId is not authorized to update key: atconnections.bob.alice.buzz$alice')));
+    });
     tearDown(() async => await verbTestsTearDown());
   });
 }

--- a/tests/at_functional_test/test/enroll_namespace_access_test.dart
+++ b/tests/at_functional_test/test/enroll_namespace_access_test.dart
@@ -143,6 +143,44 @@ void main() {
       expect(llookupResponse, 'data:bob');
     });
 
+    //  1. Cram authenticate and send the enroll request for at_contact.buzz namespace with read and write access
+    //  2. pkam using the enroll id
+    //  3. Create a key with at_contact.buzz
+    //  4. Assert that buzz key is created without an exception
+    //  5. Do a llookup of the key and assert that value is returned
+    test(
+        'enroll request on authenticated connection for at_contact.buzz namespace and creating a at_contact.buzz key',
+        () async {
+      await firstAtSignConnection.authenticateConnection(
+          authType: AuthType.cram);
+      var enrollRequest =
+          'enroll:request:{"appName":"buzz-${Uuid().v4().hashCode}","deviceName":"pixel","namespaces":{"at_contact.buzz":"rw"},"apkamPublicKey":"${pkamPublicKeyMap[firstAtSign]!}"}\n';
+      String enrollResponse =
+          await firstAtSignConnection.sendRequestToServer(enrollRequest);
+      enrollResponse = enrollResponse.replaceFirst('data:', '');
+      var enrollJsonMap = jsonDecode(enrollResponse);
+      expect(enrollJsonMap['enrollmentId'], isNotEmpty);
+      expect(enrollJsonMap['status'], 'approved');
+      String enrollmentId = enrollJsonMap['enrollmentId'];
+      // Close the connection and create a new connection and authenticate with APKAM
+      await firstAtSignConnection.close();
+      await firstAtSignConnection.initiateConnectionWithListener(
+          firstAtSign, firstAtSignHost, firstAtSignPort);
+      // now do the apkam using the enrollment id
+      await firstAtSignConnection.authenticateConnection(
+          authType: AuthType.pkam, enrollmentId: enrollmentId);
+      // key with at_contact.buzz namespace
+      String atContactBuzzKey =
+          'atconnections.bob.alice.at_contact.buzz$firstAtSign';
+      String updateResponse = await firstAtSignConnection
+          .sendRequestToServer('update:$atContactBuzzKey bob');
+      assert((!updateResponse.contains('Invalid syntax')) &&
+          (!updateResponse.contains('null')));
+      String llookupResponse = await firstAtSignConnection
+          .sendRequestToServer('llookup:$atContactBuzzKey');
+      expect(llookupResponse, 'data:bob');
+    });
+
     //  1. Cram authenticate and send the enroll request for buzz namespace with read and write access
     //  2. pkam using the enroll id
     //  3. Create a key with at_contact.buzz


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Fixes https://github.com/atsign-foundation/at_libraries/issues/636

**- How I did it**
- The root cause of the issue is `Atkey.fromString(key).namespace` returns only the last segment of the namespace. For example, if namespace is "foo.bar", then only "bar" is returned. Therefore, no matching authorized namespace is found and an unauthorized exception is raised.
- To fix the issue, add an additional logic which will use the entire key along with namespace to verify if the namespace is authorized.

**- How to verify it**
- Tested manually by running an update verb with key whose namespace is "orac.sshnp"
```
1. Generated APKAM keys with namespace - "orac.sshnp"

sitaram@sitaram-ThinkPad-E14:~/IdeaProjects/atsign/core/at_libraries/packages/at_onboarding_cli$ dart bin/activate_cli.dart enroll -s ABC123  -p sshnp   -d orac_subkey2  -n "orac.sshnp:rw,orac.sshrvd:rw" -a @sitaram --keys ~/.atsign/keys/oracsub2 -r vip.ve.atsign.zone
Submitting enrollment request
Enrollment ID: ef7542cb-8eeb-4b11-8078-db930c9f62f5
Waiting for approval; will check every 10 seconds
Checking ...  not approved. Will retry in 10 seconds
Checking ...  approved.
Creating atKeys file
[Success] Your .atKeys file saved at /home/sitaram/.atsign/keys/oracsub2.atKeys

2. Authenticate with apkam keys and run update verb with namespace "orac.sshnp"
@from:@sitaram
data:_67aab01b-d067-4115-a9f2-90ac325506b2@sitaram:eef776ca-e262-457a-9cb9-379b968a1087
@pkam:enrollmentid:ef7542cb-8eeb-4b11-8078-db930c9f62f5:dqiwnf/YaPXbBRXGcjeVxxRHlHrEWWdqUE6PiyeShPgVBQmSVwwgSYXUO1iYEyODWe7d+sMOcgT6qXE2v5AJygbjqrOGKc4UfZML4z8GR1r8hKGHrh42c9WhFvFeIIIYA/sbKXnQQlIK7f5ItjM2OeC7gNguHxbG7v6b1tmsEMMMx81622MB97WoeE5HFvjQH61Gm+OSESWrrBDbjM4ziUkJVU6gKXJ6YfB4FPVUIQQbOpBkjUyOIWwcz/XiK9Wp575H/0akZ7DmYGIFCRWz8qeo6TM+Jm07oW1ye0oGqR+CWjioVqBV8inzqn+eF/1fzFIlNLMqesaPY4524eeT7w==
data:success
@sitaram@update:@sitaram:phone.orac.sshnp@sitaram 1234
data:17
@sitaram@
```
- @purnimavenkatasubbu added unit and functional tests to assert the changes.

**- Description for the changelog**
- Enhance namespace authorisation check to verify when namespace has a period in it
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
