### PR TITLE
chore: at_server_spec: 5.0.4: remove an `@experimental` annotation

### DIFF
--- a/packages/at_secondary_server/analysis_options.yaml
+++ b/packages/at_secondary_server/analysis_options.yaml
@@ -19,8 +19,6 @@ linter:
     avoid_function_literals_in_foreach_calls: true
     prefer_interpolation_to_compose_strings: true
     strict_top_level_inference: false
-    undefined_lint: false
-    experimental_member_use: false
 
 # analyzer:
 #   exclude:

--- a/packages/at_secondary_server/analysis_options.yaml
+++ b/packages/at_secondary_server/analysis_options.yaml
@@ -19,6 +19,7 @@ linter:
     avoid_function_literals_in_foreach_calls: true
     prefer_interpolation_to_compose_strings: true
     strict_top_level_inference: false
+    undefined_lint: false
     experimental_member_use: false
 
 # analyzer:

--- a/packages/at_secondary_server/analysis_options.yaml
+++ b/packages/at_secondary_server/analysis_options.yaml
@@ -19,6 +19,7 @@ linter:
     avoid_function_literals_in_foreach_calls: true
     prefer_interpolation_to_compose_strings: true
     strict_top_level_inference: false
+    experimental_member_use: false
 
 # analyzer:
 #   exclude:

--- a/packages/at_secondary_server/lib/src/verb/handler/abstract_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/abstract_verb_handler.dart
@@ -249,6 +249,7 @@ abstract class AbstractVerbHandler implements VerbHandler {
     // the enrollManageNamespace
     // Prevents update, delete or any other operations on the enrollment key
     if (authorizedNamespace.$1 == EnrollmentConstants.enrollManageNamespace) {
+      // ignore: experimental_member_use
       return (getVerb() is Otp || getVerb() is Enroll || getVerb() is Monitor)
           ? (authorizedNamespace.$2 == 'r' || authorizedNamespace.$2 == 'rw')
           : false;

--- a/packages/at_secondary_server/lib/src/verb/handler/otp_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/otp_verb_handler.dart
@@ -13,6 +13,7 @@ import 'package:uuid/uuid.dart';
 import 'abstract_verb_handler.dart';
 
 class OtpVerbHandler extends AbstractVerbHandler {
+  // ignore: experimental_member_use
   static Otp otpVerb = Otp();
 
   @visibleForTesting

--- a/packages/at_server_spec/CHANGELOG.md
+++ b/packages/at_server_spec/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.0.4
+- chore: remove an `@experimental` annotation
+
 ## 5.0.3
 - feat: defensive code: ensure `isAuthenticated` and `isPolAuthenticated` 
   may not both be true at the same time

--- a/packages/at_server_spec/lib/src/verb/otp.dart
+++ b/packages/at_server_spec/lib/src/verb/otp.dart
@@ -3,7 +3,6 @@ import 'package:at_commons/at_commons.dart';
 import 'package:meta/meta.dart';
 
 /// Verb used for generating OTP for APKAM enrollments
-@experimental
 class Otp extends Verb {
   @override
   String name() => 'otp';

--- a/packages/at_server_spec/pubspec.yaml
+++ b/packages/at_server_spec/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_server_spec
 description: A Dart library containing abstract classes that defines what implementations of the root and secondary servers are responsible for.
-version: 5.0.3
+version: 5.0.4
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://docs.atsign.com
 documentation: https://docs.atsign.com/atplatform/secondaryserver


### PR DESCRIPTION
**- What I did**
Resolve #2428 

**- How I did it**
- Added `// ignore: experimental_member_use` in the appropriate locations
- Also removed the `@experimental annotation` which triggered this case because this has not been experimental for a long time

**- How to verify it**

