### PR TITLE
build: update CHANGELOG and pubspec for atServer release 3.7.0

### DIFF
--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 3.7.0
+- feat : better `stats:1` (inbound connections) output
+- fix: better idle time defaults for inbound and outbound connections, 
+  authenticated and unauthenticated 
+
 # 3.6.0
 - feat: Expanded http support
 

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_secondary
 description: Implementation of secondary server.
-version: 3.6.0
+version: 3.7.0
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://www.example.com
 publish_to: none


### PR DESCRIPTION
**- What I did**
build: update CHANGELOG and pubspec for atServer release 3.7.0

See also [this ticket](https://github.com/atsign-foundation/noports/issues/2149) and [this PR](https://github.com/atsign-foundation/at_server/pull/2394)