### PR TITLE
fix: Correct runner

### DIFF
--- a/.github/workflows/at_server_prod_deploy.yaml
+++ b/.github/workflows/at_server_prod_deploy.yaml
@@ -64,7 +64,7 @@ jobs:
 
   Deploy_On_Prod_K8:
     needs: Docker_Build
-    runs-on: [self-hosted, linux, x64, K8s]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
Initial attempt at root release [r3.5.2](https://github.com/atsign-foundation/at_server/releases/tag/untagged-0a1f974fc7ee60351736) failed as the [actions run](https://github.com/atsign-foundation/at_server/actions/runs/16052106841) is configured to use a self hosted runner that isn't present in this environment

**- What I did**

Use `ubuntu-latest` like we do on the dev workflow

**- How to verify it**

I'll need to re-release r3.5.2

**- Description for the changelog**

fix: Correct runner