### PR TITLE
feat: major version change for simplified keystore interface

### DIFF
--- a/packages/at_persistence_spec/CHANGELOG.md
+++ b/packages/at_persistence_spec/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.0
+- feat!: major version change for simplified keystore interface
 ## 2.0.14
 - feat: add optional param skipCommit to keystore - put,create and remove methods
 ## 2.0.12

--- a/packages/at_persistence_spec/lib/src/keystore/keystore.dart
+++ b/packages/at_persistence_spec/lib/src/keystore/keystore.dart
@@ -20,55 +20,19 @@ abstract class WritableKeystore<K, V> implements Keystore<K, V> {
   ///
   /// @param key - Key associated with a value.
   /// @param value - Value to be associated with the specified key.
-  /// @param time_to_live - Duration in milliseconds after which the key should expire automatically.
-  /// @param time_to_born - Duration in milliseconds after which the key will become active.
   /// @param skipCommit - if set to true, will skip adding entry to commit log for this update. Set to false by default.
   /// @returns sequence number from commit log if put is success. null otherwise
   /// Throws a [DataStoreException] if the the operation fails due to some issue with the data store.
-  Future<dynamic> put(K key, V value,
-      {int? time_to_live,
-      int? time_to_born,
-      int? time_to_refresh,
-      bool? isCascade,
-      bool? isBinary,
-      bool? isEncrypted,
-      String? dataSignature,
-      String? sharedKeyEncrypted,
-      String? publicKeyChecksum,
-      String? encoding,
-      String? encKeyName,
-      String? encAlgo,
-      String? ivNonce,
-      String? skeEncKeyName,
-      String? skeEncAlgo,
-      bool skipCommit = false});
+  Future<dynamic> put(K key, V value, {bool skipCommit = false});
 
   /// If the specified key is not already associated with a value (or is mapped to null) associates it with the given value and returns null, else returns the current value.
   ///
   /// @param key - Key with which the specified value is to be associated
   /// @param value - Value to be associated with the specified key
-  /// @param time_to_live - Duration in milliseconds after which the key should expire automatically.
-  /// @param time_to_born - Duration in milliseconds after which the key will become active.
   /// @param skipCommit - if set to true, will skip adding entry to commit log for this create operation. Set to false by default.
   /// @return - sequence number from commit log if put is success. null otherwise
   /// Throws a [DataStoreException] if the the operation fails due to some issue with the data store.
-  Future<dynamic> create(K key, V value,
-      {int? time_to_live,
-      int? time_to_born,
-      int? time_to_refresh,
-      bool? isCascade,
-      bool? isBinary,
-      bool? isEncrypted,
-      String? dataSignature,
-      String? sharedKeyEncrypted,
-      String? publicKeyChecksum,
-      String? encoding,
-      String? encKeyName,
-      String? encAlgo,
-      String? ivNonce,
-      String? skeEncKeyName,
-      String? skeEncAlgo,
-      bool skipCommit = false});
+  Future<dynamic> create(K key, V value, {bool skipCommit = false});
 
   /// Removes the mapping for a key from this key store if it is present
   ///

--- a/packages/at_persistence_spec/pubspec.yaml
+++ b/packages/at_persistence_spec/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_persistence_spec
 description: A Dart library containing abstract classes that defines what an implementation of the persistence layer is responsible for. This can be used to guide implementation of other persistence solutions for servers or SDKs as desired.
-version: 2.0.14
+version: 3.0.0
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://atsign.dev
 documentation: https://docs.atsign.com/


### PR DESCRIPTION
This is second of three PRs being split out from https://github.com/atsign-foundation/at_server/pull/2235 to allow for a sane merge and publish sequence

**- What I did**
Removed all of the optional "metadata" parameters from `WritableKeyStore`'s `put` and `create` functions

**- How I did it**
See commits.
