### PR TITLE
feat: allow use of different certs for incoming and outgoing SecureSocket connections

### DIFF
--- a/packages/at_secondary_server/config/config.yaml
+++ b/packages/at_secondary_server/config/config.yaml
@@ -13,13 +13,23 @@ log:
 
 # The atProtocol security configurations.
 security:
-  # To start secondary server in Secure/UnSecure mode. When [useTLS] is set to false, the secondary server starts in un-secure mode.
-  # When [useTLS] is set to true, the secondary server starts in secure mode. On setting [useTLS] to true, the [certificateChainLocation] and
-  # [privateKeyLocation] should be populated with the path's to respective certificates.
-  useTLS: true
+  # Files for the certificate presented to clients when they connect
+  # These files must exist
   certificateChainLocation: 'certs/fullchain.pem'
   privateKeyLocation: 'certs/privkey.pem'
+
+  # Files for the certificate we present to other atServers when we connect
+  # If not present, we present the same cert as we present to clients
+  certificateChainLocationMtls: 'certs/mtls/fullchain.pem'
+  privateKeyLocationMtls: 'certs/mtls/privkey.pem'
+
+  # File containing the list of root CA certs we should trust when another
+  # atServer connects to us
   trustedCertificateLocation: '/etc/cacert/cacert.pem'
+
+  # Whether to require a client certificate when another atServer
+  # connects to us. This should NEVER be set to false except in exceptional
+  # circumstances, and then probably only for testing purposes.
   clientCertificateRequired: true
 
 # The atProtocol storage configurations

--- a/packages/at_secondary_server/lib/src/connection/outbound/outbound_client.dart
+++ b/packages/at_secondary_server/lib/src/connection/outbound/outbound_client.dart
@@ -399,8 +399,13 @@ class DefaultOutboundConnectionFactory implements OutboundConnectionFactory {
     } else if (requireCerts) {
       throw StateError('SSL Certificates are required, but none were found');
     }
-    securityContext
-        .setTrustedCertificates(atSecurityContext.trustedCertificatePath);
+
+    if (File(atSecurityContext.trustedCertificatePath).existsSync()) {
+      securityContext
+          .setTrustedCertificates(atSecurityContext.trustedCertificatePath);
+    } else if (requireCerts) {
+      throw StateError('${atSecurityContext.trustedCertificatePath} is required but not found');
+    }
   }
 
   @override

--- a/packages/at_secondary_server/lib/src/connection/outbound/outbound_client.dart
+++ b/packages/at_secondary_server/lib/src/connection/outbound/outbound_client.dart
@@ -23,6 +23,9 @@ class OutboundClient {
 
   final InboundConnection inboundConnection;
   final String toAtSign;
+  late OutboundMessageListener messageListener;
+  final OutboundConnectionFactory outboundConnectionFactory;
+
 
   String? toHost;
   String? toPort;
@@ -47,10 +50,6 @@ class OutboundClient {
     return 'OutboundClient{toAtSign: $toAtSign, toHost: $toHost, toPort: $toPort, '
         'isConnectionCreated: $isConnectionCreated, isHandShakeDone: $isHandShakeDone}';
   }
-
-  late OutboundMessageListener messageListener;
-
-  late OutboundConnectionFactory outboundConnectionFactory;
 
   OutboundClient(
     this.inboundConnection,

--- a/packages/at_secondary_server/lib/src/connection/outbound/outbound_client.dart
+++ b/packages/at_secondary_server/lib/src/connection/outbound/outbound_client.dart
@@ -19,7 +19,7 @@ import 'package:meta/meta.dart';
 // Connects to an secondary and performs required handshake to be ready to run rest of the commands
 /// Handshake involves running "from", "pol" verbs on the secondary
 class OutboundClient {
-  var logger = AtSignLogger('OutboundClient');
+  static final logger = AtSignLogger('OutboundClient');
 
   final InboundConnection inboundConnection;
   final String toAtSign;
@@ -50,14 +50,15 @@ class OutboundClient {
 
   late OutboundMessageListener messageListener;
 
-  late OutboundConnectionFactory _outboundConnectionFactory;
+  late OutboundConnectionFactory outboundConnectionFactory;
 
-  OutboundClient(this.inboundConnection, this.toAtSign,
-      this.secondaryAddressFinder, this.handshakeRequired,
-      {OutboundConnectionFactory? outboundConnectionFactory}) {
-    outboundConnectionFactory ??= DefaultOutboundConnectionFactory();
-    _outboundConnectionFactory = outboundConnectionFactory;
-  }
+  OutboundClient(
+    this.inboundConnection,
+    this.toAtSign,
+    this.secondaryAddressFinder,
+    this.handshakeRequired,
+    this.outboundConnectionFactory,
+  );
 
   /// Connects to an secondary and performs required handshake to be ready to run rest of the commands
   /// Handshake involves running "from", "pol" verbs on the secondary
@@ -82,7 +83,7 @@ class OutboundClient {
       String toHost = secondaryInfo[0];
       int toPort = int.parse(secondaryInfo[1]);
       // 2. Create an outbound connection for the host and port
-      outboundConnection = await _outboundConnectionFactory
+      outboundConnection = await outboundConnectionFactory
           .createOutboundConnection(toHost, toPort, toAtSign);
 
       // Note that the outbound connection has been created successfully
@@ -377,17 +378,39 @@ abstract class OutboundConnectionFactory {
 }
 
 class DefaultOutboundConnectionFactory implements OutboundConnectionFactory {
+  final AtSignLogger logger = AtSignLogger('DefaultOutboundConnectionFactory')
+    ..level = 'info'; // Log stuff regardless of overall log level
+  final AtSecurityContextImpl atSecurityContext = AtSecurityContextImpl();
+  final SecurityContext securityContext =
+      SecurityContext(withTrustedRoots: true);
+  final bool requireCerts;
+
+  DefaultOutboundConnectionFactory({required this.requireCerts}) {
+    if (File(atSecurityContext.privateKeyPathMtls).existsSync() &&
+        File(atSecurityContext.publicKeyPathMtls).existsSync()) {
+      logger.info('Using MTLS cert when making outbound client connections');
+      securityContext.useCertificateChain('mtls_certs/fullchain.pem');
+      securityContext.usePrivateKey('mtls_certs/privkey.pem');
+    } else if (File(atSecurityContext.privateKeyPath).existsSync() &&
+        File(atSecurityContext.publicKeyPath).existsSync()) {
+      logger.info('Using server cert when making outbound client connections');
+      securityContext.useCertificateChain(atSecurityContext.publicKeyPath);
+      securityContext.usePrivateKey(atSecurityContext.privateKeyPath);
+    } else if (requireCerts) {
+      throw StateError('SSL Certificates are required, but none were found');
+    }
+    securityContext
+        .setTrustedCertificates(atSecurityContext.trustedCertificatePath);
+  }
+
   @override
   Future<OutboundSocketConnection> createOutboundConnection(
       String host, int port, String toAtSign) async {
-    AtSecurityContextImpl securityContext = AtSecurityContextImpl();
-    SecurityContext secConConnect = SecurityContext.defaultContext;
-    secConConnect.useCertificateChain(securityContext.publicKeyPath());
-    secConConnect.usePrivateKey(securityContext.privateKeyPath());
-    secConConnect
-        .setTrustedCertificates(securityContext.trustedCertificatePath());
-    var secureSocket =
-        await SecureSocket.connect(host, port, context: secConConnect);
+    var secureSocket = await SecureSocket.connect(
+      host,
+      port,
+      context: securityContext,
+    );
     return OutboundConnectionImpl(secureSocket, toAtSign);
   }
 }

--- a/packages/at_secondary_server/lib/src/connection/outbound/outbound_client_manager.dart
+++ b/packages/at_secondary_server/lib/src/connection/outbound/outbound_client_manager.dart
@@ -12,15 +12,22 @@ class OutboundClientManager {
 
   static const int defaultPoolSize = 200;
 
-  final OutboundClientPool _pool = OutboundClientPool(size: defaultPoolSize);
+  late final OutboundClientPool _pool;
 
-  OutboundClientManager(this.secondaryAddressFinder);
+  OutboundClientManager(
+    this.secondaryAddressFinder,
+    this.outboundConnectionFactory, {
+    int poolSize = defaultPoolSize,
+  }) {
+    _pool = OutboundClientPool(size: poolSize);
+  }
 
   @visibleForTesting
   bool closed = false;
 
   @visibleForTesting
   SecondaryAddressFinder secondaryAddressFinder;
+  final OutboundConnectionFactory outboundConnectionFactory;
 
   set poolSize(int s) => _pool.size = s;
 
@@ -61,7 +68,12 @@ class OutboundClientManager {
 
     // No existing client found, and Pool has capacity - create a new client
     var newClient = OutboundClient(
-        inboundConnection, toAtSign, secondaryAddressFinder, handshakeRequired);
+      inboundConnection,
+      toAtSign,
+      secondaryAddressFinder,
+      handshakeRequired,
+      outboundConnectionFactory,
+    );
     if (connect) {
       await newClient.connect();
     } else {

--- a/packages/at_secondary_server/lib/src/notification/notification_manager_impl.dart
+++ b/packages/at_secondary_server/lib/src/notification/notification_manager_impl.dart
@@ -5,13 +5,9 @@ import 'package:at_secondary/src/notification/resource_manager.dart';
 
 /// Class implementing [NotificationManagerSpec].
 class NotificationManager implements NotificationManagerSpec {
-  static final NotificationManager _singleton = NotificationManager._internal();
+  final ResourceManager resourceManager;
 
-  NotificationManager._internal();
-
-  factory NotificationManager.getInstance() {
-    return _singleton;
-  }
+  NotificationManager(this.resourceManager);
 
   @override
   Future<String?> notify(AtNotification atNotification) async {
@@ -34,7 +30,7 @@ class NotificationManager implements NotificationManagerSpec {
     if (atNotification.type == NotificationType.sent) {
       var queueManager = QueueManager.getInstance();
       queueManager.enqueue(atNotification);
-      ResourceManager.getInstance().nudge();
+      resourceManager.nudge();
     }
 
     // Adding notification to hive key-store.

--- a/packages/at_secondary_server/lib/src/notification/notify_connection_pool.dart
+++ b/packages/at_secondary_server/lib/src/notification/notify_connection_pool.dart
@@ -7,22 +7,21 @@ import 'package:at_utils/at_logger.dart';
 
 /// Class to maintains the pool of outbound connections for notifying.
 class NotifyConnectionsPool {
-  static final NotifyConnectionsPool _singleton =
-      NotifyConnectionsPool._internal();
   static final logger = AtSignLogger('NotifyConnectionPool');
 
   static const int defaultPoolSize = 200;
 
-  final OutboundClientPool _outboundClientPool =
-      OutboundClientPool(size: defaultPoolSize);
+  late final OutboundClientPool _outboundClientPool;
+  final OutboundConnectionFactory outboundConnectionFactory;
 
-  OutboundClientPool get pool => _outboundClientPool;
-
-  NotifyConnectionsPool._internal();
-
-  factory NotifyConnectionsPool.getInstance() {
-    return _singleton;
+  NotifyConnectionsPool(
+    this.outboundConnectionFactory, {
+    int poolSize = defaultPoolSize,
+  }) {
+    _outboundClientPool = OutboundClientPool(size: poolSize);
   }
+
+  OutboundClientPool get outboundClientPool => _outboundClientPool;
 
   int get size => _outboundClientPool.size;
 
@@ -60,8 +59,13 @@ class NotifyConnectionsPool {
 
     // If client is null and pool has capacity, create a new OutboundClient and add it to the pool
     // and return it back
-    var newClient = OutboundClient(inboundConnection, toAtSign,
-        AtSecondaryServerImpl.getInstance().secondaryAddressFinder, true);
+    var newClient = OutboundClient(
+      inboundConnection,
+      toAtSign,
+      AtSecondaryServerImpl.getInstance().secondaryAddressFinder,
+      true,
+      outboundConnectionFactory,
+    );
     if (connect) {
       await newClient.connect();
     } else {

--- a/packages/at_secondary_server/lib/src/notification/resource_manager.dart
+++ b/packages/at_secondary_server/lib/src/notification/resource_manager.dart
@@ -13,7 +13,6 @@ import 'package:meta/meta.dart';
 /// Class that is responsible for sending the notifications.
 class ResourceManager {
   static final logger = AtSignLogger('NotificationResourceManager');
-  static final ResourceManager _singleton = ResourceManager._internal();
 
   bool _isProcessingQueue = false;
 
@@ -25,18 +24,13 @@ class ResourceManager {
 
   static var maxRetries = AtSecondaryConfig.maxNotificationRetries;
 
-  ResourceManager._internal();
+  final NotifyConnectionsPool notifyConnectionsPool;
 
-  factory ResourceManager.getInstance() {
-    return _singleton;
-  }
+  ResourceManager(this.notifyConnectionsPool);
 
-  final NotifyConnectionsPool _notifyConnectionsPool =
-      NotifyConnectionsPool.getInstance();
+  int get outboundConnectionLimit => notifyConnectionsPool.size;
 
-  int get outboundConnectionLimit => _notifyConnectionsPool.size;
-
-  set outboundConnectionLimit(int ocl) => _notifyConnectionsPool.size = ocl;
+  set outboundConnectionLimit(int ocl) => notifyConnectionsPool.size = ocl;
 
   void start() {
     _started = true;
@@ -88,7 +82,7 @@ class ResourceManager {
     late Iterator notificationIterator;
     try {
       //1. Find the cap on the notifyConnectionsPool size
-      var numberOfOutboundConnections = _notifyConnectionsPool.size;
+      var numberOfOutboundConnections = notifyConnectionsPool.size;
 
       //2. Get the atsign on priority basis.
       var atSignIterator = AtNotificationMap.getInstance()
@@ -130,7 +124,7 @@ class ResourceManager {
   /// Returns OutboundClient, if connection is successful.
   /// Throws [ConnectionInvalidException] for any exceptions
   Future<OutboundClient> _connect(String toAtSign) async {
-    return await _notifyConnectionsPool.getOutboundClient(toAtSign);
+    return await notifyConnectionsPool.getOutboundClient(toAtSign);
   }
 
   /// Send the Notification to [atNotificationList.toAtSign]

--- a/packages/at_secondary_server/lib/src/server/at_secondary_config.dart
+++ b/packages/at_secondary_server/lib/src/server/at_secondary_config.dart
@@ -21,6 +21,11 @@ class AtSecondaryConfig {
   //Certificate Paths
   static const String _certificateChainLocation = 'certs/fullchain.pem';
   static const String _privateKeyLocation = 'certs/privkey.pem';
+
+  static const String _certificateChainLocationMtls =
+      'certs/fullchain_mtls.pem';
+  static const String _privateKeyLocationMtls = 'certs/privkey_mtls.pem';
+
   static const String _trustedCertificateLocation = '/etc/cacert/cacert.pem';
 
   //Secondary Storage
@@ -556,9 +561,9 @@ class AtSecondaryConfig {
     }
   }
 
-  static String? get trustedCertificateLocation {
+  static String get trustedCertificateLocation {
     if (_envVars.containsKey('securityTrustedCertificateLocation')) {
-      return _envVars['securityTrustedCertificateLocation'];
+      return _envVars['securityTrustedCertificateLocation']!;
     }
     try {
       return getConfigFromYaml(['security', 'trustedCertificateLocation']);
@@ -567,9 +572,9 @@ class AtSecondaryConfig {
     }
   }
 
-  static String? get privateKeyLocation {
+  static String get privateKeyLocation {
     if (_envVars.containsKey('securityPrivateKeyLocation')) {
-      return _envVars['securityPrivateKeyLocation'];
+      return _envVars['securityPrivateKeyLocation']!;
     }
     try {
       return getConfigFromYaml(['security', 'privateKeyLocation']);
@@ -578,14 +583,36 @@ class AtSecondaryConfig {
     }
   }
 
-  static String? get certificateChainLocation {
+  static String get certificateChainLocation {
     if (_envVars.containsKey('securityCertificateChainLocation')) {
-      return _envVars['securityCertificateChainLocation'];
+      return _envVars['securityCertificateChainLocation']!;
     }
     try {
       return getConfigFromYaml(['security', 'certificateChainLocation']);
     } on ElementNotFoundException {
       return _certificateChainLocation;
+    }
+  }
+
+  static String get privateKeyLocationMtls {
+    if (_envVars.containsKey('securityPrivateKeyLocationMtls')) {
+      return _envVars['securityPrivateKeyLocationMtls']!;
+    }
+    try {
+      return getConfigFromYaml(['security', 'privateKeyLocationMtls']);
+    } on ElementNotFoundException {
+      return _privateKeyLocationMtls;
+    }
+  }
+
+  static String get certificateChainLocationMtls {
+    if (_envVars.containsKey('securityCertificateChainLocationMtls')) {
+      return _envVars['securityCertificateChainLocationMtls']!;
+    }
+    try {
+      return getConfigFromYaml(['security', 'certificateChainLocationMtls']);
+    } on ElementNotFoundException {
+      return _certificateChainLocationMtls;
     }
   }
 

--- a/packages/at_secondary_server/lib/src/server/at_secondary_config.dart
+++ b/packages/at_secondary_server/lib/src/server/at_secondary_config.dart
@@ -19,12 +19,11 @@ class AtSecondaryConfig {
   static const bool _testingMode = false;
 
   //Certificate Paths
-  static const String _certificateChainLocation = 'certs/fullchain.pem';
-  static const String _privateKeyLocation = 'certs/privkey.pem';
+  static const String _fullchainLocation = 'certs/fullchain.pem';
+  static const String _privkeyLocation = 'certs/privkey.pem';
 
-  static const String _certificateChainLocationMtls =
-      'certs/fullchain_mtls.pem';
-  static const String _privateKeyLocationMtls = 'certs/privkey_mtls.pem';
+  static const String _fullchainLocationMtls = 'certs/mtls/fullchain.pem';
+  static const String _privkeyLocationMtls = 'certs/mtls/privkey.pem';
 
   static const String _trustedCertificateLocation = '/etc/cacert/cacert.pem';
 
@@ -579,7 +578,7 @@ class AtSecondaryConfig {
     try {
       return getConfigFromYaml(['security', 'privateKeyLocation']);
     } on ElementNotFoundException {
-      return _privateKeyLocation;
+      return _privkeyLocation;
     }
   }
 
@@ -590,7 +589,7 @@ class AtSecondaryConfig {
     try {
       return getConfigFromYaml(['security', 'certificateChainLocation']);
     } on ElementNotFoundException {
-      return _certificateChainLocation;
+      return _fullchainLocation;
     }
   }
 
@@ -601,7 +600,7 @@ class AtSecondaryConfig {
     try {
       return getConfigFromYaml(['security', 'privateKeyLocationMtls']);
     } on ElementNotFoundException {
-      return _privateKeyLocationMtls;
+      return _privkeyLocationMtls;
     }
   }
 
@@ -612,7 +611,7 @@ class AtSecondaryConfig {
     try {
       return getConfigFromYaml(['security', 'certificateChainLocationMtls']);
     } on ElementNotFoundException {
-      return _certificateChainLocationMtls;
+      return _fullchainLocationMtls;
     }
   }
 

--- a/packages/at_secondary_server/lib/src/server/at_secondary_impl.dart
+++ b/packages/at_secondary_server/lib/src/server/at_secondary_impl.dart
@@ -10,11 +10,14 @@ import 'package:at_persistence_secondary_server/at_persistence_secondary_server.
 import 'package:at_secondary/src/caching/cache_manager.dart';
 import 'package:at_secondary/src/caching/cache_refresh_job.dart';
 import 'package:at_secondary/src/connection/inbound/inbound_connection_manager.dart';
+import 'package:at_secondary/src/connection/outbound/outbound_client.dart'
+    show OutboundConnectionFactory, DefaultOutboundConnectionFactory;
 import 'package:at_secondary/src/connection/outbound/outbound_client_manager.dart';
 import 'package:at_secondary/src/connection/stream_manager.dart';
 import 'package:at_secondary/src/enroll/enrollment_manager.dart';
 import 'package:at_secondary/src/exception/global_exception_handler.dart';
 import 'package:at_secondary/src/notification/notification_manager_impl.dart';
+import 'package:at_secondary/src/notification/notify_connection_pool.dart';
 import 'package:at_secondary/src/notification/queue_manager.dart';
 import 'package:at_secondary/src/notification/resource_manager.dart';
 import 'package:at_secondary/src/notification/stats_notification_service.dart';
@@ -64,6 +67,7 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
 
   late SecondaryAddressFinder secondaryAddressFinder;
   late OutboundClientManager outboundClientManager;
+  late OutboundConnectionFactory outboundConnectionFactory;
 
   late bool _isPaused;
 
@@ -74,6 +78,17 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
   }
 
   AtSecondaryServerImpl._internal() {
+    // TODO There's a whole lifecycle mess here that needs to be cleaned up
+    // at some point. Currently we create this singleton which then has a
+    // lifecycle where it can be started and stopped. When it is started, all
+    // of its relevant state is recreated, since things (e.g. ssl certs) may
+    // have changed. When it is stopped, all relevant state is cleared.
+    // This should not be a singleton, and state management should be
+    // 'stop the current server; create new instance; start new instance'.
+    // Doing this will be a massive chunk of busywork.
+    // NB: These specific instance variables are depended on by unit tests
+    // so they are initialized here, but are also initialized as part of the
+    // `start()` function
     final socketConfig = SecureSocketConfig()
       ..decryptPackets = false
       ..pathToCerts = AtSecondaryConfig.trustedCertificateLocation
@@ -84,7 +99,13 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
       AtSecondaryConfig.rootServerPort,
       socketConfig: socketConfig,
     );
-    outboundClientManager = OutboundClientManager(secondaryAddressFinder);
+    outboundConnectionFactory = DefaultOutboundConnectionFactory(
+      requireCerts: false, // so unit tests can work
+    );
+    outboundClientManager = OutboundClientManager(
+      secondaryAddressFinder,
+      outboundConnectionFactory,
+    );
   }
 
   dynamic _serverSocket;
@@ -230,7 +251,34 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
     await notificationKeyStoreCompactionJobInstance
         .scheduleCompactionJob(atNotificationCompactionConfig);
 
-    outboundClientManager.poolSize = serverContext!.outboundConnectionLimit;
+    final socketConfig = SecureSocketConfig()
+      ..decryptPackets = false
+      ..pathToCerts = AtSecondaryConfig.trustedCertificateLocation
+      ..tlsKeysSavePath = null;
+
+    secondaryAddressFinder = CacheableSecondaryAddressFinder(
+      AtSecondaryConfig.rootServerUrl,
+      AtSecondaryConfig.rootServerPort,
+      socketConfig: socketConfig,
+    );
+    outboundConnectionFactory = DefaultOutboundConnectionFactory(
+      requireCerts: true,
+    );
+    outboundClientManager = OutboundClientManager(
+      secondaryAddressFinder,
+      outboundConnectionFactory,
+      poolSize: serverContext!.outboundConnectionLimit,
+    );
+    notificationResourceManager = ResourceManager(NotifyConnectionsPool(
+      outboundConnectionFactory,
+      poolSize: serverContext!.outboundConnectionLimit,
+    ));
+
+    // Start the notification sender
+    notificationResourceManager.start();
+
+    NotificationManager notificationManager =
+        NotificationManager(notificationResourceManager);
 
     // Refresh Cached Keys
     cacheManager = AtCacheManager(serverContext!.currentAtSign!,
@@ -259,7 +307,7 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
         outboundClientManager,
         cacheManager,
         StatsNotificationService.getInstance(),
-        NotificationManager.getInstance(),
+        notificationManager,
         enrollmentManager,
         currentAtSign,
       );
@@ -274,7 +322,7 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
           outboundClientManager,
           cacheManager,
           StatsNotificationService.getInstance(),
-          NotificationManager.getInstance(),
+          notificationManager,
           enrollmentManager,
           currentAtSign,
         );
@@ -287,7 +335,7 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
     if (certificateReloadJob == null) {
       certificateReloadJob = AtCertificateValidationJob(
           this,
-          AtSecondaryConfig.certificateChainLocation!
+          AtSecondaryConfig.certificateChainLocation
               .replaceAll('fullchain.pem', 'restart'),
           AtSecondaryConfig.isForceRestart!);
       await certificateReloadJob!.start();
@@ -318,12 +366,6 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
     inboundConnectionManager = InboundConnectionManager(
         serverAtSign: currentAtSign,
         poolSize: serverContext!.inboundConnectionLimit);
-
-    // Notification job
-    notificationResourceManager = ResourceManager.getInstance();
-    notificationResourceManager.outboundConnectionLimit =
-        serverContext!.outboundConnectionLimit;
-    notificationResourceManager.start();
 
     // Starts StatsNotificationService to keep monitor connections alive
     await StatsNotificationService.getInstance().schedule(currentAtSign);
@@ -562,11 +604,11 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
         if (certsAvailable || retryCount > 60) {
           break;
         }
-        secCon.useCertificateChain(
-            serverContext!.securityContext!.publicKeyPath());
-        secCon.usePrivateKey(serverContext!.securityContext!.privateKeyPath());
+        secCon
+            .useCertificateChain(serverContext!.securityContext!.publicKeyPath);
+        secCon.usePrivateKey(serverContext!.securityContext!.privateKeyPath);
         secCon.setTrustedCertificates(
-            serverContext!.securityContext!.trustedCertificatePath());
+            serverContext!.securityContext!.trustedCertificatePath);
         certsAvailable = true;
         // secCon.setAlpnProtocols(['atp/1.0', 'h2', 'http/1.1'], true);
         secCon.setAlpnProtocols(['atProtocol/1.0', 'http/1.1'], true);

--- a/packages/at_secondary_server/lib/src/server/at_security_context_impl.dart
+++ b/packages/at_secondary_server/lib/src/server/at_security_context_impl.dart
@@ -1,13 +1,8 @@
 import 'package:at_secondary/src/server/at_secondary_config.dart';
-import 'package:at_server_spec/at_server_spec.dart';
 
-class AtSecurityContextImpl implements AtSecurityContext {
+class AtSecurityContextImpl {
   static final AtSecurityContextImpl _singleton =
       AtSecurityContextImpl._internal();
-  final String? _certChainPath = AtSecondaryConfig.certificateChainLocation;
-  final String? _privateKeyPath = AtSecondaryConfig.privateKeyLocation;
-  final String? _trustedCertificatePath =
-      AtSecondaryConfig.trustedCertificateLocation;
 
   factory AtSecurityContextImpl() {
     return _singleton;
@@ -15,24 +10,21 @@ class AtSecurityContextImpl implements AtSecurityContext {
 
   AtSecurityContextImpl._internal();
 
-  @override
-  String privateKeyPath() {
-    return _privateKeyPath!;
-  }
+  /// Returns path of the public key of the server cert presented to clients.
+  String get publicKeyPath => AtSecondaryConfig.certificateChainLocation;
 
-  @override
-  String publicKeyPath() {
-    return _certChainPath!;
-  }
+  /// Returns path of the private key of the server cert.
+  String get privateKeyPath => AtSecondaryConfig.privateKeyLocation;
 
-  @override
-  String trustedCertificatePath() {
-    return _trustedCertificatePath!;
-  }
+  /// Returns path of the public key of the client cert which we will present
+  /// to other atServers when we connect to them.
+  String get publicKeyPathMtls =>
+      AtSecondaryConfig.certificateChainLocationMtls;
 
-  @override
-  String bundle() {
-    // TODO: implement bundle
-    return '';
-  }
+  /// Returns path of the private key of the client cert.
+  String get privateKeyPathMtls => AtSecondaryConfig.privateKeyLocationMtls;
+
+  /// Returns path of trusted root certificates file.
+  String get trustedCertificatePath =>
+      AtSecondaryConfig.trustedCertificateLocation;
 }

--- a/packages/at_secondary_server/lib/src/server/server_context.dart
+++ b/packages/at_secondary_server/lib/src/server/server_context.dart
@@ -1,4 +1,5 @@
 import 'package:at_persistence_spec/at_persistence_spec.dart';
+import 'package:at_secondary/src/server/at_security_context_impl.dart';
 import 'package:at_server_spec/at_server_spec.dart';
 import 'package:at_server_spec/at_verb_spec.dart';
 
@@ -43,7 +44,7 @@ class AtSecondaryContext extends AtServerContext {
 
   String? currentAtSign;
   String? sharedSecret;
-  AtSecurityContext? securityContext;
+  AtSecurityContextImpl? securityContext;
   SecondaryKeyStore? secondaryKeyStore;
   VerbExecutor? verbExecutor;
 

--- a/packages/at_secondary_server/lib/src/verb/handler/delete_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/delete_verb_handler.dart
@@ -18,7 +18,13 @@ class DeleteVerbHandler extends ChangeVerbHandler {
   static bool _autoNotify = AtSecondaryConfig.autoNotify;
   Set<String>? protectedKeys;
 
-  DeleteVerbHandler(super.keyStore, super.statsNotificationService);
+  final NotificationManager notificationManager;
+
+  DeleteVerbHandler(
+    super.keyStore,
+    super.statsNotificationService,
+    this.notificationManager,
+  );
 
   //setter to set autoNotify value from dynamic server config "config:set".
   //only works when testingMode is set to true
@@ -145,7 +151,7 @@ class DeleteVerbHandler extends ChangeVerbHandler {
       // send notification to other secondary if [AtSecondaryConfig.autoNotify] is true
       if (_autoNotify && (forAtSign != atSign)) {
         try {
-          _notify(
+          await _notify(
               forAtSign,
               atSign,
               key,
@@ -162,7 +168,7 @@ class DeleteVerbHandler extends ChangeVerbHandler {
     }
   }
 
-  void _notify(forAtSign, atSign, key, priority) {
+  Future<void> _notify(forAtSign, atSign, key, priority) async {
     if (forAtSign == null) {
       return;
     }
@@ -175,7 +181,7 @@ class DeleteVerbHandler extends ChangeVerbHandler {
           ..priority = priority
           ..opType = OperationType.delete)
         .build();
-    NotificationManager.getInstance().notify(atNotification);
+    await notificationManager.notify(atNotification);
   }
 
   Set<String> _getProtectedKeys(String? atsign) {

--- a/packages/at_secondary_server/lib/src/verb/handler/from_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/from_verb_handler.dart
@@ -138,23 +138,26 @@ class FromVerbHandler extends AbstractVerbHandler {
 
   bool _verifyClientCerts(X509Certificate cn, String host) {
     var subject = cn.subject;
-    logger.finer('Connected from: $subject');
+    logger.shout(
+        'Connected from: $cn $subject issued by ${cn.issuer} valid from ${cn.startValidity} to ${cn.endValidity}');
     if (subject.contains(host)) {
+      // TODO Dig in to the possible values of subject
       return true;
     }
     // If you would like to see the cert
     var x509Pem = cn.pem;
     // test with an internet available certificate to ensure we are picking out the SAN and not the CN
     var data = X509Utils.x509CertificateFromPem(x509Pem);
-    var subjectAlternativeName =
+    List<String> subjectAlternativeNames =
         data.tbsCertificate?.extensions?.subjectAlternativNames ?? [];
-    logger.finer('SAN: $subjectAlternativeName');
-    if (subjectAlternativeName.contains(host)) {
+    logger.shout('SAN: $subjectAlternativeNames');
+    if (subjectAlternativeNames.contains(host)) {
       return true;
     }
-    var commonName = data.tbsCertificate?.subject['2.5.4.3'] ?? '';
-    logger.finer('CN: $commonName');
+    String commonName = data.tbsCertificate?.subject['2.5.4.3'] ?? '';
+    logger.shout('CN: $commonName');
     if (commonName.contains(host)) {
+      // Probably should be an equality test
       return true;
     }
     return false;

--- a/packages/at_secondary_server/lib/src/verb/handler/from_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/from_verb_handler.dart
@@ -138,7 +138,7 @@ class FromVerbHandler extends AbstractVerbHandler {
 
   bool _verifyClientCerts(X509Certificate cn, String host) {
     var subject = cn.subject;
-    logger.shout(
+    logger.info(
         'Connected from: $cn $subject issued by ${cn.issuer} valid from ${cn.startValidity} to ${cn.endValidity}');
     if (subject.contains(host)) {
       // TODO Dig in to the possible values of subject
@@ -150,12 +150,12 @@ class FromVerbHandler extends AbstractVerbHandler {
     var data = X509Utils.x509CertificateFromPem(x509Pem);
     List<String> subjectAlternativeNames =
         data.tbsCertificate?.extensions?.subjectAlternativNames ?? [];
-    logger.shout('SAN: $subjectAlternativeNames');
+    logger.info('SAN: $subjectAlternativeNames');
     if (subjectAlternativeNames.contains(host)) {
       return true;
     }
     String commonName = data.tbsCertificate?.subject['2.5.4.3'] ?? '';
-    logger.shout('CN: $commonName');
+    logger.info('CN: $commonName');
     if (commonName.contains(host)) {
       // Probably should be an equality test
       return true;

--- a/packages/at_secondary_server/lib/src/verb/handler/notify_all_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/notify_all_verb_handler.dart
@@ -108,8 +108,7 @@ class NotifyAllVerbHandler extends AbstractVerbHandler {
               ..atMetaData = atMetadata)
             .build();
 
-        var notificationID =
-            await notificationManager.notify(atNotification);
+        var notificationID = await notificationManager.notify(atNotification);
         resultMap[forAtSign] = notificationID;
       }
     }

--- a/packages/at_secondary_server/lib/src/verb/handler/notify_all_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/notify_all_verb_handler.dart
@@ -18,7 +18,12 @@ import 'abstract_verb_handler.dart';
 class NotifyAllVerbHandler extends AbstractVerbHandler {
   static NotifyAll notifyAll = NotifyAll();
 
-  NotifyAllVerbHandler(super.keyStore);
+  final NotificationManager notificationManager;
+
+  NotifyAllVerbHandler(
+    super.keyStore,
+    this.notificationManager,
+  );
 
   @override
   bool accept(String command) =>
@@ -104,7 +109,7 @@ class NotifyAllVerbHandler extends AbstractVerbHandler {
             .build();
 
         var notificationID =
-            await NotificationManager.getInstance().notify(atNotification);
+            await notificationManager.notify(atNotification);
         resultMap[forAtSign] = notificationID;
       }
     }

--- a/packages/at_secondary_server/lib/src/verb/handler/notify_remove_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/notify_remove_verb_handler.dart
@@ -11,7 +11,12 @@ import 'package:at_server_spec/at_verb_spec.dart';
 class NotifyRemoveVerbHandler extends AbstractVerbHandler {
   static NotifyRemove notifyRemove = NotifyRemove();
 
-  NotifyRemoveVerbHandler(super.keyStore);
+  final NotificationManager notificationManager;
+
+  NotifyRemoveVerbHandler(
+    super.keyStore,
+    this.notificationManager,
+  );
 
   @override
   bool accept(String command) => command.startsWith('notify:remove:');
@@ -42,7 +47,7 @@ class NotifyRemoveVerbHandler extends AbstractVerbHandler {
             'Connection with enrollment ID ${inboundConnectionMetadata.enrollmentId} is not authorized to remove notify key: $atKey');
       }
     }
-    await NotificationManager.getInstance().remove(id);
+    await notificationManager.remove(id);
     response.data = 'success';
   }
 }

--- a/packages/at_secondary_server/lib/src/verb/handler/notify_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/notify_verb_handler.dart
@@ -23,7 +23,9 @@ class NotifyVerbHandler extends AbstractVerbHandler {
   static Notify notify = Notify();
   final int _maxKeyLength = 255;
 
-  NotifyVerbHandler(super.keyStore);
+  final NotificationManager notificationManager;
+
+  NotifyVerbHandler(super.keyStore, this.notificationManager);
 
   AtNotificationBuilder atNotificationBuilder = AtNotificationBuilder();
 
@@ -226,8 +228,8 @@ class NotifyVerbHandler extends AbstractVerbHandler {
     }
     // Send the notification to notification queue manager to notify to the forAtSign
     // and return the notification Id to the currentAtSign
-    var notificationId = await NotificationManager.getInstance()
-        .notify(atNotificationBuilder.build());
+    var notificationId =
+        await notificationManager.notify(atNotificationBuilder.build());
     response.data = notificationId;
     return;
   }

--- a/packages/at_secondary_server/lib/src/verb/handler/stream_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/stream_verb_handler.dart
@@ -14,7 +14,9 @@ class StreamVerbHandler extends AbstractVerbHandler {
 
   InboundConnection? atConnection;
 
-  StreamVerbHandler(super.keyStore);
+  final NotificationManager notificationManager;
+
+  StreamVerbHandler(super.keyStore, this.notificationManager);
 
   @override
   bool accept(String command) => command.startsWith(getName(VerbEnum.stream));
@@ -113,8 +115,7 @@ class StreamVerbHandler extends AbstractVerbHandler {
           ..notification = key
           ..opType = OperationType.update)
         .build();
-    var notificationId =
-        await NotificationManager.getInstance().notify(atNotification);
+    var notificationId = await notificationManager.notify(atNotification);
     logger.finer('notification_id : $notificationId');
   }
 

--- a/packages/at_secondary_server/lib/src/verb/manager/verb_handler_manager.dart
+++ b/packages/at_secondary_server/lib/src/verb/manager/verb_handler_manager.dart
@@ -115,20 +115,24 @@ class DefaultVerbHandlerManager implements VerbHandlerManager {
       outboundClientManager,
       cacheManager,
     ));
-    _verbHandlers.add(DeleteVerbHandler(keyStore, statsNotificationService));
+    _verbHandlers.add(DeleteVerbHandler(
+      keyStore,
+      statsNotificationService,
+      notificationManager,
+    ));
     _verbHandlers.add(StatsVerbHandler(keyStore));
     _verbHandlers.add(ConfigVerbHandler(keyStore));
     _verbHandlers.add(MonitorVerbHandler(keyStore));
-    _verbHandlers.add(StreamVerbHandler(keyStore));
-    _verbHandlers.add(NotifyVerbHandler(keyStore));
+    _verbHandlers.add(StreamVerbHandler(keyStore, notificationManager));
+    _verbHandlers.add(NotifyVerbHandler(keyStore, notificationManager));
     _verbHandlers.add(NotifyListVerbHandler(keyStore, outboundClientManager));
     _verbHandlers.add(BatchVerbHandler(keyStore, this));
     _verbHandlers.add(NotifyStatusVerbHandler(keyStore));
-    _verbHandlers.add(NotifyAllVerbHandler(keyStore));
+    _verbHandlers.add(NotifyAllVerbHandler(keyStore, notificationManager));
     _verbHandlers.add(SyncProgressiveVerbHandler(keyStore));
     _verbHandlers.add(InfoVerbHandler(keyStore));
     _verbHandlers.add(NoOpVerbHandler(keyStore));
-    _verbHandlers.add(NotifyRemoveVerbHandler(keyStore));
+    _verbHandlers.add(NotifyRemoveVerbHandler(keyStore, notificationManager));
     _verbHandlers.add(NotifyFetchVerbHandler(keyStore));
     _verbHandlers.add(EnrollVerbHandler(keyStore, enrollmentManager));
     _verbHandlers.add(OtpVerbHandler(keyStore));

--- a/packages/at_secondary_server/test/abstract_verb_handler_test.dart
+++ b/packages/at_secondary_server/test/abstract_verb_handler_test.dart
@@ -1,6 +1,5 @@
 import 'dart:collection';
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:at_commons/at_commons.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
@@ -8,20 +7,14 @@ import 'package:at_secondary/src/connection/inbound/inbound_connection_metadata.
 import 'package:at_secondary/src/verb/handler/abstract_verb_handler.dart';
 import 'package:at_server_spec/at_verb_spec.dart';
 import 'package:at_server_spec/src/connection/inbound_connection.dart';
-import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 import 'package:uuid/uuid.dart';
 
 import 'test_utils.dart';
 
 void main() {
-  late MockSocket mockSocket;
-
   setUpAll(() async {
     await verbTestsSetUpAll();
-    mockSocket = MockSocket();
-    when(() => mockSocket.setOption(SocketOption.tcpNoDelay, true))
-        .thenReturn(true);
   });
   group('A group of abstract verb handler tests', () {
     late String enrollmentId;

--- a/packages/at_secondary_server/test/cram_verb_test.dart
+++ b/packages/at_secondary_server/test/cram_verb_test.dart
@@ -12,7 +12,6 @@ import 'package:at_secondary/src/verb/handler/cram_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/from_verb_handler.dart';
 import 'package:at_server_spec/at_verb_spec.dart';
 import 'package:crypto/crypto.dart';
-import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
 import 'test_utils.dart';
@@ -28,7 +27,7 @@ void main() {
   setUp(() async {
     mockKeyStore = MockSecondaryKeyStore();
     mockSocket = FakeSocket();
-        keyStoreManager = await setUpFunc(storageDir);
+    keyStoreManager = await setUpFunc(storageDir);
   });
 
   group('A group of cram verb regex test', () {

--- a/packages/at_secondary_server/test/cram_verb_test.dart
+++ b/packages/at_secondary_server/test/cram_verb_test.dart
@@ -19,7 +19,7 @@ import 'test_utils.dart';
 
 void main() {
   late SecondaryKeyStore mockKeyStore;
-  late MockSocket mockSocket;
+  late FakeSocket mockSocket;
 
   verbTestsSetUpLogging();
 
@@ -27,10 +27,8 @@ void main() {
   late SecondaryKeyStoreManager keyStoreManager;
   setUp(() async {
     mockKeyStore = MockSecondaryKeyStore();
-    mockSocket = MockSocket();
-    when(() => mockSocket.setOption(SocketOption.tcpNoDelay, true))
-        .thenReturn(true);
-    keyStoreManager = await setUpFunc(storageDir);
+    mockSocket = FakeSocket();
+        keyStoreManager = await setUpFunc(storageDir);
   });
 
   group('A group of cram verb regex test', () {

--- a/packages/at_secondary_server/test/delete_verb_test.dart
+++ b/packages/at_secondary_server/test/delete_verb_test.dart
@@ -34,7 +34,10 @@ void main() {
 
     test('test delete getVerb', () {
       var handler = DeleteVerbHandler(
-          secondaryKeyStore, StatsNotificationService.getInstance());
+        secondaryKeyStore,
+        StatsNotificationService.getInstance(),
+        notificationManager,
+      );
       var verb = handler.getVerb();
       expect(verb is Delete, true);
     });
@@ -42,7 +45,10 @@ void main() {
     test('test delete command accept test', () {
       var command = 'delete:@bob:email@colin';
       var handler = DeleteVerbHandler(
-          secondaryKeyStore, StatsNotificationService.getInstance());
+        secondaryKeyStore,
+        StatsNotificationService.getInstance(),
+        notificationManager,
+      );
       var result = handler.accept(command);
       expect(result, true);
     });
@@ -51,7 +57,10 @@ void main() {
       var command = 'DEL ETE:@bob:email@colin';
       command = SecondaryUtil.convertCommand(command);
       var handler = DeleteVerbHandler(
-          secondaryKeyStore, StatsNotificationService.getInstance());
+        secondaryKeyStore,
+        StatsNotificationService.getInstance(),
+        notificationManager,
+      );
       var result = handler.accept(command);
       expect(result, true);
     });
@@ -108,7 +117,10 @@ void main() {
     setUp(() async {
       await verbTestsSetUp();
       handler = DeleteVerbHandler(
-          secondaryKeyStore, StatsNotificationService.getInstance());
+        secondaryKeyStore,
+        StatsNotificationService.getInstance(),
+        notificationManager,
+      );
     });
 
     test('verify deletion of signing public key throws exception', () {
@@ -196,7 +208,10 @@ void main() {
 
       inboundConnection.metaData.isAuthenticated = true;
       deleteHandler = DeleteVerbHandler(
-          secondaryKeyStore, StatsNotificationService.getInstance());
+        secondaryKeyStore,
+        StatsNotificationService.getInstance(),
+        notificationManager,
+      );
       updateHandler = UpdateVerbHandler(
         secondaryKeyStore,
         StatsNotificationService.getInstance(),
@@ -326,16 +341,22 @@ void main() {
       String deleteCommand = 'delete:$alice:phone.wavi$alice';
       HashMap<String, String?> deleteVerbParams =
           getVerbParam(VerbSyntax.delete, deleteCommand);
-      DeleteVerbHandler deleteVerbHandler =
-          DeleteVerbHandler(secondaryKeyStore, statsNotificationService);
+      DeleteVerbHandler deleteVerbHandler = DeleteVerbHandler(
+        secondaryKeyStore,
+        statsNotificationService,
+        notificationManager,
+      );
       await deleteVerbHandler.processVerb(
           response, deleteVerbParams, inboundConnection);
       expect(response.data, isNotNull);
       // Delete a key with buzz namespace
       deleteCommand = 'delete:$alice:phone.buzz$alice';
       deleteVerbParams = getVerbParam(VerbSyntax.delete, deleteCommand);
-      deleteVerbHandler =
-          DeleteVerbHandler(secondaryKeyStore, statsNotificationService);
+      deleteVerbHandler = DeleteVerbHandler(
+        secondaryKeyStore,
+        statsNotificationService,
+        notificationManager,
+      );
       await deleteVerbHandler.processVerb(
           response, deleteVerbParams, inboundConnection);
       expect(response.data, isNotNull);
@@ -364,8 +385,11 @@ void main() {
       String deleteCommand = 'delete:dummykey.wavi$alice';
       HashMap<String, String?> deleteVerbParams =
           getVerbParam(VerbSyntax.delete, deleteCommand);
-      DeleteVerbHandler deleteVerbHandler =
-          DeleteVerbHandler(secondaryKeyStore, statsNotificationService);
+      DeleteVerbHandler deleteVerbHandler = DeleteVerbHandler(
+        secondaryKeyStore,
+        statsNotificationService,
+        notificationManager,
+      );
       expect(
           () async => await deleteVerbHandler.processVerb(
               response, deleteVerbParams, inboundConnection),
@@ -398,8 +422,11 @@ void main() {
       String deleteCommand = 'delete:dummykey.wavi$alice';
       HashMap<String, String?> deleteVerbParams =
           getVerbParam(VerbSyntax.delete, deleteCommand);
-      DeleteVerbHandler deleteVerbHandler =
-          DeleteVerbHandler(secondaryKeyStore, statsNotificationService);
+      DeleteVerbHandler deleteVerbHandler = DeleteVerbHandler(
+        secondaryKeyStore,
+        statsNotificationService,
+        notificationManager,
+      );
       await deleteVerbHandler.processVerb(
           response, deleteVerbParams, inboundConnection);
       expect(response.data, isNotNull);
@@ -422,8 +449,11 @@ void main() {
       String deleteCommand = 'delete:$bob:shared_key$alice';
       HashMap<String, String?> deleteVerbParams =
           getVerbParam(VerbSyntax.delete, deleteCommand);
-      DeleteVerbHandler deleteVerbHandler =
-          DeleteVerbHandler(secondaryKeyStore, statsNotificationService);
+      DeleteVerbHandler deleteVerbHandler = DeleteVerbHandler(
+        secondaryKeyStore,
+        statsNotificationService,
+        notificationManager,
+      );
       await deleteVerbHandler.processVerb(
           response, deleteVerbParams, inboundConnection);
       expect(response.isError, false);
@@ -451,8 +481,11 @@ void main() {
       String deleteCommand = 'delete:$bob:shared_key$alice';
       HashMap<String, String?> deleteVerbParams =
           getVerbParam(VerbSyntax.delete, deleteCommand);
-      DeleteVerbHandler deleteVerbHandler =
-          DeleteVerbHandler(secondaryKeyStore, statsNotificationService);
+      DeleteVerbHandler deleteVerbHandler = DeleteVerbHandler(
+        secondaryKeyStore,
+        statsNotificationService,
+        notificationManager,
+      );
       await deleteVerbHandler.processVerb(
           response, deleteVerbParams, inboundConnection);
       expect(response.data, isNotNull);
@@ -483,6 +516,7 @@ void main() {
       DeleteVerbHandler deleteVerbHandler = DeleteVerbHandler(
         secondaryKeyStore,
         statsNotificationService,
+        notificationManager,
       );
       await deleteVerbHandler.processVerb(
           response, deleteVerbParams, inboundConnection);
@@ -511,8 +545,11 @@ void main() {
       String deleteCommand = 'delete:$alice:secretdata$alice';
       HashMap<String, String?> deleteVerbParams =
           getVerbParam(VerbSyntax.delete, deleteCommand);
-      DeleteVerbHandler deleteVerbHandler =
-          DeleteVerbHandler(secondaryKeyStore, statsNotificationService);
+      DeleteVerbHandler deleteVerbHandler = DeleteVerbHandler(
+        secondaryKeyStore,
+        statsNotificationService,
+        notificationManager,
+      );
       expect(
           () async => await deleteVerbHandler.processVerb(
               response, deleteVerbParams, inboundConnection),
@@ -557,8 +594,11 @@ void main() {
         String deleteCommand = 'delete:$alice:dummykey.wavi$alice';
         HashMap<String, String?> deleteVerbParams =
             getVerbParam(VerbSyntax.delete, deleteCommand);
-        DeleteVerbHandler deleteVerbHandler =
-            DeleteVerbHandler(secondaryKeyStore, statsNotificationService);
+        DeleteVerbHandler deleteVerbHandler = DeleteVerbHandler(
+          secondaryKeyStore,
+          statsNotificationService,
+          notificationManager,
+        );
         expect(
             () async => await deleteVerbHandler.processVerb(
                 response, deleteVerbParams, inboundConnection),
@@ -605,8 +645,11 @@ void main() {
       await Future.delayed(Duration(milliseconds: 1));
       String deleteCommand = 'delete:$alice:phone.wavi$alice';
 
-      DeleteVerbHandler deleteVerbHandler =
-          DeleteVerbHandler(secondaryKeyStore, statsNotificationService);
+      DeleteVerbHandler deleteVerbHandler = DeleteVerbHandler(
+        secondaryKeyStore,
+        statsNotificationService,
+        notificationManager,
+      );
       response = await deleteVerbHandler.processInternal(
           deleteCommand, inboundConnection);
       expect(response.isError, true);

--- a/packages/at_secondary_server/test/enroll_verb_test.dart
+++ b/packages/at_secondary_server/test/enroll_verb_test.dart
@@ -2460,8 +2460,11 @@ void main() {
       inboundConnection.metadata.isAuthenticated = true;
       castMetadata(inboundConnection).enrollmentId = '123';
 
-      DeleteVerbHandler deleteVerbHandler =
-          DeleteVerbHandler(secondaryKeyStore, statsNotificationService);
+      DeleteVerbHandler deleteVerbHandler = DeleteVerbHandler(
+        secondaryKeyStore,
+        statsNotificationService,
+        notificationManager,
+      );
 
       expect(
           () async => await deleteVerbHandler.process(

--- a/packages/at_secondary_server/test/from_verb_test.dart
+++ b/packages/at_secondary_server/test/from_verb_test.dart
@@ -10,7 +10,6 @@ import 'package:at_secondary/src/utils/handler_util.dart';
 import 'package:at_secondary/src/utils/secondary_util.dart';
 import 'package:at_secondary/src/verb/handler/from_verb_handler.dart';
 import 'package:at_server_spec/at_verb_spec.dart';
-import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 import 'test_utils.dart';
 
@@ -25,7 +24,7 @@ void main() async {
   setUp(() async {
     mockKeyStore = MockSecondaryKeyStore();
     mockSocket = FakeSocket();
-        keyStoreManager = await setUpFunc(storageDir);
+    keyStoreManager = await setUpFunc(storageDir);
   });
   group('A group of from verb regex test', () {
     test('test from correct syntax with @', () {

--- a/packages/at_secondary_server/test/from_verb_test.dart
+++ b/packages/at_secondary_server/test/from_verb_test.dart
@@ -16,7 +16,7 @@ import 'test_utils.dart';
 
 void main() async {
   late SecondaryKeyStore mockKeyStore;
-  late MockSocket mockSocket;
+  late FakeSocket mockSocket;
 
   verbTestsSetUpLogging();
 
@@ -24,10 +24,8 @@ void main() async {
   late SecondaryKeyStoreManager keyStoreManager;
   setUp(() async {
     mockKeyStore = MockSecondaryKeyStore();
-    mockSocket = MockSocket();
-    when(() => mockSocket.setOption(SocketOption.tcpNoDelay, true))
-        .thenReturn(true);
-    keyStoreManager = await setUpFunc(storageDir);
+    mockSocket = FakeSocket();
+        keyStoreManager = await setUpFunc(storageDir);
   });
   group('A group of from verb regex test', () {
     test('test from correct syntax with @', () {

--- a/packages/at_secondary_server/test/inbound_connection_impl_test.dart
+++ b/packages/at_secondary_server/test/inbound_connection_impl_test.dart
@@ -1,8 +1,5 @@
-import 'dart:io';
-
 import 'package:at_secondary/src/connection/inbound/inbound_connection_impl.dart';
 import 'package:at_server_spec/at_server_spec.dart';
-import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
 import 'test_utils.dart';
@@ -14,7 +11,7 @@ void main() async {
 
   setUp(() async {
     mockSocket = FakeSocket();
-      });
+  });
 
   group('A test to verify the rate limiter on inbound connection', () {
     test('A test to verify requests exceeding the limit are rejected', () {

--- a/packages/at_secondary_server/test/inbound_connection_impl_test.dart
+++ b/packages/at_secondary_server/test/inbound_connection_impl_test.dart
@@ -8,15 +8,13 @@ import 'package:test/test.dart';
 import 'test_utils.dart';
 
 void main() async {
-  late MockSocket mockSocket;
+  late FakeSocket mockSocket;
 
   verbTestsSetUpLogging();
 
   setUp(() async {
-    mockSocket = MockSocket();
-    when(() => mockSocket.setOption(SocketOption.tcpNoDelay, true))
-        .thenReturn(true);
-  });
+    mockSocket = FakeSocket();
+      });
 
   group('A test to verify the rate limiter on inbound connection', () {
     test('A test to verify requests exceeding the limit are rejected', () {

--- a/packages/at_secondary_server/test/inbound_connection_manager_test.dart
+++ b/packages/at_secondary_server/test/inbound_connection_manager_test.dart
@@ -12,7 +12,7 @@ import 'test_utils.dart';
 void main() {
   verbTestsSetUpLogging();
 
-  late MockSocket mockSocket;
+  late FakeSocket mockSocket;
 
   late InboundConnectionManager icm;
 
@@ -21,10 +21,8 @@ void main() {
       ..unauthenticatedInboundIdleTimeMillis = 10000;
     atServer.inboundConnectionManager = icm = InboundConnectionManager(
         serverAtSign: alice, poolSize: AtSecondaryConfig.inbound_max_limit);
-    mockSocket = MockSocket();
-    when(() => mockSocket.setOption(SocketOption.tcpNoDelay, true))
-        .thenReturn(true);
-  });
+    mockSocket = FakeSocket();
+      });
 
   tearDown(() {
     atServer.inboundConnectionManager.close();

--- a/packages/at_secondary_server/test/inbound_connection_manager_test.dart
+++ b/packages/at_secondary_server/test/inbound_connection_manager_test.dart
@@ -1,10 +1,7 @@
-import 'dart:io';
-
 import 'package:at_commons/at_commons.dart';
 import 'package:at_secondary/src/connection/inbound/inbound_connection_manager.dart';
 import 'package:at_secondary/src/server/at_secondary_config.dart';
 import 'package:at_secondary/src/server/server_context.dart';
-import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
 import 'test_utils.dart';
@@ -22,7 +19,7 @@ void main() {
     atServer.inboundConnectionManager = icm = InboundConnectionManager(
         serverAtSign: alice, poolSize: AtSecondaryConfig.inbound_max_limit);
     mockSocket = FakeSocket();
-      });
+  });
 
   tearDown(() {
     atServer.inboundConnectionManager.close();

--- a/packages/at_secondary_server/test/inbound_connection_pool_test.dart
+++ b/packages/at_secondary_server/test/inbound_connection_pool_test.dart
@@ -18,7 +18,7 @@ var serverContext = AtSecondaryContext();
 AtSignLogger logger = AtSignLogger('inbound_connection_pool_test');
 
 void main() async {
-  late MockSocket mockSocket;
+  late FakeSocket mockSocket;
 
   verbTestsSetUpLogging();
 
@@ -36,10 +36,8 @@ void main() async {
     pool = atServer.inboundConnectionManager.pool;
     pool.resize(10);
 
-    mockSocket = MockSocket();
-    when(() => mockSocket.setOption(SocketOption.tcpNoDelay, true))
-        .thenReturn(true);
-  });
+    mockSocket = FakeSocket();
+      });
   tearDown(() {
     pool.clearAllConnections();
   });

--- a/packages/at_secondary_server/test/inbound_connection_pool_test.dart
+++ b/packages/at_secondary_server/test/inbound_connection_pool_test.dart
@@ -7,7 +7,6 @@ import 'package:at_secondary/src/connection/inbound/inbound_connection_pool.dart
 import 'package:at_secondary/src/server/at_secondary_config.dart';
 import 'package:at_secondary/src/server/server_context.dart';
 import 'package:at_server_spec/at_server_spec.dart';
-import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 import 'package:at_utils/at_utils.dart';
 
@@ -37,7 +36,7 @@ void main() async {
     pool.resize(10);
 
     mockSocket = FakeSocket();
-      });
+  });
   tearDown(() {
     pool.clearAllConnections();
   });

--- a/packages/at_secondary_server/test/local_lookup_verb_test.dart
+++ b/packages/at_secondary_server/test/local_lookup_verb_test.dart
@@ -4,7 +4,6 @@ import 'dart:convert';
 import 'package:at_commons/at_commons.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:at_secondary/src/connection/inbound/dummy_inbound_connection.dart';
-import 'package:at_secondary/src/notification/notification_manager_impl.dart';
 import 'package:at_secondary/src/notification/stats_notification_service.dart';
 import 'package:at_secondary/src/server/at_secondary_impl.dart';
 import 'package:at_secondary/src/utils/handler_util.dart';
@@ -182,7 +181,7 @@ void main() {
       var updateVerbHandler = UpdateVerbHandler(
         secondaryKeyStore,
         StatsNotificationService.getInstance(),
-        NotificationManager.getInstance(),
+        notificationManager,
         alice,
       );
       var updateVerbParams = HashMap<String, String>();
@@ -236,7 +235,7 @@ void main() {
       var updateVerbHandler = UpdateVerbHandler(
         secondaryKeyStore,
         StatsNotificationService.getInstance(),
-        NotificationManager.getInstance(),
+        notificationManager,
         alice,
       );
       var updateVerbParams = HashMap<String, String>();

--- a/packages/at_secondary_server/test/notify_list_verb_test.dart
+++ b/packages/at_secondary_server/test/notify_list_verb_test.dart
@@ -20,14 +20,12 @@ import 'test_utils.dart';
 void main() async {
   SecondaryKeyStore mockKeyStore = MockSecondaryKeyStore();
   OutboundClientManager mockOutboundClientManager = MockOutboundClientManager();
-  MockSocket mockSocket = MockSocket();
+  FakeSocket mockSocket = FakeSocket();
 
   verbTestsSetUpLogging();
 
   setUpAll(() {
-    when(() => mockSocket.setOption(SocketOption.tcpNoDelay, true))
-        .thenReturn(true);
-  });
+      });
 
   var storageDir = '${Directory.current.path}/test/hive';
   late SecondaryKeyStoreManager keyStoreManager;

--- a/packages/at_secondary_server/test/notify_list_verb_test.dart
+++ b/packages/at_secondary_server/test/notify_list_verb_test.dart
@@ -13,7 +13,6 @@ import 'package:at_secondary/src/verb/handler/notify_list_verb_handler.dart';
 import 'package:at_server_spec/at_server_spec.dart';
 import 'package:at_server_spec/at_verb_spec.dart';
 import 'package:test/test.dart';
-import 'package:mocktail/mocktail.dart';
 
 import 'test_utils.dart';
 
@@ -24,8 +23,7 @@ void main() async {
 
   verbTestsSetUpLogging();
 
-  setUpAll(() {
-      });
+  setUpAll(() {});
 
   var storageDir = '${Directory.current.path}/test/hive';
   late SecondaryKeyStoreManager keyStoreManager;

--- a/packages/at_secondary_server/test/notify_remove_test.dart
+++ b/packages/at_secondary_server/test/notify_remove_test.dart
@@ -1,44 +1,28 @@
-import 'dart:io';
-
 import 'package:at_commons/at_commons.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:at_secondary/src/connection/inbound/inbound_connection_impl.dart';
 import 'package:at_secondary/src/connection/inbound/inbound_connection_metadata.dart';
-import 'package:at_secondary/src/connection/outbound/outbound_client_manager.dart';
-import 'package:at_secondary/src/notification/at_notification_map.dart';
 import 'package:at_secondary/src/utils/handler_util.dart';
 import 'package:at_secondary/src/verb/handler/notify_list_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/notify_remove_verb_handler.dart';
 import 'package:at_server_spec/verbs.dart';
-import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
 import 'test_utils.dart';
 
 void main() {
-  SecondaryKeyStore mockKeyStore = MockSecondaryKeyStore();
-  OutboundClientManager mockOutboundClientManager = MockOutboundClientManager();
-  MockSocket mockSocket = MockSocket();
+  setUp(() async => await verbTestsSetUp());
+  tearDown(() async => await verbTestsTearDown());
 
-  verbTestsSetUpLogging();
-
-  setUpAll(() {
-    when(() => mockSocket.setOption(SocketOption.tcpNoDelay, true))
-        .thenReturn(true);
-  });
-
-  var storageDir = '${Directory.current.path}/test/hive';
-  late SecondaryKeyStoreManager keyStoreManager;
   group('A group of test to verify NotifyDeleteVerb', () {
     test('Test to verify notify delete getVerb', () {
-      var handler = NotifyRemoveVerbHandler(mockKeyStore);
+      var handler = NotifyRemoveVerbHandler(secondaryKeyStore, notificationManager);
       var verb = handler.getVerb();
       expect(verb is NotifyRemove, true);
     });
   });
 
   group('A group of hive tests to verify notify delete', () {
-    setUp(() async => keyStoreManager = await setUpFunc(storageDir));
     test('A test to verify notify remove', () async {
       // Notification Object
       var notificationObj = (AtNotificationBuilder()
@@ -52,21 +36,24 @@ void main() {
       await AtNotificationKeystore.getInstance().put('122', notificationObj);
 
       // Dummy Inbound connection
-      var atConnection = InboundConnectionImpl(mockSocket, '123')
+      var atConnection = InboundConnectionImpl(FakeSocket(), '123')
         ..metaData = (InboundConnectionMetadata()
           ..fromAtSign = alice
           ..isAuthenticated = true);
       var response = Response();
       // Verify Notification is inserted into keystore
       var notifyListVerbHandler = NotifyListVerbHandler(
-          keyStoreManager.getKeyStore(), mockOutboundClientManager);
+          secondaryKeyStore, mockOutboundClientManager);
       var notifyListParams = getVerbParam(NotifyList().syntax(), 'notify:list');
       await notifyListVerbHandler.processVerb(
           response, notifyListParams, atConnection);
 
       //Notify delete verb handler
-      var notifyDeleteHandler =
-          NotifyRemoveVerbHandler(keyStoreManager.getKeyStore());
+      var notifyDeleteHandler = NotifyRemoveVerbHandler(
+        secondaryKeyStore,
+        notificationManager,
+      );
+
       await notifyDeleteHandler.processVerb(
           response,
           getVerbParam(NotifyRemove().syntax(), 'notify:remove:122'),
@@ -78,35 +65,5 @@ void main() {
           response, notifyListParams, atConnection);
       expect(response.data, null);
     });
-    tearDown(() async => await tearDownFunc());
   });
-}
-
-Future<SecondaryKeyStoreManager> setUpFunc(storageDir, {String? atsign}) async {
-  var secondaryPersistenceStore = SecondaryPersistenceStoreFactory.getInstance()
-      .getSecondaryPersistenceStore(atsign ?? '@test_user_1')!;
-  var persistenceManager =
-      secondaryPersistenceStore.getHivePersistenceManager()!;
-  await persistenceManager.init(storageDir);
-//  persistenceManager.scheduleKeyExpireTask(1); //commented this line for coverage test
-  var hiveKeyStore = secondaryPersistenceStore.getSecondaryKeyStore()!;
-  var keyStoreManager =
-      secondaryPersistenceStore.getSecondaryKeyStoreManager()!;
-  keyStoreManager.keyStore = hiveKeyStore;
-  hiveKeyStore.commitLog = await AtCommitLogManagerImpl.getInstance()
-      .getCommitLog(atsign ?? '@test_user_1', commitLogPath: storageDir);
-  await AtAccessLogManagerImpl.getInstance()
-      .getAccessLog(atsign ?? '@test_user_1', accessLogPath: storageDir);
-  var notificationInstance = AtNotificationKeystore.getInstance();
-  notificationInstance.currentAtSign = atsign ?? '@test_user_1';
-  await notificationInstance.init(storageDir);
-  return keyStoreManager;
-}
-
-Future<void> tearDownFunc() async {
-  var isExists = await Directory('test/hive').exists();
-  AtNotificationMap.getInstance().clear();
-  if (isExists) {
-    Directory('test/hive').deleteSync(recursive: true);
-  }
 }

--- a/packages/at_secondary_server/test/notify_remove_test.dart
+++ b/packages/at_secondary_server/test/notify_remove_test.dart
@@ -16,7 +16,8 @@ void main() {
 
   group('A group of test to verify NotifyDeleteVerb', () {
     test('Test to verify notify delete getVerb', () {
-      var handler = NotifyRemoveVerbHandler(secondaryKeyStore, notificationManager);
+      var handler =
+          NotifyRemoveVerbHandler(secondaryKeyStore, notificationManager);
       var verb = handler.getVerb();
       expect(verb is NotifyRemove, true);
     });
@@ -42,8 +43,8 @@ void main() {
           ..isAuthenticated = true);
       var response = Response();
       // Verify Notification is inserted into keystore
-      var notifyListVerbHandler = NotifyListVerbHandler(
-          secondaryKeyStore, mockOutboundClientManager);
+      var notifyListVerbHandler =
+          NotifyListVerbHandler(secondaryKeyStore, mockOutboundClientManager);
       var notifyListParams = getVerbParam(NotifyList().syntax(), 'notify:list');
       await notifyListVerbHandler.processVerb(
           response, notifyListParams, atConnection);

--- a/packages/at_secondary_server/test/notify_verb_test.dart
+++ b/packages/at_secondary_server/test/notify_verb_test.dart
@@ -1,6 +1,5 @@
 import 'dart:collection';
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:at_commons/at_commons.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
@@ -10,6 +9,7 @@ import 'package:at_secondary/src/connection/inbound/inbound_connection_metadata.
 import 'package:at_secondary/src/connection/outbound/outbound_client_manager.dart';
 import 'package:at_secondary/src/enroll/enrollment_manager.dart';
 import 'package:at_secondary/src/notification/at_notification_map.dart';
+import 'package:at_secondary/src/notification/notification_manager_impl.dart';
 import 'package:at_secondary/src/notification/queue_manager.dart';
 import 'package:at_secondary/src/server/at_secondary_config.dart';
 import 'package:at_secondary/src/server/at_secondary_impl.dart';
@@ -24,6 +24,7 @@ import 'package:at_secondary/src/verb/handler/notify_list_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/notify_remove_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/notify_status_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/notify_verb_handler.dart';
+import 'package:at_server_spec/at_server_spec.dart';
 import 'package:at_server_spec/at_verb_spec.dart';
 import 'package:crypto/crypto.dart';
 import 'package:crypton/crypton.dart';
@@ -36,17 +37,14 @@ import 'test_utils.dart';
 void main() {
   SecondaryKeyStore mockKeyStore = MockSecondaryKeyStore();
   OutboundClientManager mockOutboundClientManager = MockOutboundClientManager();
-  MockSocket mockSocket = MockSocket();
+  FakeSocket mockSocket = FakeSocket();
+  NotificationManager mockNotificationManager = MockNotificationManager();
 
   verbTestsSetUpLogging();
 
-  setUpAll(() {
-    when(() => mockSocket.setOption(SocketOption.tcpNoDelay, true))
-        .thenReturn(true);
+  setUpAll(() async {
+    await verbTestsSetUpAll();
   });
-
-  var storageDir = '${Directory.current.path}/test/hive';
-  late SecondaryKeyStoreManager keyStoreManager;
 
   group('A group of notify verb regex test', () {
     test('test notify for self atsign', () {
@@ -74,35 +72,35 @@ void main() {
     AtSecondaryServerImpl.getInstance().currentAtSign = alice;
     test('test notify command accept test', () {
       var command = 'notify:@colin:location@colin';
-      var handler = NotifyVerbHandler(mockKeyStore);
+      var handler = NotifyVerbHandler(mockKeyStore, mockNotificationManager);
       var result = handler.accept(command);
       expect(result, true);
     });
 
     test('test notify command accept test for different atsign', () {
       var command = 'notify:@bob:location@colin';
-      var handler = NotifyVerbHandler(mockKeyStore);
+      var handler = NotifyVerbHandler(mockKeyStore, mockNotificationManager);
       var result = handler.accept(command);
       expect(result, true);
     });
 
     test('test notify command accept negative test without WhomToNotify', () {
       var command = 'notify location@colin';
-      var handler = NotifyVerbHandler(mockKeyStore);
+      var handler = NotifyVerbHandler(mockKeyStore, mockNotificationManager);
       var result = handler.accept(command);
       expect(result, false);
     });
 
     test('test notify command accept negative test without from AtSign', () {
       var command = 'notify:@colin:location';
-      var handler = NotifyVerbHandler(mockKeyStore);
+      var handler = NotifyVerbHandler(mockKeyStore, mockNotificationManager);
       var result = handler.accept(command);
       expect(result, true);
     });
 
     test('test notify command accept negative test without what to notify', () {
       var command = 'notify:@bob:@colin';
-      var handler = NotifyVerbHandler(mockKeyStore);
+      var handler = NotifyVerbHandler(mockKeyStore, mockNotificationManager);
       var result = handler.accept(command);
       expect(result, true);
     });
@@ -111,7 +109,7 @@ void main() {
         'test to verify unauthorized exception is thrown when sharedBy atSign is not currentAtSign',
         () {
       AtSecondaryServerImpl.getInstance().currentAtSign = alice;
-      var notifyVerb = NotifyVerbHandler(mockKeyStore);
+      var notifyVerb = NotifyVerbHandler(mockKeyStore, mockNotificationManager);
       var inboundConnection = InboundConnectionImpl(mockSocket, '123');
       inboundConnection.metaData = InboundConnectionMetadata()
         ..isAuthenticated = true;
@@ -180,7 +178,7 @@ void main() {
 
     test('test notify verb - invalid ttl value', () {
       AtSecondaryServerImpl.getInstance().currentAtSign = alice;
-      var notifyVerb = NotifyVerbHandler(mockKeyStore);
+      var notifyVerb = NotifyVerbHandler(mockKeyStore, mockNotificationManager);
       var inboundConnection = InboundConnectionImpl(mockSocket, '123');
       inboundConnection.metaData = InboundConnectionMetadata()
         ..isAuthenticated = true;
@@ -199,7 +197,7 @@ void main() {
 
     test('test notify verb - invalid ttb value', () {
       AtSecondaryServerImpl.getInstance().currentAtSign = alice;
-      var notifyVerb = NotifyVerbHandler(mockKeyStore);
+      var notifyVerb = NotifyVerbHandler(mockKeyStore, mockNotificationManager);
       var inboundConnection = InboundConnectionImpl(mockSocket, '123');
       inboundConnection.metaData = InboundConnectionMetadata()
         ..isAuthenticated = true;
@@ -217,7 +215,7 @@ void main() {
 
     test('test notify verb - ttr = -2 invalid value ', () {
       AtSecondaryServerImpl.getInstance().currentAtSign = alice;
-      var notifyVerb = NotifyVerbHandler(mockKeyStore);
+      var notifyVerb = NotifyVerbHandler(mockKeyStore, mockNotificationManager);
       var inboundConnection = InboundConnectionImpl(mockSocket, '123');
       inboundConnection.metaData = InboundConnectionMetadata()
         ..isAuthenticated = true;
@@ -235,14 +233,16 @@ void main() {
 
     test('test notify key- invalid command', () {
       var command = 'notify:location$alice';
-      AbstractVerbHandler handler = NotifyVerbHandler(mockKeyStore);
+      AbstractVerbHandler handler =
+          NotifyVerbHandler(mockKeyStore, mockNotificationManager);
       expect(() => handler.parse(command),
           throwsA(predicate((dynamic e) => e is InvalidSyntaxException)));
     });
 
     test('test notify key- invalid ccd value', () {
       var command = 'notify:update:ttr:1000:ccd:test:location$alice';
-      AbstractVerbHandler handler = NotifyVerbHandler(mockKeyStore);
+      AbstractVerbHandler handler =
+          NotifyVerbHandler(mockKeyStore, mockNotificationManager);
       expect(() => handler.parse(command),
           throwsA(predicate((dynamic e) => e is InvalidSyntaxException)));
     });
@@ -259,7 +259,8 @@ void main() {
       var command = 'notify:update:messagetype:text:@bob:hello';
       var regex = verb.syntax();
 
-      var notifyVerbHandler = NotifyVerbHandler(mockKeyStore);
+      var notifyVerbHandler =
+          NotifyVerbHandler(mockKeyStore, mockNotificationManager);
       var notifyResponse = Response();
       var notifyVerbParams = getVerbParam(regex, command);
       expect(
@@ -327,103 +328,62 @@ void main() {
   });
 
   group('A group of hive related test cases', () {
-    setUp(() async => keyStoreManager = await setUpFunc(storageDir));
+    setUp(() async => await verbTestsSetUp());
+    tearDown(() async => await verbTestsTearDown());
+
     test('test notify handler with update operation', () async {
-      SecondaryKeyStore keyStore = keyStoreManager.getKeyStore();
-      var secretData = AtData();
-      secretData.data =
-          'b26455a907582760ebf35bc4847de549bc41c24b25c8b1c58d5964f7b4f8a43bc55b0e9a601c9a9657d9a8b8bbc32f88b4e38ffaca03c8710ebae1b14ca9f364';
-      await keyStore.put('privatekey:at_secret', secretData);
-      var fromVerbHandler = FromVerbHandler(keyStoreManager.getKeyStore());
-      AtSecondaryServerImpl.getInstance().currentAtSign = '@test_user_1';
-      var inBoundSessionId = '_6665436c-29ff-481b-8dc6-129e89199718';
-      var atConnection = InboundConnectionImpl(mockSocket, inBoundSessionId);
-      var fromVerbParams = HashMap<String, String>();
-      fromVerbParams.putIfAbsent('atSign', () => 'test_user_1');
-      var response = Response();
-      await fromVerbHandler.processVerb(response, fromVerbParams, atConnection);
-      var fromResponse = response.data!.replaceFirst(RegExp('^data:'), '');
-      var cramVerbParams = HashMap<String, String>();
-      var combo = '${secretData.data}$fromResponse';
-      var bytes = utf8.encode(combo);
-      var digest = sha512.convert(bytes);
-      cramVerbParams.putIfAbsent('digest', () => digest.toString());
-      var cramVerbHandler = CramVerbHandler(keyStoreManager.getKeyStore());
-      var cramResponse = Response();
-      await cramVerbHandler.processVerb(
-          cramResponse, cramVerbParams, atConnection);
-      var connectionMetadata =
-          atConnection.metaData as InboundConnectionMetadata;
-      expect(connectionMetadata.isAuthenticated, true);
-      expect(cramResponse.data, 'success');
+      DummyInboundConnection atConnection = DummyInboundConnection();
+      atConnection.metaData.fromAtSign = alice;
+      atConnection.metaData.isAuthenticated = true;
+
       //Notify Verb
-      var notifyVerbHandler = NotifyVerbHandler(keyStore);
+      var notifyVerbHandler =
+          NotifyVerbHandler(secondaryKeyStore, notificationManager);
       var notifyResponse = Response();
       var notifyVerbParams = HashMap<String, String>();
       notifyVerbParams.putIfAbsent('operation', () => 'update');
-      notifyVerbParams.putIfAbsent('forAtSign', () => '@test_user_1');
-      notifyVerbParams.putIfAbsent('atSign', () => '@test_user_1');
+      notifyVerbParams.putIfAbsent('forAtSign', () => alice);
+      notifyVerbParams.putIfAbsent('atSign', () => alice);
       notifyVerbParams.putIfAbsent('atKey', () => 'phone');
       await notifyVerbHandler.processVerb(
           notifyResponse, notifyVerbParams, atConnection);
+
       //Notify list verb handler
       var notifyListVerbHandler =
-          NotifyListVerbHandler(keyStore, mockOutboundClientManager);
+          NotifyListVerbHandler(secondaryKeyStore, mockOutboundClientManager);
       var notifyListResponse = Response();
       var notifyListVerbParams = HashMap<String, String>();
-      connectionMetadata.fromAtSign = '@test_user_1';
       await notifyListVerbHandler.processVerb(
           notifyListResponse, notifyListVerbParams, atConnection);
       var notifyData = jsonDecode(notifyListResponse.data!);
       assert(notifyData[0][AtConstants.id] != null);
       assert(notifyData[0][AtConstants.epochMilliseconds] != null);
-      expect(notifyData[0][AtConstants.to], '@test_user_1');
-      expect(notifyData[0][AtConstants.key], '@test_user_1:phone@test_user_1');
+      expect(notifyData[0][AtConstants.to], alice);
+      expect(notifyData[0][AtConstants.key], '$alice:phone$alice');
       expect(notifyData[0][AtConstants.operation], 'update');
     });
 
     test('test notify handler with delete operation', () async {
-      SecondaryKeyStore keyStore = keyStoreManager.getKeyStore();
-      var secretData = AtData();
-      secretData.data =
-          'b26455a907582760ebf35bc4847de549bc41c24b25c8b1c58d5964f7b4f8a43bc55b0e9a601c9a9657d9a8b8bbc32f88b4e38ffaca03c8710ebae1b14ca9f364';
-      await keyStore.put('privatekey:at_secret', secretData);
-      var fromVerbHandler = FromVerbHandler(keyStoreManager.getKeyStore());
-      AtSecondaryServerImpl.getInstance().currentAtSign = '@test_user_1';
-      var inBoundSessionId = '_6665436c-29ff-481b-8dc6-129e89199718';
-      var atConnection = InboundConnectionImpl(mockSocket, inBoundSessionId);
-      var fromVerbParams = HashMap<String, String>();
-      fromVerbParams.putIfAbsent('atSign', () => 'test_user_1');
-      var response = Response();
-      await fromVerbHandler.processVerb(response, fromVerbParams, atConnection);
-      var fromResponse = response.data!.replaceFirst(RegExp('^data:'), '');
-      var cramVerbParams = HashMap<String, String>();
-      var combo = '${secretData.data}$fromResponse';
-      var bytes = utf8.encode(combo);
-      var digest = sha512.convert(bytes);
-      cramVerbParams.putIfAbsent('digest', () => digest.toString());
-      var cramVerbHandler = CramVerbHandler(keyStoreManager.getKeyStore());
-      var cramResponse = Response();
-      await cramVerbHandler.processVerb(
-          cramResponse, cramVerbParams, atConnection);
-      var connectionMetadata =
-          atConnection.metaData as InboundConnectionMetadata;
-      expect(connectionMetadata.isAuthenticated, true);
-      expect(cramResponse.data, 'success');
+      DummyInboundConnection atConnection = DummyInboundConnection();
+      atConnection.metaData.fromAtSign = alice;
+      atConnection.metaData.isAuthenticated = true;
+
       //Notify Verb
-      var notifyVerbHandler = NotifyVerbHandler(keyStore);
+      var notifyVerbHandler =
+          NotifyVerbHandler(secondaryKeyStore, notificationManager);
       var notifyResponse = Response();
-      var notifyVerbParams = HashMap<String, String>();
-      notifyVerbParams.putIfAbsent('operation', () => 'delete');
-      notifyVerbParams.putIfAbsent('forAtSign', () => '@test_user_1');
-      notifyVerbParams.putIfAbsent('atSign', () => '@test_user_1');
-      connectionMetadata.fromAtSign = '@test_user_1';
-      notifyVerbParams.putIfAbsent('atKey', () => 'phone');
+
+      var notifyVerbParams = HashMap<String, String>.from({
+        'operation':'delete',
+        'forAtSign':alice,
+        'atSign':alice,
+        'atKey':'phone',
+      });
       await notifyVerbHandler.processVerb(
           notifyResponse, notifyVerbParams, atConnection);
       //Notify list verb handler
       var notifyListVerbHandler =
-          NotifyListVerbHandler(keyStore, mockOutboundClientManager);
+          NotifyListVerbHandler(secondaryKeyStore, mockOutboundClientManager);
       var notifyListResponse = Response();
       var notifyListVerbParams = HashMap<String, String>();
       await notifyListVerbHandler.processVerb(
@@ -431,8 +391,8 @@ void main() {
       var notifyData = jsonDecode(notifyListResponse.data!);
       assert(notifyData[0][AtConstants.id] != null);
       assert(notifyData[0][AtConstants.epochMilliseconds] != null);
-      expect(notifyData[0][AtConstants.to], '@test_user_1');
-      expect(notifyData[0][AtConstants.key], '@test_user_1:phone@test_user_1');
+      expect(notifyData[0][AtConstants.to], alice);
+      expect(notifyData[0][AtConstants.key], '$alice:phone$alice');
       expect(notifyData[0][AtConstants.operation], 'delete');
     });
 
@@ -441,7 +401,6 @@ void main() {
         () async {
       var verb = Notify();
       AtSecondaryServerImpl.getInstance().currentAtSign = alice;
-      SecondaryKeyStore keyStore = keyStoreManager.getKeyStore();
 
       var inBoundSessionId = '_6665436c-29ff-481b-8dc6-129e89199718';
       var atConnection = InboundConnectionImpl(mockSocket, inBoundSessionId);
@@ -450,7 +409,8 @@ void main() {
       var command = 'notify:update:messagetype:text:@bob:hello';
       var regex = verb.syntax();
 
-      var notifyVerbHandler = NotifyVerbHandler(keyStore);
+      var notifyVerbHandler =
+          NotifyVerbHandler(secondaryKeyStore, notificationManager);
       var notifyResponse = Response();
       var notifyVerbParams = getVerbParam(regex, command);
       await notifyVerbHandler.processVerb(
@@ -464,9 +424,9 @@ void main() {
       expect(atNotification?.type, NotificationType.sent);
     });
     test('test for max key length check for cached key', () async {
-      SecondaryKeyStore keyStore = keyStoreManager.getKeyStore();
       AtSecondaryServerImpl.getInstance().currentAtSign = alice;
-      var notifyVerb = NotifyVerbHandler(keyStore);
+      var notifyVerb =
+          NotifyVerbHandler(secondaryKeyStore, notificationManager);
       var inboundConnection = InboundConnectionImpl(mockSocket, '123');
       inboundConnection.metaData = InboundConnectionMetadata()
         ..isPolAuthenticated = true
@@ -486,19 +446,21 @@ void main() {
               e.message ==
                   'notification key length ${'cached:'.length + '@bob:'.length + key.length + alice.length} is greater than 255 chars')));
     });
-    tearDown(() async => await tearDownFunc());
   });
 
+  Atsign testUser1 = '@test_user_1';
+
   group('A group of notify verb test', () {
-    setUp(() async => await setUpFunc(storageDir));
+    setUp(() async => await verbTestsSetUp());
+    tearDown(() async => await verbTestsTearDown());
     test(
         'A test case to verify enqueuing error notifications increments retry count',
         () async {
       var atNotification1 = (AtNotificationBuilder()
             ..id = 'abc'
-            ..fromAtSign = '@test_user_1'
+            ..fromAtSign = alice
             ..notificationDateTime = DateTime.now()
-            ..toAtSign = alice
+            ..toAtSign = testUser1
             ..notification = 'key-1'
             ..type = NotificationType.sent
             ..opType = OperationType.update
@@ -510,19 +472,18 @@ void main() {
           .build();
       var queueManager = QueueManager.getInstance();
       queueManager.enqueue(atNotification1);
-      var response = queueManager.dequeue(alice);
+      var response = queueManager.dequeue(testUser1);
       late AtNotification atNotification;
       if (response.moveNext()) {
         atNotification = response.current;
       }
       expect(atNotification.id, 'abc');
-      expect(atNotification.fromAtSign, '@test_user_1');
-      expect(atNotification.toAtSign, alice);
+      expect(atNotification.fromAtSign, alice);
+      expect(atNotification.toAtSign, testUser1);
       expect(atNotification.priority, NotificationPriority.low);
       expect(atNotification.notification, 'key-1');
       expect(atNotification.retryCount, 1);
     });
-    tearDown(() async => await tearDownFunc());
   });
 
   group('A group of tests to compute notifications wait time', () {
@@ -531,10 +492,10 @@ void main() {
         () {
       var atNotification1 = (AtNotificationBuilder()
             ..id = '123'
-            ..fromAtSign = '@test_user_1'
+            ..fromAtSign = alice
             ..notificationDateTime =
                 DateTime.now().subtract(Duration(minutes: 4))
-            ..toAtSign = '@bob'
+            ..toAtSign = bob
             ..notification = 'key-1'
             ..type = NotificationType.sent
             ..opType = OperationType.update
@@ -550,10 +511,10 @@ void main() {
 
       var atNotification2 = (AtNotificationBuilder()
             ..id = '124'
-            ..fromAtSign = '@test_user_1'
+            ..fromAtSign = alice
             ..notificationDateTime =
                 DateTime.now().subtract(Duration(minutes: 4))
-            ..toAtSign = alice
+            ..toAtSign = testUser1
             ..notification = 'key-2'
             ..type = NotificationType.sent
             ..opType = OperationType.update
@@ -572,7 +533,7 @@ void main() {
       notificationMap.add(atNotification2);
       var atsignIterator = AtNotificationMap.getInstance().getAtSignToNotify(1);
       while (atsignIterator.moveNext()) {
-        expect(atsignIterator.current, alice);
+        expect(atsignIterator.current, testUser1);
       }
       AtNotificationMap.getInstance().clear();
     });
@@ -582,7 +543,7 @@ void main() {
         () {
       var atNotification1 = (AtNotificationBuilder()
             ..id = '123'
-            ..fromAtSign = '@test_user_1'
+            ..fromAtSign = alice
             ..notificationDateTime =
                 DateTime.now().subtract(Duration(minutes: 10))
             ..toAtSign = '@bob'
@@ -601,10 +562,10 @@ void main() {
 
       var atNotification2 = (AtNotificationBuilder()
             ..id = '123'
-            ..fromAtSign = '@test_user_1'
+            ..fromAtSign = alice
             ..notificationDateTime =
                 DateTime.now().subtract(Duration(minutes: 1))
-            ..toAtSign = alice
+            ..toAtSign = testUser1
             ..notification = 'key-2'
             ..type = NotificationType.sent
             ..opType = OperationType.update
@@ -634,7 +595,7 @@ void main() {
         () {
       var atNotification1 = (AtNotificationBuilder()
             ..id = '123'
-            ..fromAtSign = '@test_user_1'
+            ..fromAtSign = alice
             ..notificationDateTime =
                 DateTime.now().subtract(Duration(minutes: 1))
             ..toAtSign = '@bob'
@@ -653,7 +614,7 @@ void main() {
 
       var atNotification2 = (AtNotificationBuilder()
             ..id = '124'
-            ..fromAtSign = '@test_user_1'
+            ..fromAtSign = alice
             ..notificationDateTime =
                 DateTime.now().subtract(Duration(minutes: 2))
             ..toAtSign = '@bob'
@@ -692,7 +653,7 @@ void main() {
     test('A test case to verify only the latest notification is stored', () {
       var atNotification1 = (AtNotificationBuilder()
             ..id = '123'
-            ..fromAtSign = '@test_user_1'
+            ..fromAtSign = alice
             ..notificationDateTime = DateTime.now()
             ..toAtSign = '@bob'
             ..notification = 'key-1'
@@ -710,7 +671,7 @@ void main() {
 
       var atNotification2 = (AtNotificationBuilder()
             ..id = '124'
-            ..fromAtSign = '@test_user_1'
+            ..fromAtSign = alice
             ..notificationDateTime = DateTime.now()
             ..toAtSign = '@bob'
             ..notification = 'key-2'
@@ -746,7 +707,7 @@ void main() {
     test('When latest N, when N = 2', () {
       var atNotification1 = (AtNotificationBuilder()
             ..id = '123'
-            ..fromAtSign = '@test_user_1'
+            ..fromAtSign = alice
             ..notificationDateTime =
                 DateTime.now().subtract(Duration(seconds: 3))
             ..toAtSign = '@bob'
@@ -765,7 +726,7 @@ void main() {
 
       var atNotification2 = (AtNotificationBuilder()
             ..id = '124'
-            ..fromAtSign = '@test_user_1'
+            ..fromAtSign = alice
             ..notificationDateTime =
                 DateTime.now().subtract(Duration(seconds: 2))
             ..toAtSign = '@bob'
@@ -784,7 +745,7 @@ void main() {
 
       var atNotification3 = (AtNotificationBuilder()
             ..id = '125'
-            ..fromAtSign = '@test_user_1'
+            ..fromAtSign = alice
             ..notificationDateTime =
                 DateTime.now().subtract(Duration(seconds: 1))
             ..toAtSign = '@bob'
@@ -825,7 +786,7 @@ void main() {
         () {
       var atNotification1 = (AtNotificationBuilder()
             ..id = '123'
-            ..fromAtSign = '@test_user_1'
+            ..fromAtSign = alice
             ..notificationDateTime =
                 DateTime.now().subtract(Duration(seconds: 3))
             ..toAtSign = '@bob'
@@ -844,7 +805,7 @@ void main() {
 
       var atNotification2 = (AtNotificationBuilder()
             ..id = '124'
-            ..fromAtSign = '@test_user_1'
+            ..fromAtSign = alice
             ..notificationDateTime =
                 DateTime.now().subtract(Duration(seconds: 2))
             ..toAtSign = '@bob'
@@ -863,7 +824,7 @@ void main() {
 
       var atNotification3 = (AtNotificationBuilder()
             ..id = '125'
-            ..fromAtSign = '@test_user_1'
+            ..fromAtSign = alice
             ..notificationDateTime =
                 DateTime.now().subtract(Duration(seconds: 1))
             ..toAtSign = '@bob'
@@ -904,7 +865,7 @@ void main() {
       () {
     test('notify command accept test for pubKeyCS and sharedKeyEnc', () {
       var command = 'notify:sharedKeyEnc:abc:pubKeyCS:123@bob:location@colin';
-      var handler = NotifyVerbHandler(mockKeyStore);
+      var handler = NotifyVerbHandler(mockKeyStore, notificationManager);
       var result = handler.accept(command);
       expect(result, true);
     });
@@ -914,9 +875,9 @@ void main() {
         ..sharedKeyEnc = 'abc';
       var atNotification1 = (AtNotificationBuilder()
             ..id = 'abc'
-            ..fromAtSign = '@test_user_1'
+            ..fromAtSign = alice
             ..notificationDateTime = DateTime.now()
-            ..toAtSign = alice
+            ..toAtSign = bob
             ..notification = 'key-1'
             ..type = NotificationType.sent
             ..opType = OperationType.update
@@ -927,7 +888,7 @@ void main() {
           .build();
       var queueManager = QueueManager.getInstance();
       queueManager.enqueue(atNotification1);
-      var response = queueManager.dequeue(alice);
+      var response = queueManager.dequeue(bob);
       late AtNotification atNotification;
       if (response.moveNext()) {
         atNotification = response.current;
@@ -935,11 +896,11 @@ void main() {
       expect(atNotification.id, 'abc');
       expect(
         atNotification.fromAtSign,
-        '@test_user_1',
+        alice,
       );
       expect(
         atNotification.toAtSign,
-        alice,
+        bob,
       );
       expect(atNotification.notification, 'key-1');
       expect(atNotification.atMetadata, isNotNull);
@@ -959,11 +920,11 @@ void main() {
         HashMap<String, String>();
 
     setUp(() async {
-      keyStoreManager = await setUpFunc(storageDir);
-      SecondaryKeyStore keyStore = keyStoreManager.getKeyStore();
-      notifyVerbHandler = NotifyVerbHandler(keyStore);
+      await verbTestsSetUp();
+      notifyVerbHandler =
+          NotifyVerbHandler(secondaryKeyStore, notificationManager);
       notifyResponse = Response();
-      notifyFetch = NotifyFetchVerbHandler(keyStore);
+      notifyFetch = NotifyFetchVerbHandler(secondaryKeyStore);
 
       var inBoundSessionId = '_6665436c-29ff-481b-8dc6-129e89199718';
       atConnection = InboundConnectionImpl(mockSocket, inBoundSessionId);
@@ -971,7 +932,7 @@ void main() {
       // first notification
       firstNotificationVerbParams.putIfAbsent('id', () => 'abc-123');
       firstNotificationVerbParams.putIfAbsent('operation', () => 'update');
-      firstNotificationVerbParams.putIfAbsent('atSign', () => '@test_user_1');
+      firstNotificationVerbParams.putIfAbsent('atSign', () => alice);
       firstNotificationVerbParams.putIfAbsent('atKey', () => 'phone');
       firstNotificationVerbParams.putIfAbsent(
           AtConstants.forAtSign, () => '@test_user_2');
@@ -979,23 +940,22 @@ void main() {
       // second notification
       secondNotificationVerbParams.putIfAbsent('id', () => 'xyz-123');
       secondNotificationVerbParams.putIfAbsent('operation', () => 'update');
-      secondNotificationVerbParams.putIfAbsent('atSign', () => '@test_user_1');
+      secondNotificationVerbParams.putIfAbsent('atSign', () => alice);
       secondNotificationVerbParams.putIfAbsent('atKey', () => 'otp');
     });
+    tearDown(() async => await verbTestsTearDown());
 
     test('test to verify notification date time stored for self', () async {
       atConnection.metaData.isAuthenticated = true;
       // process first notification
-      firstNotificationVerbParams.putIfAbsent(
-          'forAtSign', () => '@test_user_1');
+      firstNotificationVerbParams.putIfAbsent('forAtSign', () => alice);
       await notifyVerbHandler.processVerb(
           notifyResponse, firstNotificationVerbParams, atConnection);
       // store current date time to capture the difference
       var currentDateTime = DateTime.now();
       await Future.delayed(Duration(milliseconds: 50));
       // process second notification
-      secondNotificationVerbParams.putIfAbsent(
-          'forAtSign', () => '@test_user_1');
+      secondNotificationVerbParams.putIfAbsent('forAtSign', () => alice);
       await notifyVerbHandler.processVerb(
           notifyResponse, secondNotificationVerbParams, atConnection);
       // fetch second notification
@@ -1014,8 +974,7 @@ void main() {
 
     test('test to verify notification date time on receiver side', () async {
       atConnection.metaData.isPolAuthenticated = true;
-      (atConnection.metaData as InboundConnectionMetadata).fromAtSign =
-          '@test_user1';
+      (atConnection.metaData as InboundConnectionMetadata).fromAtSign = alice;
       // process first notification
       await notifyVerbHandler.processVerb(
           notifyResponse, firstNotificationVerbParams, atConnection);
@@ -1023,8 +982,7 @@ void main() {
       var currentDateTime = DateTime.now().millisecondsSinceEpoch;
       await Future.delayed(Duration(milliseconds: 50));
       // process second notification
-      secondNotificationVerbParams.putIfAbsent(
-          'forAtSign', () => '@test_user_1');
+      secondNotificationVerbParams.putIfAbsent('forAtSign', () => alice);
       await notifyVerbHandler.processVerb(
           notifyResponse, secondNotificationVerbParams, atConnection);
       // fetch second notification
@@ -1040,114 +998,121 @@ void main() {
               currentDateTime,
           true);
     });
-
-    group('A group of test to validate notification verb params', () {
-      late NotifyVerbHandler notifyVerbHandler;
-      setUp(() async {
-        keyStoreManager = await setUpFunc(storageDir);
-        SecondaryKeyStore keyStore = keyStoreManager.getKeyStore();
-        notifyVerbHandler = NotifyVerbHandler(keyStore);
-      });
-      // tests to validate message type
-      test(
-          'A test to validate messageType.key is returned when key string is passed',
-          () {
-        expect(notifyVerbHandler.getMessageType('key'), MessageType.key);
-        expect(notifyVerbHandler.getMessageType('KEY'), MessageType.key);
-      });
-
-      test(
-          'A test to validate messageType.text is returned when text string is passed',
-          () {
-        expect(notifyVerbHandler.getMessageType('text'), MessageType.text);
-        expect(notifyVerbHandler.getMessageType('TEXT'), MessageType.text);
-      });
-
-      test(
-          'A test to validate default messageType is returned when null is passed',
-          () {
-        expect(notifyVerbHandler.getMessageType(null), MessageType.key);
-        expect(notifyVerbHandler.getMessageType(''), MessageType.key);
-      });
-
-      // tests to validate operation type
-      test(
-          'A test to validate operationType.update is returned when update string is passed',
-          () {
-        expect(
-            notifyVerbHandler.getOperationType('update'), OperationType.update);
-        expect(
-            notifyVerbHandler.getOperationType('UPDATE'), OperationType.update);
-      });
-
-      test(
-          'A test to validate operationType.delete is returned when delete string is passed',
-          () {
-        expect(
-            notifyVerbHandler.getOperationType('delete'), OperationType.delete);
-        expect(
-            notifyVerbHandler.getOperationType('DELETE'), OperationType.delete);
-      });
-
-      test(
-          'A test to validate default operationType is returned when null or empty string is passed',
-          () {
-        expect(notifyVerbHandler.getOperationType(null), OperationType.update);
-        expect(notifyVerbHandler.getOperationType(''), OperationType.update);
-      });
-
-      // test to validate notification expiry duration
-      test(
-          'A test to validate default notification expiry duration is returned when null or 0 is passed',
-          () {
-        expect(
-            notifyVerbHandler.getNotificationExpiryInMillis(null),
-            Duration(minutes: AtSecondaryConfig.notificationExpiryInMins)
-                .inMilliseconds);
-        expect(
-            notifyVerbHandler.getNotificationExpiryInMillis('0'),
-            Duration(minutes: AtSecondaryConfig.notificationExpiryInMins)
-                .inMilliseconds);
-      });
-
-      test(
-          'A test to validate notification expiry duration positive integer is passed',
-          () {
-        expect(notifyVerbHandler.getNotificationExpiryInMillis('30'), 30);
-      });
-
-      test(
-          'A test to assert exception when negative integer is passed to notification expiry duration ',
-          () {
-        expect(() => notifyVerbHandler.getNotificationExpiryInMillis('-30'),
-            throwsA(predicate((dynamic e) => e is InvalidSyntaxException)));
-      });
-
-      test(
-          'A test to assert exception when character is passed to notification expiry duration ',
-          () {
-        expect(() => notifyVerbHandler.getNotificationExpiryInMillis('abc'),
-            throwsA(predicate((dynamic e) => e is InvalidSyntaxException)));
-      });
-    });
-    tearDown(() async => await tearDownFunc());
   });
+  group('A group of test to validate notification verb params', () {
+    late NotifyVerbHandler notifyVerbHandler;
+    setUp(() async {
+      await verbTestsSetUp();
+      notifyVerbHandler = NotifyVerbHandler(
+        secondaryKeyStore,
+        notificationManager,
+      );
+    });
+    tearDown(() async => await verbTestsTearDown());
+    // tests to validate message type
+    test(
+        'A test to validate messageType.key is returned when key string is passed',
+            () {
+          expect(notifyVerbHandler.getMessageType('key'), MessageType.key);
+          expect(notifyVerbHandler.getMessageType('KEY'), MessageType.key);
+        });
+
+    test(
+        'A test to validate messageType.text is returned when text string is passed',
+            () {
+          expect(notifyVerbHandler.getMessageType('text'), MessageType.text);
+          expect(notifyVerbHandler.getMessageType('TEXT'), MessageType.text);
+        });
+
+    test(
+        'A test to validate default messageType is returned when null is passed',
+            () {
+          expect(notifyVerbHandler.getMessageType(null), MessageType.key);
+          expect(notifyVerbHandler.getMessageType(''), MessageType.key);
+        });
+
+    // tests to validate operation type
+    test(
+        'A test to validate operationType.update is returned when update string is passed',
+            () {
+          expect(
+              notifyVerbHandler.getOperationType('update'), OperationType.update);
+          expect(
+              notifyVerbHandler.getOperationType('UPDATE'), OperationType.update);
+        });
+
+    test(
+        'A test to validate operationType.delete is returned when delete string is passed',
+            () {
+          expect(
+              notifyVerbHandler.getOperationType('delete'), OperationType.delete);
+          expect(
+              notifyVerbHandler.getOperationType('DELETE'), OperationType.delete);
+        });
+
+    test(
+        'A test to validate default operationType is returned when null or empty string is passed',
+            () {
+          expect(notifyVerbHandler.getOperationType(null), OperationType.update);
+          expect(notifyVerbHandler.getOperationType(''), OperationType.update);
+        });
+
+    // test to validate notification expiry duration
+    test(
+        'A test to validate default notification expiry duration is returned when null or 0 is passed',
+            () {
+          expect(
+              notifyVerbHandler.getNotificationExpiryInMillis(null),
+              Duration(minutes: AtSecondaryConfig.notificationExpiryInMins)
+                  .inMilliseconds);
+          expect(
+              notifyVerbHandler.getNotificationExpiryInMillis('0'),
+              Duration(minutes: AtSecondaryConfig.notificationExpiryInMins)
+                  .inMilliseconds);
+        });
+
+    test(
+        'A test to validate notification expiry duration positive integer is passed',
+            () {
+          expect(notifyVerbHandler.getNotificationExpiryInMillis('30'), 30);
+        });
+
+    test(
+        'A test to assert exception when negative integer is passed to notification expiry duration ',
+            () {
+          expect(() => notifyVerbHandler.getNotificationExpiryInMillis('-30'),
+              throwsA(predicate((dynamic e) => e is InvalidSyntaxException)));
+        });
+
+    test(
+        'A test to assert exception when character is passed to notification expiry duration ',
+            () {
+          expect(() => notifyVerbHandler.getNotificationExpiryInMillis('abc'),
+              throwsA(predicate((dynamic e) => e is InvalidSyntaxException)));
+        });
+  });
+
   group(
       'A group of test to verify authorization check for notify and notify all verbs',
       () {
     late NotifyVerbHandler notifyVerbHandler;
     late NotifyAllVerbHandler notifyAllVerbHandler;
     setUp(() async {
-      keyStoreManager = await setUpFunc(storageDir, atsign: alice);
-      SecondaryKeyStore<String, AtData?, AtMetaData?> keyStore =
-          keyStoreManager.getKeyStore();
-      notifyVerbHandler = NotifyVerbHandler(keyStore);
-      notifyAllVerbHandler = NotifyAllVerbHandler(keyStore);
+      await verbTestsSetUp();
+      notifyVerbHandler = NotifyVerbHandler(
+        secondaryKeyStore,
+        notificationManager,
+      );
+      notifyAllVerbHandler = NotifyAllVerbHandler(
+        secondaryKeyStore,
+        notificationManager,
+      );
       inboundConnection = DummyInboundConnection();
       AtSecondaryServerImpl.getInstance().enrollmentManager =
-          EnrollmentManager(keyStore, alice);
+          EnrollmentManager(secondaryKeyStore, alice);
       registerFallbackValue(inboundConnection);
     });
+    tearDown(() async => await verbTestsTearDown());
     test(
         'A test to verify notification is allowed on a reserved key with authenticated connection and no apkam enrollment ',
         () async {
@@ -1181,9 +1146,10 @@ void main() {
       var enrollmentId = Uuid().v4();
       inboundConnection.metadata.enrollmentId = enrollmentId;
       var keyName = '$enrollmentId.new.enrollments.__manage$alice';
-      await keyStoreManager
-          .getKeyStore()
-          .put(keyName, AtData()..data = jsonEncode(enrollJson));
+      await secondaryKeyStore.put(
+        keyName,
+        AtData()..data = jsonEncode(enrollJson),
+      );
       await notifyVerbHandler.processVerb(
           response, notifyVerbParams, inboundConnection);
       expect(response.isError, false);
@@ -1208,9 +1174,10 @@ void main() {
         'approval': {'state': 'approved'}
       };
       var keyName = '$enrollmentId.new.enrollments.__manage$alice';
-      await keyStoreManager
-          .getKeyStore()
-          .put(keyName, AtData()..data = jsonEncode(enrollJson));
+      await secondaryKeyStore.put(
+        keyName,
+        AtData()..data = jsonEncode(enrollJson),
+      );
       // notify a key on buzz namespace
       String notifyCommand = 'notify:$bob:phone.buzz$alice';
       HashMap<String, String?> notifyVerbParams =
@@ -1242,9 +1209,10 @@ void main() {
         'approval': {'state': 'approved'}
       };
       var keyName = '$enrollmentId.new.enrollments.__manage$alice';
-      await keyStoreManager
-          .getKeyStore()
-          .put(keyName, AtData()..data = jsonEncode(enrollJson));
+      await secondaryKeyStore.put(
+        keyName,
+        AtData()..data = jsonEncode(enrollJson),
+      );
       String notifyCommand = 'notify:$bob:somekey$alice';
       HashMap<String, String?> notifyVerbParams =
           getVerbParam(VerbSyntax.notify, notifyCommand);
@@ -1271,9 +1239,10 @@ void main() {
         'approval': {'state': 'approved'}
       };
       var keyName = '$enrollmentId.new.enrollments.__manage$alice';
-      await keyStoreManager
-          .getKeyStore()
-          .put(keyName, AtData()..data = jsonEncode(enrollJson));
+      await secondaryKeyStore.put(
+        keyName,
+        AtData()..data = jsonEncode(enrollJson),
+      );
       String notifyCommand = 'notify:$bob:somekey$alice';
       HashMap<String, String?> notifyVerbParams =
           getVerbParam(VerbSyntax.notify, notifyCommand);
@@ -1305,9 +1274,10 @@ void main() {
       var enrollmentId = Uuid().v4();
       inboundConnection.metadata.enrollmentId = enrollmentId;
       var keyName = '$enrollmentId.new.enrollments.__manage$alice';
-      await keyStoreManager
-          .getKeyStore()
-          .put(keyName, AtData()..data = jsonEncode(enrollJson));
+      await secondaryKeyStore.put(
+        keyName,
+        AtData()..data = jsonEncode(enrollJson),
+      );
       var keyPair = RSAKeypair.fromRandom();
       AtSecondaryServerImpl.getInstance().signingKey =
           keyPair.privateKey.toString();
@@ -1336,9 +1306,10 @@ void main() {
       var enrollmentId = Uuid().v4();
       inboundConnection.metadata.enrollmentId = enrollmentId;
       var keyName = '$enrollmentId.new.enrollments.__manage$alice';
-      await keyStoreManager
-          .getKeyStore()
-          .put(keyName, AtData()..data = jsonEncode(enrollJson));
+      await secondaryKeyStore.put(
+        keyName,
+        AtData()..data = jsonEncode(enrollJson),
+      );
       var keyPair = RSAKeypair.fromRandom();
       AtSecondaryServerImpl.getInstance().signingKey =
           keyPair.privateKey.toString();
@@ -1370,9 +1341,10 @@ void main() {
       var enrollmentId = Uuid().v4();
       inboundConnection.metadata.enrollmentId = enrollmentId;
       var keyName = '$enrollmentId.new.enrollments.__manage$alice';
-      await keyStoreManager
-          .getKeyStore()
-          .put(keyName, AtData()..data = jsonEncode(enrollJson));
+      await secondaryKeyStore.put(
+        keyName,
+        AtData()..data = jsonEncode(enrollJson),
+      );
       var keyPair = RSAKeypair.fromRandom();
       AtSecondaryServerImpl.getInstance().signingKey =
           keyPair.privateKey.toString();
@@ -1384,7 +1356,6 @@ void main() {
               e.message ==
                   'Connection with enrollment ID $enrollmentId is not authorized to notify key: phone.wavi$alice')));
     });
-    tearDown(() async => await tearDownFunc());
   });
   group(
       'A group of test to verify authorization check for notify fetch, notify status and notify remove verbs',
@@ -1394,15 +1365,21 @@ void main() {
     late NotifyVerbHandler notifyVerbHandler;
     late NotifyRemoveVerbHandler notifyRemoveVerbHandler;
     setUp(() async {
-      keyStoreManager = await setUpFunc(storageDir, atsign: alice);
-      SecondaryKeyStore keyStore = keyStoreManager.getKeyStore();
-      notifyVerbHandler = NotifyVerbHandler(keyStore);
-      notifyFetchVerbHandler = NotifyFetchVerbHandler(keyStore);
-      notifyStatusVerbHandler = NotifyStatusVerbHandler(keyStore);
-      notifyRemoveVerbHandler = NotifyRemoveVerbHandler(keyStore);
+      await verbTestsSetUp();
+      notifyVerbHandler = NotifyVerbHandler(
+        secondaryKeyStore,
+        notificationManager,
+      );
+      notifyFetchVerbHandler = NotifyFetchVerbHandler(secondaryKeyStore);
+      notifyStatusVerbHandler = NotifyStatusVerbHandler(secondaryKeyStore);
+      notifyRemoveVerbHandler = NotifyRemoveVerbHandler(
+        secondaryKeyStore,
+        notificationManager,
+      );
       inboundConnection = DummyInboundConnection();
       registerFallbackValue(inboundConnection);
     });
+    tearDown(() async => await verbTestsTearDown());
     test(
         'A test to verify notification fetch/status is allowed on a reserved key with authenticated connection and no apkam enrollment',
         () async {
@@ -1455,9 +1432,10 @@ void main() {
       var enrollmentId = Uuid().v4();
       inboundConnection.metadata.enrollmentId = enrollmentId;
       var keyName = '$enrollmentId.new.enrollments.__manage$alice';
-      await keyStoreManager
-          .getKeyStore()
-          .put(keyName, AtData()..data = jsonEncode(enrollJson));
+      await secondaryKeyStore.put(
+        keyName,
+        AtData()..data = jsonEncode(enrollJson),
+      );
 
       await notifyVerbHandler.processVerb(
           response, notifyVerbParams, inboundConnection);
@@ -1503,9 +1481,10 @@ void main() {
         'approval': {'state': 'approved'}
       };
       var keyName = '$enrollmentId.new.enrollments.__manage$alice';
-      await keyStoreManager
-          .getKeyStore()
-          .put(keyName, AtData()..data = jsonEncode(enrollJson));
+      await secondaryKeyStore.put(
+        keyName,
+        AtData()..data = jsonEncode(enrollJson),
+      );
       //1. notify wavi key
       String notifyCommand = 'notify:$bob:phone.wavi$alice';
       HashMap<String, String?> notifyVerbParams =
@@ -1547,8 +1526,10 @@ void main() {
       };
       var newEnrollmentKeyName =
           '$newEnrollmentId.new.enrollments.__manage$alice';
-      await keyStoreManager.getKeyStore().put(
-          newEnrollmentKeyName, AtData()..data = jsonEncode(newEnrollJson));
+      await secondaryKeyStore.put(
+        newEnrollmentKeyName,
+        AtData()..data = jsonEncode(newEnrollJson),
+      );
 
       //1. fetching wavi key notification should pass
       String notifyFetchCommand = 'notify:fetch:$notificationIdWaviKey';
@@ -1645,9 +1626,10 @@ void main() {
         'approval': {'state': 'approved'}
       };
       var keyName = '$enrollmentId.new.enrollments.__manage$alice';
-      await keyStoreManager
-          .getKeyStore()
-          .put(keyName, AtData()..data = jsonEncode(enrollJson));
+      await secondaryKeyStore.put(
+        keyName,
+        AtData()..data = jsonEncode(enrollJson),
+      );
       //1. notify wavi key
       String notifyCommand = 'notify:$bob:phone.wavi$alice';
       HashMap<String, String?> notifyVerbParams =
@@ -1689,8 +1671,10 @@ void main() {
       };
       var newEnrollmentKeyName =
           '$newEnrollmentId.new.enrollments.__manage$alice';
-      await keyStoreManager.getKeyStore().put(
-          newEnrollmentKeyName, AtData()..data = jsonEncode(newEnrollJson));
+      await secondaryKeyStore.put(
+        newEnrollmentKeyName,
+        AtData()..data = jsonEncode(newEnrollJson),
+      );
 
       //1. removing wavi key notification should pass
       String notifyRemoveCommand = 'notify:remove:$notificationIdWaviKey';
@@ -1742,7 +1726,6 @@ void main() {
       expect(notifyRemoveResponse.data, isNotNull);
       expect(notifyRemoveResponse.data, 'success');
     });
-    tearDown(() async => await tearDownFunc());
   });
   group(
       'A group of test to verify authorization check for notify fetch, notify status and notify remove verbs',
@@ -1750,17 +1733,19 @@ void main() {
     late NotifyVerbHandler notifyVerbHandler;
     late NotifyListVerbHandler notifyListVerbHandler;
     setUp(() async {
-      keyStoreManager = await setUpFunc(storageDir, atsign: alice);
-      SecondaryKeyStore<String, AtData?, AtMetaData?> keyStore =
-          keyStoreManager.getKeyStore();
-      notifyVerbHandler = NotifyVerbHandler(keyStore);
+      await verbTestsSetUp();
+      notifyVerbHandler = NotifyVerbHandler(
+        secondaryKeyStore,
+        notificationManager,
+      );
       notifyListVerbHandler =
-          NotifyListVerbHandler(keyStore, mockOutboundClientManager);
+          NotifyListVerbHandler(secondaryKeyStore, mockOutboundClientManager);
       inboundConnection = DummyInboundConnection();
       AtSecondaryServerImpl.getInstance().enrollmentManager =
-          EnrollmentManager(keyStore, alice);
+          EnrollmentManager(secondaryKeyStore, alice);
       registerFallbackValue(inboundConnection);
     });
+    tearDown(() async => await verbTestsTearDown());
     test('A test to verify notify:list authorization', () async {
       // create a set of notifications on a connection with * namespace access.
       Response response = Response();
@@ -1778,9 +1763,10 @@ void main() {
         'approval': {'state': 'approved'}
       };
       var keyName = '$enrollmentId.new.enrollments.__manage$alice';
-      await keyStoreManager
-          .getKeyStore()
-          .put(keyName, AtData()..data = jsonEncode(enrollJson));
+      await secondaryKeyStore.put(
+        keyName,
+        AtData()..data = jsonEncode(enrollJson),
+      );
 
       //1. notify wavi key
       String notifyCommand = 'notify:$alice:phone.wavi$alice';
@@ -1829,8 +1815,10 @@ void main() {
       };
       var newEnrollmentKeyName =
           '$newEnrollmentId.new.enrollments.__manage$alice';
-      await keyStoreManager.getKeyStore().put(
-          newEnrollmentKeyName, AtData()..data = jsonEncode(newEnrollJson));
+      await secondaryKeyStore.put(
+        newEnrollmentKeyName,
+        AtData()..data = jsonEncode(newEnrollJson),
+      );
 
       var notifyListCommand = 'notify:list';
       var notifyListVerbParams =
@@ -1852,21 +1840,22 @@ void main() {
         }
       }
     });
-    tearDown(() async => await tearDownFunc());
   });
 
   group('Notification data correctness tests', () {
     late NotifyVerbHandler notifyVerbHandler;
 
     setUp(() async {
-      keyStoreManager = await setUpFunc(storageDir, atsign: alice);
-      SecondaryKeyStore keyStore = keyStoreManager.getKeyStore();
-      notifyVerbHandler = NotifyVerbHandler(keyStore);
+      await verbTestsSetUp();
+      notifyVerbHandler = NotifyVerbHandler(
+        secondaryKeyStore,
+        notificationManager,
+      );
       inboundConnection = DummyInboundConnection();
       registerFallbackValue(inboundConnection);
     });
 
-    tearDown(() async => await tearDownFunc());
+    tearDown(() async => await verbTestsTearDown());
 
     test('test getIsEncrypted for MessageType.text', () {
       expect(notifyVerbHandler.getIsEncrypted(MessageType.text, 'foo', null),
@@ -1946,36 +1935,4 @@ void main() {
       expect(stored.atMetadata!.isEncrypted, false);
     });
   });
-}
-
-Future<SecondaryKeyStoreManager> setUpFunc(storageDir, {String? atsign}) async {
-  AtSecondaryServerImpl.getInstance().currentAtSign = atsign ?? '@test_user_1';
-  var secondaryPersistenceStore = SecondaryPersistenceStoreFactory.getInstance()
-      .getSecondaryPersistenceStore(
-          AtSecondaryServerImpl.getInstance().currentAtSign)!;
-  var persistenceManager =
-      secondaryPersistenceStore.getHivePersistenceManager()!;
-  await persistenceManager.init(storageDir);
-//  persistenceManager.scheduleKeyExpireTask(1); //commented this line for coverage test
-  var hiveKeyStore = secondaryPersistenceStore.getSecondaryKeyStore()!;
-  var keyStoreManager =
-      secondaryPersistenceStore.getSecondaryKeyStoreManager()!;
-  keyStoreManager.keyStore = hiveKeyStore;
-  hiveKeyStore.commitLog = await AtCommitLogManagerImpl.getInstance()
-      .getCommitLog(atsign ?? '@test_user_1', commitLogPath: storageDir);
-  await AtAccessLogManagerImpl.getInstance()
-      .getAccessLog(atsign ?? '@test_user_1', accessLogPath: storageDir);
-  var notificationKeystore = AtNotificationKeystore.getInstance();
-  notificationKeystore.currentAtSign = atsign ?? '@test_user_1';
-  await notificationKeystore.init(storageDir);
-  return keyStoreManager;
-}
-
-Future<void> tearDownFunc() async {
-  var isExists = await Directory('test/hive').exists();
-  AtNotificationMap.getInstance().clear();
-  await AtNotificationKeystore.getInstance().close();
-  if (isExists) {
-    await Directory('test/hive').delete(recursive: true);
-  }
 }

--- a/packages/at_secondary_server/test/notify_verb_test.dart
+++ b/packages/at_secondary_server/test/notify_verb_test.dart
@@ -16,17 +16,13 @@ import 'package:at_secondary/src/server/at_secondary_impl.dart';
 import 'package:at_secondary/src/utils/handler_util.dart';
 import 'package:at_secondary/src/utils/secondary_util.dart';
 import 'package:at_secondary/src/verb/handler/abstract_verb_handler.dart';
-import 'package:at_secondary/src/verb/handler/cram_verb_handler.dart';
-import 'package:at_secondary/src/verb/handler/from_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/notify_all_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/notify_fetch_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/notify_list_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/notify_remove_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/notify_status_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/notify_verb_handler.dart';
-import 'package:at_server_spec/at_server_spec.dart';
 import 'package:at_server_spec/at_verb_spec.dart';
-import 'package:crypto/crypto.dart';
 import 'package:crypton/crypton.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
@@ -374,10 +370,10 @@ void main() {
       var notifyResponse = Response();
 
       var notifyVerbParams = HashMap<String, String>.from({
-        'operation':'delete',
-        'forAtSign':alice,
-        'atSign':alice,
-        'atKey':'phone',
+        'operation': 'delete',
+        'forAtSign': alice,
+        'atSign': alice,
+        'atKey': 'phone',
       });
       await notifyVerbHandler.processVerb(
           notifyResponse, notifyVerbParams, atConnection);
@@ -1012,84 +1008,84 @@ void main() {
     // tests to validate message type
     test(
         'A test to validate messageType.key is returned when key string is passed',
-            () {
-          expect(notifyVerbHandler.getMessageType('key'), MessageType.key);
-          expect(notifyVerbHandler.getMessageType('KEY'), MessageType.key);
-        });
+        () {
+      expect(notifyVerbHandler.getMessageType('key'), MessageType.key);
+      expect(notifyVerbHandler.getMessageType('KEY'), MessageType.key);
+    });
 
     test(
         'A test to validate messageType.text is returned when text string is passed',
-            () {
-          expect(notifyVerbHandler.getMessageType('text'), MessageType.text);
-          expect(notifyVerbHandler.getMessageType('TEXT'), MessageType.text);
-        });
+        () {
+      expect(notifyVerbHandler.getMessageType('text'), MessageType.text);
+      expect(notifyVerbHandler.getMessageType('TEXT'), MessageType.text);
+    });
 
     test(
         'A test to validate default messageType is returned when null is passed',
-            () {
-          expect(notifyVerbHandler.getMessageType(null), MessageType.key);
-          expect(notifyVerbHandler.getMessageType(''), MessageType.key);
-        });
+        () {
+      expect(notifyVerbHandler.getMessageType(null), MessageType.key);
+      expect(notifyVerbHandler.getMessageType(''), MessageType.key);
+    });
 
     // tests to validate operation type
     test(
         'A test to validate operationType.update is returned when update string is passed',
-            () {
-          expect(
-              notifyVerbHandler.getOperationType('update'), OperationType.update);
-          expect(
-              notifyVerbHandler.getOperationType('UPDATE'), OperationType.update);
-        });
+        () {
+      expect(
+          notifyVerbHandler.getOperationType('update'), OperationType.update);
+      expect(
+          notifyVerbHandler.getOperationType('UPDATE'), OperationType.update);
+    });
 
     test(
         'A test to validate operationType.delete is returned when delete string is passed',
-            () {
-          expect(
-              notifyVerbHandler.getOperationType('delete'), OperationType.delete);
-          expect(
-              notifyVerbHandler.getOperationType('DELETE'), OperationType.delete);
-        });
+        () {
+      expect(
+          notifyVerbHandler.getOperationType('delete'), OperationType.delete);
+      expect(
+          notifyVerbHandler.getOperationType('DELETE'), OperationType.delete);
+    });
 
     test(
         'A test to validate default operationType is returned when null or empty string is passed',
-            () {
-          expect(notifyVerbHandler.getOperationType(null), OperationType.update);
-          expect(notifyVerbHandler.getOperationType(''), OperationType.update);
-        });
+        () {
+      expect(notifyVerbHandler.getOperationType(null), OperationType.update);
+      expect(notifyVerbHandler.getOperationType(''), OperationType.update);
+    });
 
     // test to validate notification expiry duration
     test(
         'A test to validate default notification expiry duration is returned when null or 0 is passed',
-            () {
-          expect(
-              notifyVerbHandler.getNotificationExpiryInMillis(null),
-              Duration(minutes: AtSecondaryConfig.notificationExpiryInMins)
-                  .inMilliseconds);
-          expect(
-              notifyVerbHandler.getNotificationExpiryInMillis('0'),
-              Duration(minutes: AtSecondaryConfig.notificationExpiryInMins)
-                  .inMilliseconds);
-        });
+        () {
+      expect(
+          notifyVerbHandler.getNotificationExpiryInMillis(null),
+          Duration(minutes: AtSecondaryConfig.notificationExpiryInMins)
+              .inMilliseconds);
+      expect(
+          notifyVerbHandler.getNotificationExpiryInMillis('0'),
+          Duration(minutes: AtSecondaryConfig.notificationExpiryInMins)
+              .inMilliseconds);
+    });
 
     test(
         'A test to validate notification expiry duration positive integer is passed',
-            () {
-          expect(notifyVerbHandler.getNotificationExpiryInMillis('30'), 30);
-        });
+        () {
+      expect(notifyVerbHandler.getNotificationExpiryInMillis('30'), 30);
+    });
 
     test(
         'A test to assert exception when negative integer is passed to notification expiry duration ',
-            () {
-          expect(() => notifyVerbHandler.getNotificationExpiryInMillis('-30'),
-              throwsA(predicate((dynamic e) => e is InvalidSyntaxException)));
-        });
+        () {
+      expect(() => notifyVerbHandler.getNotificationExpiryInMillis('-30'),
+          throwsA(predicate((dynamic e) => e is InvalidSyntaxException)));
+    });
 
     test(
         'A test to assert exception when character is passed to notification expiry duration ',
-            () {
-          expect(() => notifyVerbHandler.getNotificationExpiryInMillis('abc'),
-              throwsA(predicate((dynamic e) => e is InvalidSyntaxException)));
-        });
+        () {
+      expect(() => notifyVerbHandler.getNotificationExpiryInMillis('abc'),
+          throwsA(predicate((dynamic e) => e is InvalidSyntaxException)));
+    });
   });
 
   group(

--- a/packages/at_secondary_server/test/outbound_client_manager_test.dart
+++ b/packages/at_secondary_server/test/outbound_client_manager_test.dart
@@ -11,17 +11,10 @@ import 'package:test/test.dart';
 import 'test_utils.dart';
 
 void main() {
-  MockSocket mockSocket_1 = MockSocket();
-  MockSocket mockSocket_2 = MockSocket();
+  FakeSocket mockSocket_1 = FakeSocket();
+  FakeSocket mockSocket_2 = FakeSocket();
 
   verbTestsSetUpLogging();
-
-  setUpAll(() async {
-    when(() => mockSocket_1.setOption(SocketOption.tcpNoDelay, true))
-        .thenReturn(true);
-    when(() => mockSocket_2.setOption(SocketOption.tcpNoDelay, true))
-        .thenReturn(true);
-  });
 
   setUp(() {
     var serverContext = AtSecondaryContext();

--- a/packages/at_secondary_server/test/outbound_client_manager_test.dart
+++ b/packages/at_secondary_server/test/outbound_client_manager_test.dart
@@ -5,7 +5,6 @@ import 'package:at_secondary/src/connection/outbound/outbound_client.dart';
 import 'package:at_secondary/src/connection/outbound/outbound_connection_impl.dart';
 import 'package:at_secondary/src/server/at_secondary_impl.dart';
 import 'package:at_secondary/src/server/server_context.dart';
-import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
 import 'test_utils.dart';

--- a/packages/at_secondary_server/test/outbound_client_pool_test.dart
+++ b/packages/at_secondary_server/test/outbound_client_pool_test.dart
@@ -15,15 +15,14 @@ import 'test_utils.dart';
 void main() async {
   // ignore: prefer_typing_uninitialized_variables
   late OutboundClientPool outboundClientPool;
+  late NotifyConnectionsPool notifyConnectionsPool;
   final int outboundIdleTimeMillis = 200;
-  MockSocket mockSocket = MockSocket();
+  FakeSocket mockSocket = FakeSocket();
 
   verbTestsSetUpLogging();
 
   setUpAll(() {
-    when(() => mockSocket.setOption(SocketOption.tcpNoDelay, true))
-        .thenReturn(true);
-  });
+      });
 
   setUp(() {
     var serverContext = AtSecondaryContext();
@@ -31,16 +30,20 @@ void main() async {
         outboundIdleTimeMillis;
     AtSecondaryServerImpl.getInstance().serverContext = serverContext;
     outboundClientPool = OutboundClientPool();
+    notifyConnectionsPool =
+        NotifyConnectionsPool(DefaultOutboundConnectionFactory(requireCerts: false));
 
-    NotifyConnectionsPool.getInstance().size = 2;
+    notifyConnectionsPool.size = 2;
   });
 
   tearDown(() {
     outboundClientPool.clearAllClients();
-    NotifyConnectionsPool.getInstance().pool.clearAllClients();
+    notifyConnectionsPool.outboundClientPool.clearAllClients();
   });
 
   group('A group of outbound client pool test', () {
+    OutboundConnectionFactory outboundConnectionFactory =
+        DefaultOutboundConnectionFactory(requireCerts: false);
     test('test outbound client pool init', () {
       outboundClientPool.size = 5;
       expect(outboundClientPool.getCapacity(), 5);
@@ -50,10 +53,12 @@ void main() async {
     OutboundClient newOutboundClient(String toAtSign) {
       var inboundConnection = InboundConnectionImpl(mockSocket, toAtSign);
       OutboundClient outboundClient = OutboundClient(
-          inboundConnection,
-          toAtSign,
-          AtSecondaryServerImpl.getInstance().secondaryAddressFinder,
-          false);
+        inboundConnection,
+        toAtSign,
+        AtSecondaryServerImpl.getInstance().secondaryAddressFinder,
+        false,
+        outboundConnectionFactory,
+      );
       outboundClient.outboundConnection =
           OutboundConnectionImpl(mockSocket, toAtSign);
 
@@ -167,72 +172,67 @@ void main() async {
     test(
         'test notify connections pool removes least recently used when at capacity, with lastUsed as per order of OutboundClient creation',
         () async {
-      NotifyConnectionsPool notifyConnectionPool =
-          NotifyConnectionsPool.getInstance();
+      notifyConnectionsPool.size = 2;
+      expect(notifyConnectionsPool.getCapacity(), 2);
 
-      notifyConnectionPool.size = 2;
-      expect(notifyConnectionPool.getCapacity(), 2);
-
-      OutboundClient toAlice = await notifyConnectionPool.getOutboundClient(
+      OutboundClient toAlice = await notifyConnectionsPool.getOutboundClient(
         '@alice',
         connect: false,
       );
-      expect(notifyConnectionPool.getCapacity(), 1);
+      expect(notifyConnectionsPool.getCapacity(), 1);
 
       await Future.delayed(Duration(milliseconds: 1));
-      OutboundClient toBob = await notifyConnectionPool.getOutboundClient(
+      OutboundClient toBob = await notifyConnectionsPool.getOutboundClient(
         '@bob',
         connect: false,
       );
-      expect(notifyConnectionPool.getCapacity(), 0);
-      expect(notifyConnectionPool.pool.clients()[0], toAlice);
-      expect(notifyConnectionPool.pool.clients()[1], toBob);
+      expect(notifyConnectionsPool.getCapacity(), 0);
+      expect(notifyConnectionsPool.outboundClientPool.clients()[0], toAlice);
+      expect(notifyConnectionsPool.outboundClientPool.clients()[1], toBob);
 
       await Future.delayed(Duration(milliseconds: 1));
-      OutboundClient toCharlie = await notifyConnectionPool.getOutboundClient(
+      OutboundClient toCharlie = await notifyConnectionsPool.getOutboundClient(
         '@charlie',
         connect: false,
       ); // as there is no capacity, alice should be evicted as the least recently used
-      expect(notifyConnectionPool.getCapacity(), 0);
-      expect(notifyConnectionPool.pool.clients()[0], toBob);
-      expect(notifyConnectionPool.pool.clients()[1], toCharlie);
+      expect(notifyConnectionsPool.getCapacity(), 0);
+      expect(notifyConnectionsPool.outboundClientPool.clients()[0], toBob);
+      expect(notifyConnectionsPool.outboundClientPool.clients()[1], toCharlie);
     });
 
     test(
         'test notify connections pool removes least recently used when at capacity, with lastUsed CHANGED compared with order of object creation',
         () async {
-      NotifyConnectionsPool notifyConnectionPool =
-          NotifyConnectionsPool.getInstance();
-
-      notifyConnectionPool.size = 2;
-      expect(notifyConnectionPool.getCapacity(), 2);
+      notifyConnectionsPool.size = 2;
+      expect(notifyConnectionsPool.getCapacity(), 2);
 
       final OutboundClient toAlice =
-          await notifyConnectionPool.getOutboundClient(
+          await notifyConnectionsPool.getOutboundClient(
         '@alice',
         connect: false,
       );
-      expect(notifyConnectionPool.getCapacity(), 1);
+      expect(notifyConnectionsPool.getCapacity(), 1);
 
       await Future.delayed(Duration(milliseconds: 1));
-      final OutboundClient toBob = await notifyConnectionPool.getOutboundClient(
+      final OutboundClient toBob =
+          await notifyConnectionsPool.getOutboundClient(
         '@bob',
         connect: false,
       );
-      expect(notifyConnectionPool.getCapacity(), 0);
+      expect(notifyConnectionsPool.getCapacity(), 0);
 
       toAlice.lastUsed = DateTime.now();
-      expect(notifyConnectionPool.pool.clients()[0], toBob);
-      expect(notifyConnectionPool.pool.clients()[1], toAlice);
+      expect(notifyConnectionsPool.outboundClientPool.clients()[0], toBob);
+      expect(notifyConnectionsPool.outboundClientPool.clients()[1], toAlice);
 
       await Future.delayed(Duration(milliseconds: 1));
-      OutboundClient toCharlie = await notifyConnectionPool.getOutboundClient(
+      OutboundClient toCharlie = await notifyConnectionsPool.getOutboundClient(
         '@charlie',
         connect: false,
       ); // as there is no capacity, bob should be evicted as the least recently used
-      expect(notifyConnectionPool.getCapacity(), 0);
-      expect(notifyConnectionPool.pool.clients()[0], toAlice);
-      expect(notifyConnectionPool.pool.clients()[1], toCharlie);
+      expect(notifyConnectionsPool.getCapacity(), 0);
+      expect(notifyConnectionsPool.outboundClientPool.clients()[0], toAlice);
+      expect(notifyConnectionsPool.outboundClientPool.clients()[1], toCharlie);
     });
   });
 }

--- a/packages/at_secondary_server/test/outbound_client_pool_test.dart
+++ b/packages/at_secondary_server/test/outbound_client_pool_test.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:at_secondary/src/connection/inbound/inbound_connection_impl.dart';
 import 'package:at_secondary/src/connection/outbound/outbound_client.dart';
 import 'package:at_secondary/src/connection/outbound/outbound_client_pool.dart';
@@ -7,7 +5,6 @@ import 'package:at_secondary/src/connection/outbound/outbound_connection_impl.da
 import 'package:at_secondary/src/notification/notify_connection_pool.dart';
 import 'package:at_secondary/src/server/at_secondary_impl.dart';
 import 'package:at_secondary/src/server/server_context.dart';
-import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
 import 'test_utils.dart';
@@ -21,8 +18,7 @@ void main() async {
 
   verbTestsSetUpLogging();
 
-  setUpAll(() {
-      });
+  setUpAll(() {});
 
   setUp(() {
     var serverContext = AtSecondaryContext();
@@ -30,8 +26,8 @@ void main() async {
         outboundIdleTimeMillis;
     AtSecondaryServerImpl.getInstance().serverContext = serverContext;
     outboundClientPool = OutboundClientPool();
-    notifyConnectionsPool =
-        NotifyConnectionsPool(DefaultOutboundConnectionFactory(requireCerts: false));
+    notifyConnectionsPool = NotifyConnectionsPool(
+        DefaultOutboundConnectionFactory(requireCerts: false));
 
     notifyConnectionsPool.size = 2;
   });

--- a/packages/at_secondary_server/test/outbound_client_test.dart
+++ b/packages/at_secondary_server/test/outbound_client_test.dart
@@ -11,7 +11,9 @@ import 'package:test/test.dart';
 import 'test_utils.dart';
 
 void main() {
-  late MockSocket mockSocket;
+  late FakeSocket mockSocket;
+  OutboundConnectionFactory outboundConnectionFactory =
+      DefaultOutboundConnectionFactory(requireCerts: false);
 
   verbTestsSetUpLogging();
 
@@ -19,17 +21,20 @@ void main() {
     var serverContext = AtSecondaryContext();
     serverContext.unauthenticatedOutboundIdleTimeMillis = 50;
     AtSecondaryServerImpl.getInstance().serverContext = serverContext;
-    mockSocket = MockSocket();
-    when(() => mockSocket.setOption(SocketOption.tcpNoDelay, true))
-        .thenReturn(true);
-  });
+    mockSocket = FakeSocket();
+      });
 
   group('A group of outbound client tests', () {
     test('test outbound client - invalid outbound client if inbound is invalid',
         () {
       var connection1 = InboundConnectionImpl(mockSocket, 'aaa');
-      var client = OutboundClient(connection1, 'bob',
-          AtSecondaryServerImpl.getInstance().secondaryAddressFinder, true);
+      var client = OutboundClient(
+        connection1,
+        'bob',
+        AtSecondaryServerImpl.getInstance().secondaryAddressFinder,
+        true,
+        outboundConnectionFactory,
+      );
       client.outboundConnection = OutboundConnectionImpl(mockSocket, 'bob');
       connection1.close();
       expect(client.isInValid(), true);
@@ -37,8 +42,13 @@ void main() {
 
     test('test outbound client - invalid outbound client idle', () {
       var connection1 = InboundConnectionImpl(mockSocket, 'aaa');
-      var client = OutboundClient(connection1, 'bob',
-          AtSecondaryServerImpl.getInstance().secondaryAddressFinder, true);
+      var client = OutboundClient(
+        connection1,
+        'bob',
+        AtSecondaryServerImpl.getInstance().secondaryAddressFinder,
+        true,
+        outboundConnectionFactory,
+      );
       client.outboundConnection = OutboundConnectionImpl(mockSocket, 'bob');
       sleep(Duration(
           milliseconds: AtSecondaryServerImpl.getInstance()
@@ -50,8 +60,13 @@ void main() {
 
     test('test outbound client - valid outbound client', () {
       var connection1 = InboundConnectionImpl(mockSocket, 'aaa');
-      var client = OutboundClient(connection1, 'bob',
-          AtSecondaryServerImpl.getInstance().secondaryAddressFinder, true);
+      var client = OutboundClient(
+        connection1,
+        'bob',
+        AtSecondaryServerImpl.getInstance().secondaryAddressFinder,
+        true,
+        outboundConnectionFactory,
+      );
       client.outboundConnection = OutboundConnectionImpl(mockSocket, 'bob');
       expect(client.isInValid(), false);
     });
@@ -60,8 +75,13 @@ void main() {
         'test outbound client - stale connection - connection invalid exception',
         () {
       var connection1 = InboundConnectionImpl(mockSocket, 'aaa');
-      var client = OutboundClient(connection1, 'bob',
-          AtSecondaryServerImpl.getInstance().secondaryAddressFinder, false);
+      var client = OutboundClient(
+        connection1,
+        'bob',
+        AtSecondaryServerImpl.getInstance().secondaryAddressFinder,
+        false,
+        outboundConnectionFactory,
+      );
       client.outboundConnection = OutboundConnectionImpl(mockSocket, 'bob');
       client.outboundConnection!.metaData.isStale = true;
       expect(
@@ -74,8 +94,13 @@ void main() {
         'test outbound client - closed connection - connection invalid exception',
         () {
       var connection1 = InboundConnectionImpl(mockSocket, 'aaa');
-      var client = OutboundClient(connection1, 'bob',
-          AtSecondaryServerImpl.getInstance().secondaryAddressFinder, false);
+      var client = OutboundClient(
+        connection1,
+        'bob',
+        AtSecondaryServerImpl.getInstance().secondaryAddressFinder,
+        false,
+        outboundConnectionFactory,
+      );
       client.outboundConnection = OutboundConnectionImpl(mockSocket, 'bob');
       client.outboundConnection!.metaData.isClosed = true;
       expect(

--- a/packages/at_secondary_server/test/outbound_client_test.dart
+++ b/packages/at_secondary_server/test/outbound_client_test.dart
@@ -5,7 +5,6 @@ import 'package:at_secondary/src/connection/outbound/outbound_connection_impl.da
 import 'package:at_secondary/src/server/at_secondary_impl.dart';
 import 'package:at_secondary/src/server/server_context.dart';
 import 'package:at_commons/at_commons.dart';
-import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
 import 'test_utils.dart';
@@ -22,7 +21,7 @@ void main() {
     serverContext.unauthenticatedOutboundIdleTimeMillis = 50;
     AtSecondaryServerImpl.getInstance().serverContext = serverContext;
     mockSocket = FakeSocket();
-      });
+  });
 
   group('A group of outbound client tests', () {
     test('test outbound client - invalid outbound client if inbound is invalid',

--- a/packages/at_secondary_server/test/pkam_verb_test.dart
+++ b/packages/at_secondary_server/test/pkam_verb_test.dart
@@ -177,9 +177,7 @@ void main() async {
     Response response = Response();
     late String enrollmentId;
 
-    setUp(() async {
-      await verbTestsSetUp();
-    });
+    setUp(() async => await verbTestsSetUp());
 
     tearDown(() async => await verbTestsTearDown());
 

--- a/packages/at_secondary_server/test/pol_verb_test.dart
+++ b/packages/at_secondary_server/test/pol_verb_test.dart
@@ -24,15 +24,14 @@ void main() async {
   SecondaryKeyStore mockKeyStore = MockSecondaryKeyStore();
   OutboundClientManager mockOutboundClientManager = MockOutboundClientManager();
   AtCacheManager mockAtCacheManager = MockAtCacheManager();
-  MockSocket mockSocket = MockSocket();
+  FakeSocket mockSocket = FakeSocket();
   EnrollmentManager mockEnrollmentManager = MockEnrollmentManager();
+  NotificationManager mockNotificationManager = MockNotificationManager();
 
   verbTestsSetUpLogging();
 
   setUpAll(() {
-    when(() => mockSocket.setOption(SocketOption.tcpNoDelay, true))
-        .thenReturn(true);
-  });
+      });
 
   test('test pol Verb', () {
     var handler = PolVerbHandler(
@@ -70,7 +69,7 @@ void main() async {
       mockOutboundClientManager,
       mockAtCacheManager,
       StatsNotificationService.getInstance(),
-      NotificationManager.getInstance(),
+      mockNotificationManager,
       mockEnrollmentManager,
       alice,
     );

--- a/packages/at_secondary_server/test/pol_verb_test.dart
+++ b/packages/at_secondary_server/test/pol_verb_test.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:at_persistence_spec/at_persistence_spec.dart';
 import 'package:at_secondary/src/caching/cache_manager.dart';
 import 'package:at_secondary/src/connection/inbound/inbound_connection_impl.dart';
@@ -16,7 +14,6 @@ import 'package:at_secondary/src/verb/manager/verb_handler_manager.dart';
 import 'package:at_commons/at_commons.dart';
 import 'package:at_server_spec/at_verb_spec.dart';
 import 'package:test/test.dart';
-import 'package:mocktail/mocktail.dart';
 
 import 'test_utils.dart';
 
@@ -30,8 +27,7 @@ void main() async {
 
   verbTestsSetUpLogging();
 
-  setUpAll(() {
-      });
+  setUpAll(() {});
 
   test('test pol Verb', () {
     var handler = PolVerbHandler(

--- a/packages/at_secondary_server/test/resource_manager_test.dart
+++ b/packages/at_secondary_server/test/resource_manager_test.dart
@@ -4,6 +4,7 @@ import 'package:at_commons/at_commons.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:at_secondary/src/connection/outbound/outbound_client.dart';
 import 'package:at_secondary/src/notification/at_notification_map.dart';
+import 'package:at_secondary/src/notification/notify_connection_pool.dart';
 import 'package:at_secondary/src/notification/queue_manager.dart';
 import 'package:at_secondary/src/notification/resource_manager.dart';
 import 'package:at_secondary/src/server/at_secondary_impl.dart';
@@ -18,7 +19,8 @@ void main() async {
 
   // mock object for outbound client
   OutboundClient mockOutboundClient = MockOutboundClient();
-  ResourceManager rm = ResourceManager.getInstance();
+  ResourceManager notifsResourceMgr = ResourceManager(
+      NotifyConnectionsPool(DefaultOutboundConnectionFactory(requireCerts: false)));
   var storageDir = '${Directory.current.path}/test/hive';
 
   //  forcing the notification sending to fail with an exception
@@ -72,7 +74,7 @@ void main() async {
       // Iterator containing all the notifications
       Iterator notificationIterator =
           [atNotification1, atNotification2, atNotification3].iterator;
-      await rm.sendNotifications(
+      await notifsResourceMgr.sendNotifications(
           atsign, mockOutboundClient, notificationIterator);
       var atNotificationList = [];
       var itr = QueueManager.getInstance().dequeue(atsign);
@@ -95,8 +97,8 @@ void main() async {
             ..notification = '@bob:phone$alice')
           .build();
 
-      var notifyCommand = ResourceManager.getInstance()
-          .prepareNotifyCommandBody(atNotification);
+      var notifyCommand =
+          notifsResourceMgr.prepareNotifyCommandBody(atNotification);
 
       /// expecting that prepareNotifyCommandBody returns the notify command same as atNotification
       expect(notifyCommand,
@@ -105,8 +107,8 @@ void main() async {
 
     test('Test to verify prepare notification without passing any fields', () {
       var atNotification = (AtNotificationBuilder()..id = '1122').build();
-      var notifyCommand = ResourceManager.getInstance()
-          .prepareNotifyCommandBody(atNotification);
+      var notifyCommand =
+          notifsResourceMgr.prepareNotifyCommandBody(atNotification);
 
       /// expecting that prepareNotifyCommandBody returns the notify command same as atNotification
       expect(notifyCommand,
@@ -120,8 +122,8 @@ void main() async {
             ..notification = '@bob:phone$alice'
             ..opType = OperationType.delete)
           .build();
-      var notifyCommand = ResourceManager.getInstance()
-          .prepareNotifyCommandBody(atNotification);
+      var notifyCommand =
+          notifsResourceMgr.prepareNotifyCommandBody(atNotification);
 
       /// expecting that prepareNotifyCommandBody returns the notify command same as atNotification
       expect(notifyCommand,
@@ -136,8 +138,8 @@ void main() async {
             ..notifier = 'wavi'
             ..messageType = MessageType.text)
           .build();
-      var notifyCommand = ResourceManager.getInstance()
-          .prepareNotifyCommandBody(atNotification);
+      var notifyCommand =
+          notifsResourceMgr.prepareNotifyCommandBody(atNotification);
 
       /// expecting that prepareNotifyCommandBody returns the notify command same as atNotification
       expect(notifyCommand,
@@ -174,8 +176,8 @@ void main() async {
             ))
           .build();
 
-      var notifyCommand = ResourceManager.getInstance()
-          .prepareNotifyCommandBody(atNotification);
+      var notifyCommand =
+          notifsResourceMgr.prepareNotifyCommandBody(atNotification);
 
       /// expecting that prepareNotifyCommandBody returns the notify command same as atNotification
       expect(

--- a/packages/at_secondary_server/test/resource_manager_test.dart
+++ b/packages/at_secondary_server/test/resource_manager_test.dart
@@ -19,8 +19,8 @@ void main() async {
 
   // mock object for outbound client
   OutboundClient mockOutboundClient = MockOutboundClient();
-  ResourceManager notifsResourceMgr = ResourceManager(
-      NotifyConnectionsPool(DefaultOutboundConnectionFactory(requireCerts: false)));
+  ResourceManager notifsResourceMgr = ResourceManager(NotifyConnectionsPool(
+      DefaultOutboundConnectionFactory(requireCerts: false)));
   var storageDir = '${Directory.current.path}/test/hive';
 
   //  forcing the notification sending to fail with an exception

--- a/packages/at_secondary_server/test/scan_verb_test.dart
+++ b/packages/at_secondary_server/test/scan_verb_test.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:at_commons/at_commons.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
@@ -15,7 +14,6 @@ import 'package:at_secondary/src/verb/handler/scan_verb_handler.dart';
 import 'package:at_secondary/src/verb/manager/verb_handler_manager.dart';
 import 'package:at_server_spec/at_server_spec.dart';
 import 'package:at_server_spec/at_verb_spec.dart';
-import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 import 'package:uuid/uuid.dart';
 
@@ -25,8 +23,7 @@ void main() {
   FakeSocket mockSocket = FakeSocket();
   NotificationManager mockNotificationManager = MockNotificationManager();
 
-  setUpAll(() {
-      });
+  setUpAll(() {});
 
   group('A group of scan verb tests', () {
     setUpAll(() async {

--- a/packages/at_secondary_server/test/scan_verb_test.dart
+++ b/packages/at_secondary_server/test/scan_verb_test.dart
@@ -22,12 +22,11 @@ import 'package:uuid/uuid.dart';
 import 'test_utils.dart';
 
 void main() {
-  MockSocket mockSocket = MockSocket();
+  FakeSocket mockSocket = FakeSocket();
+  NotificationManager mockNotificationManager = MockNotificationManager();
 
   setUpAll(() {
-    when(() => mockSocket.setOption(SocketOption.tcpNoDelay, true))
-        .thenReturn(true);
-  });
+      });
 
   group('A group of scan verb tests', () {
     setUpAll(() async {
@@ -87,7 +86,7 @@ void main() {
         mockOutboundClientManager,
         cacheManager,
         StatsNotificationService.getInstance(),
-        NotificationManager.getInstance(),
+        mockNotificationManager,
         enMgr,
         alice,
       );

--- a/packages/at_secondary_server/test/stats_verb_test.dart
+++ b/packages/at_secondary_server/test/stats_verb_test.dart
@@ -30,14 +30,13 @@ void main() {
   SecondaryKeyStore mockKeyStore = MockSecondaryKeyStore();
   OutboundClientManager mockOutboundClientManager = MockOutboundClientManager();
   AtCacheManager mockAtCacheManager = MockAtCacheManager();
-  MockSocket mockSocket = MockSocket();
+  FakeSocket mockSocket = FakeSocket();
   EnrollmentManager mockEnrollmentManager = MockEnrollmentManager();
+  NotificationManager mockNotificationManager = MockNotificationManager();
 
   setUpAll(() async {
     await verbTestsSetUpAll();
-    when(() => mockSocket.setOption(SocketOption.tcpNoDelay, true))
-        .thenReturn(true);
-  });
+      });
 
   final atServer = AtSecondaryServerImpl.getInstance();
 
@@ -128,7 +127,7 @@ void main() {
         mockOutboundClientManager,
         mockAtCacheManager,
         StatsNotificationService.getInstance(),
-        NotificationManager.getInstance(),
+        mockNotificationManager,
         mockEnrollmentManager,
         alice,
       );

--- a/packages/at_secondary_server/test/stats_verb_test.dart
+++ b/packages/at_secondary_server/test/stats_verb_test.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'dart:io';
 import 'dart:math';
 
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
@@ -22,7 +21,6 @@ import 'package:test/test.dart';
 import 'package:at_secondary/src/utils/handler_util.dart';
 import 'package:at_commons/at_commons.dart';
 import 'package:uuid/uuid.dart';
-import 'package:mocktail/mocktail.dart';
 
 import 'test_utils.dart';
 
@@ -36,7 +34,7 @@ void main() {
 
   setUpAll(() async {
     await verbTestsSetUpAll();
-      });
+  });
 
   final atServer = AtSecondaryServerImpl.getInstance();
 

--- a/packages/at_secondary_server/test/sync_unit_test.dart
+++ b/packages/at_secondary_server/test/sync_unit_test.dart
@@ -28,14 +28,13 @@ String atSign = alice;
 void main() async {
   OutboundClientManager mockOutboundClientManager = MockOutboundClientManager();
   AtCacheManager mockAtCacheManager = MockAtCacheManager();
-  MockSocket mockSocket = MockSocket();
+  FakeSocket mockSocket = FakeSocket();
+  NotificationManager mockNotificationManager = MockNotificationManager();
 
   verbTestsSetUpLogging();
 
   setUpAll(() async {
-    when(() => mockSocket.setOption(SocketOption.tcpNoDelay, true))
-        .thenReturn(true);
-  });
+      });
 
   Future<String> putData(String key) async {
     final data = Uuid().v4();
@@ -259,7 +258,7 @@ void main() async {
           mockOutboundClientManager,
           mockAtCacheManager,
           StatsNotificationService.getInstance(),
-          NotificationManager.getInstance(),
+          mockNotificationManager,
           enMgr,
           alice,
         );
@@ -333,7 +332,7 @@ void main() async {
           mockOutboundClientManager,
           mockAtCacheManager,
           StatsNotificationService.getInstance(),
-          NotificationManager.getInstance(),
+          mockNotificationManager,
           enMgr,
           alice,
         );

--- a/packages/at_secondary_server/test/sync_unit_test.dart
+++ b/packages/at_secondary_server/test/sync_unit_test.dart
@@ -1,6 +1,5 @@
 import 'dart:collection';
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:at_commons/at_commons.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
@@ -13,7 +12,6 @@ import 'package:at_secondary/src/verb/handler/batch_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/sync_progressive_verb_handler.dart';
 import 'package:at_secondary/src/verb/manager/verb_handler_manager.dart';
 import 'package:at_server_spec/at_verb_spec.dart';
-import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 import 'package:uuid/uuid.dart';
 
@@ -32,9 +30,6 @@ void main() async {
   NotificationManager mockNotificationManager = MockNotificationManager();
 
   verbTestsSetUpLogging();
-
-  setUpAll(() async {
-      });
 
   Future<String> putData(String key) async {
     final data = Uuid().v4();

--- a/packages/at_secondary_server/test/sync_verb_test.dart
+++ b/packages/at_secondary_server/test/sync_verb_test.dart
@@ -17,13 +17,11 @@ import 'package:test/test.dart';
 import 'test_utils.dart';
 
 void main() {
-  MockSocket mockSocket = MockSocket();
+  FakeSocket mockSocket = FakeSocket();
 
   setUpAll(() async {
     await verbTestsSetUpAll();
-    when(() => mockSocket.setOption(SocketOption.tcpNoDelay, true))
-        .thenReturn(true);
-  });
+      });
 
   setUp(() async {
     await verbTestsSetUp();

--- a/packages/at_secondary_server/test/sync_verb_test.dart
+++ b/packages/at_secondary_server/test/sync_verb_test.dart
@@ -1,6 +1,5 @@
 import 'dart:collection';
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:at_chops/at_chops.dart';
 import 'package:at_commons/at_commons.dart';
@@ -11,7 +10,6 @@ import 'package:at_secondary/src/utils/handler_util.dart';
 import 'package:at_secondary/src/utils/secondary_util.dart';
 import 'package:at_secondary/src/verb/handler/sync_progressive_verb_handler.dart';
 import 'package:at_server_spec/at_verb_spec.dart';
-import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
 import 'test_utils.dart';
@@ -21,7 +19,7 @@ void main() {
 
   setUpAll(() async {
     await verbTestsSetUpAll();
-      });
+  });
 
   setUp(() async {
     await verbTestsSetUp();

--- a/packages/at_secondary_server/test/test_utils.dart
+++ b/packages/at_secondary_server/test/test_utils.dart
@@ -13,7 +13,10 @@ import 'package:at_secondary/src/connection/outbound/outbound_client.dart';
 import 'package:at_secondary/src/connection/outbound/outbound_client_manager.dart';
 import 'package:at_secondary/src/connection/outbound/outbound_connection.dart';
 import 'package:at_secondary/src/enroll/enrollment_manager.dart';
+import 'package:at_secondary/src/notification/at_notification_map.dart';
 import 'package:at_secondary/src/notification/notification_manager_impl.dart';
+import 'package:at_secondary/src/notification/notify_connection_pool.dart';
+import 'package:at_secondary/src/notification/resource_manager.dart';
 import 'package:at_secondary/src/notification/stats_notification_service.dart';
 import 'package:at_secondary/src/server/at_secondary_impl.dart';
 import 'package:at_secondary/src/utils/secondary_util.dart';
@@ -58,7 +61,7 @@ class MockSecureSocket extends Mock implements SecureSocket {}
 
 class MockEnrollmentManager extends Mock implements EnrollmentManager {}
 
-class MockSocket extends Mock implements Socket {
+class FakeSocket extends Fake implements Socket {
   Completer completer = Completer();
 
   @override
@@ -75,6 +78,9 @@ class MockSocket extends Mock implements Socket {
 
   @override
   int get port => 5555;
+
+  @override
+  bool setOption(SocketOption option, bool enabled) => true;
 }
 
 class MockStreamSubscription<T> extends Mock implements StreamSubscription<T> {}
@@ -102,7 +108,7 @@ late MockOutboundConnection mockOutboundConnection;
 late MockSecondaryAddressFinder mockSecondaryAddressFinder;
 late MockSecureSocket mockSecureSocket;
 late DummyInboundConnection inboundConnection;
-late MockNotificationManager notificationManager;
+late NotificationManager notificationManager;
 late MockStatsNotificationService statsNotificationService;
 late EnrollmentManager enMgr;
 
@@ -197,16 +203,24 @@ verbTestsSetUp() async {
   // inboundPool.add(inboundConnection);
 
   outboundClientWithHandshake = OutboundClient(
-      inboundConnection, bob, mockSecondaryAddressFinder, true,
-      outboundConnectionFactory: mockOutboundConnectionFactory)
+    inboundConnection,
+    bob,
+    mockSecondaryAddressFinder,
+    true,
+    mockOutboundConnectionFactory,
+  )
     ..notifyTimeoutMillis = 100
     ..lookupTimeoutMillis = 100
     ..toHost = bobHost
     ..toPort = bobPort.toString()
     ..productionMode = false;
   outboundClientWithoutHandshake = OutboundClient(
-      inboundConnection, bob, mockSecondaryAddressFinder, false,
-      outboundConnectionFactory: mockOutboundConnectionFactory)
+    inboundConnection,
+    bob,
+    mockSecondaryAddressFinder,
+    false,
+    mockOutboundConnectionFactory,
+  )
     ..notifyTimeoutMillis = 100
     ..lookupTimeoutMillis = 100
     ..toHost = bobHost
@@ -301,10 +315,11 @@ verbTestsSetUp() async {
     socketOnDataFn("data:$bobOriginalPublicKeyAsJson\n$alice@".codeUnits);
   });
 
-  notificationManager = MockNotificationManager();
+  notificationManager = NotificationManager(ResourceManager(
+      NotifyConnectionsPool(DefaultOutboundConnectionFactory(requireCerts: false))));
   registerFallbackValue(AtNotificationBuilder().build());
-  when(() => notificationManager.notify(any()))
-      .thenAnswer((invocation) async => 'some-notification-id');
+  // when(() => notificationManager.notify(any()))
+  //     .thenAnswer((invocation) async => 'some-notification-id');
 
   statsNotificationService = MockStatsNotificationService();
 }
@@ -314,6 +329,8 @@ Future<void> verbTestsTearDown() async {
   secondaryKeyStore.postRemoveHooks.clear();
   await SecondaryPersistenceStoreFactory.getInstance().close();
   await AtCommitLogManagerImpl.getInstance().close();
+  await AtNotificationKeystore.getInstance().close(); // TODO deep
+  AtNotificationMap.getInstance().clear(); // TODO sigh
   var isExists = await Directory(storageDir).exists();
   if (isExists) {
     Directory(storageDir).deleteSync(recursive: true);

--- a/packages/at_secondary_server/test/test_utils.dart
+++ b/packages/at_secondary_server/test/test_utils.dart
@@ -316,7 +316,8 @@ verbTestsSetUp() async {
   });
 
   notificationManager = NotificationManager(ResourceManager(
-      NotifyConnectionsPool(DefaultOutboundConnectionFactory(requireCerts: false))));
+      NotifyConnectionsPool(
+          DefaultOutboundConnectionFactory(requireCerts: false))));
   registerFallbackValue(AtNotificationBuilder().build());
   // when(() => notificationManager.notify(any()))
   //     .thenAnswer((invocation) async => 'some-notification-id');

--- a/packages/at_secondary_server/test/update_verb_test.dart
+++ b/packages/at_secondary_server/test/update_verb_test.dart
@@ -32,14 +32,12 @@ import 'test_utils.dart';
 
 void main() {
   late SecondaryKeyStore mockKeyStore;
-  late MockSocket mockSocket;
+  late FakeSocket mockSocket;
 
   setUpAll(() async {
     await verbTestsSetUpAll();
     mockKeyStore = MockSecondaryKeyStore();
-    mockSocket = MockSocket();
-    when(() => mockSocket.setOption(SocketOption.tcpNoDelay, true))
-        .thenReturn(true);
+    mockSocket = FakeSocket();
   });
 
   setUp(() async {
@@ -1318,8 +1316,6 @@ void main() {
     Response response = Response();
     late String enrollmentId;
     setUp(() async {
-      await verbTestsSetUp();
-
       inboundConnection.metadata.isAuthenticated =
           true; // owner connection, authenticated
       enrollmentId = Uuid().v4();
@@ -1383,7 +1379,6 @@ void main() {
               e.message ==
                   'Connection with enrollment ID $enrollmentId is not authorized to update key: $alice:dummykey.wavi$alice')));
     });
-    tearDown(() async => await verbTestsTearDown());
   });
 
   group(
@@ -1433,14 +1428,10 @@ void main() {
                     'Connection with enrollment ID $enrollmentId is not authorized to update key: $alice:dummykey.wavi$alice')));
       });
     }
-    tearDown(() async => await verbTestsTearDown());
   });
   group('A group of tests related to access authorization', () {
     Response response = Response();
     late String enrollmentId;
-    setUp(() async {
-      await verbTestsSetUp();
-    });
 
     test('A test to verify update verb is allowed if key is a reserved key',
         () async {
@@ -1752,18 +1743,11 @@ void main() {
               e.message ==
                   'Connection with enrollment ID $enrollmentId is not authorized to update key: at_connections.bob.alice.buzz$alice')));
     });
-    tearDown(() async => await verbTestsTearDown());
   });
 
   group('A group of tests related to apkam keys expiry', () {
     Response response = Response();
     late String enrollmentId;
-
-    setUp(() async {
-      await verbTestsSetUp();
-    });
-
-    tearDown(() async => await verbTestsTearDown());
 
     test('A test to verify update verb fails when apkam keys are expired',
         () async {

--- a/packages/at_secondary_server/test/update_verb_test.dart
+++ b/packages/at_secondary_server/test/update_verb_test.dart
@@ -1,6 +1,5 @@
 import 'dart:collection';
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:at_commons/at_builders.dart';
 import 'package:at_commons/at_commons.dart';
@@ -24,7 +23,6 @@ import 'package:at_secondary/src/verb/handler/local_lookup_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/update_verb_handler.dart';
 import 'package:at_server_spec/at_verb_spec.dart';
 import 'package:crypto/crypto.dart';
-import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 import 'package:uuid/uuid.dart';
 


### PR DESCRIPTION
**- What I did**
- feat: present mtls client certs to other atServers, if available, rather than presenting the server's server certs.
- refactor: require an OutboundConnectionFactory to be injected into OutboundClient, and deal with all the ripple effects from this, including removing a few more singletons (yay!)
  - [Aside: Only eight singletons now remaining]

**- How I did it**
See commits and comments

**- How to verify it**
- existing tests pass

Have manually verified in testing. This version should be safe to merge to trunk after which we can commence testing in earnest on the staging fleet.

The actual logic changes are highlighted via comments on the file diffs. You can ignore the changes to all of the unit tests, there are no material changes, just dealing with the refactoring.
