### PR TITLE
feat: at_persistence_secondary_server 4.1.0

### DIFF
--- a/packages/at_persistence_secondary_server/CHANGELOG.md
+++ b/packages/at_persistence_secondary_server/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.1.0
+- feat: Add `preRemoveHook` and `postRemoveHook` to KeyStore interfaces
+
 ## 4.0.0
 - refactor: Take up new major version 3.0.0 of at_persistence_spec, update and 
   simplify the HiveKeyStore implementation accordingly

--- a/packages/at_persistence_secondary_server/analysis_options.yaml
+++ b/packages/at_persistence_secondary_server/analysis_options.yaml
@@ -5,9 +5,20 @@ include: package:lints/recommended.yaml
 
 # For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
 # Uncomment to specify additional rules.
-# linter:
-#   rules:
-#     - camel_case_types
+linter:
+  rules:
+    annotate_overrides: true
+    prefer_final_fields: true
+    implicit_call_tearoffs: true
+    camel_case_types : true
+    unnecessary_string_interpolations : true
+    unnecessary_brace_in_string_interps: true
+    await_only_futures : true
+    unawaited_futures: true
+    depend_on_referenced_packages : false
+    avoid_function_literals_in_foreach_calls: true
+    prefer_interpolation_to_compose_strings: true
+    strict_top_level_inference: false
 
 analyzer:
 #   exclude:

--- a/packages/at_persistence_secondary_server/lib/at_persistence_secondary_server.dart
+++ b/packages/at_persistence_secondary_server/lib/at_persistence_secondary_server.dart
@@ -1,5 +1,3 @@
-library at_persistence_secondary_server;
-
 export 'package:at_persistence_secondary_server/src/compaction/at_compaction_job.dart';
 export 'package:at_persistence_secondary_server/src/compaction/commit_log_compaction_service.dart';
 export 'package:at_persistence_secondary_server/src/compaction/at_compaction_stats_service.dart';

--- a/packages/at_persistence_secondary_server/lib/src/keystore/hive_keystore.dart
+++ b/packages/at_persistence_secondary_server/lib/src/keystore/hive_keystore.dart
@@ -228,7 +228,7 @@ class HiveKeystore implements SecondaryKeyStore<String, AtData?, AtMetaData?> {
         // from commitLog to ensure that commitLog and KeyStore are in sync
         CommitEntry? commitEntry = _commitLog.getLatestCommitEntry(key);
         if (commitEntry != null) {
-          _commitLog.commitLogKeyStore.remove(commitEntry.commitId!);
+          await _commitLog.commitLogKeyStore.remove(commitEntry.commitId!);
         }
         retVal = -1;
       } else {

--- a/packages/at_persistence_secondary_server/lib/src/keystore/hive_keystore.dart
+++ b/packages/at_persistence_secondary_server/lib/src/keystore/hive_keystore.dart
@@ -21,6 +21,12 @@ class HiveKeystore implements SecondaryKeyStore<String, AtData?, AtMetaData?> {
   var keyStoreHelper = HiveKeyStoreHelper.getInstance();
   HivePersistenceManager? persistenceManager;
   late AtCommitLog _commitLog;
+  @override
+  List<Future Function(String key, {required bool skipCommit})> preRemoveHooks =
+      [];
+  @override
+  List<Future Function(String key, {required bool skipCommit})>
+      postRemoveHooks = [];
 
   /// A map-based cache that stores "expiresAt" and "availableAt" from AtMetadata
   /// of keys with TTL or TTB set, to efficiently track the active or expired state
@@ -207,6 +213,12 @@ class HiveKeystore implements SecondaryKeyStore<String, AtData?, AtMetaData?> {
   @override
   Future<int?> remove(String key, {bool skipCommit = false}) async {
     key = key.toLowerCase();
+
+    for (final hook in preRemoveHooks) {
+      await hook(key, skipCommit: skipCommit);
+    }
+
+    int retVal;
     try {
       await persistenceManager!.getBox().delete(keyStoreHelper.prepareKey(key));
       // On deleting the key, remove it from the expiryKeyCache.
@@ -218,9 +230,9 @@ class HiveKeystore implements SecondaryKeyStore<String, AtData?, AtMetaData?> {
         if (commitEntry != null) {
           _commitLog.commitLogKeyStore.remove(commitEntry.commitId!);
         }
-        return -1;
+        retVal = -1;
       } else {
-        return await _commitLog.commit(key, CommitOp.DELETE);
+        retVal = (await _commitLog.commit(key, CommitOp.DELETE))!;
       }
     } on Exception catch (exception) {
       logger.severe('HiveKeystore delete exception: $exception');
@@ -230,6 +242,12 @@ class HiveKeystore implements SecondaryKeyStore<String, AtData?, AtMetaData?> {
       logger.severe('HiveKeystore delete error: $error');
       throw DataStoreException(error.message);
     }
+
+    for (final hook in postRemoveHooks) {
+      await hook(key, skipCommit: skipCommit);
+    }
+
+    return retVal;
   }
 
   @override

--- a/packages/at_persistence_secondary_server/lib/src/log/commitlog/at_commit_log.dart
+++ b/packages/at_persistence_secondary_server/lib/src/log/commitlog/at_commit_log.dart
@@ -209,7 +209,7 @@ class AtCommitLog extends BaseAtCommitLog {
 
 @client
 class ClientAtCommitLog extends AtCommitLog {
-  ClientAtCommitLog(CommitLogKeyStore keyStore) : super(keyStore);
+  ClientAtCommitLog(super.keyStore);
 
   /// Returns the commit entry for a given commit sequence number
   /// throws [DataStoreException] if there is an exception getting the commit entry

--- a/packages/at_persistence_secondary_server/lib/src/log/commitlog/commit_log_keystore.dart
+++ b/packages/at_persistence_secondary_server/lib/src/log/commitlog/commit_log_keystore.dart
@@ -17,7 +17,7 @@ class CommitLogKeyStore extends BaseCommitLogKeyStore {
 
   late SyncKeysFetchStrategy _syncKeysFetchStrategy;
 
-  CommitLogKeyStore(String currentAtSign) : super(currentAtSign) {
+  CommitLogKeyStore(super.currentAtSign) {
     commitLogCache = CommitLogCache(this);
     _syncKeysFetchStrategy = FetchAllKeysStrategy();
   }
@@ -290,7 +290,7 @@ class CommitLogKeyStore extends BaseCommitLogKeyStore {
     await Future.forEach(commitLogMap.keys, (key) async {
       CommitEntry? commitEntry = commitLogMap[key];
       if (commitEntry?.commitId == null) {
-        commitEntry!.commitId = key as int;
+        commitEntry!.commitId = key;
         await getBox().put(commitEntry.commitId, commitEntry);
       }
     });
@@ -350,7 +350,7 @@ class ClientCommitLogKeyStore extends CommitLogKeyStore {
   /// The key represents the regex and value represents the [CommitEntry]
   final _lastSyncedEntryCacheMap = <String, CommitEntry>{};
 
-  ClientCommitLogKeyStore(String currentAtSign) : super(currentAtSign);
+  ClientCommitLogKeyStore(super.currentAtSign);
 
   /// Initializes the key store and makes it ready for the persistence
   @override

--- a/packages/at_persistence_secondary_server/lib/src/log/commitlog/commit_log_keystore.dart
+++ b/packages/at_persistence_secondary_server/lib/src/log/commitlog/commit_log_keystore.dart
@@ -259,7 +259,7 @@ class CommitLogKeyStore extends BaseCommitLogKeyStore {
       if (commitEntry == null) {
         _logger.warning(
             'CommitLog seqNum $seqNum has a null commitEntry - removing');
-        remove(seqNum);
+        await remove(seqNum);
         return;
       }
       String? atKey = commitEntry.atKey;
@@ -273,7 +273,7 @@ class CommitLogKeyStore extends BaseCommitLogKeyStore {
         _logger.warning(
             'CommitLog seqNum $seqNum has an entry with an invalid atKey $atKey - removed');
         removed.add(atKey);
-        remove(seqNum);
+        await remove(seqNum);
         return;
       } else {
         _logger.finer(

--- a/packages/at_persistence_secondary_server/lib/src/notification/at_notification_keystore.dart
+++ b/packages/at_persistence_secondary_server/lib/src/notification/at_notification_keystore.dart
@@ -81,7 +81,7 @@ class AtNotificationKeystore
       throw DataStoreException(
           'key length ${key.length} is greater than $maxKeyLengthWithoutCached chars');
     }
-    AtNotificationCallback.getInstance().invokeCallbacks(value);
+    await AtNotificationCallback.getInstance().invokeCallbacks(value);
     await _getBox().put(key, value);
   }
 
@@ -127,8 +127,8 @@ class AtNotificationKeystore
           expired.add(key);
         }
         //Todo: remove obsolete code
-        //This method was introduced for backwards compatability to accomodate notifications without expiresAt.
-        // If concluded that all notifications have an epiresAt param defined, the below block of code is obsolete and can be removed.
+        //This method was introduced for backwards compatability to accommodate notifications without expiresAt.
+        // If concluded that all notifications have an expiresAt param defined, the below block of code is obsolete and can be removed.
         if (value?.expiresAt == null &&
             DateTime.now()
                     .toUtc()
@@ -155,7 +155,7 @@ class AtNotificationKeystore
                 ..atMetaData = value.atMetadata
                 ..ttl = value.ttl)
               .build();
-          put(key, newNotification);
+          await put(key, newNotification);
         }
       });
 

--- a/packages/at_persistence_secondary_server/lib/src/notification/at_notification_keystore.dart
+++ b/packages/at_persistence_secondary_server/lib/src/notification/at_notification_keystore.dart
@@ -20,6 +20,12 @@ class AtNotificationKeystore
   final _notificationExpiryInHours = 72;
   static const int maxKeyLengthWithoutCached = 248;
   late AtCompactionConfig atCompactionConfig;
+  @override
+  List<Future Function(String key, {required bool skipCommit})> preRemoveHooks =
+      [];
+  @override
+  List<Future Function(String key, {required bool skipCommit})>
+      postRemoveHooks = [];
 
   factory AtNotificationKeystore.getInstance() {
     return _singleton;
@@ -188,8 +194,15 @@ class AtNotificationKeystore
 
   @override
   Future remove(key, {bool skipCommit = false}) async {
+    for (final hook in preRemoveHooks) {
+      await hook(key, skipCommit: skipCommit);
+    }
     assert(key != null);
     await _getBox().delete(key);
+
+    for (final hook in postRemoveHooks) {
+      await hook(key, skipCommit: skipCommit);
+    }
   }
 
   Future<Map>? _toMap() async {

--- a/packages/at_persistence_secondary_server/pubspec.yaml
+++ b/packages/at_persistence_secondary_server/pubspec.yaml
@@ -1,11 +1,11 @@
 name: at_persistence_secondary_server
 description: A Dart library with the implementation classes for the persistence layer of the secondary server.
-version: 4.0.0
+version: 4.1.0
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://docs.atsign.com/
 
 environment:
-  sdk: '>=2.15.0 <4.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   path: ^1.8.2
@@ -16,11 +16,11 @@ dependencies:
   at_utf7: ^1.0.0
   at_commons: ^5.3.0
   at_utils: ^3.0.19
-  at_persistence_spec: ^3.0.0
+  at_persistence_spec: ^3.1.0
   meta: ^1.8.0
 
 dev_dependencies:
-  lints: ^5.0.0
+  lints: ^6.0.0
   test: ^1.25.8
   coverage: ^1.6.1
   collection: ^1.17.1


### PR DESCRIPTION
**- What I did**
- feat: took up at_persistence_spec 3.1.0, and added `preRemoveHook` and `postRemoveHook` to HiveKeystore and AtNotificationKeystore, and modified their `remove` methods to call any hooks that have been added
- chore: fixed some lint
- chore: updated analysis_options.yaml
- chore: fixed newly-uncovered lint

**- How I did it**

**- How to verify it**
- Tests pass
- This was part of #2292 and has been verified there. Separate PR here so can publish this package first

