### PR TITLE
ci: Workflow and script to check for changes to CA certs

### DIFF
--- a/.github/workflows/check_cacerts.yml
+++ b/.github/workflows/check_cacerts.yml
@@ -1,0 +1,31 @@
+name: CA Root Check
+
+on:
+  schedule:
+    # Runs at 06:26 UTC every Monday
+    - cron: '26 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify-cacerts:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Run Certificate Comparison
+        id: compare_cacerts
+        working-directory: packages/at_secondary_server/cacert
+        run: ${{ github.workspace }}/tools/compare_cacerts.sh
+
+      - name: Google Chat Notification on failure
+        if: steps.compare_cacerts.outcome == 'failure'
+        uses: Co-qn/google-chat-notification@3691ccf4763537d6e544bc6cdcccc1965799d056 # v1
+        with:
+          name: Changes found in cacerts
+          url: ${{ secrets.GOOGLE_CHAT_WEBHOOK }}
+          status: ${{ job.status }}

--- a/tools/compare_cacerts.sh
+++ b/tools/compare_cacerts.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Configuration
+ATCAS="cacert.pem"   # Your existing file
+MOZCAS="https://curl.se/ca/cacert.pem"
+TARGET_CAS=(
+    "GlobalSign ECC Root CA - R4"
+    "GTS Root R1"
+    "GTS Root R2"
+    "GTS Root R3"
+    "GTS Root R4"
+    "ISRG Root X1"
+    "ISRG Root X2"
+    "USERTrust RSA Certification Authority"
+    "USERTrust ECC Certification Authority"
+)
+
+# Function to extract fingerprint by CN from a specific file
+get_fingerprint() {
+    local label="$1"
+    local file="$2"
+    
+    # Extract the block and pipe directly to openssl
+    awk -v search="$label" '
+        BEGIN { found=0 }
+        $0 ~ search { found=1 }
+        found { print $0 }
+        /END CERTIFICATE/ && found { exit }
+    ' "$file" | openssl x509 -noout -fingerprint -sha256 2>/dev/null | cut -d'=' -f2
+}
+
+
+if [ ! -f "${ATCAS}" ]; then
+    echo "Error: Local file $ATCAS not found."
+    exit 1
+fi
+echo "--- Downloading remote cacert.pem ---"
+curl -s -L -o "moz_cacert.pem" "$MOZCAS"
+echo "-----------------------------------------------------------------------"
+printf "%-40s | %-15s\n" "Certificate Name" "Match Status"
+echo "-----------------------------------------------------------------------"
+# Main comparison loop
+CHANGES_DETECTED=0
+for target in "${TARGET_CAS[@]}"; do
+    LOCAL_FP=$(get_fingerprint "$target" "$ATCAS")
+    REMOTE_FP=$(get_fingerprint "$target" "moz_cacert.pem")
+    if [ -z "$REMOTE_FP" ]; then
+        printf "%-40s | %-15s\n" "$target" "MISSING REMOTE"
+        CHANGES_DETECTED=1
+    elif [ -z "$LOCAL_FP" ]; then
+        printf "%-40s | %-15s\n" "$target" "MISSING LOCAL"
+        CHANGES_DETECTED=1
+    elif [ "$LOCAL_FP" == "$REMOTE_FP" ]; then
+        printf "%-40s | %-15s\n" "$target" "IDENTICAL"
+    else
+        printf "%-40s | %-15s\n" "$target" "CHANGED!"
+        echo "   Local:  $LOCAL_FP"
+        echo "   Remote: $REMOTE_FP"
+        CHANGES_DETECTED=1
+    fi
+done
+echo "-----------------------------------------------------------------------"
+if [ $CHANGES_DETECTED -eq 1 ]; then
+    echo "Warning: Root certificates have changed."
+    exit 1
+else
+    echo "Verification complete. No changes in targeted roots."
+    exit 0
+fi


### PR DESCRIPTION
Make sure that CA certs don't change under our feet

**- What I did**

Added script and workflow to check for any changes to CA certs

**- How I did it**

Script and workflow created with Gemini and refined manually.

Prompts:

> I need a script that downloads a cacert.pem file from curl and checks whether a subset of the certs has changed (Google, ISRG and USERTrust)

> modify the script to compare fingerprints against an existing cacert.pem file

> refactor so the TARGET_CAS list doesn't pass 80 char line length

> write a github action that will run the script (from tools/compare_cacerts.sh) weekly

> add SHA pinning to the actions used

> add comments so we know what version the SHA refers to

> the comment should be something like # v4.2.2 on the line containing the sha

> change the timing to 0626 UTC on Monday

> modify the compare_certs step to run against the packages/at_secondary_server/cacert directory

> change the workflow not the script

> don't use ../../.. for the script location

> add a step for a google chat notification on failure

Script tested locally.

**- How to verify it**

Workflow dispatch run once merged

**- Description for the changelog**

ci: Workflow and script to check for changes to CA certs
