### PR TITLE
build(deps): Bump at_commons 4.1.2 at_utils 3.0.18 lints 5.0.0

### DIFF
--- a/packages/at_root_server/pubspec.yaml
+++ b/packages/at_root_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_root_server
 description: Root server implementation.
-version: 2.1.0
+version: 2.1.1
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://atsign.dev
 publish_to: none
@@ -12,8 +12,8 @@ dependencies:
   args: 2.5.0
   uuid: 3.0.7
   yaml: 3.1.2
-  at_commons: 4.0.10
-  at_utils: 3.0.16
+  at_commons: 4.1.2
+  at_utils: 3.0.18
   at_server_spec: 5.0.1
   at_persistence_root_server:
     git:
@@ -25,6 +25,6 @@ dependencies:
 dev_dependencies:
   # Adding test_cov for generating the test coverage.
   test_cov: ^1.0.1
-  lints: ^4.0.0
+  lints: ^5.0.0
   test: ^1.24.6
   coverage: ^1.6.3


### PR DESCRIPTION
Supersedes #2063 

Dependabot continues to fail to raise PRs for pub deps

**- What I did**

Bumps:

* at_commons to 4.1.2
* at_utils to 3.0.18
* lints to 5.0.0

**- How I did it**

Read Dependabot log from last failed run and added manual changes

**- How to verify it**

CI

**- Description for the changelog**

build(deps): Bump at_commons 4.1.2 at_utils 3.0.18 lints 5.0.0