### PR TITLE
fix: Set publicKeyHash to null when not populated

### DIFF
--- a/packages/at_secondary_server/lib/src/verb/handler/monitor_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/monitor_verb_handler.dart
@@ -138,9 +138,13 @@ class MonitorVerbHandler extends AbstractVerbHandler {
           "skeEncKeyName": atNotification.atMetadata?.skeEncKeyName,
           "skeEncAlgo": atNotification.atMetadata?.skeEncAlgo,
           "sharedKeyEnc": atNotification.atMetadata?.sharedKeyEnc,
-          "pubKeyHash":
-              jsonEncode(atNotification.atMetadata?.pubKeyHash?.toJson())
         };
+
+      notification.metadata?.putIfAbsent(
+          "pubKeyHash",
+          () => (atNotification.atMetadata?.pubKeyHash != null)
+              ? jsonEncode(atNotification.atMetadata?.pubKeyHash?.toJson())
+              : null);
 
       await _checkAndSend(notification);
     }
@@ -224,9 +228,13 @@ class Notification {
       "availableAt": atNotification.atMetadata?.availableAt.toString(),
       "expiresAt":
           (atNotification.atMetadata?.expiresAt ?? atNotification.expiresAt)
-              .toString(),
-      'pubKeyHash': jsonEncode(atNotification.atMetadata?.pubKeyHash?.toJson())
+              .toString()
     };
+    metadata?.putIfAbsent(
+        "pubKeyHash",
+        () => (atNotification.atMetadata?.pubKeyHash != null)
+            ? jsonEncode(atNotification.atMetadata?.pubKeyHash?.toJson())
+            : null);
   }
 
   Map toJson() => {

--- a/packages/at_secondary_server/test/monitor_verb_test.dart
+++ b/packages/at_secondary_server/test/monitor_verb_test.dart
@@ -1,6 +1,7 @@
 import 'dart:collection';
 import 'dart:convert';
 
+import 'package:at_chops/at_chops.dart';
 import 'package:at_commons/at_commons.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:at_secondary/src/connection/inbound/dummy_inbound_connection.dart';
@@ -104,6 +105,69 @@ void main() {
       expect(notificationMap['key'], 'phone.wavi');
       expect(notificationMap['messageType'], 'MessageType.key');
       expect(notificationMap['operation'], 'update');
+    });
+
+    test(
+        'A test to verify publicKeyHash is written on InboundConnection when populated',
+        () async {
+      HashMap<String, String?> verbParams = HashMap<String, String?>();
+      verbParams[AtConstants.regex] = 'wavi';
+      inboundConnection.metaData.isAuthenticated = true;
+      MonitorVerbHandler monitorVerbHandler =
+          MonitorVerbHandler(secondaryKeyStore);
+      await monitorVerbHandler.processVerb(
+          Response(), verbParams, inboundConnection);
+
+      var atNotification = (AtNotificationBuilder()
+            ..id = 'abc'
+            ..fromAtSign = '@bob'
+            ..notificationDateTime = DateTime.now()
+            ..toAtSign = alice
+            ..notification = 'phone.wavi'
+            ..type = NotificationType.received
+            ..opType = OperationType.update
+            ..messageType = MessageType.key
+            ..atMetaData = (AtMetaData()
+              ..pubKeyHash =
+                  PublicKeyHash('dummy_hash', HashingAlgoType.sha512.name)))
+          .build();
+      await monitorVerbHandler.processAtNotification(atNotification);
+      inboundConnection.lastWrittenData = inboundConnection.lastWrittenData
+          ?.replaceAll('notification:', '')
+          .trim();
+      Map notificationMap = jsonDecode(inboundConnection.lastWrittenData!);
+      expect(notificationMap['metadata']['pubKeyHash'],
+          '{"hash":"dummy_hash","hashingAlgo":"sha512"}');
+    });
+
+    test(
+        'A test to verify publicKeyHash is set to null on InboundConnection when not populated',
+        () async {
+      HashMap<String, String?> verbParams = HashMap<String, String?>();
+      verbParams[AtConstants.regex] = 'wavi';
+      inboundConnection.metaData.isAuthenticated = true;
+      MonitorVerbHandler monitorVerbHandler =
+          MonitorVerbHandler(secondaryKeyStore);
+      await monitorVerbHandler.processVerb(
+          Response(), verbParams, inboundConnection);
+
+      var atNotification = (AtNotificationBuilder()
+            ..id = 'abc'
+            ..fromAtSign = '@bob'
+            ..notificationDateTime = DateTime.now()
+            ..toAtSign = alice
+            ..notification = 'phone.wavi'
+            ..type = NotificationType.received
+            ..opType = OperationType.update
+            ..messageType = MessageType.key
+            ..atMetaData = (AtMetaData()..encKeyName = 'encKeyName'))
+          .build();
+      await monitorVerbHandler.processAtNotification(atNotification);
+      inboundConnection.lastWrittenData = inboundConnection.lastWrittenData
+          ?.replaceAll('notification:', '')
+          .trim();
+      var notificationMap = jsonDecode(inboundConnection.lastWrittenData!);
+      expect(notificationMap['metadata']['pubKeyHash'], null);
     });
     tearDown(() async {
       await verbTestsTearDown();


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
1. When "publicKeyHash" is not set in `AtNotification.atMetadata`, then default it to null. When populated, jsonEncode the value when writing into to the InboundConnection.

**- How to verify it**
1. Added unit tests to assert the changes.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
