### PR TITLE
fix: potential bugs handling atSigns which end in `data`

### DIFF
--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.4.1
+- fix: potential bugs handling atSigns which end in `data`
+
 # 3.4.0
 - feat: immutable records
   - When `immutable` is set in metadata, then the record may not

--- a/packages/at_secondary_server/lib/src/caching/cache_manager.dart
+++ b/packages/at_secondary_server/lib/src/caching/cache_manager.dart
@@ -153,7 +153,7 @@ class AtCacheManager {
 
     // OutboundMessageListener will throw exceptions upon any 'error:' responses, malformed response, or timeouts
     // So we only have to worry about 'data:' response here
-    remoteResponse = remoteResponse!.replaceAll('data:', '');
+    remoteResponse = remoteResponse!.replaceFirst(RegExp('^data:'), '');
     if (remoteResponse == 'null') {
       if (maintainCache) {
         logger.info(

--- a/packages/at_secondary_server/lib/src/connection/outbound/outbound_client.dart
+++ b/packages/at_secondary_server/lib/src/connection/outbound/outbound_client.dart
@@ -147,7 +147,7 @@ class OutboundClient {
     doing = 'checkRemotePublicKey removing "data:" from the response';
     try {
       if (remoteResponse.startsWith('data:')) {
-        remoteResponse = remoteResponse.replaceFirst('data:', '');
+        remoteResponse = remoteResponse.replaceFirst(RegExp('^data:'), '');
       }
       doing =
           'checkRemotePublicKey parsing response from looking up $remotePublicKeyName';

--- a/packages/at_secondary_server/lib/src/connection/outbound/outbound_message_listener.dart
+++ b/packages/at_secondary_server/lib/src/connection/outbound/outbound_message_listener.dart
@@ -100,7 +100,7 @@ class OutboundMessageListener {
           // Right now, all callers of this method only expect there ever to be a 'data:' response.
           // So right now, the right thing to do here is to throw an exception.
           // We can leave the connection open since an 'error:' response indicates normal functioning on the other end
-          result = result.toString().replaceFirst('error:', '');
+          result = result.toString().replaceFirst(RegExp('^error:'), '');
           _throwAtExceptionFromErrorResponse(result);
         } else {
           // any other response is unexpected and bad, so close the connection and throw an exception

--- a/packages/at_secondary_server/lib/src/verb/handler/pol_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/pol_verb_handler.dart
@@ -107,12 +107,12 @@ class PolVerbHandler extends AbstractVerbHandler {
       // fetch the challenge from the other secondary
       signedChallenge =
           await (_outboundClient?.lookUp(lookUpKey, handshake: false));
-      signedChallenge = signedChallenge?.replaceFirst('data:', '');
+      signedChallenge = signedChallenge?.replaceFirst(RegExp('^data:'), '');
 
       // look for the public key on the other secondary
       var plookupCommand = 'signing_publickey$fromAtSign';
       fromPublicKey = await (_outboundClient?.plookUp(plookupCommand));
-      fromPublicKey = fromPublicKey?.replaceFirst('data:', '');
+      fromPublicKey = fromPublicKey?.replaceFirst(RegExp('^data:'), '');
 
       // Getting stored secret from this secondary server
       var secret = await keyStore.get('public:$sessionID$fromAtSign');

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_secondary
 description: Implementation of secondary server.
-version: 3.4.0
+version: 3.4.1
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://www.example.com
 publish_to: none

--- a/packages/at_secondary_server/test/cram_verb_test.dart
+++ b/packages/at_secondary_server/test/cram_verb_test.dart
@@ -82,7 +82,7 @@ void main() {
       fromVerbParams.putIfAbsent('atSign', () => 'test_user_1');
       var response = Response();
       await fromVerbHandler.processVerb(response, fromVerbParams, atConnection);
-      var fromResponse = response.data!.replaceFirst('data:', '');
+      var fromResponse = response.data!.replaceFirst(RegExp('^data:'), '');
       var cramVerbParams = HashMap<String, String>();
       var combo = '${secretData.data}$fromResponse';
       var bytes = utf8.encode(combo);

--- a/packages/at_secondary_server/test/local_lookup_verb_test.dart
+++ b/packages/at_secondary_server/test/local_lookup_verb_test.dart
@@ -164,7 +164,7 @@ void main() {
       fromVerbParams.putIfAbsent('atSign', () => 'test_user_1');
       var response = Response();
       await fromVerbHandler.processVerb(response, fromVerbParams, atConnection);
-      var fromResponse = response.data!.replaceFirst('data:', '');
+      var fromResponse = response.data!.replaceFirst(RegExp('^data:'), '');
       var cramVerbParams = HashMap<String, String>();
       var combo = '${secretData.data}$fromResponse';
       var bytes = utf8.encode(combo);
@@ -215,7 +215,7 @@ void main() {
       fromVerbParams.putIfAbsent('atSign', () => 'test_user_1');
       var response = Response();
       await fromVerbHandler.processVerb(response, fromVerbParams, atConnection);
-      var fromResponse = response.data!.replaceFirst('data:', '');
+      var fromResponse = response.data!.replaceFirst(RegExp('^data:'), '');
       var cramVerbParams = HashMap<String, String>();
       var combo = '${secretData.data}$fromResponse';
       var bytes = utf8.encode(combo);

--- a/packages/at_secondary_server/test/notify_verb_test.dart
+++ b/packages/at_secondary_server/test/notify_verb_test.dart
@@ -339,7 +339,7 @@ void main() {
       fromVerbParams.putIfAbsent('atSign', () => 'test_user_1');
       var response = Response();
       await fromVerbHandler.processVerb(response, fromVerbParams, atConnection);
-      var fromResponse = response.data!.replaceFirst('data:', '');
+      var fromResponse = response.data!.replaceFirst(RegExp('^data:'), '');
       var cramVerbParams = HashMap<String, String>();
       var combo = '${secretData.data}$fromResponse';
       var bytes = utf8.encode(combo);
@@ -393,7 +393,7 @@ void main() {
       fromVerbParams.putIfAbsent('atSign', () => 'test_user_1');
       var response = Response();
       await fromVerbHandler.processVerb(response, fromVerbParams, atConnection);
-      var fromResponse = response.data!.replaceFirst('data:', '');
+      var fromResponse = response.data!.replaceFirst(RegExp('^data:'), '');
       var cramVerbParams = HashMap<String, String>();
       var combo = '${secretData.data}$fromResponse';
       var bytes = utf8.encode(combo);

--- a/packages/at_secondary_server/test/update_verb_test.dart
+++ b/packages/at_secondary_server/test/update_verb_test.dart
@@ -568,7 +568,7 @@ void main() {
       fromVerbParams.putIfAbsent('atSign', () => 'alice');
       var response = Response();
       await fromVerbHandler.processVerb(response, fromVerbParams, atConnection);
-      var fromResponse = response.data!.replaceFirst('data:', '');
+      var fromResponse = response.data!.replaceFirst(RegExp('^data:'), '');
       var cramVerbParams = HashMap<String, String>();
       var combo = '${secretData.data}$fromResponse';
       var bytes = utf8.encode(combo);
@@ -615,7 +615,7 @@ void main() {
       fromVerbParams.putIfAbsent('atSign', () => 'alice');
       var response = Response();
       await fromVerbHandler.processVerb(response, fromVerbParams, atConnection);
-      var fromResponse = response.data!.replaceFirst('data:', '');
+      var fromResponse = response.data!.replaceFirst(RegExp('^data:'), '');
       var cramVerbParams = HashMap<String, String>();
       var combo = '${secretData.data}$fromResponse';
       var bytes = utf8.encode(combo);
@@ -692,7 +692,7 @@ void main() {
       fromVerbParams.putIfAbsent('atSign', () => 'alice');
       var response = Response();
       await fromVerbHandler.processVerb(response, fromVerbParams, atConnection);
-      var fromResponse = response.data!.replaceFirst('data:', '');
+      var fromResponse = response.data!.replaceFirst(RegExp('^data:'), '');
       var cramVerbParams = HashMap<String, String>();
       var combo = '${secretData.data}$fromResponse';
       var bytes = utf8.encode(combo);


### PR DESCRIPTION
**- What I did**
fix: wherever we are parsing data: or error: responses from atServer, use replaceFirst(RegExp(r'^data:'), '') or replaceFirst(RegExp(r'^error:'), '')

**- How I did it**
See commits

**- How to verify it**
Tests pass
