### PR TITLE
fix: Locations for mtls script and certs

### DIFF
--- a/.github/workflows/refreshcerts.yaml
+++ b/.github/workflows/refreshcerts.yaml
@@ -73,10 +73,9 @@ jobs:
             ../../tools/build_ephemeral_environment/ee_base/contents/atsign/root/certs/
           cp ../../tools/build_virtual_environment/ve_base/contents/atsign/root/certs/*.pem \
             ../../tools/build_ephemeral_environment/ee_base/contents/atsign/secondary/base/certs/
-          mkdir mtls && cd mtls
-          ../create_mtls_workflow.sh vip.ve.atsign.zone
-          cp privkey.pem ../../../../../tools/build_virtual_environment/ve_base/contents/atsign/secondary/base/certs/mtls/
-          cp fullchain.pem ../../../../../tools/build_virtual_environment/ve_base/contents/atsign/secondary/base/certs/mtls/
+          ./create_mtls_workflow.sh vip.ve.atsign.zone
+          cp mtls/privkey.pem ../../tools/build_virtual_environment/ve_base/contents/atsign/secondary/base/certs/mtls/
+          cp mtls/fullchain.pem ../../tools/build_virtual_environment/ve_base/contents/atsign/secondary/base/certs/mtls/
           cp ../../tools/build_virtual_environment/ve_base/contents/atsign/secondary/base/certs/mtls/*.pem \
             ../../tools/build_ephemeral_environment/ee_base/contents/atsign/secondary/base/certs/mtls/
           cd ../../.. && rm -rf  vip.ve.atsign.zone* secondaries-scripts


### PR DESCRIPTION
Previous workflow didn't handle location of mtls certs correctly

**- What I did**

Adjusted to reflect what `create_mtls_workflow.sh` does

**- How to verify it**

Manual run once merged

**- Description for the changelog**

fix: Locations for mtls script and certs
