### PR TITLE
feat: better idle time handling for inbound connections

### DIFF
--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,7 +1,12 @@
-# 3.7.0
+# 3.7.1
 - feat : added `stats:16` for a summary of number of inbound connections by 
   type (self, other, anon) and `stats:17` for a detailed report on all 
   inbound connections including atSigns, time established, last accessed time.
+- fix: better idle time defaults for inbound and outbound connections, 
+  authenticated and unauthenticated 
+- refactor: removed a bunch of singletons
+
+# 3.7.0
 - fix: better idle time defaults for inbound and outbound connections, 
   authenticated and unauthenticated 
 

--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 3.7.0
-- feat : better `stats:1` (inbound connections) output
+- feat : added `stats:16` for a summary of number of inbound connections by 
+  type (self, other, anon) and `stats:17` for a detailed report on all 
+  inbound connections including atSigns, time established, last accessed time.
 - fix: better idle time defaults for inbound and outbound connections, 
   authenticated and unauthenticated 
 

--- a/packages/at_secondary_server/config/config.yaml
+++ b/packages/at_secondary_server/config/config.yaml
@@ -64,13 +64,13 @@ connection:
 
   # The maximum idle time in milliseconds for an **authenticated** inbound connection.
   # Connections which have been idle for longer than this will be closed.
-  # Default value is 1 hour (60 * 60 * 1000 == 3600000
-  authenticated_inbound_idle_time_millis: 3600000
+  # Default value is 10 minutes (10 * 60 * 1000 == 600000)
+  authenticated_inbound_idle_time_millis: 600000
 
   # The maximum idle time in milliseconds for an **authenticated** outbound connection.
   # Connections which have been idle for longer than this will be closed.
-  # Default value is 59 minutes 59 seconds (1 second less than authenticated_inbound_idletime_millis)
-  authenticated_outbound_idle_time_millis: 3599000
+  # Default value is 9 minutes 59 seconds (1 second less than authenticated_inbound_idletime_millis)
+  authenticated_outbound_idle_time_millis: 599000
 
   # At any point, at most [outbound_max_limit] outbound connections are allowed.
   outbound_max_limit: 200

--- a/packages/at_secondary_server/lib/src/connection/connection_metrics.dart
+++ b/packages/at_secondary_server/lib/src/connection/connection_metrics.dart
@@ -1,11 +1,13 @@
-import 'package:at_secondary/src/connection/inbound/connection_util.dart';
 import 'package:at_secondary/src/server/at_secondary_impl.dart';
 import 'package:at_server_spec/at_server_spec.dart';
 
 class ConnectionMetricsImpl implements ConnectionMetrics {
   @override
   int getInboundConnections() {
-    return ConnectionUtil.getActiveConnectionSize();
+    return AtSecondaryServerImpl.getInstance()
+        .inboundConnectionManager
+        .pool
+        .getActiveConnectionSize();
   }
 
   @override

--- a/packages/at_secondary_server/lib/src/connection/inbound/connection_util.dart
+++ b/packages/at_secondary_server/lib/src/connection/inbound/connection_util.dart
@@ -138,8 +138,8 @@ class InboundIdleChecker {
     // Unauthenticated connections should be reaped increasingly aggressively as we approach max connections
     // Authenticated connections should also be reaped as we approach max connections, but a lot less aggressively
     // Ultimately, the caller (e.g. [InboundConnectionManager] decides **whether** to reap or not.
-    int? poolMaxConnections = owningPool!.getCapacity();
-    int lowWaterMark = (poolMaxConnections! * lowWaterMarkRatio).floor();
+    int poolMaxConnections = owningPool!.getCapacity();
+    int lowWaterMark = (poolMaxConnections * lowWaterMarkRatio).floor();
     int numConnectionsOverLwm =
         max(owningPool!.getCurrentSize() - lowWaterMark, 0);
 
@@ -184,36 +184,5 @@ class InboundIdleChecker {
       var retVal = actualIdleTime > allowableIdleTime;
       return retVal;
     }
-  }
-}
-
-class ConnectionUtil {
-  /// Returns the number of active monitor connections.
-  static int getMonitorConnectionSize() {
-    var count = 0;
-    InboundConnectionPool.getInstance().getConnections().forEach((connection) {
-      if (!connection.isInValid() && connection.isMonitor!) {
-        count++;
-      }
-    });
-
-    return count;
-  }
-
-  /// Returns the number of active connections.
-  static int getActiveConnectionSize() {
-    var count = 0;
-    InboundConnectionPool.getInstance().getConnections().forEach((connection) {
-      if (!connection.isInValid()) {
-        count++;
-      }
-    });
-
-    return count;
-  }
-
-  /// Return total capacity of connection manager of connection pool.
-  static int totalConnectionSize() {
-    return InboundConnectionPool.getInstance().getConnections().length;
   }
 }

--- a/packages/at_secondary_server/lib/src/connection/inbound/inbound_connection_manager.dart
+++ b/packages/at_secondary_server/lib/src/connection/inbound/inbound_connection_manager.dart
@@ -9,30 +9,26 @@ import 'package:at_secondary/src/connection/inbound/inbound_connection_pool.dart
 
 /// Factory to create and maintain [InboundConnection] using [InboundConnectionPool]
 class InboundConnectionManager implements AtConnectionFactory {
-  static final InboundConnectionManager _singleton =
-      InboundConnectionManager._internal();
+  final int poolSize;
+  late InboundConnectionPool pool;
+  final String serverAtSign;
+  bool _closed = false;
 
-  InboundConnectionManager._internal();
+  bool get closed => _closed;
 
-  static const int defaultPoolSize = 100;
-
-  bool _isInitialized = false;
-
-  late InboundConnectionPool _pool;
-
-  factory InboundConnectionManager.getInstance() {
-    return _singleton;
+  InboundConnectionManager(
+      {required this.serverAtSign, required this.poolSize}) {
+    pool = InboundConnectionPool(serverAtSign: serverAtSign, size: poolSize);
   }
 
   /// Creates and adds an [InboundConnectionImpl] to the pool
-  /// If the pool is not initialized, initializes the pool with [defaultPoolSize]
   /// @param socket - client socket
   /// @param sessionId - current sessionId
   /// Throws a [InboundConnectionLimitException] if pool doesn't have capacity
   @override
   InboundConnection createSocketConnection(Socket socket, {String? sessionId}) {
-    if (!_isInitialized) {
-      init(defaultPoolSize);
+    if (closed) {
+      throw StateError('InboundConnectionManager is closed');
     }
     if (!hasCapacity()) {
       throw InboundConnectionLimitException(
@@ -40,8 +36,8 @@ class InboundConnectionManager implements AtConnectionFactory {
     }
     sessionId ??= '_${Uuid().v4()}';
     var atConnection =
-        InboundConnectionImpl(socket, sessionId, owningPool: _pool);
-    _pool.add(atConnection);
+        InboundConnectionImpl(socket, sessionId, owningPool: pool);
+    pool.add(atConnection);
 
     return atConnection;
   }
@@ -54,35 +50,28 @@ class InboundConnectionManager implements AtConnectionFactory {
   @override
   InboundConnection createWebSocketConnection(WebSocket ws,
       {String? sessionId}) {
-    if (!_isInitialized) {
-      init(defaultPoolSize);
+    if (closed) {
+      throw StateError('InboundConnectionManager is closed');
     }
     if (!hasCapacity()) {
       throw InboundConnectionLimitException(
           'max limit reached on inbound pool');
     }
     sessionId ??= '_${Uuid().v4()}';
-    var atConnection = InboundWebSocketConnection(ws, sessionId, _pool);
-    _pool.add(atConnection);
+    var atConnection = InboundWebSocketConnection(ws, sessionId, pool);
+    pool.add(atConnection);
 
     return atConnection;
   }
 
   bool hasCapacity() {
-    _pool.clearInvalidConnections();
-    return _pool.hasCapacity();
+    pool.clearInvalidConnections();
+    return pool.hasCapacity();
   }
 
-  /// Initialises inbound client pool with a given size.
-  /// @param - size - Maximum clients the pool can hold
-  void init(int size, {bool isColdInit = true}) {
-    _pool = InboundConnectionPool.getInstance();
-    _pool.init(size, isColdInit: isColdInit);
-    _isInitialized = true;
-  }
-
-  /// Closes all the active connections accepted by the secondary
-  bool removeAllConnections() {
-    return _pool.clearAllConnections();
+  /// Closes all the active inbound connections, prevents new ones.
+  bool close() {
+    _closed = true;
+    return pool.clearAllConnections();
   }
 }

--- a/packages/at_secondary_server/lib/src/connection/inbound/inbound_connection_pool.dart
+++ b/packages/at_secondary_server/lib/src/connection/inbound/inbound_connection_pool.dart
@@ -6,36 +6,27 @@ import 'package:at_utils/at_logger.dart';
 
 /// Pool to hold [InboundConnection]
 class InboundConnectionPool {
-  static final InboundConnectionPool _singleton =
-      InboundConnectionPool._internal();
   late int _size;
+  final String serverAtSign;
+  final List<InboundConnection> _connections = [];
 
-  factory InboundConnectionPool.getInstance() {
-    return _singleton;
+  InboundConnectionPool({required this.serverAtSign, required int size}) {
+    _size = size;
   }
-
-  InboundConnectionPool._internal();
 
   var logger = AtSignLogger('InboundConnectionPool');
 
-  late List<InboundConnection> _connections;
-
-  /// [isColdInit] when set to true will create fresh/new connection pool, has to be set to true while server start.
-  /// setting it to false will change size of pool, will not overwrite existing connections. Will preserve the state of connection pool.
-  void init(int size, {bool isColdInit = true}) {
-    _size = size;
-    if (isColdInit) {
-      _connections = [];
-    }
+  void resize(int newSize) {
+    _size = newSize;
   }
 
   Map mdSnippet(InboundConnectionMetadata md) => {
-        'from': md.fromAtSign,
+        'from': md.isAuthenticated ? serverAtSign : md.fromAtSign,
         'created': md.created?.toIso8601String(),
         'lastAccessed': md.lastAccessed?.toIso8601String()
       };
 
-  Map<String, dynamic> get stats {
+  Map<String, dynamic> getStats({required bool detailed}) {
     int selfAuthCount = 0;
     List selfAuthList = [];
 
@@ -58,12 +49,21 @@ class InboundConnectionPool {
         unAuthList.add(mdSnippet(md));
       }
     }
-    return {
-      'total': selfAuthCount + polAuthCount + unAuthCount,
-      'selfAuthenticated': {'count': selfAuthCount, 'list': selfAuthList},
-      'polAuthenticated': {'count': polAuthCount, 'list': polAuthList},
-      'unAuthenticated': {'count': unAuthCount, 'list': unAuthList},
-    };
+    if (detailed) {
+      return {
+        'total': selfAuthCount + polAuthCount + unAuthCount,
+        'self': {'count': selfAuthCount, 'list': selfAuthList},
+        'other': {'count': polAuthCount, 'list': polAuthList},
+        'anon': {'count': unAuthCount, 'list': unAuthList},
+      };
+    } else {
+      return {
+        'total': selfAuthCount + polAuthCount + unAuthCount,
+        'self': selfAuthCount,
+        'other': polAuthCount,
+        'anon': unAuthCount,
+      };
+    }
   }
 
   bool hasCapacity() {
@@ -115,9 +115,7 @@ class InboundConnectionPool {
     return _connections.length;
   }
 
-  int? getCapacity() {
-    return _size;
-  }
+  int getCapacity() => _size;
 
   bool clearAllConnections() {
     for (var connection in _connections.toList()) {
@@ -152,5 +150,34 @@ class InboundConnectionPool {
       logger.info('InboundConnectionPool < 85% of $_size');
       passedEightyFivePercent = false;
     }
+  }
+
+  /// Returns the number of active monitor connections.
+  int getMonitorConnectionSize() {
+    var count = 0;
+    getConnections().forEach((connection) {
+      if (!connection.isInValid() && connection.isMonitor!) {
+        count++;
+      }
+    });
+
+    return count;
+  }
+
+  /// Returns the number of active connections.
+  int getActiveConnectionSize() {
+    var count = 0;
+    getConnections().forEach((connection) {
+      if (!connection.isInValid()) {
+        count++;
+      }
+    });
+
+    return count;
+  }
+
+  /// Return total capacity of connection manager of connection pool.
+  int totalConnectionSize() {
+    return getConnections().length;
   }
 }

--- a/packages/at_secondary_server/lib/src/connection/inbound/inbound_message_listener.dart
+++ b/packages/at_secondary_server/lib/src/connection/inbound/inbound_message_listener.dart
@@ -4,8 +4,8 @@ import 'dart:convert';
 import 'package:at_commons/at_commons.dart';
 import 'package:at_commons/at_commons.dart' as at_commons;
 import 'package:at_secondary/src/connection/base_connection.dart';
-import 'package:at_secondary/src/connection/inbound/inbound_connection_pool.dart';
 import 'package:at_secondary/src/exception/global_exception_handler.dart';
+import 'package:at_secondary/src/server/at_secondary_impl.dart';
 import 'package:at_secondary/src/utils/logging_util.dart';
 import 'package:at_server_spec/at_server_spec.dart';
 import 'package:at_utils/at_logger.dart';
@@ -125,6 +125,9 @@ class InboundMessageListener {
   Future<void> _closeConnection() async {
     await connection.close();
     // Removes the connection from the InboundConnectionPool.
-    InboundConnectionPool.getInstance().remove(connection);
+    AtSecondaryServerImpl.getInstance()
+        .inboundConnectionManager
+        .pool
+        .remove(connection);
   }
 }

--- a/packages/at_secondary_server/lib/src/notification/stats_notification_service.dart
+++ b/packages/at_secondary_server/lib/src/notification/stats_notification_service.dart
@@ -2,8 +2,8 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
-import 'package:at_secondary/src/connection/inbound/inbound_connection_pool.dart';
 import 'package:at_secondary/src/server/at_secondary_config.dart';
+import 'package:at_secondary/src/server/at_secondary_impl.dart';
 import 'package:at_secondary/src/utils/secondary_util.dart';
 import 'package:at_secondary/src/verb/handler/monitor_verb_handler.dart';
 import 'package:at_utils/at_logger.dart';
@@ -55,8 +55,6 @@ class StatsNotificationService {
   final _logger = AtSignLogger('StatsNotificationService');
   late String currentAtSign;
   AtCommitLog? atCommitLog;
-  InboundConnectionPool inboundConnectionPool =
-      InboundConnectionPool.getInstance();
 
   static final Duration zeroDuration = Duration(microseconds: 0);
 
@@ -138,7 +136,10 @@ class StatsNotificationService {
     try {
       latestCommitID ??= atCommitLog!.lastCommittedSequenceNumber().toString();
       // Gets the list of active connections.
-      var connectionsList = inboundConnectionPool.getConnections();
+      var connectionsList = AtSecondaryServerImpl.getInstance()
+          .inboundConnectionManager
+          .pool
+          .getConnections();
       // Iterates on the list of active connections.
       for (var connection in connectionsList) {
         if (connection.isMonitor != null && connection.isMonitor!) {

--- a/packages/at_secondary_server/lib/src/server/at_certificate_validation.dart
+++ b/packages/at_secondary_server/lib/src/server/at_certificate_validation.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:math';
 
-import 'package:at_secondary/src/connection/inbound/connection_util.dart';
 import 'package:at_secondary/src/server/at_secondary_impl.dart';
 import 'package:at_utils/at_logger.dart';
 import 'package:at_server_spec/at_server_spec.dart';
@@ -128,15 +127,18 @@ class AtCertificateValidationJob {
   ///     - If count is 0, return true (we're able to restart gracefully)
   /// - If the gracefulExitWaitTimeout has passed, we need to restart anyway. Return false
   Future<bool> waitUntilReadyToRestart() async {
-    AtSecondaryServerImpl.getInstance().pause();
+    final atServer = AtSecondaryServerImpl.getInstance();
+    atServer.pause();
 
     DateTime gracePeriodEnd = DateTime.now().add(gracefulExitWaitTimeout);
 
     int monitorSize, totalSize, activeSize;
     while (DateTime.now().toUtc().microsecondsSinceEpoch <
         gracePeriodEnd.microsecondsSinceEpoch) {
-      monitorSize = ConnectionUtil.getMonitorConnectionSize();
-      totalSize = ConnectionUtil.getActiveConnectionSize();
+      monitorSize =
+          atServer.inboundConnectionManager.pool.getMonitorConnectionSize();
+      totalSize =
+          atServer.inboundConnectionManager.pool.getActiveConnectionSize();
       activeSize = totalSize - monitorSize;
       logger.info(
           'Active connections $activeSize ($totalSize total, $monitorSize monitor(s))');
@@ -148,8 +150,10 @@ class AtCertificateValidationJob {
         await Future.delayed(Duration(seconds: 1));
       }
     }
-    monitorSize = ConnectionUtil.getMonitorConnectionSize();
-    totalSize = ConnectionUtil.getActiveConnectionSize();
+    monitorSize =
+        atServer.inboundConnectionManager.pool.getMonitorConnectionSize();
+    totalSize =
+        atServer.inboundConnectionManager.pool.getActiveConnectionSize();
     activeSize = totalSize - monitorSize;
     logger.warning(
         'gracefulExitWaitTimeout $gracefulExitWaitTimeout has passed. Will restart server even though we may have active connections');

--- a/packages/at_secondary_server/lib/src/server/at_secondary_config.dart
+++ b/packages/at_secondary_server/lib/src/server/at_secondary_config.dart
@@ -79,7 +79,7 @@ class AtSecondaryConfig {
   static const int _unauthenticatedOutboundIdleTimeMillis =
       _unauthenticatedInboundIdleTimeMillis - 1000;
   static const int _authenticatedInboundIdleTimeMillis =
-      60 * 60 * 1000; // 1 hour
+      10 * 60 * 1000; // 10 minutes
   static const int _authenticatedOutboundIdleTimeMillis =
       _authenticatedInboundIdleTimeMillis - 1000;
 
@@ -381,9 +381,9 @@ class AtSecondaryConfig {
     }
   }
 
-  static String? get notificationStoragePath {
-    if (_envVars.containsKey('notificationStoragePath')) {
-      return _envVars['notificationStoragePath'];
+  static String get notificationStoragePath {
+    if (_envVars['notificationStoragePath'] != null) {
+      return _envVars['notificationStoragePath']!;
     }
     try {
       return getConfigFromYaml(['hive', 'notificationStoragePath']);
@@ -392,9 +392,9 @@ class AtSecondaryConfig {
     }
   }
 
-  static String? get accessLogPath {
-    if (_envVars.containsKey('accessLogPath')) {
-      return _envVars['accessLogPath'];
+  static String get accessLogPath {
+    if (_envVars['accessLogPath'] != null) {
+      return _envVars['accessLogPath']!;
     }
     try {
       return getConfigFromYaml(['hive', 'accessLogPath']);
@@ -403,9 +403,9 @@ class AtSecondaryConfig {
     }
   }
 
-  static String? get commitLogPath {
-    if (_envVars.containsKey('commitLogPath')) {
-      return _envVars['commitLogPath'];
+  static String get commitLogPath {
+    if (_envVars['commitLogPath'] != null) {
+      return _envVars['commitLogPath']!;
     }
     try {
       return getConfigFromYaml(['hive', 'commitLogPath']);
@@ -414,9 +414,9 @@ class AtSecondaryConfig {
     }
   }
 
-  static String? get storagePath {
-    if (_envVars.containsKey('secondaryStoragePath')) {
-      return _envVars['secondaryStoragePath'];
+  static String get storagePath {
+    if (_envVars['secondaryStoragePath'] != null) {
+      return _envVars['secondaryStoragePath']!;
     }
     try {
       return getConfigFromYaml(['hive', 'storagePath']);

--- a/packages/at_secondary_server/lib/src/server/at_secondary_impl.dart
+++ b/packages/at_secondary_server/lib/src/server/at_secondary_impl.dart
@@ -27,7 +27,6 @@ import 'package:at_secondary/src/utils/secondary_util.dart';
 import 'package:at_secondary/src/verb/handler/abstract_update_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/delete_verb_handler.dart';
 import 'package:at_secondary/src/verb/manager/verb_handler_manager.dart';
-import 'package:at_secondary/src/verb/metrics/metrics_impl.dart';
 import 'package:at_server_spec/at_server_spec.dart';
 import 'package:at_server_spec/at_verb_spec.dart';
 import 'package:at_utils/at_utils.dart';
@@ -42,13 +41,7 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
   static final bool? useTLS = AtSecondaryConfig.useTLS;
   static final AtSecondaryServerImpl _singleton =
       AtSecondaryServerImpl._internal();
-  static final inboundConnectionFactory =
-      InboundConnectionManager.getInstance();
-  static final String? storagePath = AtSecondaryConfig.storagePath;
-  static final String? commitLogPath = AtSecondaryConfig.commitLogPath;
-  static final String? accessLogPath = AtSecondaryConfig.accessLogPath;
-  static final String? notificationStoragePath =
-      AtSecondaryConfig.notificationStoragePath;
+
   static final int? expiringRunFreqMins = AtSecondaryConfig.expiringRunFreqMins;
   static final int? commitLogCompactionFrequencyMins =
       AtSecondaryConfig.commitLogCompactionFrequencyMins;
@@ -97,7 +90,7 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
   dynamic _serverSocket;
   bool _isRunning = false;
   late String currentAtSign;
-  var _commitLog;
+  late AtCommitLog commitLog;
   var _accessLog;
   var signingKey;
   AtSecondaryContext? serverContext;
@@ -119,6 +112,7 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
   late var atAccessLogCompactionConfig;
   late var atNotificationCompactionConfig;
   late EnrollmentManager enrollmentManager;
+  late InboundConnectionManager inboundConnectionManager;
 
   @override
   void setExecutor(VerbExecutor executor) {
@@ -209,7 +203,7 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
 
     //Commit Log Compaction
     commitLogCompactionJobInstance =
-        AtCompactionJob(_commitLog, secondaryPersistenceStore);
+        AtCompactionJob(commitLog, secondaryPersistenceStore);
     atCommitLogCompactionConfig = AtCompactionConfig()
       ..compactionPercentage = commitLogCompactionPercentage
       ..compactionFrequencyInMins = commitLogCompactionFrequencyMins!;
@@ -321,8 +315,9 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
     // We're currently in process of restarting, so we can delete the file which triggers restarts
     await certificateReloadJob!.deleteRestartFile();
 
-    // Initialize inbound factory and outbound manager
-    inboundConnectionFactory.init(serverContext!.inboundConnectionLimit);
+    inboundConnectionManager = InboundConnectionManager(
+        serverAtSign: currentAtSign,
+        poolSize: serverContext!.inboundConnectionLimit);
 
     // Notification job
     notificationResourceManager = ResourceManager.getInstance();
@@ -406,7 +401,7 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
       logger.finest('Subscribing to dynamic changes made to inbound_max_limit');
       AtSecondaryConfig.subscribe(ModifiableConfigs.inboundMaxLimit)
           ?.listen((newSize) {
-        inboundConnectionFactory.init(newSize, isColdInit: false);
+        inboundConnectionManager.pool.resize(newSize);
         logger.finest(
             'inbound_max_limit change received. Modifying inbound_max_limit of server to $newSize');
       });
@@ -441,7 +436,7 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
               ModifiableConfigs.commitLogCompactionFrequencyMins)
           ?.listen((newFrequency) async {
         await restartCompaction(commitLogCompactionJobInstance,
-            atCommitLogCompactionConfig, newFrequency, _commitLog);
+            atCommitLogCompactionConfig, newFrequency, commitLog);
       });
 
       //subscriber for autoNotify state change
@@ -486,8 +481,7 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
   webSocketListener(WebSocket ws) async {
     InboundConnection? connection;
     try {
-      var inBoundConnectionManager = InboundConnectionManager.getInstance();
-      connection = inBoundConnectionManager.createWebSocketConnection(ws,
+      connection = inboundConnectionManager.createWebSocketConnection(ws,
           sessionId: '_${Uuid().v4()}');
       connection.acceptRequests(_executeVerbCallBack, _streamCallBack);
       await connection.write('@');
@@ -535,8 +529,7 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
         try {
           logger.info(
               'In _listen - clientSocket.peerCertificate : ${clientSocket.peerCertificate}');
-          var inBoundConnectionManager = InboundConnectionManager.getInstance();
-          connection = inBoundConnectionManager.createSocketConnection(
+          connection = inboundConnectionManager.createSocketConnection(
               clientSocket,
               sessionId: '_${Uuid().v4()}');
           connection.acceptRequests(_executeVerbCallBack, _streamCallBack);
@@ -675,7 +668,7 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
       await StatsNotificationService.getInstance().cancel();
 
       logger.info("Terminating all inbound connections");
-      inboundConnectionFactory.removeAllConnections();
+      inboundConnectionManager.close();
 
       logger.info("Stopping Notification Resource Manager");
       notificationResourceManager.stop();
@@ -713,23 +706,22 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
   /// Initializes [SecondaryKeyStore], [AtCommitLog], [AtNotificationKeystore] and [AtAccessLog] instances.
   Future<void> _initializePersistentInstances() async {
     // Initialize commit log
-    _commitLog = await AtCommitLogManagerImpl.getInstance().getCommitLog(
+    commitLog = (await AtCommitLogManagerImpl.getInstance().getCommitLog(
         serverContext!.currentAtSign!,
-        commitLogPath: commitLogPath);
-    LastCommitIDMetricImpl.getInstance().atCommitLog = _commitLog;
-    _commitLog!.addEventListener(
-        CommitLogCompactionService(_commitLog.commitLogKeyStore));
+        commitLogPath: AtSecondaryConfig.commitLogPath))!;
+    commitLog.addEventListener(
+        CommitLogCompactionService(commitLog.commitLogKeyStore));
 
     // Initialize access log
     var atAccessLog = await AtAccessLogManagerImpl.getInstance().getAccessLog(
         serverContext!.currentAtSign!,
-        accessLogPath: accessLogPath);
+        accessLogPath: AtSecondaryConfig.accessLogPath);
     _accessLog = atAccessLog;
 
     // Initialize notification storage
     var notificationKeystore = AtNotificationKeystore.getInstance();
     notificationKeystore.currentAtSign = serverContext!.currentAtSign!;
-    await notificationKeystore.init(notificationStoragePath!);
+    await notificationKeystore.init(AtSecondaryConfig.notificationStoragePath);
     // Loads the notifications into Map.
     await NotificationUtil.loadNotificationMap();
 
@@ -739,7 +731,7 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
             .getSecondaryPersistenceStore(serverContext!.currentAtSign)!;
     hivePersistenceManager =
         secondaryPersistenceStore.getHivePersistenceManager()!;
-    await hivePersistenceManager.init(storagePath!);
+    await hivePersistenceManager.init(AtSecondaryConfig.storagePath);
 
     var atData = AtData();
     atData.data = serverContext!.sharedSecret;
@@ -749,7 +741,7 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
     secondaryKeyStore = SecondaryPersistenceStoreFactory.getInstance()
         .getSecondaryPersistenceStore(serverContext!.currentAtSign)!
         .getSecondaryKeyStore()!;
-    secondaryKeyStore.commitLog = _commitLog;
+    secondaryKeyStore.commitLog = commitLog;
 
     keyStoreManager.keyStore = secondaryKeyStore;
     // Initialize the hive store

--- a/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
@@ -5,7 +5,6 @@ import 'dart:convert';
 import 'package:at_commons/at_commons.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:at_secondary/src/connection/inbound/inbound_connection_metadata.dart';
-import 'package:at_secondary/src/connection/inbound/inbound_connection_pool.dart';
 import 'package:at_secondary/src/enroll/enroll_datastore_value.dart';
 import 'package:at_secondary/src/enroll/enrollment_manager.dart';
 import 'package:at_secondary/src/server/at_secondary_config.dart';
@@ -384,7 +383,8 @@ class EnrollVerbHandler extends AbstractVerbHandler {
 
   Future<void> _dropRevokedClientConnection(String enrollmentId, bool forceFlag,
       InboundConnection currentInboundConnection, responseJson) async {
-    final inboundPool = InboundConnectionPool.getInstance();
+    final inboundPool =
+        AtSecondaryServerImpl.getInstance().inboundConnectionManager.pool;
     List<InboundConnection> connectionsToRemove = [];
     for (InboundConnection connection in inboundPool.getConnections()) {
       var inboundConnectionMetadata =

--- a/packages/at_secondary_server/lib/src/verb/handler/stats_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/stats_verb_handler.dart
@@ -16,7 +16,7 @@ import 'package:at_server_spec/at_verb_spec.dart';
 // StatsVerbHandler class is used to process stats verb
 // Stats verb will return all the possible keys you can lookup
 //Ex: stats\n
-enum MetricNames {
+enum Metric {
   INBOUND,
   OUTBOUND,
   LASTCOMMIT,
@@ -31,70 +31,75 @@ enum MetricNames {
   COMMIT_LOG_COMPACTION,
   ACCESS_lOG_COMPACTION,
   NOTIFICATION_COMPACTION,
-  LATEST_COMMIT_ENTRY_OF_EACH_KEY
-}
-
-extension MetricClasses on MetricNames? {
-  MetricProvider? get name {
-    switch (this) {
-      case MetricNames.INBOUND:
-        return InboundMetricImpl.getInstance();
-      case MetricNames.OUTBOUND:
-        return OutBoundMetricImpl.getInstance();
-      case MetricNames.LASTCOMMIT:
-        return LastCommitIDMetricImpl.getInstance();
-      case MetricNames.SECONDARY_STORAGE_SIZE:
-        return SecondaryStorageMetricImpl.getInstance();
-      case MetricNames.MOST_VISITED_ATSIGN:
-        return MostVisitedAtSignMetricImpl.getInstance();
-      case MetricNames.MOST_VISITED_ATKEYS:
-        return MostVisitedAtKeyMetricImpl.getInstance();
-      case MetricNames.SECONDARY_SERVER_VERSION:
-        return SecondaryServerVersion.getInstance();
-      case MetricNames.LAST_LOGGEDIN_DATETIME:
-        return LastLoggedInDatetimeMetricImpl.getInstance();
-      case MetricNames.DISK_SIZE:
-        return DiskSizeMetricImpl.getInstance();
-      case MetricNames.LAST_AUTH_TIME:
-        return LastPkamMetricImpl.getInstance();
-      case MetricNames.NOTIFICATION_COUNT:
-        return NotificationsMetricImpl.getInstance();
-      case MetricNames.COMMIT_LOG_COMPACTION:
-        return CommitLogCompactionStats.getInstance();
-      case MetricNames.ACCESS_lOG_COMPACTION:
-        return AccessLogCompactionStats.getInstance();
-      case MetricNames.NOTIFICATION_COMPACTION:
-        return NotificationCompactionStats.getInstance();
-      case MetricNames.LATEST_COMMIT_ENTRY_OF_EACH_KEY:
-        return LatestCommitEntryOfEachKey();
-      default:
-        return null;
-    }
-  }
+  LATEST_COMMIT_ENTRY_OF_EACH_KEY,
+  INBOUND_SUMMARY,
+  INBOUND_DETAILED,
 }
 
 final Map statsMap = {
-  '1': MetricNames.INBOUND,
-  '2': MetricNames.OUTBOUND,
-  '3': MetricNames.LASTCOMMIT,
-  '4': MetricNames.SECONDARY_STORAGE_SIZE,
-  '5': MetricNames.MOST_VISITED_ATSIGN,
-  '6': MetricNames.MOST_VISITED_ATKEYS,
-  '7': MetricNames.SECONDARY_SERVER_VERSION,
-  '8': MetricNames.LAST_LOGGEDIN_DATETIME,
-  '9': MetricNames.DISK_SIZE,
-  '10': MetricNames.LAST_AUTH_TIME,
-  '11': MetricNames.NOTIFICATION_COUNT,
-  '12': MetricNames.COMMIT_LOG_COMPACTION,
-  '13': MetricNames.ACCESS_lOG_COMPACTION,
-  '14': MetricNames.NOTIFICATION_COMPACTION,
-  '15': MetricNames.LATEST_COMMIT_ENTRY_OF_EACH_KEY
+  '1': Metric.INBOUND,
+  '2': Metric.OUTBOUND,
+  '3': Metric.LASTCOMMIT,
+  '4': Metric.SECONDARY_STORAGE_SIZE,
+  '5': Metric.MOST_VISITED_ATSIGN,
+  '6': Metric.MOST_VISITED_ATKEYS,
+  '7': Metric.SECONDARY_SERVER_VERSION,
+  '8': Metric.LAST_LOGGEDIN_DATETIME,
+  '9': Metric.DISK_SIZE,
+  '10': Metric.LAST_AUTH_TIME,
+  '11': Metric.NOTIFICATION_COUNT,
+  '12': Metric.COMMIT_LOG_COMPACTION,
+  '13': Metric.ACCESS_lOG_COMPACTION,
+  '14': Metric.NOTIFICATION_COMPACTION,
+  '15': Metric.LATEST_COMMIT_ENTRY_OF_EACH_KEY,
+  '16': Metric.INBOUND_SUMMARY,
+  '17': Metric.INBOUND_DETAILED,
 };
 
 class StatsVerbHandler extends AbstractVerbHandler {
+  AtSecondaryServerImpl atServer = AtSecondaryServerImpl.getInstance();
   static Stats stats = Stats();
 
   dynamic _regex;
+
+  MetricProvider getProvider(Metric metric) {
+    switch (metric) {
+      case Metric.INBOUND:
+        return InboundMetricImpl(atServer);
+      case Metric.OUTBOUND:
+        return OutBoundMetricImpl(atServer);
+      case Metric.LASTCOMMIT:
+        return LastCommitIDMetricImpl(atServer);
+      case Metric.SECONDARY_STORAGE_SIZE:
+        return SecondaryStorageMetricImpl(atServer);
+      case Metric.MOST_VISITED_ATSIGN:
+        return MostVisitedAtSignMetricImpl(atServer);
+      case Metric.MOST_VISITED_ATKEYS:
+        return MostVisitedAtKeyMetricImpl(atServer);
+      case Metric.SECONDARY_SERVER_VERSION:
+        return SecondaryServerVersion(atServer);
+      case Metric.LAST_LOGGEDIN_DATETIME:
+        return LastLoggedInDatetimeMetricImpl(atServer);
+      case Metric.DISK_SIZE:
+        return DiskSizeMetricImpl(atServer);
+      case Metric.LAST_AUTH_TIME:
+        return LastPkamMetricImpl(atServer);
+      case Metric.NOTIFICATION_COUNT:
+        return NotificationsMetricImpl(atServer);
+      case Metric.COMMIT_LOG_COMPACTION:
+        return CommitLogCompactionStats(atServer);
+      case Metric.ACCESS_lOG_COMPACTION:
+        return AccessLogCompactionStats(atServer);
+      case Metric.NOTIFICATION_COMPACTION:
+        return NotificationCompactionStats(atServer);
+      case Metric.LATEST_COMMIT_ENTRY_OF_EACH_KEY:
+        return LatestCommitEntryOfEachKey(atServer);
+      case Metric.INBOUND_SUMMARY:
+        return InboundSummaryMetricImpl(atServer);
+      case Metric.INBOUND_DETAILED:
+        return InboundDetailedMetricImpl(atServer);
+    }
+  }
 
   StatsVerbHandler(super.keyStore);
 
@@ -112,8 +117,8 @@ class StatsVerbHandler extends AbstractVerbHandler {
   Future<void> addStatToResult(
       id, result, List<String> enrolledNamespaces) async {
     logger.info('addStatToResult for id : $id, regex: $_regex');
-    var metric = _getMetrics(id);
-    var name = metric.name!.getName();
+    Metric metric = metricById(id);
+    MetricProvider provider = getProvider(metric);
     dynamic value;
     if (id == '3') {
       if (_regex == null || _regex.isEmpty) {
@@ -121,14 +126,14 @@ class StatsVerbHandler extends AbstractVerbHandler {
       }
       // When connection is authenticated via the APKAM, return the highest commit-Id
       // among the specified namespaces.
-      value = await (metric.name as LastCommitIDMetricImpl)
+      value = await (provider as LastCommitIDMetricImpl)
           .getMetrics(regex: _regex, enrolledNamespaces: enrolledNamespaces);
     } else if (id == '15' && _regex != null) {
-      value = await metric.name!.getMetrics(regex: _regex);
+      value = await provider.getMetrics(regex: _regex);
     } else {
-      value = await metric.name!.getMetrics();
+      value = await provider.getMetrics();
     }
-    var stat = Stat(id, name, value);
+    var stat = Stat(id, provider.getName(), value);
     result.add(jsonEncode(stat));
   }
 
@@ -140,53 +145,45 @@ class StatsVerbHandler extends AbstractVerbHandler {
       Response response,
       HashMap<String, String?> verbParams,
       InboundConnection atConnection) async {
-    try {
-      var statID = verbParams[AtConstants.statId];
-      _regex = verbParams[AtConstants.regex];
-      logger.finer('In statsVerbHandler statID : $statID, regex : $_regex');
-      Set statsList;
-      if (statID != null) {
-        //If user provides stats ID's create set out of it
-        statsList = getStatsIDSet(statID);
-      } else {
-        // if user send only stats verb get list of all the stat ID's
-        statsList = statsMap.keys.toSet();
-      }
-      var result = [];
-      List<String> enrolledNamespaces = [];
-      if ((atConnection.metaData as InboundConnectionMetadata).enrollmentId !=
-          null) {
-        enrolledNamespaces = (await AtSecondaryServerImpl.getInstance()
-                .enrollmentManager
-                .getEnrollmentById(
-                    (atConnection.metaData as InboundConnectionMetadata)
-                        .enrollmentId!))
-            .namespaces
-            .keys
-            .toList();
-      }
-      //Iterate through stats_id_list
-      await Future.forEach(
-          statsList,
-          (dynamic element) =>
-              addStatToResult(element, result, enrolledNamespaces));
-      // Create response json
-      var responseJson = result.toString();
-      response.data = responseJson;
-    } catch (exception) {
-      response.isError = true;
-      response.errorMessage = exception.toString();
-      return;
+    var statID = verbParams[AtConstants.statId];
+    _regex = verbParams[AtConstants.regex];
+    logger.finer('In statsVerbHandler statID : $statID, regex : $_regex');
+    Set statsList;
+    if (statID != null) {
+      //If user provides stats ID's create set out of it
+      statsList = getStatsIDSet(statID);
+    } else {
+      // if user send only stats verb get list of all the stat ID's
+      statsList = statsMap.keys.toSet();
     }
+    var result = [];
+    List<String> enrolledNamespaces = [];
+    if ((atConnection.metaData as InboundConnectionMetadata).enrollmentId !=
+        null) {
+      enrolledNamespaces = (await atServer.enrollmentManager.getEnrollmentById(
+              (atConnection.metaData as InboundConnectionMetadata)
+                  .enrollmentId!))
+          .namespaces
+          .keys
+          .toList();
+    }
+    //Iterate through stats_id_list
+    await Future.forEach(
+        statsList,
+        (dynamic element) =>
+            addStatToResult(element, result, enrolledNamespaces));
+    // Create response json
+    var responseJson = result.toString();
+    response.data = responseJson;
   }
 
   // get Metric based on ID
-  MetricNames? _getMetrics(String key) {
+  Metric metricById(String key) {
     //use map and get name based on ID
     if (statsMap.containsKey(key)) {
       return statsMap[key];
     } else {
-      throw InvalidSyntaxException;
+      throw InvalidSyntaxException('No metric with ID $key');
     }
   }
 

--- a/packages/at_secondary_server/lib/src/verb/metrics/metrics_impl.dart
+++ b/packages/at_secondary_server/lib/src/verb/metrics/metrics_impl.dart
@@ -3,28 +3,19 @@ import 'dart:io';
 import 'dart:math';
 
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
-import 'package:at_secondary/src/connection/connection_metrics.dart';
-import 'package:at_secondary/src/connection/inbound/inbound_connection_pool.dart';
 import 'package:at_secondary/src/server/at_secondary_config.dart';
-import 'package:at_secondary/src/server/at_secondary_impl.dart';
 import 'package:at_secondary/src/utils/regex_util.dart';
 import 'package:at_secondary/src/verb/metrics/metrics_provider.dart';
 import 'package:at_commons/at_commons.dart';
 
-class InboundMetricImpl implements MetricProvider {
-  static final InboundMetricImpl _singleton = InboundMetricImpl._internal();
-  var connectionMetrics = ConnectionMetricsImpl();
-
-  InboundMetricImpl._internal();
-
-  factory InboundMetricImpl.getInstance() {
-    return _singleton;
-  }
+class InboundMetricImpl extends MetricProvider {
+  InboundMetricImpl(super.atServer);
 
   @override
-  Map<String, dynamic> getMetrics({String? regex}) {
-    var connections = InboundConnectionPool.getInstance();
-    return connections.stats;
+  String getMetrics({String? regex}) {
+    return atServer.inboundConnectionManager.pool
+        .getActiveConnectionSize()
+        .toString();
   }
 
   @override
@@ -33,20 +24,40 @@ class InboundMetricImpl implements MetricProvider {
   }
 }
 
-class OutBoundMetricImpl implements MetricProvider {
-  static final OutBoundMetricImpl _singleton = OutBoundMetricImpl._internal();
-  var connectionMetrics = ConnectionMetricsImpl();
+class InboundSummaryMetricImpl extends MetricProvider {
+  InboundSummaryMetricImpl(super.atServer);
 
-  OutBoundMetricImpl._internal();
-
-  factory OutBoundMetricImpl.getInstance() {
-    return _singleton;
+  @override
+  Map<String, dynamic> getMetrics({String? regex}) {
+    return atServer.inboundConnectionManager.pool.getStats(detailed: false);
   }
 
   @override
+  String getName() {
+    return 'activeInboundConnectionsSummary';
+  }
+}
+
+class InboundDetailedMetricImpl extends MetricProvider {
+  InboundDetailedMetricImpl(super.atServer);
+
+  @override
+  Map<String, dynamic> getMetrics({String? regex}) {
+    return atServer.inboundConnectionManager.pool.getStats(detailed: true);
+  }
+
+  @override
+  String getName() {
+    return 'activeInboundConnectionsDetailed';
+  }
+}
+
+class OutBoundMetricImpl extends MetricProvider {
+  OutBoundMetricImpl(super.atServer);
+
+  @override
   String getMetrics({String? regex}) {
-    var connections = connectionMetrics.getOutboundConnections().toString();
-    return connections;
+    return atServer.outboundClientManager.getActiveConnectionSize().toString();
   }
 
   @override
@@ -55,20 +66,8 @@ class OutBoundMetricImpl implements MetricProvider {
   }
 }
 
-class LastCommitIDMetricImpl implements MetricProvider {
-  static final LastCommitIDMetricImpl _singleton =
-      LastCommitIDMetricImpl._internal();
-  AtCommitLog? _atCommitLog;
-
-  set atCommitLog(value) {
-    _atCommitLog = value;
-  }
-
-  LastCommitIDMetricImpl._internal();
-
-  factory LastCommitIDMetricImpl.getInstance() {
-    return _singleton;
-  }
+class LastCommitIDMetricImpl extends MetricProvider {
+  LastCommitIDMetricImpl(super.atServer);
 
   @override
   Future<String> getMetrics(
@@ -77,12 +76,12 @@ class LastCommitIDMetricImpl implements MetricProvider {
     int? lastCommitID;
     if (regex != null || enrolledNamespaces != null) {
       regex ??= '.*';
-      lastCommitID = await _atCommitLog?.lastCommittedSequenceNumberWithRegex(
-          regex,
-          enrolledNamespace: enrolledNamespaces);
+      lastCommitID = await atServer.commitLog
+          .lastCommittedSequenceNumberWithRegex(regex,
+              enrolledNamespace: enrolledNamespaces);
       return lastCommitID.toString();
     }
-    lastCommitID = _atCommitLog?.lastCommittedSequenceNumber();
+    lastCommitID = atServer.commitLog.lastCommittedSequenceNumber();
     return lastCommitID.toString();
   }
 
@@ -92,23 +91,17 @@ class LastCommitIDMetricImpl implements MetricProvider {
   }
 }
 
-class SecondaryStorageMetricImpl implements MetricProvider {
-  static final SecondaryStorageMetricImpl _singleton =
-      SecondaryStorageMetricImpl._internal();
-  var secondaryStorageLocation = Directory(AtSecondaryServerImpl.storagePath!);
-
-  SecondaryStorageMetricImpl._internal();
-
-  factory SecondaryStorageMetricImpl.getInstance() {
-    return _singleton;
-  }
+class SecondaryStorageMetricImpl extends MetricProvider {
+  SecondaryStorageMetricImpl(super.atServer);
 
   @override
   int getMetrics({String? regex}) {
     var secondaryStorageSize = 0;
     //The listSync function returns the list of files in the hive storage location.
     // The below loop iterates recursively into sub-directories over each file and gets the file size using lengthSync function
-    secondaryStorageLocation.listSync(recursive: true).forEach((element) {
+    Directory(AtSecondaryConfig.storagePath)
+        .listSync(recursive: true)
+        .forEach((element) {
       if (element is File) {
         secondaryStorageSize =
             secondaryStorageSize + File(element.path).lengthSync();
@@ -124,21 +117,14 @@ class SecondaryStorageMetricImpl implements MetricProvider {
   }
 }
 
-class MostVisitedAtSignMetricImpl implements MetricProvider {
-  static final MostVisitedAtSignMetricImpl _singleton =
-      MostVisitedAtSignMetricImpl._internal();
-
-  MostVisitedAtSignMetricImpl._internal();
-
-  factory MostVisitedAtSignMetricImpl.getInstance() {
-    return _singleton;
-  }
+class MostVisitedAtSignMetricImpl extends MetricProvider {
+  MostVisitedAtSignMetricImpl(super.atServer);
 
   @override
   Future<String> getMetrics({String? regex}) async {
     final length = AtSecondaryConfig.stats_top_visits!;
     var atAccessLog = await (AtAccessLogManagerImpl.getInstance()
-        .getAccessLog(AtSecondaryServerImpl.getInstance().currentAtSign));
+        .getAccessLog(atServer.currentAtSign));
     return jsonEncode(await atAccessLog?.mostVisitedAtSigns(length));
   }
 
@@ -148,21 +134,14 @@ class MostVisitedAtSignMetricImpl implements MetricProvider {
   }
 }
 
-class MostVisitedAtKeyMetricImpl implements MetricProvider {
-  static final MostVisitedAtKeyMetricImpl _singleton =
-      MostVisitedAtKeyMetricImpl._internal();
-
-  MostVisitedAtKeyMetricImpl._internal();
-
-  factory MostVisitedAtKeyMetricImpl.getInstance() {
-    return _singleton;
-  }
+class MostVisitedAtKeyMetricImpl extends MetricProvider {
+  MostVisitedAtKeyMetricImpl(super.atServer);
 
   @override
   Future<String> getMetrics({String? regex}) async {
     final length = AtSecondaryConfig.stats_top_keys!;
     var atAccessLog = await (AtAccessLogManagerImpl.getInstance()
-        .getAccessLog(AtSecondaryServerImpl.getInstance().currentAtSign));
+        .getAccessLog(atServer.currentAtSign));
     return jsonEncode(await atAccessLog?.mostVisitedKeys(length));
   }
 
@@ -172,15 +151,8 @@ class MostVisitedAtKeyMetricImpl implements MetricProvider {
   }
 }
 
-class SecondaryServerVersion implements MetricProvider {
-  static final SecondaryServerVersion _singleton =
-      SecondaryServerVersion._internal();
-
-  SecondaryServerVersion._internal();
-
-  factory SecondaryServerVersion.getInstance() {
-    return _singleton;
-  }
+class SecondaryServerVersion extends MetricProvider {
+  SecondaryServerVersion(super.atServer);
 
   @override
   String? getMetrics({String? regex}) {
@@ -193,20 +165,13 @@ class SecondaryServerVersion implements MetricProvider {
   }
 }
 
-class LastLoggedInDatetimeMetricImpl implements MetricProvider {
-  static final LastLoggedInDatetimeMetricImpl _singleton =
-      LastLoggedInDatetimeMetricImpl._internal();
-
-  LastLoggedInDatetimeMetricImpl._internal();
-
-  factory LastLoggedInDatetimeMetricImpl.getInstance() {
-    return _singleton;
-  }
+class LastLoggedInDatetimeMetricImpl extends MetricProvider {
+  LastLoggedInDatetimeMetricImpl(super.atServer);
 
   @override
   Future<String?> getMetrics({String? regex}) async {
     var atAccessLog = await (AtAccessLogManagerImpl.getInstance()
-        .getAccessLog(AtSecondaryServerImpl.getInstance().currentAtSign));
+        .getAccessLog(atServer.currentAtSign));
     var entry = await atAccessLog!.getLastAccessLogEntry();
     return entry.requestDateTime!.toUtc().toString();
   }
@@ -217,22 +182,16 @@ class LastLoggedInDatetimeMetricImpl implements MetricProvider {
   }
 }
 
-class DiskSizeMetricImpl implements MetricProvider {
-  static final DiskSizeMetricImpl _singleton = DiskSizeMetricImpl._internal();
-
-  DiskSizeMetricImpl._internal();
-
-  factory DiskSizeMetricImpl.getInstance() {
-    return _singleton;
-  }
+class DiskSizeMetricImpl extends MetricProvider {
+  DiskSizeMetricImpl(super.atServer);
 
   @override
   String getMetrics({String? regex}) {
-    Directory storageLocation = Directory(AtSecondaryServerImpl.storagePath!);
     var diskSize = 0;
     //The listSync function returns the list of files in the hive storage location.
     // In the loop iterating recursively into sub-directories and gets the size of each file using lengthSync
-    for (var file in storageLocation.listSync(recursive: true)) {
+    for (var file
+        in Directory(AtSecondaryConfig.storagePath).listSync(recursive: true)) {
       if (file is File) {
         diskSize = diskSize + File(file.path).lengthSync();
       }
@@ -261,19 +220,13 @@ class DiskSizeMetricImpl implements MetricProvider {
   }
 }
 
-class LastPkamMetricImpl implements MetricProvider {
-  static final LastPkamMetricImpl _singleton = LastPkamMetricImpl._internal();
-
-  LastPkamMetricImpl._internal();
-
-  factory LastPkamMetricImpl.getInstance() {
-    return _singleton;
-  }
+class LastPkamMetricImpl extends MetricProvider {
+  LastPkamMetricImpl(super.atServer);
 
   @override
   Future<String?> getMetrics({String? regex}) async {
     var atAccessLog = await (AtAccessLogManagerImpl.getInstance()
-        .getAccessLog(AtSecondaryServerImpl.getInstance().currentAtSign));
+        .getAccessLog(atServer.currentAtSign));
     var entry = await atAccessLog!.getLastPkamAccessLogEntry();
     return (entry != null)
         ? entry.requestDateTime!.toUtc().toString()
@@ -286,15 +239,8 @@ class LastPkamMetricImpl implements MetricProvider {
   }
 }
 
-class NotificationsMetricImpl implements MetricProvider {
-  static final NotificationsMetricImpl _singleton =
-      NotificationsMetricImpl._internal();
-
-  NotificationsMetricImpl._internal();
-
-  factory NotificationsMetricImpl.getInstance() {
-    return _singleton;
-  }
+class NotificationsMetricImpl extends MetricProvider {
+  NotificationsMetricImpl(super.atServer);
 
   String _asString(dynamic enumData) {
     return enumData == null ? 'null' : enumData.toString().split('.')[1];
@@ -372,19 +318,12 @@ class NotificationsMetricImpl implements MetricProvider {
   }
 }
 
-class KeyStorageMetricImpl implements MetricProvider {
-  static final KeyStorageMetricImpl _singleton =
-      KeyStorageMetricImpl._internal();
-
-  KeyStorageMetricImpl._internal();
-
-  factory KeyStorageMetricImpl.getInstance() {
-    return _singleton;
-  }
+class KeyStorageMetricImpl extends MetricProvider {
+  KeyStorageMetricImpl(super.atServer);
 
   @override
   Future<String?> getMetrics({String? regex}) async {
-    return AtSecondaryServerImpl.getInstance().currentAtSign;
+    return atServer.currentAtSign;
   }
 
   @override
@@ -393,21 +332,13 @@ class KeyStorageMetricImpl implements MetricProvider {
   }
 }
 
-class CommitLogCompactionStats implements MetricProvider {
-  static final CommitLogCompactionStats _singleton =
-      CommitLogCompactionStats.internal();
-
-  CommitLogCompactionStats.internal();
-
-  factory CommitLogCompactionStats.getInstance() {
-    return _singleton;
-  }
+class CommitLogCompactionStats extends MetricProvider {
+  CommitLogCompactionStats(super.atServer);
 
   @override
   getMetrics({String? regex}) async {
     var keyStore = SecondaryPersistenceStoreFactory.getInstance()
-        .getSecondaryPersistenceStore(
-            AtSecondaryServerImpl.getInstance().currentAtSign)
+        .getSecondaryPersistenceStore(atServer.currentAtSign)
         ?.getSecondaryKeyStore();
     if (keyStore!.isKeyExists(AtConstants.commitLogCompactionKey)) {
       AtData? atData = await keyStore.get(AtConstants.commitLogCompactionKey);
@@ -424,21 +355,13 @@ class CommitLogCompactionStats implements MetricProvider {
   }
 }
 
-class AccessLogCompactionStats implements MetricProvider {
-  static final AccessLogCompactionStats _singleton =
-      AccessLogCompactionStats._internal();
-
-  AccessLogCompactionStats._internal();
-
-  factory AccessLogCompactionStats.getInstance() {
-    return _singleton;
-  }
+class AccessLogCompactionStats extends MetricProvider {
+  AccessLogCompactionStats(super.atServer);
 
   @override
   getMetrics({String? regex}) async {
     var keyStore = SecondaryPersistenceStoreFactory.getInstance()
-        .getSecondaryPersistenceStore(
-            AtSecondaryServerImpl.getInstance().currentAtSign)
+        .getSecondaryPersistenceStore(atServer.currentAtSign)
         ?.getSecondaryKeyStore();
     if (keyStore!.isKeyExists(AtConstants.accessLogCompactionKey)) {
       AtData? atData = await keyStore.get(AtConstants.accessLogCompactionKey);
@@ -455,21 +378,13 @@ class AccessLogCompactionStats implements MetricProvider {
   }
 }
 
-class NotificationCompactionStats implements MetricProvider {
-  static final NotificationCompactionStats _singleton =
-      NotificationCompactionStats.internal();
-
-  NotificationCompactionStats.internal();
-
-  factory NotificationCompactionStats.getInstance() {
-    return _singleton;
-  }
+class NotificationCompactionStats extends MetricProvider {
+  NotificationCompactionStats(super.atServer);
 
   @override
   getMetrics({String? regex}) async {
     var keyStore = SecondaryPersistenceStoreFactory.getInstance()
-        .getSecondaryPersistenceStore(
-            AtSecondaryServerImpl.getInstance().currentAtSign)
+        .getSecondaryPersistenceStore(atServer.currentAtSign)
         ?.getSecondaryKeyStore();
     if (keyStore!.isKeyExists(AtConstants.notificationCompactionKey)) {
       AtData? atData =
@@ -487,12 +402,14 @@ class NotificationCompactionStats implements MetricProvider {
   }
 }
 
-class LatestCommitEntryOfEachKey implements MetricProvider {
+class LatestCommitEntryOfEachKey extends MetricProvider {
+  LatestCommitEntryOfEachKey(super.atServer);
+
   @override
   getMetrics({String? regex = '.*'}) async {
     var responseMap = <String, List<dynamic>>{};
     var atCommitLog = await (AtCommitLogManagerImpl.getInstance()
-        .getCommitLog(AtSecondaryServerImpl.getInstance().currentAtSign));
+        .getCommitLog(atServer.currentAtSign));
 
     int? lastCommitId = atCommitLog?.lastCommittedSequenceNumber();
     int lastCommitIdReceived = -1;

--- a/packages/at_secondary_server/lib/src/verb/metrics/metrics_provider.dart
+++ b/packages/at_secondary_server/lib/src/verb/metrics/metrics_provider.dart
@@ -1,4 +1,11 @@
+import 'package:at_secondary/src/server/at_secondary_impl.dart';
+
 abstract class MetricProvider {
+  AtSecondaryServerImpl atServer;
+
+  MetricProvider(this.atServer);
+
   String getName();
+
   dynamic getMetrics({String? regex});
 }

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_secondary
 description: Implementation of secondary server.
-version: 3.7.0
+version: 3.7.1
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://www.example.com
 publish_to: none

--- a/packages/at_secondary_server/test/inbound_connection_manager_test.dart
+++ b/packages/at_secondary_server/test/inbound_connection_manager_test.dart
@@ -1,9 +1,8 @@
 import 'dart:io';
 
 import 'package:at_commons/at_commons.dart';
-import 'package:at_secondary/src/connection/inbound/connection_util.dart';
 import 'package:at_secondary/src/connection/inbound/inbound_connection_manager.dart';
-import 'package:at_secondary/src/server/at_secondary_impl.dart';
+import 'package:at_secondary/src/server/at_secondary_config.dart';
 import 'package:at_secondary/src/server/server_context.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
@@ -15,80 +14,76 @@ void main() {
 
   late MockSocket mockSocket;
 
+  late InboundConnectionManager icm;
+
   setUp(() {
-    var serverContext = AtSecondaryContext();
-    serverContext.unauthenticatedInboundIdleTimeMillis = 10000;
-    AtSecondaryServerImpl.getInstance().serverContext = serverContext;
+    atServer.serverContext = AtSecondaryContext()
+      ..unauthenticatedInboundIdleTimeMillis = 10000;
+    atServer.inboundConnectionManager = icm = InboundConnectionManager(
+        serverAtSign: alice, poolSize: AtSecondaryConfig.inbound_max_limit);
     mockSocket = MockSocket();
     when(() => mockSocket.setOption(SocketOption.tcpNoDelay, true))
         .thenReturn(true);
   });
 
   tearDown(() {
-    InboundConnectionManager.getInstance().removeAllConnections();
+    atServer.inboundConnectionManager.close();
   });
 
   group('A group of inbound connection manager tests', () {
     test('test inbound connection manager - create connection ', () {
-      var connManager = InboundConnectionManager.getInstance();
-      connManager.init(5);
+      icm.pool.resize(5);
       var createdConnection =
-          connManager.createSocketConnection(mockSocket, sessionId: 'aaa');
+          icm.createSocketConnection(mockSocket, sessionId: 'aaa');
       expect(createdConnection.metaData.sessionID, 'aaa');
       expect(createdConnection.metaData.isCreated, true);
     });
 
     test('test inbound connection manager - current pool size', () {
-      var connManager = InboundConnectionManager.getInstance();
-      connManager.init(2);
-      connManager.createSocketConnection(mockSocket, sessionId: 'aaa');
-      expect(ConnectionUtil.getActiveConnectionSize(), 1);
+      icm.pool.resize(2);
+      icm.createSocketConnection(mockSocket, sessionId: 'aaa');
+      expect(icm.pool.getActiveConnectionSize(), 1);
     });
 
     test('test inbound connection manager - current pool size no connections',
         () {
-      expect(ConnectionUtil.getActiveConnectionSize(), 0);
+      expect(icm.pool.getActiveConnectionSize(), 0);
     });
 
     test('test inbound connection manager - connect limit test', () {
-      var connManager = InboundConnectionManager.getInstance();
-      connManager.init(2);
-      connManager.createSocketConnection(mockSocket, sessionId: 'aaa');
-      connManager.createSocketConnection(mockSocket, sessionId: 'bbb');
+      icm.pool.resize(2);
+      icm.createSocketConnection(mockSocket, sessionId: 'aaa');
+      icm.createSocketConnection(mockSocket, sessionId: 'bbb');
       expect(
-          () =>
-              connManager.createSocketConnection(mockSocket, sessionId: 'ccc'),
+          () => icm.createSocketConnection(mockSocket, sessionId: 'ccc'),
           throwsA(predicate((dynamic e) =>
               e is InboundConnectionLimitException &&
               e.message == 'max limit reached on inbound pool')));
     });
 
     test('test inbound connection manager - has capacity true', () {
-      var connManager = InboundConnectionManager.getInstance();
-      connManager.init(5);
-      connManager.createSocketConnection(mockSocket, sessionId: 'aaa');
-      connManager.createSocketConnection(mockSocket, sessionId: 'bbb');
-      connManager.createSocketConnection(mockSocket, sessionId: 'ccc');
-      expect(connManager.hasCapacity(), true);
+      icm.pool.resize(5);
+      icm.createSocketConnection(mockSocket, sessionId: 'aaa');
+      icm.createSocketConnection(mockSocket, sessionId: 'bbb');
+      icm.createSocketConnection(mockSocket, sessionId: 'ccc');
+      expect(icm.hasCapacity(), true);
     });
 
     test('test inbound connection manager - has capacity false', () {
-      var connManager = InboundConnectionManager.getInstance();
-      connManager.init(3);
-      connManager.createSocketConnection(mockSocket, sessionId: 'aaa');
-      connManager.createSocketConnection(mockSocket, sessionId: 'bbb');
-      connManager.createSocketConnection(mockSocket, sessionId: 'ccc');
-      expect(connManager.hasCapacity(), false);
+      icm.pool.resize(3);
+      icm.createSocketConnection(mockSocket, sessionId: 'aaa');
+      icm.createSocketConnection(mockSocket, sessionId: 'bbb');
+      icm.createSocketConnection(mockSocket, sessionId: 'ccc');
+      expect(icm.hasCapacity(), false);
     });
 
     test('test inbound connection manager -clear connections', () {
-      var connManager = InboundConnectionManager.getInstance();
-      connManager.init(3);
-      connManager.createSocketConnection(mockSocket, sessionId: 'aaa');
-      connManager.createSocketConnection(mockSocket, sessionId: 'bbb');
-      connManager.createSocketConnection(mockSocket, sessionId: 'ccc');
-      connManager.removeAllConnections();
-      expect(ConnectionUtil.getActiveConnectionSize(), 0);
+      icm.pool.resize(3);
+      icm.createSocketConnection(mockSocket, sessionId: 'aaa');
+      icm.createSocketConnection(mockSocket, sessionId: 'bbb');
+      icm.createSocketConnection(mockSocket, sessionId: 'ccc');
+      icm.close();
+      expect(icm.pool.getActiveConnectionSize(), 0);
     });
   });
 }

--- a/packages/at_secondary_server/test/inbound_connection_pool_test.dart
+++ b/packages/at_secondary_server/test/inbound_connection_pool_test.dart
@@ -2,8 +2,9 @@ import 'dart:io';
 import 'dart:math';
 
 import 'package:at_secondary/src/connection/inbound/inbound_connection_impl.dart';
+import 'package:at_secondary/src/connection/inbound/inbound_connection_manager.dart';
 import 'package:at_secondary/src/connection/inbound/inbound_connection_pool.dart';
-import 'package:at_secondary/src/server/at_secondary_impl.dart';
+import 'package:at_secondary/src/server/at_secondary_config.dart';
 import 'package:at_secondary/src/server/server_context.dart';
 import 'package:at_server_spec/at_server_spec.dart';
 import 'package:mocktail/mocktail.dart';
@@ -21,91 +22,96 @@ void main() async {
 
   verbTestsSetUpLogging();
 
+  late InboundConnectionPool pool;
+
   setUpAll(() {
     serverContext.unauthenticatedInboundIdleTimeMillis = 250;
     serverContext.authenticatedInboundIdleTimeMillis = 500;
     serverContext.inboundConnectionLowWaterMarkRatio = 0.5;
     serverContext.unauthenticatedMinAllowableIdleTimeMillis = 20;
     serverContext.authenticatedMinAllowableIdleTimeMillis = 100;
-    AtSecondaryServerImpl.getInstance().serverContext = serverContext;
-    InboundConnectionPool.getInstance().init(10);
+    atServer.serverContext = serverContext;
+    atServer.inboundConnectionManager = InboundConnectionManager(
+        serverAtSign: alice, poolSize: AtSecondaryConfig.inbound_max_limit);
+    pool = atServer.inboundConnectionManager.pool;
+    pool.resize(10);
 
     mockSocket = MockSocket();
     when(() => mockSocket.setOption(SocketOption.tcpNoDelay, true))
         .thenReturn(true);
   });
   tearDown(() {
-    InboundConnectionPool.getInstance().clearAllConnections();
+    pool.clearAllConnections();
   });
   group('A group of inbound connection pool test', () {
     test('test connection pool init', () {
-      InboundConnectionPool.getInstance().init((5));
-      expect(InboundConnectionPool.getInstance().getCapacity(), 5);
-      expect(InboundConnectionPool.getInstance().getCurrentSize(), 0);
+      pool.resize(5);
+      expect(pool.getCapacity(), 5);
+      expect(pool.getCurrentSize(), 0);
     });
 
     test('test connection pool add connections', () {
-      var poolInstance = InboundConnectionPool.getInstance();
-      poolInstance.init(5);
+      pool.resize(5);
       var connection1 = InboundConnectionImpl(mockSocket, 'aaa');
       var connection2 = InboundConnectionImpl(mockSocket, 'bbb');
-      poolInstance.add(connection1);
-      poolInstance.add(connection2);
-      expect(poolInstance.getCapacity(), 5);
-      expect(poolInstance.getCurrentSize(), 2);
+      pool.add(connection1);
+      pool.add(connection2);
+      expect(pool.getCapacity(), 5);
+      expect(pool.getCurrentSize(), 2);
     });
     test('test connection pool has capacity', () {
-      var poolInstance = InboundConnectionPool.getInstance();
-      poolInstance.init(2);
+      pool.resize(2);
       var connection1 = InboundConnectionImpl(mockSocket, 'aaa');
-      poolInstance.add(connection1);
-      expect(poolInstance.hasCapacity(), true);
+      pool.add(connection1);
+      expect(pool.hasCapacity(), true);
     });
 
     test('test connection pool has no capacity', () {
-      var poolInstance = InboundConnectionPool.getInstance();
-      poolInstance.init(2);
+      pool.resize(2);
       var connection1 = InboundConnectionImpl(mockSocket, 'aaa');
       var connection2 = InboundConnectionImpl(mockSocket, 'bbb');
-      poolInstance.add(connection1);
-      poolInstance.add(connection2);
-      expect(poolInstance.hasCapacity(), false);
+      pool.add(connection1);
+      pool.add(connection2);
+      expect(pool.hasCapacity(), false);
     });
 
     test('test connection pool - clear closed connection', () {
-      var poolInstance = InboundConnectionPool.getInstance();
-      poolInstance.init(2);
-      var connection1 = MockInboundConnectionImpl(mockSocket, 'aaa');
-      var connection2 = MockInboundConnectionImpl(mockSocket, 'bbb');
-      poolInstance.add(connection1);
-      poolInstance.add(connection2);
-      expect(poolInstance.getCurrentSize(), 2);
+      pool.resize(2);
+      var connection1 =
+          FakeInboundConnectionImpl(mockSocket, 'aaa', owningPool: pool);
+      var connection2 =
+          FakeInboundConnectionImpl(mockSocket, 'bbb', owningPool: pool);
+      pool.add(connection1);
+      pool.add(connection2);
+      expect(pool.getCurrentSize(), 2);
       connection1.close();
-      poolInstance.clearInvalidConnections();
-      expect(poolInstance.getCurrentSize(), 1);
+      pool.clearInvalidConnections();
+      expect(pool.getCurrentSize(), 1);
     });
 
     test('test connection pool - clear idle connection', () async {
-      var poolInstance = InboundConnectionPool.getInstance();
-      poolInstance.init(10);
-      var connection1 = MockInboundConnectionImpl(mockSocket, 'aaa');
-      var connection2 = MockInboundConnectionImpl(mockSocket, 'bbb');
-      var connection3 = MockInboundConnectionImpl(mockSocket, 'ccc');
-      poolInstance.add(connection1);
-      poolInstance.add(connection2);
-      poolInstance.add(connection3);
+      pool.resize(10);
+      var connection1 =
+          FakeInboundConnectionImpl(mockSocket, 'aaa', owningPool: pool);
+      var connection2 =
+          FakeInboundConnectionImpl(mockSocket, 'bbb', owningPool: pool);
+      var connection3 =
+          FakeInboundConnectionImpl(mockSocket, 'ccc', owningPool: pool);
+      pool.add(connection1);
+      pool.add(connection2);
+      pool.add(connection3);
       sleep(Duration(
           milliseconds:
               (serverContext.unauthenticatedInboundIdleTimeMillis * 0.9)
                   .floor()));
       await connection2.write('test data');
-      expect(poolInstance.getCurrentSize(), 3);
+      expect(pool.getCurrentSize(), 3);
       sleep(Duration(
           milliseconds:
               (serverContext.unauthenticatedInboundIdleTimeMillis * 0.2)
                   .floor()));
-      poolInstance.clearInvalidConnections();
-      expect(poolInstance.getCurrentSize(), 1);
+      pool.clearInvalidConnections();
+      expect(pool.getCurrentSize(), 1);
     });
 
     /// Verify that, at lowWaterMark, allowable idle time is still as configured by inboundIdleTimeMillis
@@ -113,18 +119,18 @@ void main() async {
         () async {
       int maxPoolSize = 10;
 
-      var poolInstance = InboundConnectionPool.getInstance();
-      poolInstance.init(maxPoolSize);
+      pool.resize(maxPoolSize);
       List<AtConnection> connections = [];
 
       int lowWaterMark =
           (maxPoolSize * serverContext.inboundConnectionLowWaterMarkRatio)
               .floor();
       for (int i = 0; i < lowWaterMark; i++) {
-        var mockConnection =
-            MockInboundConnectionImpl(mockSocket, 'mock session $i');
+        var mockConnection = FakeInboundConnectionImpl(
+            mockSocket, 'mock session $i',
+            owningPool: pool);
         connections.add(mockConnection);
-        poolInstance.add(mockConnection);
+        pool.add(mockConnection);
       }
 
       sleep(Duration(
@@ -133,14 +139,14 @@ void main() async {
                   .floor()));
 
       await connections[1].write('test data');
-      expect(poolInstance.getCurrentSize(), lowWaterMark);
+      expect(pool.getCurrentSize(), lowWaterMark);
       sleep(Duration(
           milliseconds:
               ((serverContext.unauthenticatedInboundIdleTimeMillis * 0.1) + 1)
                   .floor()));
 
-      poolInstance.clearInvalidConnections();
-      expect(poolInstance.getCurrentSize(), 1);
+      pool.clearInvalidConnections();
+      expect(pool.getCurrentSize(), 1);
     });
 
     /// Verify that, beyond lowWaterMark, allowable idle time progressively reduces
@@ -159,22 +165,22 @@ void main() async {
         () async {
       int maxPoolSize = 100; // Please don't change this
 
-      var poolInstance = InboundConnectionPool.getInstance();
-      poolInstance.init(maxPoolSize);
-      List<MockInboundConnectionImpl> connections = [];
+      pool.resize(maxPoolSize);
+      List<FakeInboundConnectionImpl> connections = [];
 
       int desiredPoolSize = (maxPoolSize * 0.9).floor();
       int numUnauthenticated = 0;
       for (int i = 0; i < desiredPoolSize; i++) {
-        var mockConnection =
-            MockInboundConnectionImpl(mockSocket, 'mock session $i');
+        var mockConnection = FakeInboundConnectionImpl(
+            mockSocket, 'mock session $i',
+            owningPool: pool);
         if (i.isEven) {
           mockConnection.metaData.isAuthenticated = true;
         } else {
           numUnauthenticated++;
         }
         connections.add(mockConnection);
-        poolInstance.add(mockConnection);
+        pool.add(mockConnection);
       }
 
       DateTime startTimeAsDateTime = DateTime.now();
@@ -187,7 +193,7 @@ void main() async {
       }
 
       int unauthenticatedActualAllowableIdleTime = calcActualAllowableIdleTime(
-          poolInstance,
+          pool,
           maxPoolSize,
           serverContext.unauthenticatedMinAllowableIdleTimeMillis,
           serverContext.unauthenticatedInboundIdleTimeMillis);
@@ -213,12 +219,12 @@ void main() async {
             .write('test data'); // odds are not authenticated
       }
 
-      expect(poolInstance.getCurrentSize(), desiredPoolSize);
+      expect(pool.getCurrentSize(), desiredPoolSize);
 
       // pool size should be as expected before checking invalidity
-      poolInstance.clearInvalidConnections();
+      pool.clearInvalidConnections();
       // no invalid connections should have yet been cleared
-      expect(poolInstance.getCurrentSize(), desiredPoolSize);
+      expect(pool.getCurrentSize(), desiredPoolSize);
 
       // now let's sleep until the unused connections will have been idle for longer than the currently allowable idle time for UNAUTHENTICATED connections
       elapsed = DateTime.now().millisecondsSinceEpoch - startTimeAsMillis;
@@ -231,18 +237,18 @@ void main() async {
 
       // now when we clear invalid connections, we're going to see all of the unused unauthenticated connections returned to pool
       // Since we wrote to 10 unauthenticated connections, that means we will clean up numUnauthenticated - 10
-      var preClearSize = poolInstance.getCurrentSize();
-      poolInstance.clearInvalidConnections();
+      var preClearSize = pool.getCurrentSize();
+      pool.clearInvalidConnections();
       int expected =
           desiredPoolSize - (numUnauthenticated - numUnAuthToWriteTo);
       elapsed = DateTime.now().millisecondsSinceEpoch - startTimeAsMillis;
       logger.info(
           '$elapsed milliseconds after start: expect pool size after unauthenticated clean up to be $expected (pre-clear size was $preClearSize)');
-      expect(poolInstance.getCurrentSize(), expected);
+      expect(pool.getCurrentSize(), expected);
 
       // now let's sleep until the unused connections will have been idle for longer than the currently allowable idle time for AUTHENTICATED connections
       int authenticatedActualAllowableIdleTime = calcActualAllowableIdleTime(
-          poolInstance,
+          pool,
           maxPoolSize,
           serverContext.authenticatedMinAllowableIdleTimeMillis,
           serverContext.authenticatedInboundIdleTimeMillis);
@@ -259,23 +265,22 @@ void main() async {
       // Since we wrote to 3 (numAuthToWriteTo variable above) authenticated connections, that means we will clean up an additional numAuthenticated - 3 connections
       // And we'll also be cleaning up all of the UN-Authenticated connections, leaving us
       // with just the 3 'authenticated' connections
-      preClearSize = poolInstance.getCurrentSize();
-      poolInstance.clearInvalidConnections();
+      preClearSize = pool.getCurrentSize();
+      pool.clearInvalidConnections();
       expected = numAuthToWriteTo;
       elapsed = DateTime.now().millisecondsSinceEpoch - startTimeAsMillis;
       logger.info(
           '$elapsed milliseconds after start : expect pool size after AUTHenticated clean up to be $expected (pre-clear size was $preClearSize)');
-      expect(poolInstance.getCurrentSize(), expected);
+      expect(pool.getCurrentSize(), expected);
     });
   });
 }
 
 int calcActualAllowableIdleTime(
-    poolInstance, maxPoolSize, minAllowableIdleTime, maxAllowableIdleTime) {
+    pool, maxPoolSize, minAllowableIdleTime, maxAllowableIdleTime) {
   int lowWaterMark =
       (maxPoolSize * serverContext.inboundConnectionLowWaterMarkRatio).floor();
-  int numConnectionsOverLwm =
-      max(poolInstance.getCurrentSize() - lowWaterMark, 0);
+  int numConnectionsOverLwm = max(pool.getCurrentSize() - lowWaterMark, 0);
   double idleTimeReductionFactor =
       1 - (numConnectionsOverLwm / (maxPoolSize - lowWaterMark));
   return (((maxAllowableIdleTime - minAllowableIdleTime) *
@@ -284,9 +289,9 @@ int calcActualAllowableIdleTime(
       .floor();
 }
 
-class MockInboundConnectionImpl extends InboundConnectionImpl {
-  MockInboundConnectionImpl(super.socket, String super.sessionId)
-      : super(owningPool: InboundConnectionPool.getInstance());
+class FakeInboundConnectionImpl extends InboundConnectionImpl {
+  FakeInboundConnectionImpl(super.socket, String super.sessionId,
+      {required super.owningPool});
 
   @override
   Future<void> close() async {

--- a/packages/at_secondary_server/test/monitor_verb_test.dart
+++ b/packages/at_secondary_server/test/monitor_verb_test.dart
@@ -5,7 +5,7 @@ import 'package:at_chops/at_chops.dart';
 import 'package:at_commons/at_commons.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:at_secondary/src/connection/inbound/dummy_inbound_connection.dart';
-import 'package:at_secondary/src/connection/inbound/inbound_connection_pool.dart';
+import 'package:at_secondary/src/connection/inbound/inbound_connection_manager.dart';
 import 'package:at_secondary/src/utils/handler_util.dart';
 import 'package:at_secondary/src/verb/handler/enroll_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/monitor_verb_handler.dart';
@@ -17,15 +17,15 @@ import 'package:uuid/uuid.dart';
 import 'test_utils.dart';
 
 void main() {
-  setUpAll(() {
-    InboundConnectionPool.getInstance().init(3, isColdInit: true);
+  setUp(() async {
+    await verbTestsSetUp();
+    atServer.inboundConnectionManager =
+        InboundConnectionManager(serverAtSign: alice, poolSize: 3);
   });
+
   group(
       'A group tests to verify monitor verb when connection is authenticate using legacy PKAM',
       () {
-    setUp(() async {
-      await verbTestsSetUp();
-    });
     test('A test to verify monitor verb writes all notifications', () async {
       HashMap<String, String?> verbParams = HashMap<String, String?>();
       inboundConnection.metaData.isAuthenticated = true;

--- a/packages/at_secondary_server/test/stats_notification_test.dart
+++ b/packages/at_secondary_server/test/stats_notification_test.dart
@@ -24,7 +24,9 @@ class MockInboundConnectionPool extends Mock implements InboundConnectionPool {
 }
 
 void main() {
-  verbTestsSetUpLogging();
+  setUp(() async {
+    await verbTestsSetUp();
+  });
 
   AtCommitLog mockAtCommitLog = MockAtCommitLog();
   InboundConnectionPool mockInboundConnectionPool = MockInboundConnectionPool();
@@ -41,7 +43,7 @@ void main() {
         StatsNotificationServiceState.notScheduled);
 
     statsNotificationService.atCommitLog = mockAtCommitLog;
-    statsNotificationService.inboundConnectionPool = mockInboundConnectionPool;
+    atServer.inboundConnectionManager.pool = mockInboundConnectionPool;
 
     when(() => mockAtCommitLog.lastCommittedSequenceNumber())
         .thenAnswer((_) => 4);

--- a/packages/at_secondary_server/test/stats_verb_test.dart
+++ b/packages/at_secondary_server/test/stats_verb_test.dart
@@ -22,23 +22,31 @@ import 'package:test/test.dart';
 import 'package:at_secondary/src/utils/handler_util.dart';
 import 'package:at_commons/at_commons.dart';
 import 'package:uuid/uuid.dart';
-import 'notify_verb_test.dart';
 import 'package:mocktail/mocktail.dart';
 
 import 'test_utils.dart';
 
 void main() {
-  verbTestsSetUpLogging();
-
   SecondaryKeyStore mockKeyStore = MockSecondaryKeyStore();
   OutboundClientManager mockOutboundClientManager = MockOutboundClientManager();
   AtCacheManager mockAtCacheManager = MockAtCacheManager();
   MockSocket mockSocket = MockSocket();
   EnrollmentManager mockEnrollmentManager = MockEnrollmentManager();
 
-  setUpAll(() {
+  setUpAll(() async {
+    await verbTestsSetUpAll();
     when(() => mockSocket.setOption(SocketOption.tcpNoDelay, true))
         .thenReturn(true);
+  });
+
+  final atServer = AtSecondaryServerImpl.getInstance();
+
+  setUp(() async {
+    await verbTestsSetUp();
+  });
+
+  tearDown(() async {
+    await verbTestsTearDown();
   });
 
   group('A group of stats verb tests', () {
@@ -132,10 +140,6 @@ void main() {
     });
   });
   group('A group of notificationStats verb tests', () {
-    SecondaryKeyStoreManager? keyStoreManager;
-    setUp(() async => keyStoreManager = await setUpFunc(
-        '${Directory.current.path}/unit_test_storage',
-        atsign: alice));
     // test for Notification Stats
     test('notification stats command accept test', () {
       var command = 'stats:11';
@@ -145,7 +149,7 @@ void main() {
     });
 
     test('the name of the notificationStats', () async {
-      var metric = NotificationsMetricImpl.getInstance();
+      var metric = NotificationsMetricImpl(atServer);
       String name = metric.getName();
       expect(name, 'NotificationCount');
     });
@@ -172,8 +176,8 @@ void main() {
         },
         'createdOn': 0,
       };
-      var notifyListVerbHandler = NotifyListVerbHandler(
-          keyStoreManager!.getKeyStore(), mockOutboundClientManager);
+      var notifyListVerbHandler =
+          NotifyListVerbHandler(secondaryKeyStore, mockOutboundClientManager);
       var testNotification = (AtNotificationBuilder()
             ..id = '1031'
             ..fromAtSign = '@bob'
@@ -278,7 +282,7 @@ void main() {
           response, verbParams3, atConnection);
       await notifyListVerbHandler.processVerb(
           response, verbParams4, atConnection);
-      metricsMap = await NotificationsMetricImpl.getInstance()
+      metricsMap = await NotificationsMetricImpl(atServer)
           .getNotificationStats(metricsMap);
       expect(metricsMap['total'], 4);
       expect(metricsMap['type']['sent'], 2);
@@ -292,15 +296,9 @@ void main() {
       expect(metricsMap['messageType']['text'], 1);
       expect(metricsMap['createdOn'] is int, true);
     });
-    tearDown(() async => await tearDownFunc());
   });
 
   group('A group of commitLogCompactionStats verb tests', () {
-    SecondaryKeyStoreManager? keyStoreManager;
-    setUp(() async => keyStoreManager = await setUpFunc(
-        '${Directory.current.path}/unit_test_storage',
-        atsign: alice));
-
     test('commitLogCompactionStats command accept test', () {
       var command = 'stats:12';
       var handler = StatsVerbHandler(mockKeyStore);
@@ -309,15 +307,13 @@ void main() {
     });
 
     test('test name returned for commitLogCompaction Stats', () async {
-      var commitLogInstance = CommitLogCompactionStats.getInstance();
+      var commitLogInstance = CommitLogCompactionStats(atServer);
       String name = commitLogInstance.getName();
       expect(name, 'CommitLogCompactionStats');
     });
 
     test('commit Log stats get value test', () async {
       AtCompactionStats atCompactionStats = AtCompactionStats();
-      var keyStore = keyStoreManager?.getKeyStore();
-
       atCompactionStats.compactionDurationInMills = 1000;
       atCompactionStats.deletedKeysCount = 41;
       atCompactionStats.lastCompactionRun = DateTime.now();
@@ -326,10 +322,10 @@ void main() {
       atCompactionStats.atCompactionType =
           (await AtAccessLogManagerImpl.getInstance().getAccessLog(alice))!
               .toString();
-      await keyStore?.put(AtConstants.commitLogCompactionKey,
+      await secondaryKeyStore.put(AtConstants.commitLogCompactionKey,
           AtData()..data = jsonEncode(atCompactionStats));
 
-      var atData = await CommitLogCompactionStats.getInstance().getMetrics();
+      var atData = await CommitLogCompactionStats(atServer).getMetrics();
       var decodedData = jsonDecode(atData!) as Map;
       expect(
           decodedData[AtCompactionConstants.deletedKeysCount].toString(), '41');
@@ -349,11 +345,6 @@ void main() {
   });
 
   group('A group of accessLogCompactionStats verb tests', () {
-    SecondaryKeyStoreManager? keyStoreManager;
-    setUp(() async => keyStoreManager = await setUpFunc(
-        '${Directory.current.path}/unit_test_storage',
-        atsign: alice));
-
     test('accessLogCompactionStats command acceptance test', () {
       var command = 'stats:13';
       var handler = StatsVerbHandler(mockKeyStore);
@@ -362,15 +353,13 @@ void main() {
     });
 
     test('name returned for accessLogCompaction Stats test', () async {
-      var accessLogInstance = AccessLogCompactionStats.getInstance();
+      var accessLogInstance = AccessLogCompactionStats(atServer);
       String name = accessLogInstance.getName();
       expect(name, 'AccessLogCompactionStats');
     });
 
     test('accessLogCompactionStats getValue test', () async {
       AtCompactionStats atCompactionStats = AtCompactionStats();
-      var keyStore = keyStoreManager?.getKeyStore();
-
       atCompactionStats.compactionDurationInMills = 10000;
       atCompactionStats.deletedKeysCount = 431;
       atCompactionStats.lastCompactionRun = DateTime.now();
@@ -379,10 +368,10 @@ void main() {
       atCompactionStats.atCompactionType =
           (await AtAccessLogManagerImpl.getInstance().getAccessLog(alice))!
               .toString();
-      await keyStore?.put(AtConstants.accessLogCompactionKey,
+      await secondaryKeyStore.put(AtConstants.accessLogCompactionKey,
           AtData()..data = jsonEncode(atCompactionStats));
 
-      var atData = await AccessLogCompactionStats.getInstance().getMetrics();
+      var atData = await AccessLogCompactionStats(atServer).getMetrics();
       var decodedData = jsonDecode(atData!) as Map;
       expect(decodedData[AtCompactionConstants.deletedKeysCount], '431');
       expect(
@@ -395,11 +384,6 @@ void main() {
   });
 
   group('A group of notificationCompactionStats verb tests', () {
-    SecondaryKeyStoreManager? keyStoreManager;
-    setUp(() async => keyStoreManager = await setUpFunc(
-        '${Directory.current.path}/unit_test_storage',
-        atsign: alice));
-
     test('notificationCompactionStats command accept test', () {
       var command = 'stats:14';
       var handler = StatsVerbHandler(mockKeyStore);
@@ -408,15 +392,13 @@ void main() {
     });
 
     test('test name returned for notificationCompaction Stats', () async {
-      var notificationInstance = NotificationCompactionStats.getInstance();
+      var notificationInstance = NotificationCompactionStats(atServer);
       String name = notificationInstance.getName();
       expect(name, 'NotificationCompactionStats');
     });
 
     test('notificationCompactionStats get value test', () async {
       AtCompactionStats atCompactionStats = AtCompactionStats();
-      var keyStore = keyStoreManager?.getKeyStore();
-
       atCompactionStats.compactionDurationInMills = 10000;
       atCompactionStats.deletedKeysCount = 1;
       atCompactionStats.lastCompactionRun = DateTime.now();
@@ -424,10 +406,10 @@ void main() {
       atCompactionStats.preCompactionEntriesCount = 1;
       atCompactionStats.atCompactionType =
           AtNotificationKeystore.getInstance().toString();
-      await keyStore?.put(AtConstants.commitLogCompactionKey,
+      await secondaryKeyStore.put(AtConstants.commitLogCompactionKey,
           AtData()..data = jsonEncode(atCompactionStats));
 
-      var atData = await CommitLogCompactionStats.getInstance().getMetrics();
+      var atData = await CommitLogCompactionStats(atServer).getMetrics();
       var decodedData = jsonDecode(atData!) as Map;
       expect(decodedData[AtCompactionConstants.deletedKeysCount], '1');
       expect(
@@ -439,34 +421,26 @@ void main() {
   });
 
   group('A group of test to validate latestCommitEntryOfEachKey', () {
-    setUp(() async {
-      await verbTestsSetUp();
-    });
     test('A test to validate latestCommitEntryOfEachKey', () async {
-      secondaryPersistenceStore = SecondaryPersistenceStoreFactory.getInstance()
-          .getSecondaryPersistenceStore(alice);
-      LastCommitIDMetricImpl.getInstance().atCommitLog =
-          secondaryPersistenceStore!.getSecondaryKeyStore()!.commitLog;
-      var lastCommitId =
-          await LastCommitIDMetricImpl.getInstance().getMetrics();
+      var lastCommitId = await LastCommitIDMetricImpl(atServer).getMetrics();
       var randomString = Uuid().v4();
-      await secondaryPersistenceStore!.getSecondaryKeyStore()!.put(
+      await secondaryPersistenceStore.getSecondaryKeyStore()!.put(
           '$alice:phone-$randomString$alice', AtData()..data = '9848033443');
       // create a new key
-      await secondaryPersistenceStore!.getSecondaryKeyStore()!.put(
+      await secondaryPersistenceStore.getSecondaryKeyStore()!.put(
           '$alice:location-$randomString$alice', AtData()..data = 'Hyderabad');
       // Update the first key again
-      await secondaryPersistenceStore!.getSecondaryKeyStore()!.put(
+      await secondaryPersistenceStore.getSecondaryKeyStore()!.put(
           '$alice:phone-$randomString$alice', AtData()..data = '9848033444');
       // Insert and delete a key
-      await secondaryPersistenceStore!.getSecondaryKeyStore()!.put(
+      await secondaryPersistenceStore.getSecondaryKeyStore()!.put(
           '$alice:deleteKey-$randomString$alice',
           AtData()..data = '9848033444');
-      await secondaryPersistenceStore!
+      await secondaryPersistenceStore
           .getSecondaryKeyStore()!
           .remove('$alice:deleteKey-$randomString$alice');
       var latestCommitIdForEachKey =
-          await LatestCommitEntryOfEachKey().getMetrics();
+          await LatestCommitEntryOfEachKey(atServer).getMetrics();
       var latestCommitIdMap = jsonDecode(latestCommitIdForEachKey);
       expect(latestCommitIdMap['$alice:location-$randomString$alice'][0],
           (int.parse(lastCommitId) + 2));
@@ -484,11 +458,7 @@ void main() {
     test(
         'A test to validate commit entries when commit log entry count is greater than default sync buffer zie',
         () async {
-      secondaryPersistenceStore = SecondaryPersistenceStoreFactory.getInstance()
-          .getSecondaryPersistenceStore(alice);
-      LastCommitIDMetricImpl.getInstance().atCommitLog =
-          secondaryPersistenceStore!.getSecondaryKeyStore()!.commitLog;
-      await LastCommitIDMetricImpl.getInstance().getMetrics();
+      await LastCommitIDMetricImpl(atServer).getMetrics();
       var randomString = Uuid().v4();
       int phoneNumber = 1234;
       int min = 5;
@@ -497,13 +467,13 @@ void main() {
       int randomNumber = min + Random().nextInt(max - min) + 1;
       for (int i = 1; i <= randomNumber; i++) {
         phoneNumber = phoneNumber + i;
-        await secondaryPersistenceStore!.getSecondaryKeyStore()!.put(
+        await secondaryPersistenceStore.getSecondaryKeyStore()!.put(
             '$alice:phone-${randomString}_$i$alice',
             AtData()..data = phoneNumber.toString());
       }
-      await LastCommitIDMetricImpl.getInstance().getMetrics();
+      await LastCommitIDMetricImpl(atServer).getMetrics();
       var latestCommitIdForEachKey =
-          await LatestCommitEntryOfEachKey().getMetrics();
+          await LatestCommitEntryOfEachKey(atServer).getMetrics();
       Map<String, dynamic> latestCommitIdMap =
           jsonDecode(latestCommitIdForEachKey);
       for (int i = 1; i <= randomNumber; i++) {
@@ -517,19 +487,17 @@ void main() {
     test(
         'A test to verify latest commitId among enrolled namespaces is returned',
         () async {
-      await secondaryPersistenceStore!
+      await secondaryPersistenceStore
           .getSecondaryKeyStore()!
           .put('$alice:phone.wavi$alice', AtData()..data = '9848033443');
-      await secondaryPersistenceStore!
+      await secondaryPersistenceStore
           .getSecondaryKeyStore()!
           .put('$alice:location.wavi$alice', AtData()..data = 'Hyderabad');
-      await secondaryPersistenceStore!
+      await secondaryPersistenceStore
           .getSecondaryKeyStore()!
           .put('$alice:mobile.buzz$alice', AtData()..data = '9848033444');
 
-      LastCommitIDMetricImpl.getInstance().atCommitLog =
-          secondaryPersistenceStore!.getSecondaryKeyStore()!.commitLog;
-      var lastCommitId = await LastCommitIDMetricImpl.getInstance()
+      var lastCommitId = await LastCommitIDMetricImpl(atServer)
           .getMetrics(enrolledNamespaces: ['wavi']);
       expect(lastCommitId, '1');
     });
@@ -537,21 +505,19 @@ void main() {
     test(
         'A test to verify highest commitId among the authorized namespaces is returned',
         () async {
-      await secondaryPersistenceStore!
+      await secondaryPersistenceStore
           .getSecondaryKeyStore()!
           .put('$alice:phone.wavi$alice', AtData()..data = '9848033443');
-      await secondaryPersistenceStore!
+      await secondaryPersistenceStore
           .getSecondaryKeyStore()!
           .put('$alice:location.wavi$alice', AtData()..data = 'Hyderabad');
-      await secondaryPersistenceStore!
+      await secondaryPersistenceStore
           .getSecondaryKeyStore()!
           .put('$alice:mobile.buzz$alice', AtData()..data = '9848033444');
-      await secondaryPersistenceStore!.getSecondaryKeyStore()!.put(
+      await secondaryPersistenceStore.getSecondaryKeyStore()!.put(
           '$alice:contact.atmosphere$alice', AtData()..data = '9848033444');
 
-      LastCommitIDMetricImpl.getInstance().atCommitLog =
-          secondaryPersistenceStore!.getSecondaryKeyStore()!.commitLog;
-      var lastCommitId = await LastCommitIDMetricImpl.getInstance()
+      var lastCommitId = await LastCommitIDMetricImpl(atServer)
           .getMetrics(enrolledNamespaces: ['wavi', 'buzz']);
       expect(lastCommitId, '2');
     });
@@ -559,58 +525,48 @@ void main() {
     test(
         'A test to verify latestCommitId is returned when enrolledNamespace and regex are not supplied',
         () async {
-      await secondaryPersistenceStore!
+      await secondaryPersistenceStore
           .getSecondaryKeyStore()!
           .put('$alice:phone.wavi$alice', AtData()..data = '9848033443');
-      await secondaryPersistenceStore!
+      await secondaryPersistenceStore
           .getSecondaryKeyStore()!
           .put('$alice:location.wavi$alice', AtData()..data = 'Hyderabad');
-      await secondaryPersistenceStore!
+      await secondaryPersistenceStore
           .getSecondaryKeyStore()!
           .put('$alice:mobile.buzz$alice', AtData()..data = '9848033444');
-      await secondaryPersistenceStore!.getSecondaryKeyStore()!.put(
+      await secondaryPersistenceStore.getSecondaryKeyStore()!.put(
           '$alice:contact.atmosphere$alice', AtData()..data = '9848033444');
 
-      LastCommitIDMetricImpl.getInstance().atCommitLog =
-          secondaryPersistenceStore!.getSecondaryKeyStore()!.commitLog;
-      var lastCommitId =
-          await LastCommitIDMetricImpl.getInstance().getMetrics();
+      var lastCommitId = await LastCommitIDMetricImpl(atServer).getMetrics();
       expect(lastCommitId, '3');
     });
 
     test(
         'A test to verify latestCommitId is returned when only regex is not supplied',
         () async {
-      await secondaryPersistenceStore!
+      await secondaryPersistenceStore
           .getSecondaryKeyStore()!
           .put('$alice:phone.wavi$alice', AtData()..data = '9848033443');
-      await secondaryPersistenceStore!
+      await secondaryPersistenceStore
           .getSecondaryKeyStore()!
           .put('$alice:location.wavi$alice', AtData()..data = 'Hyderabad');
-      await secondaryPersistenceStore!
+      await secondaryPersistenceStore
           .getSecondaryKeyStore()!
           .put('$alice:mobile.buzz$alice', AtData()..data = '9848033444');
-      await secondaryPersistenceStore!.getSecondaryKeyStore()!.put(
+      await secondaryPersistenceStore.getSecondaryKeyStore()!.put(
           '$alice:contact.atmosphere$alice', AtData()..data = '9848033444');
 
-      LastCommitIDMetricImpl.getInstance().atCommitLog =
-          secondaryPersistenceStore!.getSecondaryKeyStore()!.commitLog;
       var lastCommitId =
-          await LastCommitIDMetricImpl.getInstance().getMetrics(regex: 'buzz');
+          await LastCommitIDMetricImpl(atServer).getMetrics(regex: 'buzz');
       expect(lastCommitId, '2');
     });
     test('A test to check LatestCommitEntryOfEachKey for empty commit log',
         () async {
-      secondaryPersistenceStore = SecondaryPersistenceStoreFactory.getInstance()
-          .getSecondaryPersistenceStore(alice);
-      LastCommitIDMetricImpl.getInstance().atCommitLog =
-          secondaryPersistenceStore!.getSecondaryKeyStore()!.commitLog;
       var latestCommitIdForEachKey =
-          await LatestCommitEntryOfEachKey().getMetrics();
+          await LatestCommitEntryOfEachKey(atServer).getMetrics();
       Map<String, dynamic> latestCommitIdMap =
           jsonDecode(latestCommitIdForEachKey);
       expect(latestCommitIdMap.isEmpty, true);
     });
-    tearDown(() async => await verbTestsTearDown());
   });
 }

--- a/packages/at_secondary_server/test/sync_unit_test.dart
+++ b/packages/at_secondary_server/test/sync_unit_test.dart
@@ -71,7 +71,7 @@ void main() async {
         DateTime start = DateTime.now();
         await putData('$alice:phone$alice');
         // verify metadata
-        AtMetaData md = (await secondaryPersistenceStore!
+        AtMetaData md = (await secondaryPersistenceStore
                 .getSecondaryKeyStore()!
                 .get('$alice:phone$alice'))!
             .metaData!;
@@ -116,13 +116,13 @@ void main() async {
           expect(itr.current.value.commitId, 0);
           // Update the same key again
           var keyUpdateDateTime = DateTime.now().toUtc();
-          await secondaryPersistenceStore!.getSecondaryKeyStore()?.put(
+          await secondaryPersistenceStore.getSecondaryKeyStore()?.put(
               '$alice:phone$alice',
               AtData()
                 ..data = '345'
                 ..metaData = (AtMetaData()..ttl = 10000));
           // Assert the metadata
-          AtData? atDataAfterUpdate = await secondaryPersistenceStore!
+          AtData? atDataAfterUpdate = await secondaryPersistenceStore
               .getSecondaryKeyStore()!
               .get('$alice:phone$alice');
           expect(atDataAfterUpdate!.data, '345');
@@ -169,7 +169,7 @@ void main() async {
         var keyUpdateDateTime = DateTime.now().toUtc();
         await putMetaData('$alice:phone$alice', AtMetaData()..ttl = 10000);
         // verify the metadata
-        AtData? atData = await secondaryPersistenceStore!
+        AtData? atData = await secondaryPersistenceStore
             .getSecondaryKeyStore()!
             .get('$alice:phone$alice');
         expect(
@@ -201,11 +201,11 @@ void main() async {
         /// 1. The key should be deleted from the keystore
         /// 2. The commit log should be updated with a new commit entry where CommitOperation is delete
         await putData('$alice:phone$alice');
-        await secondaryPersistenceStore!
+        await secondaryPersistenceStore
             .getSecondaryKeyStore()
             ?.remove('$alice:phone$alice');
         // Verify key does not exist in the keystore
-        var isKeyExist = secondaryPersistenceStore!
+        var isKeyExist = secondaryPersistenceStore
             .getSecondaryKeyStore()
             ?.isKeyExists('$alice:phone$alice');
         expect(isKeyExist, false);
@@ -224,11 +224,11 @@ void main() async {
         ///
         /// Assertions:
         /// A new entry associated with the key should be added to commit log with CommitOp.Delete
-        await secondaryPersistenceStore!
+        await secondaryPersistenceStore
             .getSecondaryKeyStore()
             ?.remove('$alice:mobile$alice');
         // Verify key does not exist in the keystore
-        var isKeyExist = secondaryPersistenceStore!
+        var isKeyExist = secondaryPersistenceStore
             .getSecondaryKeyStore()
             ?.isKeyExists('$alice:mobile$alice');
         expect(isKeyExist, false);
@@ -255,7 +255,7 @@ void main() async {
         /// 2. The commit-id's should be incremented sequentially
         /// 3. Assert the data and metadata updated to keystore
         VerbHandlerManager verbHandlerManager = DefaultVerbHandlerManager(
-          secondaryPersistenceStore!.getSecondaryKeyStore()!,
+          secondaryPersistenceStore.getSecondaryKeyStore()!,
           mockOutboundClientManager,
           mockAtCacheManager,
           StatsNotificationService.getInstance(),
@@ -273,7 +273,7 @@ void main() async {
         ]);
         // Process Batch request
         var batchVerbHandler = BatchVerbHandler(
-            secondaryPersistenceStore!.getSecondaryKeyStore()!,
+            secondaryPersistenceStore.getSecondaryKeyStore()!,
             verbHandlerManager);
 
         var inBoundSessionId = '_6665436c-29ff-481b-8dc6-129e89199718';
@@ -293,12 +293,12 @@ void main() async {
         expect(batchResponseList[2]['response']['data'], '2');
         expect(batchResponseList[3]['response']['data'], '3');
         // Assert the data stored in the keystore
-        var atData = await secondaryPersistenceStore!
+        var atData = await secondaryPersistenceStore
             .getSecondaryKeyStore()!
             .get('city$alice');
         expect(atData!.data, 'copenhagen');
         // Assert the data and metadata stored in the keystore
-        atData = await secondaryPersistenceStore!
+        atData = await secondaryPersistenceStore
             .getSecondaryKeyStore()!
             .get('mobile$alice');
         expect(atData!.data, '1234');
@@ -307,14 +307,14 @@ void main() async {
         expect(atData.metaData!.ttr, 3000);
         expect(atData.metaData!.isCascade, true);
         // Assert the data and metadata of a public key
-        atData = await secondaryPersistenceStore!
+        atData = await secondaryPersistenceStore
             .getSecondaryKeyStore()!
             .get('public:country$alice');
         expect(atData!.data, 'denmark');
         expect(atData.metaData!.dataSignature, 'dummy_data_signature');
         // Assert the key is removed on delete operation
         expect(
-            secondaryPersistenceStore!
+            secondaryPersistenceStore
                 .getSecondaryKeyStore()!
                 .isKeyExists('phone$alice'),
             false);
@@ -329,7 +329,7 @@ void main() async {
         /// 1. The valid commands should be processed and commit-id should be added to batch response
         /// 2. For the invalid batch request command, the error code and error message should be updated in the batch response
         VerbHandlerManager verbHandlerManager = DefaultVerbHandlerManager(
-          secondaryPersistenceStore!.getSecondaryKeyStore()!,
+          secondaryPersistenceStore.getSecondaryKeyStore()!,
           mockOutboundClientManager,
           mockAtCacheManager,
           StatsNotificationService.getInstance(),
@@ -343,7 +343,7 @@ void main() async {
           BatchRequest(3, 'update:public:country$alice denmark')
         ]);
         var batchVerbHandler = BatchVerbHandler(
-            secondaryPersistenceStore!.getSecondaryKeyStore()!,
+            secondaryPersistenceStore.getSecondaryKeyStore()!,
             verbHandlerManager);
         var inBoundSessionId = '_6665436c-29ff-481b-8dc6-129e89199718';
         var response = Response();
@@ -405,7 +405,7 @@ void main() async {
         // The entry with highest commit should be returned.
         await putData('$alice:phone.wavi$alice');
         var syncProgressiveVerbHandler = SyncProgressiveVerbHandler(
-            secondaryPersistenceStore!.getSecondaryKeyStore()!);
+            secondaryPersistenceStore.getSecondaryKeyStore()!);
         var response = Response();
         var inBoundSessionId = '_6665436c-29ff-481b-8dc6-129e89199718';
         var atConnection = InboundConnectionImpl(mockSocket, inBoundSessionId);
@@ -440,19 +440,19 @@ void main() async {
           'test to verify last delete commit entry is sent when skipDeletesUntil flag is set',
           () async {
         await putData('test_key_1$alice');
-        await secondaryPersistenceStore!
+        await secondaryPersistenceStore
             .getSecondaryKeyStore()
             ?.remove('test_key_1$alice');
         await putData('test_key_2$alice');
-        await secondaryPersistenceStore!
+        await secondaryPersistenceStore
             .getSecondaryKeyStore()
             ?.remove('test_key_2$alice');
         await putData('test_key_3$alice');
-        await secondaryPersistenceStore!
+        await secondaryPersistenceStore
             .getSecondaryKeyStore()
             ?.remove('test_key_3$alice');
         var syncProgressiveVerbHandler = SyncProgressiveVerbHandler(
-            secondaryPersistenceStore!.getSecondaryKeyStore()!);
+            secondaryPersistenceStore.getSecondaryKeyStore()!);
         var response = Response();
         var inBoundSessionId = '_6665436c-29ff-481b-8dc6-129e89199718';
         var atConnection = InboundConnectionImpl(mockSocket, inBoundSessionId);
@@ -476,17 +476,17 @@ void main() async {
           'test to verify delete commit entries are not sent when skipDeletesUntil flag is set and only matching keys are sent when regex is set',
           () async {
         await putData('test_key_1.wavi$alice');
-        await secondaryPersistenceStore!
+        await secondaryPersistenceStore
             .getSecondaryKeyStore()
             ?.remove('test_key_1.wavi$alice');
         await putData('test_key_2.buzz$alice');
-        await secondaryPersistenceStore!
+        await secondaryPersistenceStore
             .getSecondaryKeyStore()
             ?.remove('test_key_2.buzz$alice');
         await putData('test_key_3.buzz$alice');
         await putData('test_key_4.wavi$alice');
         var syncProgressiveVerbHandler = SyncProgressiveVerbHandler(
-            secondaryPersistenceStore!.getSecondaryKeyStore()!);
+            secondaryPersistenceStore.getSecondaryKeyStore()!);
         var response = Response();
         var inBoundSessionId = '_6665436c-29ff-481b-8dc6-129e89199718';
         var atConnection = InboundConnectionImpl(mockSocket, inBoundSessionId);
@@ -512,21 +512,21 @@ void main() async {
           'test to verify last delete commit entry is NOT sent when skipDeletesUntil flag is set and key does not match regex',
           () async {
         await putData('test_key_1.wavi$alice');
-        await secondaryPersistenceStore!
+        await secondaryPersistenceStore
             .getSecondaryKeyStore()
             ?.remove('test_key_1.wavi$alice');
         await putData('test_key_2.buzz$alice');
-        await secondaryPersistenceStore!
+        await secondaryPersistenceStore
             .getSecondaryKeyStore()
             ?.remove('test_key_2.buzz$alice');
         await putData('test_key_3.buzz$alice');
         await putData('test_key_4.wavi$alice');
         await putData('test_key_5.buzz$alice');
-        await secondaryPersistenceStore!
+        await secondaryPersistenceStore
             .getSecondaryKeyStore()
             ?.remove('test_key_4.wavi$alice');
         var syncProgressiveVerbHandler = SyncProgressiveVerbHandler(
-            secondaryPersistenceStore!.getSecondaryKeyStore()!);
+            secondaryPersistenceStore.getSecondaryKeyStore()!);
         var response = Response();
         var inBoundSessionId = '_6665436c-29ff-481b-8dc6-129e89199718';
         var atConnection = InboundConnectionImpl(mockSocket, inBoundSessionId);
@@ -559,7 +559,7 @@ void main() async {
         /// Assertions
         /// The sync response contains the keys that matches the regex in sync request
         var syncProgressiveVerbHandler = SyncProgressiveVerbHandler(
-            secondaryPersistenceStore!.getSecondaryKeyStore()!);
+            secondaryPersistenceStore.getSecondaryKeyStore()!);
         var response = Response();
         var inBoundSessionId = '_6665436c-29ff-481b-8dc6-129e89199718';
         var atConnection = InboundConnectionImpl(mockSocket, inBoundSessionId);
@@ -594,7 +594,7 @@ void main() async {
         /// Assertions:
         /// The sync response should not exceed the sync buffer size
         var syncProgressiveVerbHandler = SyncProgressiveVerbHandler(
-            secondaryPersistenceStore!.getSecondaryKeyStore()!);
+            secondaryPersistenceStore.getSecondaryKeyStore()!);
         // Setting buffer size to 250 Bytes
         syncProgressiveVerbHandler.capacity = 275;
         var response = Response();
@@ -624,18 +624,18 @@ void main() async {
         // throw exception for invalid key, calling put method on the hive box.
         // and inserting the entry into the commit log
         // The "**" in the key - @invalidkey**.buzz$alice is added to set key as invalid key
-        await secondaryPersistenceStore!
+        await secondaryPersistenceStore
             .getSecondaryKeyStore()
             ?.persistenceManager
             ?.getBox()
             .put('@invalidkey**.buzz$alice', AtData()..data = alice);
-        AtCommitLog atCommitLog = (secondaryPersistenceStore!
+        AtCommitLog atCommitLog = (secondaryPersistenceStore
             .getSecondaryKeyStore()
             ?.commitLog) as AtCommitLog;
         await atCommitLog.commit('@invalidkey**.buzz$alice', CommitOp.UPDATE);
 
         var syncProgressiveVerbHandler = SyncProgressiveVerbHandler(
-            secondaryPersistenceStore!.getSecondaryKeyStore()!);
+            secondaryPersistenceStore.getSecondaryKeyStore()!);
         var response = Response();
         var inBoundSessionId = '_6665436c-29ff-481b-8dc6-129e89199718';
         var atConnection = InboundConnectionImpl(mockSocket, inBoundSessionId);
@@ -710,13 +710,13 @@ void main() async {
               'an_encrypting_algorithm_name_for_the_inlined_encrypted_shared_key'
           ..pubKeyHash = somePubKeyHash
           ..immutable = true;
-        await secondaryPersistenceStore!.getSecondaryKeyStore()?.put(
+        await secondaryPersistenceStore.getSecondaryKeyStore()?.put(
             'public:phone.wavi$alice',
             AtData()
               ..data = '8897896765'
               ..metaData = atMetadata);
         var syncProgressiveVerbHandler = SyncProgressiveVerbHandler(
-            secondaryPersistenceStore!.getSecondaryKeyStore()!);
+            secondaryPersistenceStore.getSecondaryKeyStore()!);
         var response = Response();
         var inBoundSessionId = '_6665436c-29ff-481b-8dc6-129e89199718';
         var atConnection = InboundConnectionImpl(mockSocket, inBoundSessionId);
@@ -779,7 +779,7 @@ void main() async {
         await putMetaData(
             'public:phone.wavi$alice', (AtMetaData()..ttl = 1000));
         var syncProgressiveVerbHandler = SyncProgressiveVerbHandler(
-            secondaryPersistenceStore!.getSecondaryKeyStore()!);
+            secondaryPersistenceStore.getSecondaryKeyStore()!);
         var response = Response();
         var inBoundSessionId = '_6665436c-29ff-481b-8dc6-129e89199718';
         var atConnection = InboundConnectionImpl(mockSocket, inBoundSessionId);
@@ -813,11 +813,11 @@ void main() async {
         ///    "operation": "-"
         await putData('public:phone.wavi$alice');
         // Delete the key
-        await secondaryPersistenceStore!
+        await secondaryPersistenceStore
             .getSecondaryKeyStore()
             ?.remove('public:phone.wavi$alice');
         var syncProgressiveVerbHandler = SyncProgressiveVerbHandler(
-            secondaryPersistenceStore!.getSecondaryKeyStore()!);
+            secondaryPersistenceStore.getSecondaryKeyStore()!);
         var response = Response();
         var inBoundSessionId = '_6665436c-29ff-481b-8dc6-129e89199718';
         var atConnection = InboundConnectionImpl(mockSocket, inBoundSessionId);
@@ -846,18 +846,18 @@ void main() async {
         ///
         /// Assertions:
         /// 1. The sync response should contain the commit entry of commitOp.delete
-        await secondaryPersistenceStore!.getSecondaryKeyStore()?.put(
+        await secondaryPersistenceStore.getSecondaryKeyStore()?.put(
             'public:lastname.wavi$alice',
             AtData()
               ..data = '8897896765'
               ..metaData = (AtMetaData()..ttl = 1));
         await Future.delayed(Duration(milliseconds: 2));
         // manually trigger the deleteExpiredKeys to remove the expired keys
-        await secondaryPersistenceStore!
+        await secondaryPersistenceStore
             .getSecondaryKeyStore()
             ?.deleteExpiredKeys();
         var syncProgressiveVerbHandler = SyncProgressiveVerbHandler(
-            secondaryPersistenceStore!.getSecondaryKeyStore()!);
+            secondaryPersistenceStore.getSecondaryKeyStore()!);
         var response = Response();
         var inBoundSessionId = '_6665436c-29ff-481b-8dc6-129e89199718';
         var atConnection = InboundConnectionImpl(mockSocket, inBoundSessionId);
@@ -897,14 +897,14 @@ void main() async {
         /// instead of original value until TTB is met.
         /// But when sync process, fetches the value, original value will be met even before the
         /// TTB is met.
-        await secondaryPersistenceStore!.getSecondaryKeyStore()?.put(
+        await secondaryPersistenceStore.getSecondaryKeyStore()?.put(
             'public:phone.wavi$alice',
             AtData()
               ..data = '8897896765'
               ..metaData =
                   (AtMetaData()..ttb = Duration(minutes: 1).inMilliseconds));
         var syncProgressiveVerbHandler = SyncProgressiveVerbHandler(
-            secondaryPersistenceStore!.getSecondaryKeyStore()!);
+            secondaryPersistenceStore.getSecondaryKeyStore()!);
         var response = Response();
         var inBoundSessionId = '_6665436c-29ff-481b-8dc6-129e89199718';
         var atConnection = InboundConnectionImpl(mockSocket, inBoundSessionId);
@@ -1057,16 +1057,16 @@ void main() async {
           'test to verify delete commit entries are not sent when skipDeletesUntil flag is set',
           () async {
         await putData('test_key_1$alice');
-        await secondaryPersistenceStore!
+        await secondaryPersistenceStore
             .getSecondaryKeyStore()
             ?.remove('test_key_1$alice');
         await putData('test_key_2$alice');
-        await secondaryPersistenceStore!
+        await secondaryPersistenceStore
             .getSecondaryKeyStore()
             ?.remove('test_key_2$alice');
         await putData('test_key_3$alice');
         var syncProgressiveVerbHandler = SyncProgressiveVerbHandler(
-            secondaryPersistenceStore!.getSecondaryKeyStore()!);
+            secondaryPersistenceStore.getSecondaryKeyStore()!);
         var response = Response();
         var inBoundSessionId = '_6665436c-29ff-481b-8dc6-129e89199718';
         var atConnection = InboundConnectionImpl(mockSocket, inBoundSessionId);
@@ -1095,12 +1095,12 @@ void main() async {
           await putData('test_key_$i$alice');
         }
         for (int i = 0; i < 25; i++) {
-          await secondaryPersistenceStore!
+          await secondaryPersistenceStore
               .getSecondaryKeyStore()
               ?.remove('test_key_$i$alice');
         }
         var syncProgressiveVerbHandler = SyncProgressiveVerbHandler(
-            secondaryPersistenceStore!.getSecondaryKeyStore()!);
+            secondaryPersistenceStore.getSecondaryKeyStore()!);
         var response = Response();
         var inBoundSessionId = '_6665436c-29ff-481b-8dc6-129e89199718';
         var atConnection = InboundConnectionImpl(mockSocket, inBoundSessionId);
@@ -1133,13 +1133,13 @@ void main() async {
           await putData('test_key_$i$alice');
         }
         for (int i = 0; i < 25; i++) {
-          await secondaryPersistenceStore!
+          await secondaryPersistenceStore
               .getSecondaryKeyStore()
               ?.remove('test_key_$i$alice');
         }
 
         var syncProgressiveVerbHandler = SyncProgressiveVerbHandler(
-            secondaryPersistenceStore!.getSecondaryKeyStore()!);
+            secondaryPersistenceStore.getSecondaryKeyStore()!);
         var response = Response();
         var inBoundSessionId = '_6665436c-29ff-481b-8dc6-129e89199718';
         var atConnection = InboundConnectionImpl(mockSocket, inBoundSessionId);
@@ -1182,13 +1182,13 @@ void main() async {
           await putData('test_key_$i$alice');
         }
         for (int i = 0; i < 1; i++) {
-          await secondaryPersistenceStore!
+          await secondaryPersistenceStore
               .getSecondaryKeyStore()
               ?.remove('test_key_$i$alice');
         }
 
         var syncProgressiveVerbHandler = SyncProgressiveVerbHandler(
-            secondaryPersistenceStore!.getSecondaryKeyStore()!);
+            secondaryPersistenceStore.getSecondaryKeyStore()!);
         var response = Response();
         var inBoundSessionId = '_6665436c-29ff-481b-8dc6-129e89199718';
         var atConnection = InboundConnectionImpl(mockSocket, inBoundSessionId);
@@ -1218,13 +1218,13 @@ void main() async {
           await putData('test_key_$i$alice');
         }
         for (int i = 0; i < 10; i++) {
-          await secondaryPersistenceStore!
+          await secondaryPersistenceStore
               .getSecondaryKeyStore()
               ?.remove('test_key_$i$alice');
         }
 
         var syncProgressiveVerbHandler = SyncProgressiveVerbHandler(
-            secondaryPersistenceStore!.getSecondaryKeyStore()!);
+            secondaryPersistenceStore.getSecondaryKeyStore()!);
         var response = Response();
         var inBoundSessionId = '_6665436c-29ff-481b-8dc6-129e89199718';
         var atConnection = InboundConnectionImpl(mockSocket, inBoundSessionId);
@@ -1260,12 +1260,12 @@ void main() async {
           await putData('test_key_$i$alice');
         }
         await putData('test_key_25$alice');
-        await secondaryPersistenceStore!
+        await secondaryPersistenceStore
             .getSecondaryKeyStore()
             ?.remove('test_key_25$alice');
 
         var syncProgressiveVerbHandler = SyncProgressiveVerbHandler(
-            secondaryPersistenceStore!.getSecondaryKeyStore()!);
+            secondaryPersistenceStore.getSecondaryKeyStore()!);
         var response = Response();
         var inBoundSessionId = '_6665436c-29ff-481b-8dc6-129e89199718';
         var atConnection = InboundConnectionImpl(mockSocket, inBoundSessionId);
@@ -1308,13 +1308,13 @@ void main() async {
           await putData('test_key_$i$alice');
         }
         for (int i = 0; i < 10; i++) {
-          await secondaryPersistenceStore!
+          await secondaryPersistenceStore
               .getSecondaryKeyStore()
               ?.remove('test_key_$i$alice');
         }
 
         var syncProgressiveVerbHandler = SyncProgressiveVerbHandler(
-            secondaryPersistenceStore!.getSecondaryKeyStore()!);
+            secondaryPersistenceStore.getSecondaryKeyStore()!);
         var response = Response();
         var inBoundSessionId = '_6665436c-29ff-481b-8dc6-129e89199718';
         var atConnection = InboundConnectionImpl(mockSocket, inBoundSessionId);
@@ -1348,13 +1348,13 @@ void main() async {
           await putData('test_key_$i$alice');
         }
         for (int i = 0; i < 10; i++) {
-          await secondaryPersistenceStore!
+          await secondaryPersistenceStore
               .getSecondaryKeyStore()
               ?.remove('test_key_$i$alice');
         }
 
         var syncProgressiveVerbHandler = SyncProgressiveVerbHandler(
-            secondaryPersistenceStore!.getSecondaryKeyStore()!);
+            secondaryPersistenceStore.getSecondaryKeyStore()!);
         var response = Response();
         var inBoundSessionId = '_6665436c-29ff-481b-8dc6-129e89199718';
         var atConnection = InboundConnectionImpl(mockSocket, inBoundSessionId);
@@ -1388,7 +1388,7 @@ void main() async {
           await putData('test_key_$i$alice');
         }
         for (int i = 0; i < 10; i++) {
-          await secondaryPersistenceStore!
+          await secondaryPersistenceStore
               .getSecondaryKeyStore()
               ?.remove('test_key_$i$alice');
         }
@@ -1397,7 +1397,7 @@ void main() async {
         }
 
         var syncProgressiveVerbHandler = SyncProgressiveVerbHandler(
-            secondaryPersistenceStore!.getSecondaryKeyStore()!);
+            secondaryPersistenceStore.getSecondaryKeyStore()!);
         var response = Response();
         var inBoundSessionId = '_6665436c-29ff-481b-8dc6-129e89199718';
         var atConnection = InboundConnectionImpl(mockSocket, inBoundSessionId);
@@ -1435,12 +1435,12 @@ void main() async {
         }
         //2. 10-29 commit id will be updates. 30-39 will be deletes since only one key entry will be maintained for update followed by delete.
         for (int i = 0; i < 10; i++) {
-          await secondaryPersistenceStore!
+          await secondaryPersistenceStore
               .getSecondaryKeyStore()
               ?.remove('test_key_$i$alice');
         }
         var syncProgressiveVerbHandler = SyncProgressiveVerbHandler(
-            secondaryPersistenceStore!.getSecondaryKeyStore()!);
+            secondaryPersistenceStore.getSecondaryKeyStore()!);
         var response = Response();
         var inBoundSessionId = '_6665436c-29ff-481b-8dc6-129e89199718';
         var atConnection = InboundConnectionImpl(mockSocket, inBoundSessionId);
@@ -1487,12 +1487,12 @@ void main() async {
           await putData('test_key_$i$alice');
         }
         for (int i = 0; i < 5; i++) {
-          await secondaryPersistenceStore!
+          await secondaryPersistenceStore
               .getSecondaryKeyStore()
               ?.remove('test_key_$i$alice');
         }
         var syncProgressiveVerbHandler = SyncProgressiveVerbHandler(
-            secondaryPersistenceStore!.getSecondaryKeyStore()!);
+            secondaryPersistenceStore.getSecondaryKeyStore()!);
         var response = Response();
         var inBoundSessionId = '_6665436c-29ff-481b-8dc6-129e89199718';
         var atConnection = InboundConnectionImpl(mockSocket, inBoundSessionId);
@@ -1529,7 +1529,7 @@ void main() async {
           await putData('test_key_$i$alice');
         }
         for (int i = 0; i < 5; i++) {
-          await secondaryPersistenceStore!
+          await secondaryPersistenceStore
               .getSecondaryKeyStore()
               ?.remove('test_key_$i$alice');
         }
@@ -1537,7 +1537,7 @@ void main() async {
           await putData('test_key_$i$alice');
         }
         for (int i = 10; i < 15; i++) {
-          await secondaryPersistenceStore!
+          await secondaryPersistenceStore
               .getSecondaryKeyStore()
               ?.remove('test_key_$i$alice');
         }
@@ -1546,7 +1546,7 @@ void main() async {
         }
 
         var syncProgressiveVerbHandler = SyncProgressiveVerbHandler(
-            secondaryPersistenceStore!.getSecondaryKeyStore()!);
+            secondaryPersistenceStore.getSecondaryKeyStore()!);
         var response = Response();
         var inBoundSessionId = '_6665436c-29ff-481b-8dc6-129e89199718';
         var atConnection = InboundConnectionImpl(mockSocket, inBoundSessionId);

--- a/packages/at_secondary_server/test/test_utils.dart
+++ b/packages/at_secondary_server/test/test_utils.dart
@@ -8,7 +8,7 @@ import 'package:at_lookup/at_lookup.dart' as at_lookup;
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:at_secondary/src/caching/cache_manager.dart';
 import 'package:at_secondary/src/connection/inbound/dummy_inbound_connection.dart';
-import 'package:at_secondary/src/connection/inbound/inbound_connection_pool.dart';
+import 'package:at_secondary/src/connection/inbound/inbound_connection_manager.dart';
 import 'package:at_secondary/src/connection/outbound/outbound_client.dart';
 import 'package:at_secondary/src/connection/outbound/outbound_client_manager.dart';
 import 'package:at_secondary/src/connection/outbound/outbound_connection.dart';
@@ -113,7 +113,7 @@ late Function() socketOnDoneFn;
 late Function(Exception e, StackTrace st) socketOnErrorFn;
 
 String storageDir = '${Directory.current.path}/unit_test_storage';
-SecondaryPersistenceStore? secondaryPersistenceStore;
+late SecondaryPersistenceStore secondaryPersistenceStore;
 late AtCommitLog atCommitLog;
 
 /// Creates and persists a new approved enrollment
@@ -135,13 +135,15 @@ Future<String> createAndPersistAnEnrollment(
     'requestType': 'newEnrollment',
     'approval': {'state': 'approved'}
   };
-  await secondaryPersistenceStore!.getSecondaryKeyStore()?.put(
+  await secondaryPersistenceStore.getSecondaryKeyStore()?.put(
         key,
         AtData()..data = jsonEncode(enrollJson),
         skipCommit: true,
       );
   return id;
 }
+
+AtSecondaryServerImpl get atServer => AtSecondaryServerImpl.getInstance();
 
 void verbTestsSetUpLogging() {
   AtSignLogger.root_level = 'shout';
@@ -157,18 +159,17 @@ verbTestsSetUpAll() async {
 verbTestsSetUp() async {
   verbTestsSetUpLogging();
   // Initialize secondary persistent store
-  secondaryPersistenceStore = SecondaryPersistenceStoreFactory.getInstance()
-      .getSecondaryPersistenceStore(alice);
+  atServer.secondaryPersistenceStore = secondaryPersistenceStore =
+      SecondaryPersistenceStoreFactory.getInstance()
+          .getSecondaryPersistenceStore(alice)!;
   // Initialize commit log
-  atCommitLog = (await AtCommitLogManagerImpl.getInstance()
+  atServer.commitLog = atCommitLog = (await AtCommitLogManagerImpl.getInstance()
       .getCommitLog(alice, commitLogPath: storageDir, enableCommitId: true))!;
-  secondaryPersistenceStore!.getSecondaryKeyStore()?.commitLog = atCommitLog;
+  secondaryPersistenceStore.getSecondaryKeyStore()?.commitLog = atCommitLog;
   // Init the hive instances
-  await secondaryPersistenceStore!
-      .getHivePersistenceManager()!
-      .init(storageDir);
+  await secondaryPersistenceStore.getHivePersistenceManager()!.init(storageDir);
 
-  secondaryKeyStore = secondaryPersistenceStore!.getSecondaryKeyStore()!;
+  secondaryKeyStore = secondaryPersistenceStore.getSecondaryKeyStore()!;
 
   var notificationKeystore = AtNotificationKeystore.getInstance();
   notificationKeystore.currentAtSign = alice;
@@ -189,9 +190,11 @@ verbTestsSetUp() async {
 
   inboundConnection = DummyInboundConnection();
   registerFallbackValue(inboundConnection);
-  final inboundPool = InboundConnectionPool.getInstance();
-  inboundPool.init(5);
-  inboundPool.add(inboundConnection);
+  atServer.inboundConnectionManager =
+      InboundConnectionManager(serverAtSign: alice, poolSize: 5);
+  // final inboundPool = InboundConnectionPool.getInstance();
+  // inboundPool.init(5);
+  // inboundPool.add(inboundConnection);
 
   outboundClientWithHandshake = OutboundClient(
       inboundConnection, bob, mockSecondaryAddressFinder, true,

--- a/packages/at_secondary_server/test/update_verb_test.dart
+++ b/packages/at_secondary_server/test/update_verb_test.dart
@@ -810,7 +810,7 @@ void main() {
     });
 
     test('test auto_notify notification expiry', () async {
-      SecondaryKeyStore keyStore = secondaryPersistenceStore!
+      SecondaryKeyStore keyStore = secondaryPersistenceStore
           .getSecondaryKeyStoreManager()!
           .getKeyStore();
       AbstractUpdateVerbHandler.setAutoNotify(true);

--- a/tests/at_functional_test/test/enroll_verb_test.dart
+++ b/tests/at_functional_test/test/enroll_verb_test.dart
@@ -1151,7 +1151,7 @@ void main() {
       inboundConnectionResult =
           inboundConnectionResult.replaceFirst('data:', '');
       int numberOfInboundConnectionsBeforeRevoke =
-          jsonDecode(inboundConnectionResult)[0]['value']['total'];
+          int.parse(jsonDecode(inboundConnectionResult)[0]['value']);
       await firstAtSignConnection.sendRequestToServer(
           'enroll:revoke:{"enrollmentId":"${enrollmentIds[2]}"}');
       // get number of inbound connections after revoke
@@ -1160,7 +1160,7 @@ void main() {
       inboundConnectionResult =
           inboundConnectionResult.replaceFirst('data:', '');
       int numberOfInboundConnectionsAfterRevoke =
-          jsonDecode(inboundConnectionResult)[0]['value']['total'];
+          int.parse(jsonDecode(inboundConnectionResult)[0]['value']);
       expect(numberOfInboundConnectionsAfterRevoke,
           numberOfInboundConnectionsBeforeRevoke - 1);
 


### PR DESCRIPTION
**- What I did**
- feat: change default inbound idle time for authenticated connections to 10 minutes (same as unauthenticated connections)
- feat: revert stats:1 to previous behaviour; add stats:16 (summary of inbound connections by type) and stats:17 (detail on all inbound connections)
- refactor: removed singleton nature of InboundConnectionManager and InboundConnectionPool
- feat: added a `closed` guard to InboundConnectionManager (and renamed its `clearInvalidConnections` function to `close`) to prevent new connections being established when the manager is closed (which happens when the atServer is doing a soft restart)
- refactor: removed the `ConnectionUtil` class and moved  its static methods to be instance methods of InboundConnectionPool
- refactor: renamed the `MetricNames` enum to just `Metric`; removed the `MetricClasses` extension and moved its functionality to StatsVerbHandler
- fix: removed a try-catch from StatsVerbHandler which was masking actual causes of exceptions
- refactor: removed singleton nature of all MetricProviders
- refactor: some other small refactorings (removing redundant variables etc)

**- How I did it**

**- How to verify it**
Tests pass
