### PR TITLE
feat: enable skipCommitsForExpiredKeys flag

### DIFF
--- a/packages/at_persistence_secondary_server/lib/src/keystore/hive_keystore.dart
+++ b/packages/at_persistence_secondary_server/lib/src/keystore/hive_keystore.dart
@@ -224,8 +224,10 @@ class HiveKeystore implements SecondaryKeyStore<String, AtData?, AtMetaData?> {
       // On deleting the key, remove it from the expiryKeyCache.
       _expiryKeysCache.remove(key);
       if (skipCommit) {
-        // when skipping commits for expired keys, remove the existing commitEntries
-        // from commitLog to ensure that commitLog and KeyStore are in sync
+        // When skipping commits, remove any existing commit entries for this
+        // key from commitLog. This is critical for synchronization - during
+        // sync, other commit entries for this key might be considered valid
+        // if we don't remove them.
         CommitEntry? commitEntry = _commitLog.getLatestCommitEntry(key);
         if (commitEntry != null) {
           await _commitLog.commitLogKeyStore.remove(commitEntry.commitId!);

--- a/packages/at_persistence_secondary_server/lib/src/keystore/hive_keystore.dart
+++ b/packages/at_persistence_secondary_server/lib/src/keystore/hive_keystore.dart
@@ -253,7 +253,7 @@ class HiveKeystore implements SecondaryKeyStore<String, AtData?, AtMetaData?> {
   @override
   @server
   @client
-  Future<bool> deleteExpiredKeys({bool? skipCommit = false}) async {
+  Future<bool> deleteExpiredKeys({bool skipCommit = false}) async {
     logger.finer('Removing expired keys');
     bool result = true;
     try {
@@ -266,7 +266,7 @@ class HiveKeystore implements SecondaryKeyStore<String, AtData?, AtMetaData?> {
         try {
           // delete entries for expired keys will not be added to the commitLog
           // Removal of expired keys will be handled on the client side
-          await remove(element, skipCommit: skipCommit!);
+          await remove(element, skipCommit: skipCommit);
         } on KeyNotFoundException {
           continue;
         }

--- a/packages/at_secondary_server/config/config.yaml
+++ b/packages/at_secondary_server/config/config.yaml
@@ -53,6 +53,8 @@ hive:
   # The keys added to the following list will be considered as protectedKeys and will be forbidden from deletion
   # Any key that contains the 'atSign' should be formatted as key<@atsign>. <@atsign> will be replaced with the actual atsign during runtime
   protectedKeys: []
+  # Skips creating commitLog entries when deleting expired keys as part of compaction job
+  skipCommitsForExpiredKeys: true
 
 # The atProtocol connection configurations.
 connection:

--- a/packages/at_secondary_server/lib/src/server/at_secondary_config.dart
+++ b/packages/at_secondary_server/lib/src/server/at_secondary_config.dart
@@ -112,7 +112,7 @@ class AtSecondaryConfig {
   static final List<String> _malformedKeys = [];
   static const bool _shouldRemoveMalformedKeys = true;
 
-  static final bool _skipCommitsForExpiredKeys = false;
+  static final bool _skipCommitsForExpiredKeys = true;
 
   // Protected Keys
   // <@atsign> is a placeholder. To be replaced with actual atsign during runtime

--- a/packages/at_secondary_server/lib/src/server/at_secondary_config.dart
+++ b/packages/at_secondary_server/lib/src/server/at_secondary_config.dart
@@ -759,6 +759,22 @@ class AtSecondaryConfig {
     }
   }
 
+  static bool get skipCommitsForExpiredKeys {
+    // read from env var if set
+    bool? result = _getBoolEnvVar('skipCommitsForExpiredKeys');
+    if (result != null) {
+      return result;
+    }
+
+    // read from config file if available
+    try {
+      return getConfigFromYaml(['hive', 'skipCommitsForExpiredKeys']);
+    } on ElementNotFoundException {
+      // if not found, fallback to class variable
+      return _skipCommitsForExpiredKeys;
+    }
+  }
+
   static Set<String> get protectedKeys {
     try {
       YamlList keys = getConfigFromYaml(['hive', 'protectedKeys']);
@@ -819,10 +835,6 @@ class AtSecondaryConfig {
 
   static set timeFrameInMills(int timeWindowInMills) {
     _timeFrameInMills = timeWindowInMills;
-  }
-
-  static get skipCommitsForExpiredKeys {
-    return _skipCommitsForExpiredKeys;
   }
 
   static int get enrollmentResponseDelayIntervalInSeconds {

--- a/packages/at_secondary_server/test/secondary_config_test.dart
+++ b/packages/at_secondary_server/test/secondary_config_test.dart
@@ -26,8 +26,8 @@ void main() async {
       expect(atLogger.logger.level, equals(logging.Level.WARNING));
     });
 
-    test('verify skipCommitsForExpiredKeys is set to FALSE', () {
-      expect(AtSecondaryConfig.skipCommitsForExpiredKeys, false);
+    test('verify skipCommitsForExpiredKeys is set to TRUE', () {
+      expect(AtSecondaryConfig.skipCommitsForExpiredKeys, true);
     });
   });
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
Closes https://github.com/atsign-foundation/at_server/issues/1728

**- What I did**
- Enable the `skipCommitsForExpiredKeys` flag.
- Add `skipCommitsForExpiredKeys` to the at_server config file and supporting logic to read from it.
- This ensures that commit entries for keys deleted during compaction (expired key removal) are not written to the commit log. As a result, deletions of expired keys do not need to be synced and are instead handled by client-side compaction jobs.
- This also removes any existing commit entries for the affected key, ensuring that no other commit entries for that key are synced to clients.

**- How I did it**
- Add `skipCommitsForExpiredKeys` to the at_server config file under the hive section (set to true)
- Set the fallback class variable `_skipCommitsForExpiredKeys` to true in AtSecondaryConfig
- Add getter for the same in `AtSecondaryConfig`

**- How to verify it**
- Tests pass here
- Manually:
   - Insert a bunch of keys into the server that expire in x minutes. 
   - After x minutes, start an at_client instance, and this specific bunch of keys should not be sent/received through sync.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
feat: enable skipCommitsForExpiredKeys flag