### PR TITLE
fix: do not de-dup an 'enroll' request if the connection is CRAM-authenticated

### DIFF
--- a/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
@@ -205,7 +205,16 @@ class EnrollVerbHandler extends AbstractVerbHandler {
       }
     }
 
-    await validateEnrollmentRequest(enrollParams);
+    if (atConnection.metaData.authType != AuthType.cram) {
+      // If this is not a CRAM-authenticated connection, then we need to ensure
+      // that there is not an existing enrollment with the same info.
+      await preventDuplicateEnrollRequest(enrollParams);
+    } else {
+      // However, if it is a CRAM-authenticated connection, then we should
+      // allow a 'duplicate' enrollment request. See #2208
+      logger.warning('CRAM-authenticated connection - i.e. initial enrollment;'
+          ' will replace the existing initial enrollment, if any');
+    }
 
     // When threshold is met, set "_lastInvalidOtpReceivedInMills" and "delayForInvalidOTPSeries"
     // to default values.
@@ -256,6 +265,7 @@ class EnrollVerbHandler extends AbstractVerbHandler {
           skipCommit: true);
       enrollData = AtData()..data = jsonEncode(enrollmentValue.toJson());
     } else {
+      // send a notification to be received by an approver app
       enrollmentValue.encryptedAPKAMSymmetricKey =
           enrollParams.encryptedAPKAMSymmetricKey;
       enrollmentValue.approval = EnrollApproval(EnrollmentStatus.pending.name);
@@ -577,7 +587,7 @@ class EnrollVerbHandler extends AbstractVerbHandler {
   /// If a matching enrollment is found, [AtEnrollmentException] exception is thrown.
   /// Otherwise, the enrollment request is accepted.
   @visibleForTesting
-  Future<void> validateEnrollmentRequest(EnrollParams enrollParams) async {
+  Future<void> preventDuplicateEnrollRequest(EnrollParams enrollParams) async {
     // Fetches all the enrollment keys from the keystore.
     List<dynamic> enrollmentKeys = keyStore.getKeys(regex: 'enrollments');
 

--- a/packages/at_secondary_server/lib/src/verb/handler/pkam_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/pkam_verb_handler.dart
@@ -81,8 +81,8 @@ class PkamVerbHandler extends AbstractVerbHandler {
   }
 
   @visibleForTesting
-  Future<ApkamVerificationResult> handleApkamVerification(String enrollmentId,
-      String atSign) async {
+  Future<ApkamVerificationResult> handleApkamVerification(
+      String enrollmentId, String atSign) async {
     late final EnrollDataStoreValue enrollDataStoreValue;
     ApkamVerificationResult apkamResult = ApkamVerificationResult();
     EnrollmentStatus? enrollStatus;

--- a/packages/at_secondary_server/test/enroll_verb_test.dart
+++ b/packages/at_secondary_server/test/enroll_verb_test.dart
@@ -70,6 +70,33 @@ void main() {
       expect(enrollmentId_1 == enrollmentId_2, false);
     });
 
+    test('Should not reject CRAM-authenticated initial enrollment as duplicate',
+        () async {
+      HashMap<String, String?> verbParams = getVerbParam(
+          VerbSyntax.enroll,
+          'enroll:request:{"appName":"firstApp","deviceName":"firstDevice"'
+          ',"namespaces":{"*":"rw"}'
+          ',"apkamPublicKey":"lorem_apkam"'
+          ',"encryptedAPKAMSymmetricKey":"ipsum_apkam"}');
+      inboundConnection.metaData.isAuthenticated = true;
+      inboundConnection.metaData.authType = AuthType.cram;
+      inboundConnection.metaData.sessionID = 'dummy_session';
+      EnrollVerbHandler enrollVerbHandler =
+          EnrollVerbHandler(secondaryKeyStore);
+
+      Response response;
+      response = Response();
+      await enrollVerbHandler.processVerb(
+          response, verbParams, inboundConnection);
+      String firstEnrollmentId = jsonDecode(response.data!)['enrollmentId'];
+
+      response = Response();
+      await enrollVerbHandler.processVerb(
+          response, verbParams, inboundConnection);
+      String secondEnrollmentId = jsonDecode(response.data!)['enrollmentId'];
+
+      expect(secondEnrollmentId == firstEnrollmentId, false);
+    });
     test(
         'A test to verify enrollment of CRAM auth connection have __manage and * namespaces added to enrollment value',
         () async {
@@ -1357,8 +1384,8 @@ void main() {
         ..namespaces = {'wavi': 'rw'};
 
       expect(
-          () async =>
-              await enrollVerbHandler.validateEnrollmentRequest(enrollParams),
+          () async => await enrollVerbHandler
+              .preventDuplicateEnrollRequest(enrollParams),
           throwsA(predicate((dynamic e) =>
               e is AtEnrollmentException &&
               e.message ==
@@ -1386,8 +1413,8 @@ void main() {
         ..namespaces = {'wavi': 'rw'};
 
       expect(
-          () async =>
-              await enrollVerbHandler.validateEnrollmentRequest(enrollParams),
+          () async => await enrollVerbHandler
+              .preventDuplicateEnrollRequest(enrollParams),
           throwsA(predicate((dynamic e) =>
               e is AtEnrollmentException &&
               e.message ==


### PR DESCRIPTION
**- What I did**
fix: do not reject duplicate 'enroll' requests if the connection is CRAM-authenticated. This matches legacy onboarding behaviour. Resolves #2208

**- How I did it**
- Modified EnrollVerbHandler so that the duplicate check is skipped when the connection has been CRAM-authenticated
- Added unit test
- Renamed the duplicate-checking function for readability purposes

**- How to verify it**
Tests pass
