### PR TITLE
fix: set the trusted cacert path for AtSecondaryFinder

### DIFF
--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.5.3
+- fix: Set the trusted cacert path for AtSecondaryFinder
+
 # 3.5.2
 - fix: Prevent OutboundClient from creating new socket connections unnecessarily
 

--- a/packages/at_secondary_server/lib/src/connection/outbound/outbound_client.dart
+++ b/packages/at_secondary_server/lib/src/connection/outbound/outbound_client.dart
@@ -380,7 +380,7 @@ class DefaultOutboundConnectionFactory implements OutboundConnectionFactory {
   Future<OutboundSocketConnection> createOutboundConnection(
       String host, int port, String toAtSign) async {
     AtSecurityContextImpl securityContext = AtSecurityContextImpl();
-    SecurityContext secConConnect = SecurityContext();
+    SecurityContext secConConnect = SecurityContext.defaultContext;
     secConConnect.useCertificateChain(securityContext.publicKeyPath());
     secConConnect.usePrivateKey(securityContext.privateKeyPath());
     secConConnect

--- a/packages/at_secondary_server/lib/src/server/at_secondary_impl.dart
+++ b/packages/at_secondary_server/lib/src/server/at_secondary_impl.dart
@@ -80,7 +80,7 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
 
   AtSecondaryServerImpl._internal() {
     final socketConfig = SecureSocketConfig()
-      ..decryptPackets = true
+      ..decryptPackets = false
       ..pathToCerts = AtSecondaryConfig.trustedCertificateLocation
       ..tlsKeysSavePath = null;
 

--- a/packages/at_secondary_server/lib/src/server/at_secondary_impl.dart
+++ b/packages/at_secondary_server/lib/src/server/at_secondary_impl.dart
@@ -79,8 +79,16 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
   }
 
   AtSecondaryServerImpl._internal() {
+    final socketConfig = SecureSocketConfig()
+      ..decryptPackets = true
+      ..pathToCerts = AtSecondaryConfig.trustedCertificateLocation
+      ..tlsKeysSavePath = null;
+
     secondaryAddressFinder = CacheableSecondaryAddressFinder(
-        AtSecondaryConfig.rootServerUrl, AtSecondaryConfig.rootServerPort);
+      AtSecondaryConfig.rootServerUrl,
+      AtSecondaryConfig.rootServerPort,
+      socketConfig: socketConfig,
+    );
     outboundClientManager = OutboundClientManager(secondaryAddressFinder);
   }
 

--- a/packages/at_secondary_server/lib/src/server/at_secondary_impl.dart
+++ b/packages/at_secondary_server/lib/src/server/at_secondary_impl.dart
@@ -577,7 +577,7 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
 
   /// Starts the secondary server in secure mode and calls the listen method of server socket.
   Future<void> _startSecuredServer() async {
-    var secCon = SecurityContext();
+    var secCon = SecurityContext.defaultContext;
     var retryCount = 0;
     var certsAvailable = false;
     // if certs are unavailable then retry max 10 minutes

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -1,12 +1,12 @@
 name: at_secondary
 description: Implementation of secondary server.
-version: 3.5.2
+version: 3.5.3
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://www.example.com
 publish_to: none
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   args: 2.7.0
@@ -40,3 +40,10 @@ dev_dependencies:
   coverage: ^1.6.1
   lints: ^6.0.0
   mocktail: ^1.0.3
+
+dependency_overrides:
+  at_lookup:
+    git:
+      url: https://github.com/atsign-foundation/at_libraries
+      ref: 52bce94d107548d73f9f4086706bd4913a725aa8
+      path: packages/at_lookup

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   at_commons: 5.4.1
   at_utils: 3.2.0
   at_chops: 2.2.0
-  at_lookup: 3.1.0
+  at_lookup: 3.2.0
   at_server_spec: 5.0.3
   at_persistence_spec: 3.1.0
   at_persistence_secondary_server: 4.1.0
@@ -40,10 +40,3 @@ dev_dependencies:
   coverage: ^1.6.1
   lints: ^6.0.0
   mocktail: ^1.0.3
-
-dependency_overrides:
-  at_lookup:
-    git:
-      url: https://github.com/atsign-foundation/at_libraries
-      ref: 3b0a4ec6c6dcc460e87b50b3f7ba6117d8a675e0
-      path: packages/at_lookup

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -45,5 +45,5 @@ dependency_overrides:
   at_lookup:
     git:
       url: https://github.com/atsign-foundation/at_libraries
-      ref: 52bce94d107548d73f9f4086706bd4913a725aa8
+      ref: 3b0a4ec6c6dcc460e87b50b3f7ba6117d8a675e0
       path: packages/at_lookup


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Ensure trusted ca bundle is used when talking atServer to root server.

**- How I did it**

**- How to verify it**

- Needs to be deployed with a trusted ca bundle in a non-standard location and an application which triggers the atServer to lookup another atSign needs to be called (such as npt).

@cpswan I think you're most equipped to test this, would you mind lending a hand?

**- Description for the changelog**
fix: set the trusted cacert path for AtSecondaryFinder
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
