### PR TITLE
fix: improved memory usage and error handling in StatsNotificationService

### DIFF
--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 3.7.2
+
+- fix: improved memory usage and error handling in StatsNotificationService. 
+  Fixes a minor bug in StatsNotificationService which would only occur when 
+  running an atServer on a development machine which is put to "sleep" for a 
+  while.
+- refactor: Removed unnecessary instance variable from StatsNotificationService
+
 # 3.7.1
 - feat : added `stats:16` for a summary of number of inbound connections by 
   type (self, other, anon) and `stats:17` for a detailed report on all 

--- a/packages/at_secondary_server/lib/src/connection/inbound/inbound_message_listener.dart
+++ b/packages/at_secondary_server/lib/src/connection/inbound/inbound_message_listener.dart
@@ -43,6 +43,7 @@ class InboundMessageListener {
   /// Handles messages on the inbound client's connection and calls the verb executor
   /// Closes the inbound connection in case of any error.
   Future<void> _messageHandler(streamData) async {
+    connection.metaData.lastAccessed = DateTime.now().toUtc();
     logger.finest('_messageHandler received ${streamData.runtimeType}'
         ' : $streamData ');
     List<int> data;

--- a/packages/at_secondary_server/lib/src/notification/stats_notification_service.dart
+++ b/packages/at_secondary_server/lib/src/notification/stats_notification_service.dart
@@ -58,9 +58,6 @@ class StatsNotificationService {
 
   static final Duration zeroDuration = Duration(microseconds: 0);
 
-  // Counter for number of active monitor connections. Used for logging purpose.
-  int numOfMonitorConn = 0;
-
   Notification notification = Notification.empty();
 
   @visibleForTesting
@@ -108,16 +105,13 @@ class StatsNotificationService {
         await AtCommitLogManagerImpl.getInstance().getCommitLog(currentAtSign);
 
     // Runs the _schedule method as long as server is up and running.
-    timer = Timer.periodic(interval, (timer) {
+    timer = Timer.periodic(interval, (timer) async {
       try {
         _logger.finer('Stats Notification Job triggered');
-        writeStatsToMonitor();
+        await writeStatsToMonitor();
         _logger.finer('Stats Notification Job completed');
-      } on Exception catch (exception) {
-        _logger.severe(
-            'Exception occurred when writing stats ${exception.toString()}');
-      } on Error catch (error) {
-        _logger.severe('Error occurred when writing stats ${error.toString()}');
+      } catch (e) {
+        _logger.severe('Exception while writing stats: $e');
       }
     });
     state = StatsNotificationServiceState.scheduled;
@@ -133,41 +127,44 @@ class StatsNotificationService {
   /// Writes the lastCommitID to all Monitor connections
   Future<void> writeStatsToMonitor(
       {String? latestCommitID, String? operationType}) async {
-    try {
-      latestCommitID ??= atCommitLog!.lastCommittedSequenceNumber().toString();
-      // Gets the list of active connections.
-      var connectionsList = AtSecondaryServerImpl.getInstance()
-          .inboundConnectionManager
-          .pool
-          .getConnections();
-      // Iterates on the list of active connections.
-      for (var connection in connectionsList) {
-        if (connection.isMonitor != null && connection.isMonitor!) {
-          numOfMonitorConn = numOfMonitorConn + 1;
-          // Set notification fields
-          notification
-            ..id = '-1'
-            ..fromAtSign = currentAtSign
-            ..notification = 'statsNotification.$currentAtSign'
-            ..toAtSign = currentAtSign
-            ..dateTime = DateTime.now().toUtc().millisecondsSinceEpoch
-            ..operation = SecondaryUtil.getOperationType(operationType)
-                .toString()
-                .replaceAll('OperationType.', '')
-            ..value = latestCommitID
-            ..messageType = MessageType.key.toString()
-            ..isTextMessageEncrypted = false;
+    latestCommitID ??= atCommitLog!.lastCommittedSequenceNumber().toString();
+    // Gets the list of active connections.
+    var connectionsList = AtSecondaryServerImpl.getInstance()
+        .inboundConnectionManager
+        .pool
+        .getConnections();
+    // For each inbound connection: if it is a monitor, write stats
+    int numOfMonitorConn = 0;
+    notification
+      ..id = '-1'
+      ..fromAtSign = currentAtSign
+      ..notification = 'statsNotification.$currentAtSign'
+      ..toAtSign = currentAtSign
+      ..dateTime = DateTime.now().toUtc().millisecondsSinceEpoch
+      ..operation = SecondaryUtil.getOperationType(operationType)
+          .toString()
+          .replaceAll('OperationType.', '')
+      ..value = latestCommitID
+      ..messageType = MessageType.key.toString()
+      ..isTextMessageEncrypted = false;
+    for (var connection in connectionsList) {
+      if (connection.isMonitor ?? false) {
+        numOfMonitorConn++;
+        try {
           // Convert notification object to JSON and write to connection
           await connection.write('notification:'
               ' ${jsonEncode(notification.toJson())}\n');
+        } catch (e) {
+          _logger.severe('Exception occurred when writing stats to'
+              ' inbound connection session ${connection.metaData.sessionID}'
+              ' : ${e.toString()}');
         }
       }
-      if (numOfMonitorConn == 0) {
-        _logger.finer(
-            'No monitor connections found. Skipping writing stats to monitor connection');
-      }
-    } finally {
-      numOfMonitorConn = 0;
+    }
+    if (numOfMonitorConn == 0) {
+      _logger.finer('No stats written. (No monitor connections.)');
+    } else {
+      _logger.info('Wrote stats to $numOfMonitorConn monitor connections');
     }
   }
 }

--- a/packages/at_secondary_server/lib/src/notification/stats_notification_service.dart
+++ b/packages/at_secondary_server/lib/src/notification/stats_notification_service.dart
@@ -133,6 +133,10 @@ class StatsNotificationService {
         .inboundConnectionManager
         .pool
         .getConnections();
+    if (connectionsList.isEmpty) {
+      _logger.finer('No stats written. (No connections.)');
+      return;
+    }
     // For each inbound connection: if it is a monitor, write stats
     int numOfMonitorConn = 0;
     notification

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_secondary
 description: Implementation of secondary server.
-version: 3.7.1
+version: 3.7.2
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://www.example.com
 publish_to: none


### PR DESCRIPTION
**- What I did**
- fix: improved memory usage and error handling in StatsNotificationService. Fixes a minor bug in StatsNotificationService which would only occur when running an atServer on a development machine which is put to "sleep" for a while.
- refactor: Removed unnecessary instance variable from StatsNotificationService

**- How I did it**

**- How to verify it**
Tests pass

**- Context**
The problem being fixed was as follows:
- Given
  - You are running an atServer on your dev machine
  - And you have a monitor connection from a client
- When
  - You put your machine to sleep for more than the idle timeout time (10 minutes) so the atServer has not received any `noop` heartbeats from the client
  - And you then resume from sleep
- Then
  - The atServer StatsNotificationService would attempt to write stats to the monitor connection
  - Which would be deemed invalid
  - And therefore cause the `write` on the InboundConnectionImpl to throw an exception back to `writeStatsToMonitor`
  - And therefore cause the atServer to exit with an uncaught exception because `writeStatsToMonitor` was not called with an `await`