### PR TITLE
docs: Add sbomified badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_server/badge)](https://securityscorecards.dev/viewer/?uri=github.com/atsign-foundation/at_server&sort_by=check-score&sort_direction=desc)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/6713/badge)](https://www.bestpractices.dev/projects/6713)
 [![SLSA 3](https://slsa.dev/images/gh-badge-level3.svg)](https://slsa.dev)
+[![sbomified](https://sbomify.com/assets/images/logo/badge.svg)](https://app.sbomify.com/component/wF66pn8rHZ)
 
 # at_server
 


### PR DESCRIPTION
Adding a visual indicator that SBOMs are available for this repo

**- What I did**

Added sbomified badge

**- How I did it**

Badge URL provided by @vpetersson modified to point to our (public) component

**- How to verify it**

Rich diff

**- Description for the changelog**

docs: Add sbomified badge
