### PR TITLE
fix: Path for mtls script

### DIFF
--- a/.github/workflows/refreshcerts.yaml
+++ b/.github/workflows/refreshcerts.yaml
@@ -74,7 +74,7 @@ jobs:
           cp ../../tools/build_virtual_environment/ve_base/contents/atsign/root/certs/*.pem \
             ../../tools/build_ephemeral_environment/ee_base/contents/atsign/secondary/base/certs/
           mkdir mtls && cd mtls
-          ./create_mtls_workflow.sh vip.ve.atsign.zone
+          ../create_mtls_workflow.sh vip.ve.atsign.zone
           cp privkey.pem ../../../../../tools/build_virtual_environment/ve_base/contents/atsign/secondary/base/certs/mtls/
           cp fullchain.pem ../../../../../tools/build_virtual_environment/ve_base/contents/atsign/secondary/base/certs/mtls/
           cp ../../tools/build_virtual_environment/ve_base/contents/atsign/secondary/base/certs/mtls/*.pem \


### PR DESCRIPTION
Script needs to be run from parent directory :facepalm: 

https://github.com/atsign-foundation/at_server/actions/runs/20960107478

**- What I did**

s/./../

**- How to verify it**

Another manual run of the workflow

**- Description for the changelog**

fix: Path for mtls script
