### PR TITLE
fix: only allow `enroll:deny` to operate on `pending` enrollments

### DIFF
--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.9.3
+
+- fix: only allow `enroll:deny` to operate on `pending` enrollments
+
 # 3.9.2
 
 - fix: remove call to `flush` from `BaseSocketConnection.write()` thus

--- a/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
@@ -562,6 +562,10 @@ class EnrollVerbHandler extends AbstractVerbHandler {
       throw IllegalStateException(
           'Cannot approve a ${enrollStatus.name} enrollment. Only pending enrollments can be approved');
     }
+    if (operation == 'deny' && EnrollmentStatus.pending != enrollStatus) {
+      throw IllegalStateException(
+          'Cannot deny a ${enrollStatus.name} enrollment. Only pending enrollments can be denied');
+    }
     if (operation == 'revoke' && EnrollmentStatus.approved != enrollStatus) {
       throw IllegalStateException(
           'Cannot revoke a ${enrollStatus.name} enrollment. Only approved enrollments can be revoked');

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_secondary
 description: Implementation of secondary server.
-version: 3.9.2
+version: 3.9.3
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://www.example.com
 publish_to: none

--- a/packages/at_secondary_server/test/enroll_verb_test.dart
+++ b/packages/at_secondary_server/test/enroll_verb_test.dart
@@ -1582,6 +1582,36 @@ void main() {
                   'Failed to approve enrollment id: $enrollmentId. Cannot approve a revoked enrollment. Only pending enrollments can be approved')));
     });
 
+    test('A test to verify that an approved enrollment cannot be denied',
+        () async {
+      Response response = Response();
+      //approve enrollment
+      String approveEnrollmentCommand =
+          'enroll:approve:{"enrollmentId":"$enrollmentId","encryptedDefaultEncryptionPrivateKey":"dummy_encrypted_private_key","encryptedDefaultSelfEncryptionKey":"dummy_self_encrypted_key"}';
+      HashMap<String, String?> approveEnrollVerbParams =
+          getVerbParam(VerbSyntax.enroll, approveEnrollmentCommand);
+      inboundConnection.metaData.isAuthenticated = true;
+      inboundConnection.metaData.sessionID = 'dummy_session_id';
+      await enrollVerbHandler.processVerb(
+          response, approveEnrollVerbParams, inboundConnection);
+      expect(jsonDecode(response.data!)['enrollmentId'], enrollmentId);
+      expect(jsonDecode(response.data!)['status'], 'approved');
+
+      // Deny an approved enrollment throws AtEnrollmentException
+      expect(
+          () async => await enrollVerbHandler.processVerb(
+              response,
+              getVerbParam(VerbSyntax.enroll,
+                  'enroll:deny:{"enrollmentId":"$enrollmentId"}'),
+              inboundConnection),
+          throwsA(predicate((dynamic e) =>
+              e is IllegalStateException &&
+              e.message ==
+                  'Failed to deny enrollment id: $enrollmentId.'
+                      ' Cannot deny a approved enrollment.'
+                      ' Only pending enrollments can be denied')));
+    });
+
     test('A test to verify pending enrollment cannot be revoked', () async {
       Response response = Response();
       //revoke enrollment


### PR DESCRIPTION
**- What I did**
- fix: only allow `enroll:deny` to operate on `pending` enrollments
- fixes #2509 
- build: update CHANGELOG and pubspec for 3.9.3

**- How I did it**
- added missing guard to EnrollVerbHandler
- added unit test

**- How to verify it**
- Tests pass
