### PR TITLE
fix: Update the error message and add skip commit for enrollment key deletion

### DIFF
--- a/packages/at_secondary_server/lib/src/enroll/enrollment_manager.dart
+++ b/packages/at_secondary_server/lib/src/enroll/enrollment_manager.dart
@@ -79,4 +79,18 @@ class EnrollmentManager {
     String enrollmentKey = buildEnrollmentKey(enrollmentId);
     await _keyStore.put(enrollmentKey, atData, skipCommit: true);
   }
+
+  /// Deletes the enrollment key from the keystore.
+  ///
+  /// This method generates an enrollment key using the provided enrollmentId and
+  /// removes the enrollment key from the keystore. The skipCommit parameter is
+  /// set to true to prevent this deletion from being logged in the commit log,
+  /// ensuring it is not synced to the clients.
+  ///
+  /// Parameters:
+  ///  - [enrollmentId]: The ID associated with the enrollment.
+  Future<void> remove(String enrollmentId) async {
+    String enrollmentKey = buildEnrollmentKey(enrollmentId);
+    await _keyStore.remove(enrollmentKey, skipCommit: true);
+  }
 }

--- a/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
@@ -255,7 +255,8 @@ class EnrollVerbHandler extends AbstractVerbHandler {
       // store this apkam as default pkam public key for old clients
       // The keys with AT_PKAM_PUBLIC_KEY does not sync to client.
       await keyStore.put(AtConstants.atPkamPublicKey,
-          AtData()..data = enrollParams.apkamPublicKey!);
+          AtData()..data = enrollParams.apkamPublicKey!,
+          skipCommit: true);
       enrollData = AtData()..data = jsonEncode(enrollmentValue.toJson());
     } else {
       enrollmentValue.encryptedAPKAMSymmetricKey =
@@ -359,7 +360,7 @@ class EnrollVerbHandler extends AbstractVerbHandler {
           'public:${enrollDataStoreValue.appName}.${enrollDataStoreValue.deviceName}.pkam.$pkamNamespace.__public_keys$currentAtSign';
       var valueJson = {'apkamPublicKey': enrollDataStoreValue.apkamPublicKey};
       var atData = AtData()..data = jsonEncode(valueJson);
-      await keyStore.put(apkamPublicKeyInKeyStore, atData);
+      await keyStore.put(apkamPublicKeyInKeyStore, atData, skipCommit: true);
       await _storeEncryptionKeys(
           enrollmentIdFromParams!, enrollParams, currentAtSign);
     }

--- a/packages/at_secondary_server/test/enroll_verb_test.dart
+++ b/packages/at_secondary_server/test/enroll_verb_test.dart
@@ -6,6 +6,7 @@ import 'package:at_persistence_secondary_server/at_persistence_secondary_server.
 import 'package:at_secondary/src/connection/inbound/inbound_connection_metadata.dart';
 import 'package:at_secondary/src/constants/enroll_constants.dart';
 import 'package:at_secondary/src/enroll/enroll_datastore_value.dart';
+import 'package:at_secondary/src/enroll/enrollment_manager.dart';
 import 'package:at_secondary/src/server/at_secondary_config.dart';
 import 'package:at_secondary/src/utils/handler_util.dart';
 import 'package:at_secondary/src/verb/handler/delete_verb_handler.dart';
@@ -2038,6 +2039,238 @@ void main() {
               e.toString() ==
               'Exception: Failed to delete enrollment id: 345345345141 | Cause: Cannot delete approved enrollments. Only denied and revoked enrollments can be deleted')));
     });
+    tearDown(() async => await verbTestsTearDown());
+  });
+
+  group(
+      'A group of tests to validate the commit log state when performing enrollment operations',
+      () {
+    setUp(() async {
+      await verbTestsSetUp();
+    });
+
+    test(
+        'A test to verify commit log state during create approve revoke and delete an enrollment request',
+        () async {
+      Response response = Response();
+      // OTP Verb
+      inboundConnection.metaData.isAuthenticated = true;
+      inboundConnection.metaData.sessionID = 'dummy_session';
+      HashMap<String, String?> otpVerbParams =
+          getVerbParam(VerbSyntax.otp, 'otp:get');
+      OtpVerbHandler otpVerbHandler = OtpVerbHandler(secondaryKeyStore);
+      await otpVerbHandler.processVerb(
+          response, otpVerbParams, inboundConnection);
+      String otp = response.data!;
+
+      // 1. Create an enrollment request
+      String enrollmentRequest =
+          'enroll:request:{"appName":"wavi","deviceName":"mydevice"'
+          ',"namespaces":{"buzz":"r"},"otp":"$otp"'
+          ',"apkamPublicKey":"lorem_apkam"'
+          ',"encryptedAPKAMSymmetricKey": "ipsum_apkam"}';
+      HashMap<String, String?> enrollmentRequestVerbParams =
+          getVerbParam(VerbSyntax.enroll, enrollmentRequest);
+      inboundConnection.metaData.isAuthenticated = false;
+      EnrollVerbHandler enrollVerbHandler =
+          EnrollVerbHandler(secondaryKeyStore);
+      await enrollVerbHandler.processVerb(
+          response, enrollmentRequestVerbParams, inboundConnection);
+      String enrollmentId = jsonDecode(response.data!)['enrollmentId'];
+
+      String enrollmentKey =
+          EnrollmentManager(secondaryKeyStore).buildEnrollmentKey(enrollmentId);
+
+      // Verify key is created in the secondary keystore.
+      AtData? atData = await secondaryKeyStore.get(enrollmentKey);
+      expect(atData!.data!.isNotEmpty, true);
+
+      AtCommitLog? atCommitLog =
+          await AtCommitLogManagerImpl.getInstance().getCommitLog(alice);
+      var itr = atCommitLog?.getEntries(-1);
+      // Since there are no entries in commit log, iterator.moveNext() returns false.
+      expect(itr!.moveNext(), false);
+
+      // 2. Approve an enrollment and verify enrollmentKey is not stored in the commit log.
+      String approveEnrollment =
+          'enroll:approve:{"enrollmentId":"$enrollmentId","encryptedDefaultEncryptionPrivateKey": "dummy_encrypted_default_encryption_private_key","encryptedDefaultSelfEncryptionKey":"dummy_encrypted_default_self_encryption_key"}';
+      HashMap<String, String?> approveEnrollmentVerbParams =
+          getVerbParam(VerbSyntax.enroll, approveEnrollment);
+      inboundConnection.metaData.isAuthenticated = true;
+      enrollVerbHandler = EnrollVerbHandler(secondaryKeyStore);
+      await enrollVerbHandler.processVerb(
+          response, approveEnrollmentVerbParams, inboundConnection);
+      expect(jsonDecode(response.data!)['status'], 'approved');
+
+      atCommitLog =
+          await AtCommitLogManagerImpl.getInstance().getCommitLog(alice);
+      itr = atCommitLog?.getEntries(-1);
+      while (itr!.moveNext()) {
+        // When approving an enrollment, stores the public key with
+        // public:appName.deviceName.pkam.__pkams.__public_keys@atSign key. Therefore,
+        // commit log has an entry.
+        expect(
+            itr.current.key.contains('pkam.__pkams.__public_keys$alice'), true);
+      }
+      // Ensure there are no other keys in the commit log.
+      expect(itr.moveNext(), false);
+
+      // 3. Revoke an enrollment and verify the commit log state.
+      enrollmentRequest = 'enroll:revoke:{"enrollmentId":"$enrollmentId"}';
+      HashMap<String, String?> revokeEnrollmentVerbParams =
+          getVerbParam(VerbSyntax.enroll, enrollmentRequest);
+      inboundConnection.metaData.isAuthenticated = true;
+      inboundConnection.metaData.sessionID = 'dummy_session';
+      response = Response();
+      enrollVerbHandler = EnrollVerbHandler(secondaryKeyStore);
+      await enrollVerbHandler.processVerb(
+          response, revokeEnrollmentVerbParams, inboundConnection);
+      expect(jsonDecode(response.data!)['status'], 'revoked');
+
+      atCommitLog =
+          await AtCommitLogManagerImpl.getInstance().getCommitLog(alice);
+      itr = atCommitLog?.getEntries(-1);
+      // Since there are no entries in commit log, iterator.moveNext() returns false.
+      while (itr!.moveNext()) {
+        // When approving an enrollment, stores the public key with
+        // public:appName.deviceName.pkam.__pkams.__public_keys@atSign key. Therefore,
+        // commit log has an entry.
+        expect(
+            itr.current.key.contains('pkam.__pkams.__public_keys$alice'), true);
+      }
+      // Ensure there are no other keys in the commit log.
+      expect(itr.moveNext(), false);
+
+      // 4. Delete an enrollment request.
+      enrollmentRequest = 'enroll:delete:{"enrollmentId":"$enrollmentId"}';
+      HashMap<String, String?> verbParams =
+          getVerbParam(VerbSyntax.enroll, enrollmentRequest);
+      inboundConnection.metaData.isAuthenticated = true;
+      inboundConnection.metaData.sessionID = 'dummy_session';
+      response = Response();
+      enrollVerbHandler = EnrollVerbHandler(secondaryKeyStore);
+      await enrollVerbHandler.processVerb(
+          response, verbParams, inboundConnection);
+      expect(jsonDecode(response.data!)['status'], 'deleted');
+
+      atCommitLog =
+          await AtCommitLogManagerImpl.getInstance().getCommitLog(alice);
+      itr = atCommitLog?.getEntries(-1);
+      // Since there are no entries in commit log, iterator.moveNext() returns false.
+      while (itr!.moveNext()) {
+        // When approving an enrollment, stores the public key with
+        // public:appName.deviceName.pkam.__pkams.__public_keys@atSign key. Therefore,
+        // commit log has an entry.
+        expect(
+            itr.current.key.contains('pkam.__pkams.__public_keys$alice'), true);
+      }
+      // Ensure there are no other keys in the commit log.
+      expect(itr.moveNext(), false);
+
+      // Verify key is deleted in the secondary keystore.
+      expect(() async => await secondaryKeyStore.get(enrollmentKey),
+          throwsA(predicate((dynamic e) => e is KeyNotFoundException)));
+    });
+
+    test(
+        'A test to verify commit log state during create deny and delete an enrollment request',
+        () async {
+      Response response = Response();
+      // OTP Verb
+      inboundConnection.metaData.isAuthenticated = true;
+      inboundConnection.metaData.sessionID = 'dummy_session';
+      HashMap<String, String?> otpVerbParams =
+          getVerbParam(VerbSyntax.otp, 'otp:get');
+      OtpVerbHandler otpVerbHandler = OtpVerbHandler(secondaryKeyStore);
+      await otpVerbHandler.processVerb(
+          response, otpVerbParams, inboundConnection);
+      String otp = response.data!;
+
+      // 1. Create an enrollment request
+      String enrollmentRequest =
+          'enroll:request:{"appName":"wavi","deviceName":"mydevice"'
+          ',"namespaces":{"buzz":"r"},"otp":"$otp"'
+          ',"apkamPublicKey":"lorem_apkam"'
+          ',"encryptedAPKAMSymmetricKey": "ipsum_apkam"}';
+      HashMap<String, String?> enrollmentRequestVerbParams =
+          getVerbParam(VerbSyntax.enroll, enrollmentRequest);
+      inboundConnection.metaData.isAuthenticated = false;
+      EnrollVerbHandler enrollVerbHandler =
+          EnrollVerbHandler(secondaryKeyStore);
+      await enrollVerbHandler.processVerb(
+          response, enrollmentRequestVerbParams, inboundConnection);
+      String enrollmentId = jsonDecode(response.data!)['enrollmentId'];
+
+      String enrollmentKey =
+          EnrollmentManager(secondaryKeyStore).buildEnrollmentKey(enrollmentId);
+
+      // Verify key is created in the secondary keystore.
+      AtData? atData = await secondaryKeyStore.get(enrollmentKey);
+      expect(atData!.data!.isNotEmpty, true);
+
+      AtCommitLog? atCommitLog =
+          await AtCommitLogManagerImpl.getInstance().getCommitLog(alice);
+      var itr = atCommitLog?.getEntries(-1);
+      // Since there are no entries in commit log, iterator.moveNext() returns false.
+      expect(itr!.moveNext(), false);
+
+      // 3. Deny an enrollment and verify the commit log state.
+      enrollmentRequest = 'enroll:deny:{"enrollmentId":"$enrollmentId"}';
+      HashMap<String, String?> revokeEnrollmentVerbParams =
+          getVerbParam(VerbSyntax.enroll, enrollmentRequest);
+      inboundConnection.metaData.isAuthenticated = true;
+      inboundConnection.metaData.sessionID = 'dummy_session';
+      response = Response();
+      enrollVerbHandler = EnrollVerbHandler(secondaryKeyStore);
+      await enrollVerbHandler.processVerb(
+          response, revokeEnrollmentVerbParams, inboundConnection);
+      expect(jsonDecode(response.data!)['status'], 'denied');
+
+      atCommitLog =
+          await AtCommitLogManagerImpl.getInstance().getCommitLog(alice);
+      itr = atCommitLog?.getEntries(-1);
+      // Since there are no entries in commit log, iterator.moveNext() returns false.
+      while (itr!.moveNext()) {
+        // When approving an enrollment, stores the public key with
+        // public:appName.deviceName.pkam.__pkams.__public_keys@atSign key. Therefore,
+        // commit log has an entry.
+        expect(
+            itr.current.key.contains('pkam.__pkams.__public_keys$alice'), true);
+      }
+      // Ensure there are no other keys in the commit log.
+      expect(itr.moveNext(), false);
+
+      // 3. Delete an enrollment request.
+      enrollmentRequest = 'enroll:delete:{"enrollmentId":"$enrollmentId"}';
+      HashMap<String, String?> verbParams =
+          getVerbParam(VerbSyntax.enroll, enrollmentRequest);
+      inboundConnection.metaData.isAuthenticated = true;
+      inboundConnection.metaData.sessionID = 'dummy_session';
+      response = Response();
+      enrollVerbHandler = EnrollVerbHandler(secondaryKeyStore);
+      await enrollVerbHandler.processVerb(
+          response, verbParams, inboundConnection);
+      expect(jsonDecode(response.data!)['status'], 'deleted');
+
+      atCommitLog =
+          await AtCommitLogManagerImpl.getInstance().getCommitLog(alice);
+      itr = atCommitLog?.getEntries(-1);
+      // Since there are no entries in commit log, iterator.moveNext() returns false.
+      while (itr!.moveNext()) {
+        // When approving an enrollment, stores the public key with
+        // public:appName.deviceName.pkam.__pkams.__public_keys@atSign key. Therefore,
+        // commit log has an entry.
+        expect(
+            itr.current.key.contains('pkam.__pkams.__public_keys$alice'), true);
+      }
+      // Ensure there are no other keys in the commit log.
+      expect(itr.moveNext(), false);
+
+      // Verify key is deleted in the secondary keystore.
+      expect(() async => await secondaryKeyStore.get(enrollmentKey),
+          throwsA(predicate((dynamic e) => e is KeyNotFoundException)));
+    });
+
     tearDown(() async => await verbTestsTearDown());
   });
 }

--- a/packages/at_secondary_server/test/enroll_verb_test.dart
+++ b/packages/at_secondary_server/test/enroll_verb_test.dart
@@ -2036,7 +2036,7 @@ void main() {
               response, enrollVerbParams, inboundConnection),
           throwsA(predicate((e) =>
               e.toString() ==
-              'Exception: Failed to delete enrollment id: 345345345141 | Cause: Cannot delete approved enrollments. Only denied enrollments can be deleted')));
+              'Exception: Failed to delete enrollment id: 345345345141 | Cause: Cannot delete approved enrollments. Only denied and revoked enrollments can be deleted')));
     });
     tearDown(() async => await verbTestsTearDown());
   });

--- a/packages/at_secondary_server/test/enroll_verb_test.dart
+++ b/packages/at_secondary_server/test/enroll_verb_test.dart
@@ -635,8 +635,6 @@ void main() {
       Iterator iterator =
           (secondaryKeyStore.commitLog as AtCommitLog).getEntries(-1);
       iterator.moveNext();
-      expect(iterator.current.key,
-          'public:wavi.mydevice.pkam.__pkams.__public_keys@alice');
       expect(iterator.moveNext(), false);
     });
     tearDown(() async => await verbTestsTearDown());
@@ -2084,6 +2082,11 @@ void main() {
       // Verify key is created in the secondary keystore.
       AtData? atData = await secondaryKeyStore.get(enrollmentKey);
       expect(atData!.data!.isNotEmpty, true);
+      var enrollmentDataMap = jsonDecode(atData.data!);
+      expect(enrollmentDataMap['appName'], 'wavi');
+      expect(enrollmentDataMap['deviceName'], 'mydevice');
+      expect(enrollmentDataMap['namespaces'], {'buzz': 'r'});
+      expect(enrollmentDataMap['apkamPublicKey'], 'lorem_apkam');
 
       AtCommitLog? atCommitLog =
           await AtCommitLogManagerImpl.getInstance().getCommitLog(alice);
@@ -2105,15 +2108,8 @@ void main() {
       atCommitLog =
           await AtCommitLogManagerImpl.getInstance().getCommitLog(alice);
       itr = atCommitLog?.getEntries(-1);
-      while (itr!.moveNext()) {
-        // When approving an enrollment, stores the public key with
-        // public:appName.deviceName.pkam.__pkams.__public_keys@atSign key. Therefore,
-        // commit log has an entry.
-        expect(
-            itr.current.key.contains('pkam.__pkams.__public_keys$alice'), true);
-      }
       // Ensure there are no other keys in the commit log.
-      expect(itr.moveNext(), false);
+      expect(itr!.moveNext(), false);
 
       // 3. Revoke an enrollment and verify the commit log state.
       enrollmentRequest = 'enroll:revoke:{"enrollmentId":"$enrollmentId"}';
@@ -2130,16 +2126,8 @@ void main() {
       atCommitLog =
           await AtCommitLogManagerImpl.getInstance().getCommitLog(alice);
       itr = atCommitLog?.getEntries(-1);
-      // Since there are no entries in commit log, iterator.moveNext() returns false.
-      while (itr!.moveNext()) {
-        // When approving an enrollment, stores the public key with
-        // public:appName.deviceName.pkam.__pkams.__public_keys@atSign key. Therefore,
-        // commit log has an entry.
-        expect(
-            itr.current.key.contains('pkam.__pkams.__public_keys$alice'), true);
-      }
       // Ensure there are no other keys in the commit log.
-      expect(itr.moveNext(), false);
+      expect(itr!.moveNext(), false);
 
       // 4. Delete an enrollment request.
       enrollmentRequest = 'enroll:delete:{"enrollmentId":"$enrollmentId"}';
@@ -2157,15 +2145,8 @@ void main() {
           await AtCommitLogManagerImpl.getInstance().getCommitLog(alice);
       itr = atCommitLog?.getEntries(-1);
       // Since there are no entries in commit log, iterator.moveNext() returns false.
-      while (itr!.moveNext()) {
-        // When approving an enrollment, stores the public key with
-        // public:appName.deviceName.pkam.__pkams.__public_keys@atSign key. Therefore,
-        // commit log has an entry.
-        expect(
-            itr.current.key.contains('pkam.__pkams.__public_keys$alice'), true);
-      }
       // Ensure there are no other keys in the commit log.
-      expect(itr.moveNext(), false);
+      expect(itr!.moveNext(), false);
 
       // Verify key is deleted in the secondary keystore.
       expect(() async => await secondaryKeyStore.get(enrollmentKey),
@@ -2207,6 +2188,11 @@ void main() {
       // Verify key is created in the secondary keystore.
       AtData? atData = await secondaryKeyStore.get(enrollmentKey);
       expect(atData!.data!.isNotEmpty, true);
+      var enrollmentDataMap = jsonDecode(atData.data!);
+      expect(enrollmentDataMap['appName'], 'wavi');
+      expect(enrollmentDataMap['deviceName'], 'mydevice');
+      expect(enrollmentDataMap['namespaces'], {'buzz': 'r'});
+      expect(enrollmentDataMap['apkamPublicKey'], 'lorem_apkam');
 
       AtCommitLog? atCommitLog =
           await AtCommitLogManagerImpl.getInstance().getCommitLog(alice);

--- a/packages/at_secondary_server/test/enroll_verb_test.dart
+++ b/packages/at_secondary_server/test/enroll_verb_test.dart
@@ -2214,31 +2214,23 @@ void main() {
       // Since there are no entries in commit log, iterator.moveNext() returns false.
       expect(itr!.moveNext(), false);
 
-      // 3. Deny an enrollment and verify the commit log state.
+      // 2. Deny an enrollment and verify the commit log state.
       enrollmentRequest = 'enroll:deny:{"enrollmentId":"$enrollmentId"}';
-      HashMap<String, String?> revokeEnrollmentVerbParams =
+      HashMap<String, String?> denyEnrollmentVerbParams =
           getVerbParam(VerbSyntax.enroll, enrollmentRequest);
       inboundConnection.metaData.isAuthenticated = true;
       inboundConnection.metaData.sessionID = 'dummy_session';
       response = Response();
       enrollVerbHandler = EnrollVerbHandler(secondaryKeyStore);
       await enrollVerbHandler.processVerb(
-          response, revokeEnrollmentVerbParams, inboundConnection);
+          response, denyEnrollmentVerbParams, inboundConnection);
       expect(jsonDecode(response.data!)['status'], 'denied');
 
       atCommitLog =
           await AtCommitLogManagerImpl.getInstance().getCommitLog(alice);
       itr = atCommitLog?.getEntries(-1);
       // Since there are no entries in commit log, iterator.moveNext() returns false.
-      while (itr!.moveNext()) {
-        // When approving an enrollment, stores the public key with
-        // public:appName.deviceName.pkam.__pkams.__public_keys@atSign key. Therefore,
-        // commit log has an entry.
-        expect(
-            itr.current.key.contains('pkam.__pkams.__public_keys$alice'), true);
-      }
-      // Ensure there are no other keys in the commit log.
-      expect(itr.moveNext(), false);
+      expect(itr!.moveNext(), false);
 
       // 3. Delete an enrollment request.
       enrollmentRequest = 'enroll:delete:{"enrollmentId":"$enrollmentId"}';
@@ -2256,15 +2248,7 @@ void main() {
           await AtCommitLogManagerImpl.getInstance().getCommitLog(alice);
       itr = atCommitLog?.getEntries(-1);
       // Since there are no entries in commit log, iterator.moveNext() returns false.
-      while (itr!.moveNext()) {
-        // When approving an enrollment, stores the public key with
-        // public:appName.deviceName.pkam.__pkams.__public_keys@atSign key. Therefore,
-        // commit log has an entry.
-        expect(
-            itr.current.key.contains('pkam.__pkams.__public_keys$alice'), true);
-      }
-      // Ensure there are no other keys in the commit log.
-      expect(itr.moveNext(), false);
+      expect(itr!.moveNext(), false);
 
       // Verify key is deleted in the secondary keystore.
       expect(() async => await secondaryKeyStore.get(enrollmentKey),

--- a/tests/at_functional_test/test/enroll_verb_test.dart
+++ b/tests/at_functional_test/test/enroll_verb_test.dart
@@ -1629,7 +1629,7 @@ void main() {
           jsonDecodedResponse['errorDescription'],
           'Internal server exception : Failed to delete enrollment id: '
           '$enrollmentId | Cause: Cannot delete approved enrollments. '
-          'Only denied enrollments can be deleted');
+          'Only denied and revoked enrollments can be deleted');
     });
 
     test('negative test - delete an pending enrollment', () async {
@@ -1675,7 +1675,7 @@ void main() {
           jsonDecodedResponse['errorDescription'],
           'Internal server exception : Failed to delete enrollment id: '
           '$enrollmentId | Cause: Cannot delete pending enrollments. '
-          'Only denied enrollments can be deleted');
+          'Only denied and revoked enrollments can be deleted');
     });
 
     test(

--- a/tests/at_functional_test/test/sync_verb_test.dart
+++ b/tests/at_functional_test/test/sync_verb_test.dart
@@ -121,7 +121,7 @@ void main() {
       expect(
           int.parse(
               jsonDecode(statsResponse.replaceAll('data:', ''))[0]['value']),
-          lastCommitIdBeforeUpdate + 4);
+          lastCommitIdBeforeUpdate + 3);
       await authenticatedSocket.close();
 
       await authenticatedSocket.initiateConnectionWithListener(
@@ -135,11 +135,11 @@ void main() {
       expect(syncResponseList.length, 2);
       expect(syncResponseList[0]['atKey'],
           '$secondAtSign:phone-$randomString.wavi$firstAtSign');
-      expect(syncResponseList[0]['commitId'], lastCommitIdBeforeUpdate + 2);
+      expect(syncResponseList[0]['commitId'], lastCommitIdBeforeUpdate + 1);
 
       expect(syncResponseList[1]['atKey'],
           '$secondAtSign:phone-$randomString.buzz$firstAtSign');
-      expect(syncResponseList[1]['commitId'], lastCommitIdBeforeUpdate + 3);
+      expect(syncResponseList[1]['commitId'], lastCommitIdBeforeUpdate + 2);
     });
   });
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- In enroll_verb_handler.dart, modify the error message to specify that enrollment keys can only be deleted for enrollments that are denied or revoked.
- Add "remove" method to the enrollment_manager.dart class which will delete the enrollment key and set "skipCommit" to true to prevent the entry getting logged into the commit log and to prevent enrollment data getting sync'ed between the client and server, therefore skip it.
- Since client does not need to the apkamPublicKey to be sync'ed, set skipCommit to true when storing them into the keystore and update the tests accordingly.
- Use the "remove" method from enrollment_manager.dart in enroll_verb_handler.dart to delete the enrollment key.
- Update the unit test accordingly to match the error message.

**- How to verify it**
- Added the following unit tests to verify the commit log state during various enrollment operations:
  - A test to verify commit log state during create approve revoke and delete an enrollment request
  - A test to verify commit log state during create deny and delete an enrollment request 

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
