### PR TITLE
fix: initial monitor response (existing matching notifications) was not including all metadata

### DIFF
--- a/packages/at_secondary_server/lib/src/verb/handler/monitor_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/monitor_verb_handler.dart
@@ -138,6 +138,8 @@ class MonitorVerbHandler extends AbstractVerbHandler {
           "skeEncKeyName": atNotification.atMetadata?.skeEncKeyName,
           "skeEncAlgo": atNotification.atMetadata?.skeEncAlgo,
           "sharedKeyEnc": atNotification.atMetadata?.sharedKeyEnc,
+          "pubKeyCS": atNotification.atMetadata?.pubKeyCS,
+          "dataSignature": atNotification.atMetadata?.dataSignature,
         };
 
       notification.metadata?.putIfAbsent(
@@ -217,6 +219,9 @@ class Notification {
         ? atNotification.atMetadata!.isEncrypted!
         : false;
     metadata = {
+      "sharedKeyEnc": atNotification.atMetadata?.sharedKeyEnc,
+      "pubKeyCS": atNotification.atMetadata?.pubKeyCS,
+      "dataSignature": atNotification.atMetadata?.dataSignature,
       "encKeyName": atNotification.atMetadata?.encKeyName,
       "encAlgo": atNotification.atMetadata?.encAlgo,
       "ivNonce": atNotification.atMetadata?.ivNonce,

--- a/packages/at_secondary_server/test/monitor_verb_test.dart
+++ b/packages/at_secondary_server/test/monitor_verb_test.dart
@@ -159,7 +159,9 @@ void main() {
             ..type = NotificationType.received
             ..opType = OperationType.update
             ..messageType = MessageType.key
-            ..atMetaData = (AtMetaData()..encKeyName = 'encKeyName'))
+            ..atMetaData = (AtMetaData()
+              ..encKeyName = 'encKeyName'
+              ..sharedKeyEnc = 'shared_key_encrypted'))
           .build();
       await monitorVerbHandler.processAtNotification(atNotification);
       inboundConnection.lastWrittenData = inboundConnection.lastWrittenData
@@ -167,6 +169,9 @@ void main() {
           .trim();
       var notificationMap = jsonDecode(inboundConnection.lastWrittenData!);
       expect(notificationMap['metadata']['pubKeyHash'], null);
+      expect(notificationMap['metadata']['encKeyName'], 'encKeyName');
+      expect(
+          notificationMap['metadata']['sharedKeyEnc'], 'shared_key_encrypted');
     });
     tearDown(() async {
       await verbTestsTearDown();
@@ -735,6 +740,7 @@ void main() {
       await monitorVerbHandler.processVerb(
           Response(), verbParams, inboundConnection);
 
+      AtMetaData randomMetadata = createRandomAtMetaData('@bob');
       var atNotification = (AtNotificationBuilder()
             ..id = 'abc'
             ..fromAtSign = '@bob'
@@ -743,7 +749,8 @@ void main() {
             ..notification = 'phone.wavi'
             ..type = NotificationType.self
             ..opType = OperationType.update
-            ..messageType = MessageType.key)
+            ..messageType = MessageType.key
+            ..atMetaData = randomMetadata)
           .build();
       // The notification callback method is registered in "MonitorVerbHandler.processVerb"
       await AtNotificationCallback.getInstance()
@@ -759,6 +766,15 @@ void main() {
       expect(notificationMap['key'], 'phone.wavi');
       expect(notificationMap['messageType'], 'MessageType.key');
       expect(notificationMap['operation'], 'update');
+      expect(notificationMap['metadata']['pubKeyCS'], randomMetadata.pubKeyCS);
+      expect(notificationMap['metadata']['sharedKeyEnc'],
+          randomMetadata.sharedKeyEnc);
+      expect(
+          notificationMap['metadata']['encKeyName'], randomMetadata.encKeyName);
+      expect(notificationMap['metadata']['dataSignature'],
+          randomMetadata.dataSignature);
+      expect(notificationMap['metadata']['pubKeyHash'],
+          jsonEncode(randomMetadata.pubKeyHash?.toJson()));
     });
 
     test(
@@ -771,6 +787,7 @@ void main() {
       await monitorVerbHandler.processVerb(
           Response(), verbParams, inboundConnection);
 
+      AtMetaData randomMetadata = createRandomAtMetaData('@bob');
       var atNotification = (AtNotificationBuilder()
             ..id = 'abc'
             ..fromAtSign = '@bob'
@@ -779,7 +796,8 @@ void main() {
             ..notification = 'phone.wavi'
             ..type = NotificationType.received
             ..opType = OperationType.update
-            ..messageType = MessageType.key)
+            ..messageType = MessageType.key
+            ..atMetaData = randomMetadata)
           .build();
       // The notification callback method is registered in "MonitorVerbHandler.processVerb"
       await AtNotificationCallback.getInstance()
@@ -795,6 +813,15 @@ void main() {
       expect(notificationMap['key'], 'phone.wavi');
       expect(notificationMap['messageType'], 'MessageType.key');
       expect(notificationMap['operation'], 'update');
+      expect(notificationMap['metadata']['pubKeyCS'], randomMetadata.pubKeyCS);
+      expect(notificationMap['metadata']['sharedKeyEnc'],
+          randomMetadata.sharedKeyEnc);
+      expect(
+          notificationMap['metadata']['encKeyName'], randomMetadata.encKeyName);
+      expect(notificationMap['metadata']['dataSignature'],
+          randomMetadata.dataSignature);
+      expect(notificationMap['metadata']['pubKeyHash'],
+          jsonEncode(randomMetadata.pubKeyHash?.toJson()));
     });
 
     test(
@@ -821,6 +848,119 @@ void main() {
       await AtNotificationCallback.getInstance()
           .invokeCallbacks(atNotification);
       expect(inboundConnection.lastWrittenData, null);
+    });
+
+    tearDown(() async {
+      await verbTestsTearDown();
+      AtNotificationCallback.getInstance().callbackMethods.clear();
+    });
+  });
+
+  group('A test to verify initial notifications list has all metadata', () {
+    setUp(() async {
+      await verbTestsSetUp();
+    });
+
+    test(
+        'A test to verify self notification is written to monitor connection in initial list',
+        () async {
+      int epoch = DateTime.timestamp().millisecondsSinceEpoch;
+      await Future.delayed(Duration(milliseconds: 1));
+      AtMetaData randomMetadata = createRandomAtMetaData('@bob');
+      var atNotification = (AtNotificationBuilder()
+            ..id = 'abc'
+            ..fromAtSign = '@bob'
+            ..notificationDateTime = DateTime.now()
+            ..toAtSign = alice
+            ..notification = 'phone.wavi'
+            ..type = NotificationType.self
+            ..opType = OperationType.update
+            ..messageType = MessageType.key
+            ..atMetaData = randomMetadata)
+          .build();
+      await AtNotificationKeystore.getInstance()
+          .put(atNotification.id, atNotification);
+
+      String monitorCommand = 'monitor:selfNotifications:$epoch';
+
+      MonitorVerbHandler monitorVerbHandler =
+          MonitorVerbHandler(secondaryKeyStore);
+      HashMap<String, String?> verbParams =
+          monitorVerbHandler.parse(monitorCommand);
+      inboundConnection.metaData.isAuthenticated = true;
+      await monitorVerbHandler.processVerb(
+          Response(), verbParams, inboundConnection);
+
+      inboundConnection.lastWrittenData = inboundConnection.lastWrittenData
+          ?.replaceAll('notification:', '')
+          .trim();
+      var notificationMap = jsonDecode(inboundConnection.lastWrittenData!);
+      expect(notificationMap['id'], 'abc');
+      expect(notificationMap['from'], '@bob');
+      expect(notificationMap['to'], alice);
+      expect(notificationMap['key'], 'phone.wavi');
+      expect(notificationMap['messageType'], 'MessageType.key');
+      expect(notificationMap['operation'], 'update');
+      expect(notificationMap['metadata']['pubKeyCS'], randomMetadata.pubKeyCS);
+      expect(notificationMap['metadata']['sharedKeyEnc'],
+          randomMetadata.sharedKeyEnc);
+      expect(
+          notificationMap['metadata']['encKeyName'], randomMetadata.encKeyName);
+      expect(notificationMap['metadata']['dataSignature'],
+          randomMetadata.dataSignature);
+      expect(notificationMap['metadata']['pubKeyHash'],
+          jsonEncode(randomMetadata.pubKeyHash?.toJson()));
+    });
+
+    test(
+        'A test to verify received notification is written to monitor connection in initial list',
+        () async {
+      int epoch = DateTime.timestamp().millisecondsSinceEpoch;
+      await Future.delayed(Duration(milliseconds: 1));
+
+      AtMetaData randomMetadata = createRandomAtMetaData('@bob');
+      var atNotification = (AtNotificationBuilder()
+            ..id = 'abc'
+            ..fromAtSign = '@bob'
+            ..notificationDateTime = DateTime.now()
+            ..toAtSign = alice
+            ..notification = 'phone.wavi'
+            ..type = NotificationType.received
+            ..opType = OperationType.update
+            ..messageType = MessageType.key
+            ..atMetaData = randomMetadata)
+          .build();
+      await AtNotificationKeystore.getInstance()
+          .put(atNotification.id, atNotification);
+
+      String monitorCommand = 'monitor:$epoch';
+      MonitorVerbHandler monitorVerbHandler =
+          MonitorVerbHandler(secondaryKeyStore);
+      HashMap<String, String?> verbParams =
+          monitorVerbHandler.parse(monitorCommand);
+      inboundConnection.metaData.isAuthenticated = true;
+      await monitorVerbHandler.processVerb(
+          Response(), verbParams, inboundConnection);
+
+      inboundConnection.lastWrittenData = inboundConnection.lastWrittenData
+          ?.replaceAll('notification:', '')
+          .trim();
+      var notificationMap = jsonDecode(inboundConnection.lastWrittenData!);
+      expect(notificationMap['id'], 'abc');
+      expect(notificationMap['from'], '@bob');
+      expect(notificationMap['to'], alice);
+      expect(notificationMap['key'], 'phone.wavi');
+      expect(notificationMap['messageType'], 'MessageType.key');
+      expect(notificationMap['operation'], 'update');
+      expect(notificationMap['metadata']['pubKeyCS'], randomMetadata.pubKeyCS);
+      expect(notificationMap['metadata']['sharedKeyEnc'],
+          randomMetadata.sharedKeyEnc);
+      expect(
+          notificationMap['metadata']['encKeyName'], randomMetadata.encKeyName);
+      expect(notificationMap['metadata']['dataSignature'],
+          randomMetadata.dataSignature);
+      expect(notificationMap['metadata']['pubKeyHash'],
+          jsonEncode(randomMetadata.pubKeyHash?.toJson()));
     });
 
     tearDown(() async {

--- a/packages/at_secondary_server/test/test_utils.dart
+++ b/packages/at_secondary_server/test/test_utils.dart
@@ -389,11 +389,13 @@ AtMetaData createRandomAtMetaData(String owner,
     md.encoding = createRandomString(5);
     md.pubKeyCS = createRandomString(5);
     md.sharedKeyEnc = createRandomString(10);
+    md.encKeyName = createRandomString(10);
     md.dataSignature = createRandomString(7);
     md.isCascade = createRandomNullableBoolean();
     md.ttl = createRandomNullablePositiveInt();
     md.ttb = createRandomNullablePositiveInt();
     md.ttr = createRandomNullablePositiveInt();
+    md.pubKeyHash = PublicKeyHash(createRandomString(6), createRandomString(4));
   }
 
   if (refreshAt != null) {


### PR DESCRIPTION
**- What I did**
- fix: Fixed issue where notifications in the initial response from atServer were not including the (very important) `sharedKeyEnc` metadata attribute, while notifications received after the initial monitor command were correctly including the `sharedKeyEnc`.
- test: added tests for the same

**- How I did it**
See commits

**- How to verify it**
Tests pass

