### PR TITLE
fix: set  at_persistence_secondary_server version to 3.0.66

### DIFF
--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,6 +1,10 @@
 # 3.0.52
 - build[deps]: Upgraded the following package:
-  - at_commons to v5.0.1
+  - at_commons to v5.0.2
+  - at_chops to v2.2.0
+  - meta to v1.16.0
+  - test to v1.25.9
+  - args to v2.6.0
   - at_persistence_secondary_server to v3.0.66 to consume publicKeyHash changes.
 ## 3.0.51
 - feat: Introduce option to unrevoke revoked enrollments

--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 3.0.52
 - build[deps]: Upgraded the following package:
   - at_commons to v5.0.1
-  - at_persistence_secondary_server to v3.0.65
+  - at_persistence_secondary_server to v3.0.66 to consume publicKeyHash changes.
 ## 3.0.51
 - feat: Introduce option to unrevoke revoked enrollments
 - feat: Introduce option to delete enrollments that are denied/revoked

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   intl: ^0.19.0
   json_annotation: ^4.8.0
   version: 3.0.2
-  meta: 1.15.0
+  meta: 1.16.0
   mutex: 3.1.0
   yaml: 3.1.2
   logging: 1.2.0

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
-  args: 2.5.0
+  args: 2.6.0
   uuid: 3.0.7
   convert: 3.1.1
   cron: 0.5.1
@@ -19,9 +19,9 @@ dependencies:
   basic_utils: 5.7.0
   ecdsa: 0.1.0
   encrypt: 5.0.3
-  at_commons: 5.0.1
+  at_commons: 5.0.2
   at_utils: 3.0.19
-  at_chops: 2.0.1
+  at_chops: 2.2.0
   at_lookup: 3.0.49
   at_server_spec: 5.0.2
   at_persistence_spec: 2.0.14
@@ -33,6 +33,13 @@ dependencies:
   mutex: 3.1.0
   yaml: 3.1.2
   logging: 1.2.0
+
+dependency_overrides:
+  at_persistence_secondary_server:
+    git:
+      url: https://github.com/atsign-foundation/at_server.git
+      path: packages/at_persistence_secondary_server
+      ref: trunk
 
 dev_dependencies:
   build_runner: ^2.3.3

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   at_lookup: 3.0.49
   at_server_spec: 5.0.2
   at_persistence_spec: 2.0.14
-  at_persistence_secondary_server: 3.0.65
+  at_persistence_secondary_server: 3.0.66
   intl: ^0.19.0
   json_annotation: ^4.8.0
   version: 3.0.2
@@ -34,16 +34,9 @@ dependencies:
   yaml: 3.1.2
   logging: 1.2.0
 
-dependency_overrides:
-  at_persistence_secondary_server:
-    git:
-      url: https://github.com/atsign-foundation/at_server.git
-      path: packages/at_persistence_secondary_server
-      ref: trunk
-
 dev_dependencies:
   build_runner: ^2.3.3
-  test: ^1.24.4
+  test: ^1.25.9
   coverage: ^1.6.1
   lints: ^5.0.0
   mocktail: ^1.0.3

--- a/tests/at_end2end_test/pubspec.yaml
+++ b/tests/at_end2end_test/pubspec.yaml
@@ -12,14 +12,7 @@ dependencies:
   at_lookup: ^3.0.49
   at_commons: ^5.0.2
 
-dependency_overrides:
-  at_persistence_secondary_server:
-    git:
-      url: https://github.com/atsign-foundation/at_server.git
-      path: packages/at_persistence_secondary_server
-      ref: trunk
-
 dev_dependencies:
-  lints: ^1.0.1
-  test: ^1.14.4
+  lints: ^5.0.0
+  test: ^1.25.9
   version: ^3.0.2

--- a/tests/at_end2end_test/pubspec.yaml
+++ b/tests/at_end2end_test/pubspec.yaml
@@ -9,7 +9,15 @@ environment:
 dependencies:
   encrypt: 5.0.3
   at_demo_data: ^1.0.3
-  at_lookup: ^3.0.48
+  at_lookup: ^3.0.49
+  at_commons: ^5.0.2
+
+dependency_overrides:
+  at_persistence_secondary_server:
+    git:
+      url: https://github.com/atsign-foundation/at_server.git
+      path: packages/at_persistence_secondary_server
+      ref: trunk
 
 dev_dependencies:
   lints: ^1.0.1

--- a/tests/at_functional_test/pubspec.yaml
+++ b/tests/at_functional_test/pubspec.yaml
@@ -11,9 +11,16 @@ dependencies:
   at_demo_data: ^1.1.0
   at_chops: ^2.0.0
   at_lookup: ^3.0.48
-  at_commons: ^4.1.2
+  at_commons: ^5.0.2
   uuid: ^3.0.7
   elliptic: ^0.3.8
+
+dependency_overrides:
+  at_persistence_secondary_server:
+    git:
+      url: https://github.com/atsign-foundation/at_server.git
+      path: packages/at_persistence_secondary_server
+      ref: trunk
 
 dev_dependencies:
   lints: ^4.0.0

--- a/tests/at_functional_test/pubspec.yaml
+++ b/tests/at_functional_test/pubspec.yaml
@@ -9,20 +9,13 @@ environment:
 dependencies:
   hex: ^0.2.0
   at_demo_data: ^1.1.0
-  at_chops: ^2.0.0
-  at_lookup: ^3.0.48
+  at_chops: ^2.2.0
+  at_lookup: ^3.0.49
   at_commons: ^5.0.2
   uuid: ^3.0.7
   elliptic: ^0.3.8
 
-dependency_overrides:
-  at_persistence_secondary_server:
-    git:
-      url: https://github.com/atsign-foundation/at_server.git
-      path: packages/at_persistence_secondary_server
-      ref: trunk
-
 dev_dependencies:
-  lints: ^4.0.0
-  test: ^1.25.8
+  lints: ^5.0.0
+  test: ^1.25.9
   version: ^3.0.2


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Set at_persistence_secondary_server to 3.0.66 to consume "publicKeyHash" changes

**- How to verify it**
- All E2E tests should pass.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
