### PR TITLE
ci: Steps add time but no value, just let runner exit

### DIFF
--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -279,14 +279,6 @@ jobs:
         working-directory: ${{ env.ftest-working-directory }}
         run: dart run test --concurrency=1
 
-      - name: Stop docker container
-        run: docker container stop at_virtual_env_cont
-
-      # Remove image created for at_virtual_env:trunk for running functional tests in pipeline.
-      - name: Remove docker image
-        run: docker rmi at_virtual_env:trunk
-
-
   end2end_test_prep:
     # Don't run on PRs from a fork or Dependabot as the secrets aren't available
     if: ${{ github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]'}}

--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -207,7 +207,6 @@ jobs:
       upload-assets: true
 
   # Runs functional tests on at_secondary.
-  # If tests are successful, uploads root server and secondary server binaries for subsequent jobs
   functional_tests:
     runs-on: ubuntu-latest
     strategy:
@@ -279,14 +278,6 @@ jobs:
       - name: Run tests
         working-directory: ${{ env.ftest-working-directory }}
         run: dart run test --concurrency=1
-
-      # On push event, upload secondary server binary
-      - name: upload secondary server
-        if: ${{ github.event_name == 'push' && matrix.dart-channel == 'stable' }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: secondary-server
-          path: packages/at_secondary_server/secondary
 
       - name: Stop docker container
         run: docker container stop at_virtual_env_cont


### PR DESCRIPTION
Functional tests are failing on the step to remove the VE Docker image even though it should be stopped at that point and only exists in the context of the runner.

We don't really need to stop the container and remove the image - just let the runner die.

**- What I did**

* Removed step to upload binaries, as we no longer use them (now that we do multi arch builds)
* Removed steps to stop and remove VE container and its image.

**- How to verify it**

CI will run clean on this PR.

**- Description for the changelog**

ci: Steps add time but no value, just let runner exit