### PR TITLE
feat: small tweaks to improve http support

### DIFF
--- a/packages/at_root_server/lib/src/server/at_root_server_impl.dart
+++ b/packages/at_root_server/lib/src/server/at_root_server_impl.dart
@@ -160,10 +160,11 @@ class RootServerImpl implements AtRootServer {
           }
           List<String> pathParts = decodedRequestPath.split('/');
           String atSignToLookUp;
-          String redirectPath = '';
+          String encodedRedirectPath = '';
           atSignToLookUp = pathParts.removeAt(0);
           if (pathParts.isNotEmpty) {
-            redirectPath = pathParts.join('/');
+            encodedRedirectPath =
+                pathParts.map((s) => Uri.encodeComponent(s)).join('/');
           }
 
           String? v = await keyStoreManager.getKeyStore().get(atSignToLookUp);
@@ -172,13 +173,12 @@ class RootServerImpl implements AtRootServer {
             request.response.statusCode = HttpStatus.notFound;
             request.response.write('404 not found');
           } else {
-            if (redirectPath.isEmpty) {
+            if (encodedRedirectPath.isEmpty) {
               request.response.statusCode = HttpStatus.ok;
               request.response.write(v);
             } else {
               final locationHeaderValue = StringBuffer('https://$v');
-              locationHeaderValue
-                  .write('/${Uri.encodeComponent(redirectPath)}');
+              locationHeaderValue.write('/$encodedRedirectPath');
               if (request.uri.query.isNotEmpty) {
                 locationHeaderValue.write('?${request.uri.query}');
               }

--- a/packages/at_secondary_server/lib/src/connection/inbound/inbound_connection_impl.dart
+++ b/packages/at_secondary_server/lib/src/connection/inbound/inbound_connection_impl.dart
@@ -51,7 +51,7 @@ class InboundConnectionImpl<T extends Socket> extends BaseSocketConnection
     socket.done.onError((error, stackTrace) {
       logger
           .info('socket.done.onError called with $error. Calling this.close()');
-      this.close();
+      close();
     });
   }
 

--- a/packages/at_secondary_server/lib/src/connection/outbound/outbound_connection_impl.dart
+++ b/packages/at_secondary_server/lib/src/connection/outbound/outbound_connection_impl.dart
@@ -28,7 +28,7 @@ class OutboundConnectionImpl<T extends Socket>
     socket.done.onError((error, stackTrace) {
       logger
           .info('socket.done.onError called with $error. Calling this.close()');
-      this.close();
+      close();
     });
   }
 

--- a/packages/at_secondary_server/lib/src/server/http_request_handler.dart
+++ b/packages/at_secondary_server/lib/src/server/http_request_handler.dart
@@ -134,17 +134,23 @@ class AtServerHttpRequestHandler {
     if (queryParams[paramNameAtRequestType] == 'meta') {
       return ContentType.parse('application/json; charset=utf-8');
     }
-    String? inferredContentType =
+    String? inferredMimeType =
         mime.lookupMimeType(getPseudoWebPath(keyStoreKey));
     if (isBinary) {
-      return ContentType.parse(queryParams[paramNameContentType] ??
-          inferredContentType ??
-          'application/octet-stream');
-    } else {
       String mimeType = queryParams[paramNameContentType] ??
-          inferredContentType ??
-          'text/plain';
-      return ContentType.parse('$mimeType; charset=utf-8');
+          inferredMimeType ??
+          'application/octet-stream';
+      final cts = '$mimeType; charset=utf-8';
+      final ct = ContentType.parse(cts);
+      logger.finer('Got content-type $ct from $cts');
+      return ct;
+    } else {
+      String mimeType =
+          queryParams[paramNameContentType] ?? inferredMimeType ?? 'text/plain';
+      final cts = '$mimeType; charset=utf-8';
+      final ct = ContentType.parse(cts);
+      logger.finer('Got content-type $ct from $cts');
+      return ct;
     }
   }
 
@@ -163,10 +169,10 @@ class AtServerHttpRequestHandler {
           atData,
         );
       } else {
-        logger.info('2e15-encoded data length: ${atData.data!.length}');
+        logger.finer('2e15-encoded data length: ${atData.data!.length}');
         // decode to Uint8list
         final bytes = Base2e15.decode(atData.data!);
-        logger.info('decoded data length: ${bytes.length}');
+        logger.finer('decoded data length: ${bytes.length}');
         return bytes;
       }
     } else {

--- a/packages/at_secondary_server/test/http_request_test.dart
+++ b/packages/at_secondary_server/test/http_request_test.dart
@@ -208,7 +208,7 @@ void main() async {
       await basicChecks(
           expectedStatus: HttpStatus.ok,
           expectedBody: valueJpeg,
-          expectedContentType: ContentType.parse('image/jpeg'),
+          expectedContentType: ContentType.parse('image/jpeg; charset=utf-8'),
           method: 'GET',
           key: keyJpeg);
     });
@@ -216,7 +216,7 @@ void main() async {
       await basicChecks(
           expectedStatus: HttpStatus.ok,
           expectedBody: valueAac,
-          expectedContentType: ContentType.parse('audio/aac'),
+          expectedContentType: ContentType.parse('audio/aac; charset=utf-8'),
           method: 'GET',
           key: keyAac);
     });
@@ -224,7 +224,8 @@ void main() async {
       await basicChecks(
           expectedStatus: HttpStatus.ok,
           expectedBody: valueGenericBinary,
-          expectedContentType: ContentType.parse('application/octet-stream'),
+          expectedContentType:
+              ContentType.parse('application/octet-stream; charset=utf-8'),
           method: 'GET',
           key: keyGenericBinary);
     });


### PR DESCRIPTION
**- What I did**
- fix: root: do not urlEncode the path separators in the redirect path; urlEncode the path fragments before joining. (So you don't see encoded path separators in the redirected url which look weird in a browser)
- fix: atServer: http: fix content type charsets for when data was uploaded as binary data but is actually textual
- chore: atServer: remove some lint from the connection impls
- test: fix failing unit test

**- How I did it**
See commits

**- How to verify it**
Tests pass
