### PR TITLE
fix: scan verb now using AbstractVerbHandler.isAuthorized for namespace access checks

### DIFF
--- a/packages/at_secondary_server/lib/src/verb/handler/abstract_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/abstract_verb_handler.dart
@@ -366,7 +366,8 @@ abstract class AbstractVerbHandler implements VerbHandler {
             verb is NotifyFetch ||
             verb is NotifyStatus ||
             verb is NotifyList ||
-            verb is Monitor) &&
+            verb is Monitor ||
+            verb is Scan) &&
         (access == 'r' || access == 'rw');
   }
 

--- a/packages/at_secondary_server/lib/src/verb/handler/scan_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/scan_verb_handler.dart
@@ -223,12 +223,9 @@ class ScanVerbHandler extends AbstractVerbHandler {
         localKeysList.remove(key);
         continue;
       }
-      // Extract namespace from the key.
-      String namespaceFromTheKey = key.toString().substring(
-          (key.toString().lastIndexOf('.') + 1),
-          key.toString().lastIndexOf('@'));
-      if (!enrollNamespaces.containsKey(namespaceFromTheKey) ||
-          namespaceFromTheKey == enrollManageNamespace) {
+
+      bool mayRead = await super.isAuthorized(atConnectionMetadata, atKey: key);
+      if (!mayRead) {
         localKeysList.remove(key);
         continue;
       }

--- a/packages/at_secondary_server/test/scan_verb_test.dart
+++ b/packages/at_secondary_server/test/scan_verb_test.dart
@@ -11,6 +11,7 @@ import 'package:at_secondary/src/server/at_secondary_impl.dart';
 import 'package:at_secondary/src/utils/handler_util.dart';
 import 'package:at_secondary/src/utils/secondary_util.dart';
 import 'package:at_secondary/src/verb/executor/default_verb_executor.dart';
+import 'package:at_secondary/src/verb/handler/local_lookup_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/scan_verb_handler.dart';
 import 'package:at_secondary/src/verb/manager/verb_handler_manager.dart';
 import 'package:at_server_spec/at_server_spec.dart';
@@ -120,10 +121,12 @@ void main() {
   group('A group of mock tests to verify scan verb on authenticated connection',
       () {
     late ScanVerbHandler scanVerbHandler;
+    late LocalLookupVerbHandler llookupVH;
     setUp(() async {
       await verbTestsSetUp();
       scanVerbHandler = ScanVerbHandler(
           secondaryKeyStore, mockOutboundClientManager, cacheManager);
+      llookupVH = LocalLookupVerbHandler(secondaryKeyStore);
     });
     test('A test to verify all keys are returned for a simple scan', () async {
       AtSecondaryServerImpl.getInstance().currentAtSign = alice;
@@ -206,6 +209,53 @@ void main() {
       List scanResponse = jsonDecode(inboundConnection.lastWrittenData!);
       expect(scanResponse.length, 0);
     });
+
+    /// Set up an enrollment with limited access
+    /// Create an __atserver event
+    /// Verify that scan on this enrollment will return the __atserver event
+    test('Test that __atserver events are returned by scan', () async {
+      String enrollmentId = Uuid().v4();
+      inboundConnection.metadata.enrollmentId = enrollmentId;
+      final enrollJson = {
+        'sessionId': '123',
+        'appName': 'my_app',
+        'deviceName': 'my_device',
+        'namespaces': {'my_app': 'rw'},
+        'apkamPublicKey': 'testPublicKeyValue',
+        'requestType': 'newEnrollment',
+        'approval': {'state': 'approved'}
+      };
+      await AtSecondaryServerImpl.getInstance()
+          .enrollmentManager
+          .put(enrollmentId, AtData()..data = jsonEncode(enrollJson));
+
+      inboundConnection.metaData.isAuthenticated = true;
+
+      final event = AtSignPKChangedEvent(bob);
+      // store the event for retrieval by clients
+      int nowMicros = DateTime.now().microsecondsSinceEpoch;
+      String keyName = '$nowMicros.events'
+          '.${AtConstants.atServerReservedNamespace}'
+          '@${alice.withoutAt()}';
+      await secondaryKeyStore.put(
+          keyName, AtData()..data = jsonEncode(event.toJson()));
+
+      await llookupVH.process('llookup:$keyName', inboundConnection);
+      inboundConnection.lastWrittenData = inboundConnection.lastWrittenData!
+          .split('\n')[0]
+          .replaceAll('data:', '');
+      final fetchedEvent = AtSignPKChangedEvent.fromJson(
+          jsonDecode(inboundConnection.lastWrittenData!));
+      expect(fetchedEvent.toJson(), event.toJson());
+
+      await scanVerbHandler.process('scan __atserver', inboundConnection);
+      inboundConnection.lastWrittenData = inboundConnection.lastWrittenData!
+          .split('\n')[0]
+          .replaceAll('data:', '');
+      List scanResponse = jsonDecode(inboundConnection.lastWrittenData!);
+      expect(scanResponse.length, 1);
+    });
+
     tearDown(() async {
       await verbTestsTearDown();
     });


### PR DESCRIPTION
**- What I did**
fix: scan verb now using AbstractVerbHandler.isAuthorized for namespace access checks. Previously it was doing its own thing which meant that enrollments with limited namespace access were able to lookup atserver events (as intended) but were unable to scan them (not as intended)

**- How I did it**
- See commits
- Added unit test

**- How to verify it**
Tests pass

