### PR TITLE
fix: remove call to `flush` from `BaseSocketConnection.write()` to prevent a race condition

### DIFF
--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.9.2
+
+- fix: remove call to `flush` from `BaseSocketConnection.write()` thus
+  preventing a race which was triggering a `StreamSink is bound to a stream`
+  StateError
+
 # 3.9.1
 
 - chore: deal with breaking changes introduced by at_commons 5.8.0

--- a/packages/at_secondary_server/lib/src/connection/base_connection.dart
+++ b/packages/at_secondary_server/lib/src/connection/base_connection.dart
@@ -43,11 +43,10 @@ abstract class BaseSocketConnection<T extends Socket> extends AtConnection {
     }
     try {
       underlying.write(data);
-      await underlying.flush();
       metaData.lastAccessed = DateTime.now().toUtc();
-    } on Exception catch (e) {
+    } catch (e) {
       metaData.isStale = true;
-      logger.severe(e.toString());
+      logger.severe('write caught ${e.toString()}');
       throw AtIOException(e.toString());
     }
   }

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_secondary
 description: Implementation of secondary server.
-version: 3.9.1
+version: 3.9.2
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://www.example.com
 publish_to: none


### PR DESCRIPTION
**- What I did**
fix: remove call to `flush` from `BaseSocketConnection.write()` thus preventing a race which was causing a `StreamSink is bound to a stream` StateError which in turn was resulting in premature closing of socket connections in certain situations. 

Example - an atServer with many `monitor` connections, while processing a `notify:` request from another atServer, would write the notification immediately to all of those monitor connections. Every now and again, and more likely the more `monitor` connections there are, a previous `flush` on that monitor connection would still be in progress, causing `write` to throw a StateError, which was uncaught except by the socket handler's runZonedGuarded which would then close the inbound connection without writing a response.

**- How I did it**
See commits. Also changed the catch so it catches (and rethrows) everything. (Previously was only catching Exception, but StateError is an Error which is not a subclass of Exception)

**- How to verify it**
Tests pass. Then soak with atSign combo where this has been more likely to occur.
