### PR TITLE
feat: at_server_spec 5.0.3: better handling of `isAuthenticated` and `isPolAuthenticated`

### DIFF
--- a/packages/at_server_spec/CHANGELOG.md
+++ b/packages/at_server_spec/CHANGELOG.md
@@ -1,5 +1,7 @@
+## 5.0.3
+- feat: defensive code: ensure `isAuthenticated` and `isPolAuthenticated` 
+  may not both be true at the same time
 ## 5.0.2
-
 - build[deps]: Upgraded the following package:
   - at_commons to v5.0.0
 ## 5.0.1

--- a/packages/at_server_spec/lib/at_server_spec.dart
+++ b/packages/at_server_spec/lib/at_server_spec.dart
@@ -8,4 +8,3 @@ export 'package:at_server_spec/src/connection/inbound_connection.dart';
 export 'package:at_server_spec/src/verb/update_meta.dart';
 export 'package:at_server_spec/src/verb/verb.dart';
 export 'package:at_server_spec/src/at_rate_limiter/at_rate_limiter.dart';
-

--- a/packages/at_server_spec/lib/src/connection/at_connection.dart
+++ b/packages/at_server_spec/lib/src/connection/at_connection.dart
@@ -27,8 +27,35 @@ abstract class AtConnectionMetaData {
   bool isCreated = false;
   bool isStale = false;
   bool isListening = false;
-  bool isAuthenticated = false;
-  bool isPolAuthenticated = false;
+
+  bool _isAuthenticated = false;
+
+  /// Authenticated via CRAM, PKAM, APKAM
+  bool get isAuthenticated => _isAuthenticated;
+
+  /// Was authenticated via CRAM, PKAM, APKAM
+  set isAuthenticated(bool b) {
+    _isAuthenticated = b;
+    if (_isAuthenticated) {
+      // if isAuthenticated is set to true, isPolAuthenticated must be false
+      _isPolAuthenticated = false;
+    }
+  }
+
+  bool _isPolAuthenticated = false;
+
+  /// Authenticated as another atSign
+  bool get isPolAuthenticated => _isPolAuthenticated;
+
+  /// Authenticated as another atSign
+  set isPolAuthenticated(bool b) {
+    _isPolAuthenticated = b;
+    if (_isPolAuthenticated) {
+      // if isPolAuthenticated is set to true, isAuthenticated must be false
+      _isAuthenticated = false;
+    }
+  }
+
   bool isStream = false;
   String? streamId;
   //// if [isAuthenticated] is true, then authType is set to cram/legacy_pkam/apkam

--- a/packages/at_server_spec/pubspec.yaml
+++ b/packages/at_server_spec/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_server_spec
 description: A Dart library containing abstract classes that defines what implementations of the root and secondary servers are responsible for.
-version: 5.0.2
+version: 5.0.3
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://docs.atsign.com
 documentation: https://docs.atsign.com/atplatform/secondaryserver


### PR DESCRIPTION
This is first of three PRs being split out from #2235 to allow for a sane merge and publish sequence

**- What I did**
feat: at_server_spec 5.0.3: defensive code: ensure `isAuthenticated` and `isPolAuthenticated` may not both be true at the same time

**- How I did it**
See commits. Note that tests of this change are in #2235 

**- How to verify it**
