### PR TITLE
fix: Override default venv trust store

### DIFF
--- a/.github/workflows/refreshcerts.yaml
+++ b/.github/workflows/refreshcerts.yaml
@@ -92,6 +92,9 @@ jobs:
           WS: ${{ github.workspace }}
           DO_KEY: ${{ secrets.DO_KEY }}
           gChat_url: ${{ secrets.GOOGLE_CHAT_WEBHOOK }}
+          # Python in venv will use certifi trust store by default
+          REQUESTS_CA_BUNDLE: /etc/ssl/certs/ca-certificates.crt
+          SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
       # create PR with renewed certificates
       - name: Create Pull Request
         id: cpr


### PR DESCRIPTION
Looks like mTLS cert generation is failing as the script is running in a venv that will have its own cacerts

**- What I did**

Added env variables that should be used by the requests package to (re)use the system cacerts

**- How I did it**

Gemini prompts:

> what can cause a python3 requests.get to fail when curl works for the same url?

identified: 

>`curl` and `python` use different "trust stores" (bundles of Root Certificates). If the server uses a self-signed certificate or a newer Certificate Authority (CA), Python might reject it while your system’s curl accepts it.
>
>* Python's Store: Usually provided by the certifi package.
>* Curl's Store: Usually the system-wide OpenSSL store.

then:

> how do I update certifi to point to my system ca bundle

suggested setting env variables used by requests

```sh
export REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
```

**- How to verify it**

Manual refreshcerts workflow run

**- Description for the changelog**

fix: Override default venv trust store
