### PR TITLE
fix: LatestCommitEntryOfEachKey bug due to commit log getEntries default limit 25

### DIFF
--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -2,6 +2,7 @@
 - feat: Introduce option to unrevoke revoked enrollments
 - feat: Introduce option to delete enrollments that are denied/revoked
 - build[deps]: update dependency versions of at_commons -> 4.1.2, at_utils -> 3.0.18, at_lookup -> 3.0.48
+- fix: LatestCommitEntryOfEachKey metric fixed to return commit log entries till last commitID instead of default limit 25.
 ## 3.0.50
 - fix: Enhance namespace authorisation check to verify when namespace has a period in it
 ## 3.0.49

--- a/packages/at_secondary_server/lib/src/verb/metrics/metrics_impl.dart
+++ b/packages/at_secondary_server/lib/src/verb/metrics/metrics_impl.dart
@@ -493,14 +493,19 @@ class LatestCommitEntryOfEachKey implements MetricProvider {
     var atCommitLog = await (AtCommitLogManagerImpl.getInstance()
         .getCommitLog(AtSecondaryServerImpl.getInstance().currentAtSign));
 
-    Iterator commitEntryIterator = atCommitLog!.getEntries(-1, regex: regex);
-
-    while (commitEntryIterator.moveNext()) {
-      CommitEntry commitEntry = commitEntryIterator.current.value;
-      responseMap[commitEntry.atKey!] = [
-        commitEntry.commitId,
-        commitEntry.operation.name
-      ];
+    int? lastCommitId = atCommitLog?.lastCommittedSequenceNumber();
+    int lastCommitIdReceived = -1;
+    while (lastCommitId != null && lastCommitIdReceived != lastCommitId) {
+      Iterator commitEntryIterator =
+          atCommitLog!.getEntries(lastCommitIdReceived, regex: regex);
+      while (commitEntryIterator.moveNext()) {
+        CommitEntry commitEntry = commitEntryIterator.current.value;
+        responseMap[commitEntry.atKey!] = [
+          commitEntry.commitId,
+          commitEntry.operation.name
+        ];
+        lastCommitIdReceived = commitEntry.commitId!;
+      }
     }
     return jsonEncode(responseMap);
   }

--- a/packages/at_secondary_server/test/stats_verb_test.dart
+++ b/packages/at_secondary_server/test/stats_verb_test.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
+import 'dart:math';
 
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:at_secondary/src/caching/cache_manager.dart';
@@ -469,6 +470,41 @@ void main() {
       expect(latestCommitIdMap['@alice:deletekey-$randomString@alice'][0],
           (int.parse(lastCommitId) + 5));
       expect(latestCommitIdMap['@alice:deletekey-$randomString@alice'][1], '-');
+    });
+
+    test(
+        'A test to validate when entry count is greater than default sync buffer zie',
+        () async {
+      secondaryPersistenceStore = SecondaryPersistenceStoreFactory.getInstance()
+          .getSecondaryPersistenceStore(alice);
+      LastCommitIDMetricImpl.getInstance().atCommitLog =
+          secondaryPersistenceStore!.getSecondaryKeyStore()!.commitLog;
+      var lastCommitId =
+          await LastCommitIDMetricImpl.getInstance().getMetrics();
+      print('lastCommitId before op: $lastCommitId');
+      var randomString = Uuid().v4();
+      int phoneNumber = 1234;
+      int min = 5;
+      int max = 100;
+      // generate a random integer between 5 and 100
+      int randomNumber = min + Random().nextInt(max - min) + 1;
+      for (int i = 1; i <= randomNumber; i++) {
+        phoneNumber = phoneNumber + i;
+        await secondaryPersistenceStore!.getSecondaryKeyStore()!.put(
+            '@alice:phone-${randomString}_$i@alice',
+            AtData()..data = phoneNumber.toString());
+      }
+      lastCommitId = await LastCommitIDMetricImpl.getInstance().getMetrics();
+      var latestCommitIdForEachKey =
+          await LatestCommitEntryOfEachKey().getMetrics();
+      Map<String, dynamic> latestCommitIdMap =
+          jsonDecode(latestCommitIdForEachKey);
+      for (int i = 1; i <= randomNumber; i++) {
+        expect(
+            latestCommitIdMap
+                .containsKey('@alice:phone-${randomString}_$i@alice'),
+            true);
+      }
     });
 
     test(

--- a/packages/at_secondary_server/test/stats_verb_test.dart
+++ b/packages/at_secondary_server/test/stats_verb_test.dart
@@ -473,7 +473,7 @@ void main() {
     });
 
     test(
-        'A test to validate when entry count is greater than default sync buffer zie',
+        'A test to validate commit entries when commit log entry count is greater than default sync buffer zie',
         () async {
       secondaryPersistenceStore = SecondaryPersistenceStoreFactory.getInstance()
           .getSecondaryPersistenceStore(alice);
@@ -591,6 +591,18 @@ void main() {
       var lastCommitId =
           await LastCommitIDMetricImpl.getInstance().getMetrics(regex: 'buzz');
       expect(lastCommitId, '2');
+    });
+    test('A test to check LatestCommitEntryOfEachKey for empty commit log',
+        () async {
+      secondaryPersistenceStore = SecondaryPersistenceStoreFactory.getInstance()
+          .getSecondaryPersistenceStore(alice);
+      LastCommitIDMetricImpl.getInstance().atCommitLog =
+          secondaryPersistenceStore!.getSecondaryKeyStore()!.commitLog;
+      var latestCommitIdForEachKey =
+          await LatestCommitEntryOfEachKey().getMetrics();
+      Map<String, dynamic> latestCommitIdMap =
+          jsonDecode(latestCommitIdForEachKey);
+      expect(latestCommitIdMap.isEmpty, true);
     });
     tearDown(() async => await verbTestsTearDown());
   });


### PR DESCRIPTION
Fixed https://github.com/atsign-foundation/at_client_sdk/issues/1404
**- What I did**
- Fixed a bug in LatestCommitEntryOfEachKey --> getMetrics which was returning only 25(default limit) 
**- How I did it**
- Added pagination logic in the method to get entries till lastCommitID
- added unit test
**- How to verify it**
- tests should pass
