### PR TITLE
fix: Intermittent failure in create_update_key_test.dart

### DIFF
--- a/tests/at_functional_test/test/create_update_key_test.dart
+++ b/tests/at_functional_test/test/create_update_key_test.dart
@@ -19,7 +19,8 @@ void main() {
     await firstAtSignConnection.initiateConnectionWithListener(
         firstAtSign, firstAtSignHost, firstAtSignPort);
     String authResponse = await firstAtSignConnection.authenticateConnection();
-    expect(authResponse, 'data:success', reason: 'Authentication failed when executing test');
+    expect(authResponse, 'data:success',
+        reason: 'Authentication failed when executing test');
   });
 
   setUp(() {
@@ -50,7 +51,7 @@ void main() {
       expect(atData['metaData']['version'], 0);
       expect(
           DateTime.parse(atData['metaData']['createdAt'])
-                  .millisecondsSinceEpoch >
+                  .millisecondsSinceEpoch >=
               keyCreationDateTime.millisecondsSinceEpoch,
           true);
       expect(atData['metaData']['createdBy'], firstAtSign);
@@ -104,6 +105,7 @@ void main() {
       var commitIDValue = jsonDecode(jsonData[0]['value']);
       int noOfTests = 5;
       late String response;
+
       /// UPDATE VERB
       for (int i = 1; i <= noOfTests; i++) {
         response = await firstAtSignConnection.sendRequestToServer(
@@ -114,12 +116,15 @@ void main() {
       // sync
       response = await firstAtSignConnection.sendRequestToServer(
           'sync:from:${commitIDValue - 1}:limit:$noOfTests');
-      expect('public:location-$uniqueId$firstAtSign'.allMatches(response).length, 1);
+      expect(
+          'public:location-$uniqueId$firstAtSign'.allMatches(response).length,
+          1);
     });
 
     test('delete same key multiple times test', () async {
       int noOfTests = 3;
       late String response;
+
       /// Delete VERB
       for (int i = 1; i <= noOfTests; i++) {
         response = await firstAtSignConnection
@@ -134,6 +139,7 @@ void main() {
       late String response;
       var atKey = 'public:key-$uniqueId';
       var atValue = 'val';
+
       /// UPDATE VERB
       for (int i = 1, j = 1; i <= noOfTests; i++, j++) {
         response = await firstAtSignConnection


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- The failure is because of the timing issue between the key creation date time and date time in the metadata. 

```dart
var keyCreationDateTime = DateTime.now().toUtc();
expect(DateTime.parse(atData['metaData']['createdAt']).millisecondsSinceEpoch > keyCreationDateTime.millisecondsSinceEpoch, true);
```
Since, the check contains only greater than, if the date time in keyCreationDateTime and in metadata happens at the same time, then the test fails.  To fix the issue, modified the condition as greater than or equal to:
```dart 
expect(DateTime.parse(atData['metaData']['createdAt']).millisecondsSinceEpoch >= keyCreationDateTime.millisecondsSinceEpoch, true);
```

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
