### PR TITLE
feat: at_persistence_spec: Add `preRemoveHook` and `postRemoveHook` to WritableKeyStore interface

### DIFF
--- a/packages/at_persistence_spec/CHANGELOG.md
+++ b/packages/at_persistence_spec/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.1.0
+- feat: Add `preRemoveHook` and `postRemoveHook` to WritableKeyStore interface
 ## 3.0.0
 - feat!: major version change for simplified keystore interface
 ## 2.0.14

--- a/packages/at_persistence_spec/lib/at_persistence_spec.dart
+++ b/packages/at_persistence_spec/lib/at_persistence_spec.dart
@@ -1,5 +1,3 @@
-library at_persistence_spec;
-
 export 'package:at_persistence_spec/src/annotation/at_annotation.dart';
 export 'package:at_persistence_spec/src/compaction/at_compaction_strategy.dart';
 export 'package:at_persistence_spec/src/compaction/at_compaction_stats.dart';

--- a/packages/at_persistence_spec/lib/src/keystore/keystore.dart
+++ b/packages/at_persistence_spec/lib/src/keystore/keystore.dart
@@ -1,7 +1,5 @@
 /// Keystore represents a data store like a database which can store mapping between keys and values.
-// ignore_for_file: non_constant_identifier_names, constant_identifier_names
-
-abstract class Keystore<K, V> {
+abstract interface class Keystore<K, V> {
   /// Retrieves a Future value for the key passed from the key store.
   ///
   /// @param key Key associated with a value.
@@ -10,7 +8,7 @@ abstract class Keystore<K, V> {
 }
 
 /// WritableKeystore represents a data store like a database that allows CRUD operations on the values belonging to the keys
-abstract class WritableKeystore<K, V> implements Keystore<K, V> {
+abstract interface class WritableKeystore<K, V> implements Keystore<K, V> {
   /// Subclasses should put any necessary post-construction async initialization
   /// in this method
   Future<void> initialize() async {}
@@ -41,9 +39,14 @@ abstract class WritableKeystore<K, V> implements Keystore<K, V> {
   /// @return - sequence number from commit log if remove is success. null otherwise
   /// Throws a [DataStoreException] if the operation fails due to some issue with the data store.
   Future<dynamic> remove(K key, {bool skipCommit = false});
+
+  List<Future<dynamic> Function(String key, {required bool skipCommit})>
+      get preRemoveHooks;
+  List<Future<dynamic> Function(String key, {required bool skipCommit})>
+      get postRemoveHooks;
 }
 
-abstract class SynchronizableKeyStore<K, V, T> {
+abstract interface class SynchronizableKeyStore<K, V, T> {
   Future<dynamic> putMeta(K key, T metadata);
 
   Future<dynamic> putAll(K key, V value, T metadata);
@@ -52,4 +55,5 @@ abstract class SynchronizableKeyStore<K, V, T> {
 }
 
 /// Enumeration indicating the store type.
+// ignore: constant_identifier_names
 enum StoreType { ROOT, SECONDARY }

--- a/packages/at_persistence_spec/lib/src/keystore/log_keystore.dart
+++ b/packages/at_persistence_spec/lib/src/keystore/log_keystore.dart
@@ -39,7 +39,7 @@ abstract class LogKeyStore<K, V> {
 
   ///Returns the list of expired keys
   ///@param expiryInDays
-  ///@return List<dynamic>
+  ///@return `List<dynamic>`
   Future<List<dynamic>> getExpired(int expiryInDays);
 
   /// Returns the size of the storage

--- a/packages/at_persistence_spec/lib/src/keystore/secondary_keystore.dart
+++ b/packages/at_persistence_spec/lib/src/keystore/secondary_keystore.dart
@@ -1,6 +1,6 @@
 import 'package:at_persistence_spec/at_persistence_spec.dart';
 
-abstract class SecondaryKeyStore<K, V, T>
+abstract interface class SecondaryKeyStore<K, V, T>
     implements WritableKeystore<K, V>, SynchronizableKeyStore<K, V, T> {
   /// Retrieves all keys have that expired.
   /// @return - List of keys that have expired
@@ -12,7 +12,7 @@ abstract class SecondaryKeyStore<K, V, T>
   ///Returns the list of keys, optionally keys can be searched on regular expression
   ///@param - String : This is an optional parameter that accepts the regular expression
   /// and returns keys that finds the match
-  /// @return - List<K> : Returns list of keys
+  /// @return - `List<K>` : Returns list of keys
   List<K> getKeys({String? regex});
 
   /// Checks whether the keystore contains the key. Returns a true if key is present, else false.

--- a/packages/at_persistence_spec/pubspec.yaml
+++ b/packages/at_persistence_spec/pubspec.yaml
@@ -1,12 +1,12 @@
 name: at_persistence_spec
 description: A Dart library containing abstract classes that defines what an implementation of the persistence layer is responsible for. This can be used to guide implementation of other persistence solutions for servers or SDKs as desired.
-version: 3.0.0
+version: 3.1.0
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://atsign.dev
 documentation: https://docs.atsign.com/
 
 environment:
-  sdk: '>=2.15.0 <4.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dev_dependencies:
-  lints: ^1.0.1
+  lints: ^6.0.0


### PR DESCRIPTION
**- What I did**
- feat: Add `preRemoveHook` and `postRemoveHook` to WritableKeyStore interface
- refactor: use Dart 3.x feature to mark various classes as `abstract interface class` rather than just `abstract class`
- chore: upgraded lints package to 6.0.0 and cleaned up some lint

**- How I did it**

**- How to verify it**
This was part of #2292 and has been verified there. Separate PR here so can publish this package first