### PR TITLE
fix: Add unrevoke operation to enroll verb

### DIFF
--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -19,10 +19,10 @@ dependencies:
   basic_utils: 5.7.0
   ecdsa: 0.1.0
   encrypt: 5.0.3
-  at_commons: 4.0.11
-  at_utils: 3.0.16
+  at_commons: 4.1.2
+  at_utils: 3.0.18
   at_chops: 2.0.0
-  at_lookup: 3.0.47
+  at_lookup: 3.0.48
   at_server_spec: 5.0.1
   at_persistence_spec: 2.0.14
   at_persistence_secondary_server: 3.0.63

--- a/packages/at_secondary_server/test/enroll_verb_test.dart
+++ b/packages/at_secondary_server/test/enroll_verb_test.dart
@@ -1116,8 +1116,9 @@ void main() {
           'enroll:unrevoke:{"enrollmentId":"$enrollmentId"}';
       enrollVerbParams =
           getVerbParam(VerbSyntax.enroll, unrevokeEnrollmentCommand);
-      expect(
-          () async => await enrollVerbHandler.processVerb(
+
+      await expectLater(
+          () => enrollVerbHandler.processVerb(
               response, enrollVerbParams, inboundConnection),
           throwsA(predicate((dynamic e) =>
               e is AtEnrollmentException &&
@@ -1153,8 +1154,8 @@ void main() {
       String unrevokeEnrollmentCommand = 'enroll:unrevoke:{"enrollmentId":""}';
       enrollVerbParams =
           getVerbParam(VerbSyntax.enroll, unrevokeEnrollmentCommand);
-      expect(
-          () async => await enrollVerbHandler.processVerb(
+      await expectLater(
+          () => enrollVerbHandler.processVerb(
               response, enrollVerbParams, inboundConnection),
           throwsA(predicate((dynamic e) =>
               e is AtEnrollmentException &&

--- a/packages/at_secondary_server/test/enroll_verb_test.dart
+++ b/packages/at_secondary_server/test/enroll_verb_test.dart
@@ -1014,6 +1014,153 @@ void main() {
               e.message ==
                   'Failed to revoke enrollment id: $enrollmentId. Cannot revoke a pending enrollment. Only approved enrollments can be revoked')));
     });
+  });
+
+  group('A group of tests related enrollment unrevoke operation', () {
+    String enrollmentIdWithManageNamespace = Uuid().v4();
+    String? otp;
+    late String enrollmentId;
+    late EnrollVerbHandler enrollVerbHandler;
+    HashMap<String, String?> enrollVerbParams;
+    Response defaultResponse = Response();
+    setUp(() async {
+      await verbTestsSetUp();
+      // Store an enrollment request which has access to "__manage" namespace to approve enrollment requests.
+      EnrollDataStoreValue enrollDataStoreValue = EnrollDataStoreValue(
+          'manage-session-id',
+          'buzz',
+          'my-phone',
+          'manage-enrollment-public-key')
+        ..namespaces = {'__manage': 'rw', 'wavi': 'rw'}
+        ..approval = EnrollApproval(EnrollmentStatus.approved.name);
+      await secondaryKeyStore.put(
+          '$enrollmentIdWithManageNamespace.$newEnrollmentKeyPattern.$enrollManageNamespace$alice',
+          AtData()..data = jsonEncode(enrollDataStoreValue.toJson()));
+      // Fetch OTP
+      String totpCommand = 'otp:get';
+      HashMap<String, String?> totpVerbParams =
+          getVerbParam(VerbSyntax.otp, totpCommand);
+      OtpVerbHandler otpVerbHandler = OtpVerbHandler(secondaryKeyStore);
+      inboundConnection.metaData.isAuthenticated = true;
+      await otpVerbHandler.processVerb(
+          defaultResponse, totpVerbParams, inboundConnection);
+      otp = defaultResponse.data;
+      // Enroll a request on an unauthenticated connection which will expire in 1 minute
+      enrollVerbHandler = EnrollVerbHandler(secondaryKeyStore);
+      enrollVerbHandler.enrollmentExpiryInMills = 60000;
+      String enrollmentRequest =
+          'enroll:request:{"appName":"wavi-${Uuid().v4().hashCode}","deviceName":"mydevice","namespaces":{"wavi":"r"},"otp":"$otp","apkamPublicKey":"dummy_apkam_public_key","encryptedAPKAMSymmetricKey": "dummy_encrypted_symm_key"}';
+      HashMap<String, String?> enrollVerbParams =
+          getVerbParam(VerbSyntax.enroll, enrollmentRequest);
+      inboundConnection.metaData.isAuthenticated = false;
+      inboundConnection.metaData.sessionID = 'dummy_session_id';
+      await enrollVerbHandler.processVerb(
+          defaultResponse, enrollVerbParams, inboundConnection);
+      enrollmentId = jsonDecode(defaultResponse.data!)['enrollmentId'];
+      String status = jsonDecode(defaultResponse.data!)['status'];
+      expect(status, 'pending');
+    });
+
+    test(
+        'A test to verify unrevoke enrollment sets the enrollment state to approved',
+        () async {
+      Response response = Response();
+      //approve enrollment
+      String approveEnrollmentCommand =
+          'enroll:approve:{"enrollmentId":"$enrollmentId","encryptedDefaultEncryptionPrivateKey":"dummy_encrypted_private_key","encryptedDefaultSelfEncryptionKey":"dummy_self_encrypted_key"}';
+      HashMap<String, String?> approveEnrollVerbParams =
+          getVerbParam(VerbSyntax.enroll, approveEnrollmentCommand);
+      inboundConnection.metaData.isAuthenticated = true;
+      inboundConnection.metaData.sessionID = 'dummy_session_id';
+      await enrollVerbHandler.processVerb(
+          response, approveEnrollVerbParams, inboundConnection);
+      expect(jsonDecode(response.data!)['enrollmentId'], enrollmentId);
+      expect(jsonDecode(response.data!)['status'], 'approved');
+      //revoke enrollment
+      String revokeEnrollmentCommand =
+          'enroll:revoke:{"enrollmentId":"$enrollmentId"}';
+      enrollVerbParams =
+          getVerbParam(VerbSyntax.enroll, revokeEnrollmentCommand);
+      await enrollVerbHandler.processVerb(
+          response, enrollVerbParams, inboundConnection);
+      expect(jsonDecode(response.data!)['enrollmentId'], enrollmentId);
+      expect(jsonDecode(response.data!)['status'], 'revoked');
+      // un- revoke enrollment
+      String unrevokeEnrollmentCommand =
+          'enroll:unrevoke:{"enrollmentId":"$enrollmentId"}';
+      enrollVerbParams =
+          getVerbParam(VerbSyntax.enroll, unrevokeEnrollmentCommand);
+      await enrollVerbHandler.processVerb(
+          response, enrollVerbParams, inboundConnection);
+      expect(jsonDecode(response.data!)['enrollmentId'], enrollmentId);
+      expect(jsonDecode(response.data!)['status'], 'approved');
+    });
+
+    test(
+        'A test to verify unrevoke enrollment throws exception when enrollment state is not revoked',
+        () async {
+      Response response = Response();
+      //approve enrollment
+      String approveEnrollmentCommand =
+          'enroll:approve:{"enrollmentId":"$enrollmentId","encryptedDefaultEncryptionPrivateKey":"dummy_encrypted_private_key","encryptedDefaultSelfEncryptionKey":"dummy_self_encrypted_key"}';
+      HashMap<String, String?> approveEnrollVerbParams =
+          getVerbParam(VerbSyntax.enroll, approveEnrollmentCommand);
+      inboundConnection.metaData.isAuthenticated = true;
+      inboundConnection.metaData.sessionID = 'dummy_session_id';
+      await enrollVerbHandler.processVerb(
+          response, approveEnrollVerbParams, inboundConnection);
+      expect(jsonDecode(response.data!)['enrollmentId'], enrollmentId);
+      expect(jsonDecode(response.data!)['status'], 'approved');
+      // un- revoke enrollment
+      String unrevokeEnrollmentCommand =
+          'enroll:unrevoke:{"enrollmentId":"$enrollmentId"}';
+      enrollVerbParams =
+          getVerbParam(VerbSyntax.enroll, unrevokeEnrollmentCommand);
+      expect(
+          () async => await enrollVerbHandler.processVerb(
+              response, enrollVerbParams, inboundConnection),
+          throwsA(predicate((dynamic e) =>
+              e is AtEnrollmentException &&
+              e.message ==
+                  'Failed to unrevoke enrollment id: $enrollmentId. Cannot un-revoke a approved enrollment. Only revoked enrollments can be un-revoked')));
+    });
+
+    test(
+        'A test to verify unrevoke enrollment throws exception when enrollmentId is not supplied',
+        () async {
+      Response response = Response();
+      //approve enrollment
+      String approveEnrollmentCommand =
+          'enroll:approve:{"enrollmentId":"$enrollmentId","encryptedDefaultEncryptionPrivateKey":"dummy_encrypted_private_key","encryptedDefaultSelfEncryptionKey":"dummy_self_encrypted_key"}';
+      HashMap<String, String?> approveEnrollVerbParams =
+          getVerbParam(VerbSyntax.enroll, approveEnrollmentCommand);
+      inboundConnection.metaData.isAuthenticated = true;
+      inboundConnection.metaData.sessionID = 'dummy_session_id';
+      await enrollVerbHandler.processVerb(
+          response, approveEnrollVerbParams, inboundConnection);
+      expect(jsonDecode(response.data!)['enrollmentId'], enrollmentId);
+      expect(jsonDecode(response.data!)['status'], 'approved');
+      //revoke enrollment
+      String revokeEnrollmentCommand =
+          'enroll:revoke:{"enrollmentId":"$enrollmentId"}';
+      enrollVerbParams =
+          getVerbParam(VerbSyntax.enroll, revokeEnrollmentCommand);
+      await enrollVerbHandler.processVerb(
+          response, enrollVerbParams, inboundConnection);
+      expect(jsonDecode(response.data!)['enrollmentId'], enrollmentId);
+      expect(jsonDecode(response.data!)['status'], 'revoked');
+      // un- revoke enrollment
+      String unrevokeEnrollmentCommand = 'enroll:unrevoke:{"enrollmentId":""}';
+      enrollVerbParams =
+          getVerbParam(VerbSyntax.enroll, unrevokeEnrollmentCommand);
+      expect(
+          () async => await enrollVerbHandler.processVerb(
+              response, enrollVerbParams, inboundConnection),
+          throwsA(predicate((dynamic e) =>
+              e is AtEnrollmentException &&
+              e.message ==
+                  'enrollmentId is mandatory for enroll:revoke/enroll:deny')));
+    });
     tearDown(() async => await verbTestsTearDown());
   });
 

--- a/tests/at_end2end_test/pubspec.yaml
+++ b/tests/at_end2end_test/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   encrypt: 5.0.3
   at_demo_data: ^1.0.3
-  at_lookup: ^3.0.45
+  at_lookup: ^3.0.48
 
 dev_dependencies:
   lints: ^1.0.1

--- a/tests/at_functional_test/pubspec.yaml
+++ b/tests/at_functional_test/pubspec.yaml
@@ -10,8 +10,8 @@ dependencies:
   hex: ^0.2.0
   at_demo_data: ^1.1.0
   at_chops: ^2.0.0
-  at_lookup: ^3.0.45
-  at_commons: ^4.0.9
+  at_lookup: ^3.0.48
+  at_commons: ^4.1.2
   uuid: ^3.0.7
   elliptic: ^0.3.8
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Enhance the enroll verb to un-revoke the revoked enrollments.

**- How I did it**
- Updated the  at_commons version to v4.1.2 to consume the updated syntax of enroll verb.
- When the operation for the enroll verb is "un-revoke," set the enrollment status to "approved" to resume authentication and authorization checks using the enrollmentId.
- Unrevoke can only be executed on revoked enrollments. If executed on enrollments with different state, an exception will be thrown.

**- How to verify it**
- Added unit tests:
   - A test to verify unrevoke enrollment sets the enrollment state to approved.
   - A test to verify unrevoke enrollment throws exception when enrollment state is not revoked
   - A test to verify unrevoke enrollment throws exception when enrollmentId is not supplied

- Added functional tests
  - A test to verify unrevoke enrollment operation
  - A test to verify unrevoke operation cannot be performed without revoke enrollment first

**- Description for the changelog**
- fix: Add unrevoke operation to enroll verb
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
