### PR TITLE
ci: Refactor to minimise time from npt tunnel to mtls cert creation

### DIFF
--- a/.github/workflows/refreshcerts.yaml
+++ b/.github/workflows/refreshcerts.yaml
@@ -25,12 +25,6 @@ jobs:
           path: secondaries-scripts
           token: ${{ secrets.MY_GITHUB_TOKEN }}
           ref: trunk
-      # Install NoPorts and atKeys
-      - name: Setup NoPorts and Authentication
-        uses: atsign-foundation/noports-action@464b931232f49cd302ecf5eb913cfe2c778fbd6e # v1.0.0
-        with:
-          atsign: '@stepcaprod'
-          atkeys-secret: ${{ secrets.ATKEYS_STEPCAPROD }}
       # Create required directory, and copy keys files from secrets
       - name: Create required directory and pull secrets
         run: |-
@@ -40,6 +34,28 @@ jobs:
           echo "${{secrets.LETSENCRYPT_PRIVKEY}}" > /gluster/@/api/keys/letsencrypt.key
           echo "${{secrets.ZEROSSL_PRIVKEY}}" > /gluster/@/api/keys/zerossl.key
           echo "${{secrets.GOOGLE_PRIVKEY}}" > /gluster/@/api/keys/google.key
+      # Install Python Libraries
+      - name: Install uv
+        uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0
+      - name: Install Python Libraries
+        run: |-
+          sudo apt-get install python3-poetry-plugin-export
+          uv venv
+          . .venv/bin/activate
+          cd tools
+          poetry export --format requirements.txt --output requirements.txt
+          uv pip install --require-hashes -r requirements.txt
+      # Ensure runner trusts our CA
+      - name: Add Custom CA to Runner Trust Store
+        run: |
+          echo "${{ vars.PRODCA }}" | sudo tee /usr/local/share/ca-certificates/stepcaprod.crt > /dev/null
+          sudo update-ca-certificates
+      # Install NoPorts and atKeys
+      - name: Setup NoPorts and Authentication
+        uses: atsign-foundation/noports-action@464b931232f49cd302ecf5eb913cfe2c778fbd6e # v1.0.0
+        with:
+          atsign: '@stepcaprod'
+          atkeys-secret: ${{ secrets.ATKEYS_STEPCAPROD }}
       # Connect to the Atsign Prod CA
       - name: Establish a NoPorts tunnel
         run: |
@@ -47,45 +63,33 @@ jobs:
             -l 3443 -p 3443 --rh 127.0.0.1 --lh 127.0.0.1 -T 0 \
             > npt.log 2> npt.err < /dev/null &
           tail -f npt.err | grep -m 1 "npt is listening"
-      # Ensure runner trusts our CA
-      - name: Add Custom CA to Runner Trust Store
-        run: |
-          echo "${{ vars.PRODCA }}" | sudo tee /usr/local/share/ca-certificates/stepcaprod.crt > /dev/null
-          sudo update-ca-certificates
       # Test npt connection to prod CA
       - name: Test npt connection to prod CA
         run: |
           curl https://ca.atsign.org:3443/acme/acme/directory
-      # Install Python Libraries and run Python ACME script
-      - name: Install uv
-        uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0
-      - name: Install Python Libraries, run create_cert script then copy certs to right place
+      # Create and copy certs (mTLS first)
+      - name: Run create_cert scripts then copy certs to right place
         run: |-
           chmod -R 777 secondaries-scripts
-          sudo apt-get install python3-poetry-plugin-export
-          cd tools
-          uv venv
           . .venv/bin/activate
-          poetry export --format requirements.txt --output requirements.txt
-          uv pip install --require-hashes -r requirements.txt
-          cd ../secondaries-scripts/sec_ops
-          ./create_cert_workflow.sh vip.ve.atsign.zone
-          mv privkey.pem ../../tools/build_virtual_environment/ve_base/contents/atsign/root/certs/privkey.pem
-          mv fullchain.pem ../../tools/build_virtual_environment/ve_base/contents/atsign/root/certs/fullchain.pem
-          cp ../../tools/build_virtual_environment/ve_base/contents/atsign/root/certs/*.pem \
-            ../../tools/build_virtual_environment/ve_base/contents/atsign/secondary/base/certs/
-          cp ../../tools/build_virtual_environment/ve_base/contents/atsign/root/certs/*.pem \
-            ../../tools/build_ephemeral_environment/ee_base/contents/atsign/root/certs/
-          cp ../../tools/build_virtual_environment/ve_base/contents/atsign/root/certs/*.pem \
-            ../../tools/build_ephemeral_environment/ee_base/contents/atsign/secondary/base/certs/
-          rm vip.ve.atsign.zone*
+          cd secondaries-scripts/sec_ops
           ./create_mtls_workflow.sh vip.ve.atsign.zone
-          cp mtls/privkey.pem ../../tools/build_virtual_environment/ve_base/contents/atsign/secondary/base/certs/mtls/
-          cp mtls/fullchain.pem ../../tools/build_virtual_environment/ve_base/contents/atsign/secondary/base/certs/mtls/
-          cp ../../tools/build_virtual_environment/ve_base/contents/atsign/secondary/base/certs/mtls/*.pem \
-            ../../tools/build_ephemeral_environment/ee_base/contents/atsign/secondary/base/certs/mtls/
-          cd ../.. && rm -rf secondaries-scripts
+          cp mtls/privkey.pem ${WS}/tools/build_virtual_environment/ve_base/contents/atsign/secondary/base/certs/mtls/
+          cp mtls/fullchain.pem ${WS}/tools/build_virtual_environment/ve_base/contents/atsign/secondary/base/certs/mtls/
+          cp ${WS}/tools/build_virtual_environment/ve_base/contents/atsign/secondary/base/certs/mtls/*.pem \
+            ${WS}/tools/build_ephemeral_environment/ee_base/contents/atsign/secondary/base/certs/mtls/
+          ./create_cert_workflow.sh vip.ve.atsign.zone
+          cp privkey.pem ${WS}/tools/build_virtual_environment/ve_base/contents/atsign/root/certs/privkey.pem
+          cp fullchain.pem ${WS}/tools/build_virtual_environment/ve_base/contents/atsign/root/certs/fullchain.pem
+          cp ${WS}/tools/build_virtual_environment/ve_base/contents/atsign/root/certs/*.pem \
+            ${WS}/tools/build_virtual_environment/ve_base/contents/atsign/secondary/base/certs/
+          cp ${WS}/tools/build_virtual_environment/ve_base/contents/atsign/root/certs/*.pem \
+            ${WS}/tools/build_ephemeral_environment/ee_base/contents/atsign/root/certs/
+          cp ${WS}/tools/build_virtual_environment/ve_base/contents/atsign/root/certs/*.pem \
+            ${WS}/tools/build_ephemeral_environment/ee_base/contents/atsign/secondary/base/certs/
+          cd ${WS} && rm -rf secondaries-scripts
         env:
+          WS: ${{ github.workspace }}
           DO_KEY: ${{ secrets.DO_KEY }}
           gChat_url: ${{ secrets.GOOGLE_CHAT_WEBHOOK }}
       # create PR with renewed certificates


### PR DESCRIPTION
The refreshcerts workflow is still failing when it gets to the `create_mtls_workflow.sh` call returning an error that it can't get the ACME directory (suggesting a connectivity problem to the CA).

**- What I did**

* Refactored so that time between establishing (and testing) then using the npt tunnel is minimised.
* Replaced lots of `../..` with an env variable `${WS}` pointing to `{{ github.workspace }}` so that the locations are less confusing

**- How to verify it**

Will need another manual run of the workflow.

**- Description for the changelog**

ci: Refactor to minimise time from npt tunnel to mtls cert creation
