### PR TITLE
feat: better handling of idle inbound connections

### DIFF
--- a/packages/at_secondary_server/config/config.yaml
+++ b/packages/at_secondary_server/config/config.yaml
@@ -50,24 +50,27 @@ connection:
   # pool takes care of ensuring that idle connections are closed as necessary
   inbound_max_limit: 200
 
-  # The maximum time in milliseconds for an **unauthenticated** inbound connection to expire.
+  # The maximum idle time in milliseconds for an **unauthenticated** inbound connection.
+  # Connections which have been idle for longer than this will be closed.
   # Default value is 10 minutes (10 * 60 * 1000 == 600000)
   # Internally, the effective value used is reduced progressively towards 5 seconds as the current
   # number of connections approaches the inbound_max_limit.
   inbound_idle_time_millis: 600000
 
-  # The maximum time in milliseconds for an **AUTHENTICATED** inbound connection to expire.
-  # Default value is 30 days (30 * 24 * 60 * 60 * 1000 == 2592000000)
-  # Internally, the effective value used is reduced progressively towards 60 seconds as the current
-  # number of connections approaches the max limit. So for example if the max number of connections is
-  # 200, and there are currently 200 connections, and a new client tries to connect,
-  # then any authenticated connection which has been idle for more than 60 seconds will be closed
-  # However: if there are only, say, 100 connections currently, then only authenticated connections
-  # which have been idle for more than 30 days will be closed
-  authenticated_inbound_idletime_millis: 2592000000
+  # The maximum idle time in milliseconds for an **unauthenticated** outbound connection.
+  # Connections which have been idle for longer than this will be closed.
+  # Default value is 9 minutes 59 seconds (1 second less than inbound_idle_time_millis)
+  outbound_idle_time_millis: 599000
 
-  # The maximum time in milliseconds for an outbound connection to expire.
-  outbound_idle_time_millis: 600000
+  # The maximum idle time in milliseconds for an **authenticated** inbound connection.
+  # Connections which have been idle for longer than this will be closed.
+  # Default value is 1 hour (60 * 60 * 1000 == 3600000
+  authenticated_inbound_idle_time_millis: 3600000
+
+  # The maximum idle time in milliseconds for an **authenticated** outbound connection.
+  # Connections which have been idle for longer than this will be closed.
+  # Default value is 59 minutes 59 seconds (1 second less than authenticated_inbound_idletime_millis)
+  authenticated_outbound_idle_time_millis: 3599000
 
   # At any point, at most [outbound_max_limit] outbound connections are allowed.
   outbound_max_limit: 200

--- a/packages/at_secondary_server/lib/src/connection/inbound/inbound_connection_pool.dart
+++ b/packages/at_secondary_server/lib/src/connection/inbound/inbound_connection_pool.dart
@@ -1,5 +1,6 @@
 import 'dart:collection';
 
+import 'package:at_secondary/src/connection/inbound/inbound_connection_metadata.dart';
 import 'package:at_server_spec/at_server_spec.dart';
 import 'package:at_utils/at_logger.dart';
 
@@ -28,12 +29,49 @@ class InboundConnectionPool {
     }
   }
 
+  Map mdSnippet(InboundConnectionMetadata md) => {
+        'from': md.fromAtSign,
+        'created': md.created?.toIso8601String(),
+        'lastAccessed': md.lastAccessed?.toIso8601String()
+      };
+
+  Map<String, dynamic> get stats {
+    int selfAuthCount = 0;
+    List selfAuthList = [];
+
+    int polAuthCount = 0;
+    List polAuthList = [];
+
+    int unAuthCount = 0;
+    List unAuthList = [];
+
+    for (final c in _connections) {
+      InboundConnectionMetadata md = c.metaData as InboundConnectionMetadata;
+      if (md.isAuthenticated) {
+        selfAuthCount++;
+        selfAuthList.add(mdSnippet(md));
+      } else if (c.metaData.isPolAuthenticated) {
+        polAuthCount++;
+        polAuthList.add(mdSnippet(md));
+      } else {
+        unAuthCount++;
+        unAuthList.add(mdSnippet(md));
+      }
+    }
+    return {
+      'selfAuthenticated': {'count': selfAuthCount, 'list': selfAuthList},
+      'polAuthenticated': {'count': polAuthCount, 'list': polAuthList},
+      'unAuthenticated': {'count': unAuthCount, 'list': unAuthList},
+    };
+  }
+
   bool hasCapacity() {
     return _connections.length < _size;
   }
 
   bool passedEightyFivePercent = false;
   bool passedNinetyFivePercent = false;
+
   void add(InboundConnection inboundConnection) {
     _connections.add(inboundConnection);
     _checkWarningStatesOnAdd();

--- a/packages/at_secondary_server/lib/src/connection/inbound/inbound_connection_pool.dart
+++ b/packages/at_secondary_server/lib/src/connection/inbound/inbound_connection_pool.dart
@@ -59,6 +59,7 @@ class InboundConnectionPool {
       }
     }
     return {
+      'total': selfAuthCount + polAuthCount + unAuthCount,
       'selfAuthenticated': {'count': selfAuthCount, 'list': selfAuthList},
       'polAuthenticated': {'count': polAuthCount, 'list': polAuthList},
       'unAuthenticated': {'count': unAuthCount, 'list': unAuthList},

--- a/packages/at_secondary_server/lib/src/connection/outbound/outbound_client.dart
+++ b/packages/at_secondary_server/lib/src/connection/outbound/outbound_client.dart
@@ -204,6 +204,7 @@ class OutboundClient {
       var currentAtSign = AtSecondaryServerImpl.getInstance().currentAtSign;
       if (handShakeResult.startsWith('$currentAtSign@')) {
         logger.info("pol handshake complete");
+        outboundConnection!.authenticated = true;
         return true;
       } else {
         logger.info(

--- a/packages/at_secondary_server/lib/src/connection/outbound/outbound_connection.dart
+++ b/packages/at_secondary_server/lib/src/connection/outbound/outbound_connection.dart
@@ -7,6 +7,8 @@ import 'package:at_server_spec/at_server_spec.dart';
 abstract class OutboundSocketConnection<T extends Socket>
     extends BaseSocketConnection {
   OutboundSocketConnection(T super.socket);
+  bool get authenticated;
+  set authenticated(bool b);
 }
 
 /// Metadata information for [OutboundSocketConnection]

--- a/packages/at_secondary_server/lib/src/connection/outbound/outbound_connection_impl.dart
+++ b/packages/at_secondary_server/lib/src/connection/outbound/outbound_connection_impl.dart
@@ -7,8 +7,20 @@ import 'package:uuid/uuid.dart';
 
 class OutboundConnectionImpl<T extends Socket>
     extends OutboundSocketConnection {
-  static int? outboundIdleTime =
-      AtSecondaryServerImpl.getInstance().serverContext!.outboundIdleTimeMillis;
+  @override
+  bool authenticated = false;
+
+  int get outboundIdleTime {
+    if (authenticated) {
+      return AtSecondaryServerImpl.getInstance()
+          .serverContext!
+          .authenticatedOutboundIdleTimeMillis;
+    } else {
+      return AtSecondaryServerImpl.getInstance()
+          .serverContext!
+          .unauthenticatedOutboundIdleTimeMillis;
+    }
+  }
 
   OutboundConnectionImpl(T socket, String? toAtSign) : super(socket) {
     var sessionId = '_${Uuid().v4()}';
@@ -40,7 +52,7 @@ class OutboundConnectionImpl<T extends Socket>
   }
 
   bool _isIdle() {
-    return _getIdleTimeMillis() > outboundIdleTime!;
+    return _getIdleTimeMillis() > outboundIdleTime;
   }
 
   @override

--- a/packages/at_secondary_server/lib/src/server/at_secondary_config.dart
+++ b/packages/at_secondary_server/lib/src/server/at_secondary_config.dart
@@ -76,9 +76,12 @@ class AtSecondaryConfig {
   static const int _outboundMaxLimit = 200;
   static const int _unauthenticatedInboundIdleTimeMillis =
       10 * 60 * 1000; // 10 minutes
+  static const int _unauthenticatedOutboundIdleTimeMillis =
+      _unauthenticatedInboundIdleTimeMillis - 1000;
   static const int _authenticatedInboundIdleTimeMillis =
-      30 * 24 * 60 * 60 * 1000; // 30 days
-  static const int _outboundIdleTimeMillis = 600000;
+      60 * 60 * 1000; // 1 hour
+  static const int _authenticatedOutboundIdleTimeMillis =
+      _authenticatedInboundIdleTimeMillis - 1000;
 
   //Lookup
   static const int _lookupDepthOfResolution = 3;
@@ -423,7 +426,7 @@ class AtSecondaryConfig {
   }
 
   // ignore: non_constant_identifier_names
-  static int get outbound_idletime_millis {
+  static int get unauthenticated_outbound_idletime_millis {
     var result = _getIntEnvVar('outbound_idletime_millis');
     if (result != null) {
       return result;
@@ -431,12 +434,12 @@ class AtSecondaryConfig {
     try {
       return getConfigFromYaml(['connection', 'outbound_idle_time_millis']);
     } on ElementNotFoundException {
-      return _outboundIdleTimeMillis;
+      return _unauthenticatedOutboundIdleTimeMillis;
     }
   }
 
   // ignore: non_constant_identifier_names
-  static int get inbound_idletime_millis {
+  static int get unauthenticated_inbound_idletime_millis {
     var result = _getIntEnvVar('inbound_idletime_millis');
     if (result != null) {
       return result;
@@ -459,6 +462,20 @@ class AtSecondaryConfig {
           ['connection', 'authenticated_inbound_idle_time_millis']);
     } on ElementNotFoundException {
       return _authenticatedInboundIdleTimeMillis;
+    }
+  }
+
+  // ignore: non_constant_identifier_names
+  static int get authenticated_outbound_idletime_millis {
+    var result = _getIntEnvVar('authenticated_outbound_idletime_millis');
+    if (result != null) {
+      return result;
+    }
+    try {
+      return getConfigFromYaml(
+          ['connection', 'authenticated_outbound_idle_time_millis']);
+    } on ElementNotFoundException {
+      return _authenticatedOutboundIdleTimeMillis;
     }
   }
 

--- a/packages/at_secondary_server/lib/src/server/bootstrapper.dart
+++ b/packages/at_secondary_server/lib/src/server/bootstrapper.dart
@@ -31,16 +31,6 @@ class SecondaryServerBootStrapper {
       secondaryContext.port = int.parse(results['server_port']);
       secondaryContext.currentAtSign = AtUtils.fixAtSign(results['at_sign']);
       secondaryContext.sharedSecret = results['shared_secret'];
-      secondaryContext.inboundConnectionLimit =
-          AtSecondaryConfig.inbound_max_limit;
-      secondaryContext.outboundConnectionLimit =
-          AtSecondaryConfig.outbound_max_limit;
-      secondaryContext.unauthenticatedInboundIdleTimeMillis =
-          AtSecondaryConfig.inbound_idletime_millis;
-      secondaryContext.authenticatedInboundIdleTimeMillis =
-          AtSecondaryConfig.authenticated_inbound_idletime_millis;
-      secondaryContext.outboundIdleTimeMillis =
-          AtSecondaryConfig.outbound_idletime_millis;
       if (useTLS!) {
         secondaryContext.securityContext = AtSecurityContextImpl();
       }

--- a/packages/at_secondary_server/lib/src/server/server_context.dart
+++ b/packages/at_secondary_server/lib/src/server/server_context.dart
@@ -2,45 +2,43 @@ import 'package:at_persistence_spec/at_persistence_spec.dart';
 import 'package:at_server_spec/at_server_spec.dart';
 import 'package:at_server_spec/at_verb_spec.dart';
 
+import 'at_secondary_config.dart';
+
+/// Config values in this class are set to the values in AtSecondaryConfig.
+/// However we allow them to be overridden here, mainly for testability reasons.
 class AtSecondaryContext extends AtServerContext {
   String host = 'localhost';
   late int port;
   bool isKeyStoreInitialized = false;
 
-  /// This value is normally initialized with the value from
-  /// [AtSecondaryConfig.inbound_max_limit]
-  int inboundConnectionLimit = 200;
+  int inboundConnectionLimit = AtSecondaryConfig.inbound_max_limit;
 
-  /// This value is normally initialized with the value from
-  /// [AtSecondaryConfig.outbound_max_limit]
-  int outboundConnectionLimit = 200;
+  int outboundConnectionLimit = AtSecondaryConfig.outbound_max_limit;
 
-  /// This value is normally initialized with the value from
-  /// [AtSecondaryConfig.inbound_idletime_millis]
-  int unauthenticatedInboundIdleTimeMillis = 10 * 60 * 1000; // 10 minutes
+  int unauthenticatedInboundIdleTimeMillis =
+      AtSecondaryConfig.unauthenticated_inbound_idletime_millis;
+  int unauthenticatedOutboundIdleTimeMillis =
+      AtSecondaryConfig.unauthenticated_outbound_idletime_millis;
 
-  /// This value is normally initialized with the value from
-  /// [AtSecondaryConfig.authenticated_inbound_idletime_millis]
-  int authenticatedInboundIdleTimeMillis = 30 * 24 * 60 * 60 * 1000; // 30 days
-
-  /// This value is normally initialized with the value from
-  /// [AtSecondaryConfig.outbound_idletime_millis]
-  int outboundIdleTimeMillis = 10 * 60 * 1000; // ten minutes
+  int authenticatedInboundIdleTimeMillis =
+      AtSecondaryConfig.authenticated_inbound_idletime_millis;
+  int authenticatedOutboundIdleTimeMillis =
+      AtSecondaryConfig.authenticated_outbound_idletime_millis;
 
   /// Even when number of connections is close to max allowed, we don't want to
   /// close unauthenticated connections before they've had a change to send
   /// a cram or pkam request
-  int unauthenticatedMinAllowableIdleTimeMillis = 5 * 1000;
+  int unauthenticatedMinAllowableIdleTimeMillis = 5 * 1000; // 5 seconds
 
   /// Even when number of connections is close to max allowed, we don't want to
   /// be overly aggressive when closing authenticated connections
-  int authenticatedMinAllowableIdleTimeMillis = 60 * 1000;
+  int authenticatedMinAllowableIdleTimeMillis = 300 * 1000; // 5 minutes
 
   /// When the number of connections grows beyond this proportion of the max
   /// allowed number of connections, in effect we start to reduce the 'max'
   /// idle time permitted before the server starts to close existing 'idle'
   /// connections. See [InboundConnectionImpl.isInValid]
-  double inboundConnectionLowWaterMarkRatio = 0.5;
+  double inboundConnectionLowWaterMarkRatio = 0.8;
   bool progressivelyReduceAllowableInboundIdleTime = true;
 
   String? currentAtSign;

--- a/packages/at_secondary_server/lib/src/verb/metrics/metrics_impl.dart
+++ b/packages/at_secondary_server/lib/src/verb/metrics/metrics_impl.dart
@@ -4,6 +4,7 @@ import 'dart:math';
 
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:at_secondary/src/connection/connection_metrics.dart';
+import 'package:at_secondary/src/connection/inbound/inbound_connection_pool.dart';
 import 'package:at_secondary/src/server/at_secondary_config.dart';
 import 'package:at_secondary/src/server/at_secondary_impl.dart';
 import 'package:at_secondary/src/utils/regex_util.dart';
@@ -21,9 +22,9 @@ class InboundMetricImpl implements MetricProvider {
   }
 
   @override
-  String getMetrics({String? regex}) {
-    var connections = connectionMetrics.getInboundConnections().toString();
-    return connections;
+  Map<String, dynamic> getMetrics({String? regex}) {
+    var connections = InboundConnectionPool.getInstance();
+    return connections.stats;
   }
 
   @override

--- a/packages/at_secondary_server/test/outbound_client_manager_test.dart
+++ b/packages/at_secondary_server/test/outbound_client_manager_test.dart
@@ -26,7 +26,7 @@ void main() {
   setUp(() {
     var serverContext = AtSecondaryContext();
     serverContext.unauthenticatedInboundIdleTimeMillis = 50;
-    serverContext.outboundIdleTimeMillis = 30;
+    serverContext.unauthenticatedOutboundIdleTimeMillis = 30;
     AtSecondaryServerImpl.getInstance().serverContext = serverContext;
   });
 
@@ -151,13 +151,13 @@ void main() {
       sleep(Duration(
           milliseconds: AtSecondaryServerImpl.getInstance()
                   .serverContext!
-                  .outboundIdleTimeMillis ~/
+                  .unauthenticatedOutboundIdleTimeMillis ~/
               2));
       expect(outBoundClient_1.isInValid(), false);
       sleep(Duration(
           milliseconds: AtSecondaryServerImpl.getInstance()
                       .serverContext!
-                      .outboundIdleTimeMillis ~/
+                      .unauthenticatedOutboundIdleTimeMillis ~/
                   2 +
               1));
       expect(outBoundClient_1.isInValid(), true);

--- a/packages/at_secondary_server/test/outbound_client_pool_test.dart
+++ b/packages/at_secondary_server/test/outbound_client_pool_test.dart
@@ -27,7 +27,8 @@ void main() async {
 
   setUp(() {
     var serverContext = AtSecondaryContext();
-    serverContext.outboundIdleTimeMillis = outboundIdleTimeMillis;
+    serverContext.unauthenticatedOutboundIdleTimeMillis =
+        outboundIdleTimeMillis;
     AtSecondaryServerImpl.getInstance().serverContext = serverContext;
     outboundClientPool = OutboundClientPool();
 

--- a/packages/at_secondary_server/test/outbound_client_test.dart
+++ b/packages/at_secondary_server/test/outbound_client_test.dart
@@ -17,7 +17,7 @@ void main() {
 
   setUp(() {
     var serverContext = AtSecondaryContext();
-    serverContext.outboundIdleTimeMillis = 50;
+    serverContext.unauthenticatedOutboundIdleTimeMillis = 50;
     AtSecondaryServerImpl.getInstance().serverContext = serverContext;
     mockSocket = MockSocket();
     when(() => mockSocket.setOption(SocketOption.tcpNoDelay, true))
@@ -43,7 +43,7 @@ void main() {
       sleep(Duration(
           milliseconds: AtSecondaryServerImpl.getInstance()
                   .serverContext!
-                  .outboundIdleTimeMillis +
+                  .unauthenticatedOutboundIdleTimeMillis +
               1));
       expect(client.isInValid(), true);
     });

--- a/tests/at_functional_test/test/enroll_verb_test.dart
+++ b/tests/at_functional_test/test/enroll_verb_test.dart
@@ -1151,7 +1151,7 @@ void main() {
       inboundConnectionResult =
           inboundConnectionResult.replaceFirst('data:', '');
       int numberOfInboundConnectionsBeforeRevoke =
-          int.parse(jsonDecode(inboundConnectionResult)[0]['value']['total']);
+          jsonDecode(inboundConnectionResult)[0]['value']['total'];
       await firstAtSignConnection.sendRequestToServer(
           'enroll:revoke:{"enrollmentId":"${enrollmentIds[2]}"}');
       // get number of inbound connections after revoke
@@ -1160,7 +1160,7 @@ void main() {
       inboundConnectionResult =
           inboundConnectionResult.replaceFirst('data:', '');
       int numberOfInboundConnectionsAfterRevoke =
-          int.parse(jsonDecode(inboundConnectionResult)[0]['value']['total']);
+          jsonDecode(inboundConnectionResult)[0]['value']['total'];
       expect(numberOfInboundConnectionsAfterRevoke,
           numberOfInboundConnectionsBeforeRevoke - 1);
 

--- a/tests/at_functional_test/test/enroll_verb_test.dart
+++ b/tests/at_functional_test/test/enroll_verb_test.dart
@@ -1151,7 +1151,7 @@ void main() {
       inboundConnectionResult =
           inboundConnectionResult.replaceFirst('data:', '');
       int numberOfInboundConnectionsBeforeRevoke =
-          int.parse(jsonDecode(inboundConnectionResult)[0]['value']);
+          int.parse(jsonDecode(inboundConnectionResult)[0]['value']['total']);
       await firstAtSignConnection.sendRequestToServer(
           'enroll:revoke:{"enrollmentId":"${enrollmentIds[2]}"}');
       // get number of inbound connections after revoke
@@ -1160,7 +1160,7 @@ void main() {
       inboundConnectionResult =
           inboundConnectionResult.replaceFirst('data:', '');
       int numberOfInboundConnectionsAfterRevoke =
-          int.parse(jsonDecode(inboundConnectionResult)[0]['value']);
+          int.parse(jsonDecode(inboundConnectionResult)[0]['value']['total']);
       expect(numberOfInboundConnectionsAfterRevoke,
           numberOfInboundConnectionsBeforeRevoke - 1);
 

--- a/tools/build_ephemeral_environment/ee_base/contents/atsign/secondary/base/config/config.yaml
+++ b/tools/build_ephemeral_environment/ee_base/contents/atsign/secondary/base/config/config.yaml
@@ -48,7 +48,7 @@ connection:
   # value used is reduced progressively as the number of connections approaches the max limit
   inbound_idle_time_millis: 600000
   # The maximum time in milliseconds for an outbound connection to expire.
-  outbound_idle_time_millis: 600000
+  outbound_idle_time_millis: 599000
   # Creates an inbound connection and adds the connection to inbound connection pool. At any point, at most [inbound_max_limit] connections can only be created.
   # When all connections are active, additional connection requested can be served upon one of the active connection is closed.
   # The connection in the pool will exist until its [inbound_idle_time_millis] expires.

--- a/tools/build_virtual_environment/ve_base/contents/atsign/secondary/base/config/config.yaml
+++ b/tools/build_virtual_environment/ve_base/contents/atsign/secondary/base/config/config.yaml
@@ -48,7 +48,7 @@ connection:
   # value used is reduced progressively as the number of connections approaches the max limit
   inbound_idle_time_millis: 600000
   # The maximum time in milliseconds for an outbound connection to expire.
-  outbound_idle_time_millis: 600000
+  outbound_idle_time_millis: 599000
   # Creates an inbound connection and adds the connection to inbound connection pool. At any point, at most [inbound_max_limit] connections can only be created.
   # When all connections are active, additional connection requested can be served upon one of the active connection is closed.
   # The connection in the pool will exist until its [inbound_idle_time_millis] expires.

--- a/tools/run_locally/scripts/macos/at_server
+++ b/tools/run_locally/scripts/macos/at_server
@@ -62,7 +62,7 @@ export accessLogPath="$storageDir/accessLog"
 export notificationStoragePath="$storageDir/notificationLog.v1"
 export inbound_max_limit=200
 
-export logLevel="INFO"
+export logLevel="WARNING"
 
 export testingMode="true"
 


### PR DESCRIPTION
**- What I did**
- fix: set the max idle time for authenticated inbound connections to 1 hour rather than the previous, ludicrous, 30 days.
- refactor: remove unnecessary code from AtSecondaryServerImpl and have AtServerContext initialize its configurable values from AtSecondaryConfig
- feat: add more details on inbound connection stats
- feat: set outbound idle times to 1 second less than the corresponding (authenticated / unauthenticated) inbound idle times

**- How I did it**
See commits

**- How to verify it**
Tests pass
