### PR TITLE
fix: Ensure that dummy.key is in place for mTLS cert creation

### DIFF
--- a/.github/workflows/refreshcerts.yaml
+++ b/.github/workflows/refreshcerts.yaml
@@ -36,6 +36,7 @@ jobs:
         run: |-
           sudo mkdir -p /gluster/@/api/keys
           sudo chmod -R 777 /gluster/@/api/keys
+          echo "${{secrets.DUMMY_PRIVKEY}}" > /gluster/@/api/keys/dummy.key
           echo "${{secrets.LETSENCRYPT_PRIVKEY}}" > /gluster/@/api/keys/letsencrypt.key
           echo "${{secrets.ZEROSSL_PRIVKEY}}" > /gluster/@/api/keys/zerossl.key
           echo "${{secrets.GOOGLE_PRIVKEY}}" > /gluster/@/api/keys/google.key


### PR DESCRIPTION
Actions run failed as dummy.key not found

**- What I did**

* Added dummy.key to secrets
* Added a line to copy it into place

**- How to verify it**

Another manual workflow run

**- Description for the changelog**

fix: Ensure that dummy.key is in place for mTLS cert creation
