### PR TITLE
ci: Update root.atsign.wtf to use deployment

### DIFF
--- a/.github/workflows/at_server_dev_deploy.yaml
+++ b/.github/workflows/at_server_dev_deploy.yaml
@@ -69,4 +69,5 @@ jobs:
         # Deploy the Docker image to the GKE cluster
         - name: Deploy
           run: |-
-            kubectl -n root set image statefulset root root=atsigncompany/root:dev_env-gha${{ github.run_number }}
+            kubectl -n root set image set image deployment/root root=atsigncompany/root:dev_env-gha${{ github.run_number }}
+            kubectl rollout restart deployment root -n root

--- a/.github/workflows/at_server_dev_deploy.yaml
+++ b/.github/workflows/at_server_dev_deploy.yaml
@@ -69,5 +69,5 @@ jobs:
         # Deploy the Docker image to the GKE cluster
         - name: Deploy
           run: |-
-            kubectl -n root set image set image deployment/root root=atsigncompany/root:dev_env-gha${{ github.run_number }}
+            kubectl -n root set image deployment/root root=atsigncompany/root:dev_env-gha${{ github.run_number }}
             kubectl rollout restart deployment root -n root


### PR DESCRIPTION
Work on https://github.com/atsign-foundation/operations/issues/177 has caused the at_root_deploy_dev workflow to fail - https://github.com/atsign-foundation/at_server/actions/runs/10714651636

```log
Error from server (NotFound): statefulsets.apps "root" not found
```

**- What I did**

Updated workflow to use a deployment

**- How I did it**

Copied from production workflow

**- How to verify it**

Should succeed once this is merged

**- Description for the changelog**

ci: Update root.atsign.wtf to use deployment
