### PR TITLE
ci: Use a unique COMPONENT_VERSION rather than deprecated SBOM_VERSION

### DIFF
--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -122,7 +122,7 @@ jobs:
           TOKEN: ${{ secrets.SBOMIFY_TOKEN }}
           COMPONENT_ID: "3hQHrn8mwK"
           LOCK_FILE: ${{ env.root-working-directory }}/pubspec.lock
-          SBOM_VERSION: ${{github.ref_name}}
+          COMPONENT_VERSION: ${{github.ref_name}}-gha${{github.run_number}}
           OUTPUT_FILE: "sboms/atdirectory-gha${{github.run_number}}-sbom.cdx.json"
           AUGMENT: true
           ENRICH: true
@@ -134,7 +134,7 @@ jobs:
           TOKEN: ${{ secrets.SBOMIFY_TOKEN }}
           COMPONENT_ID: "wF66pn8rHZ"
           LOCK_FILE: ${{ env.secondary-working-directory }}/pubspec.lock
-          SBOM_VERSION: ${{github.ref_name}}
+          COMPONENT_VERSION: ${{github.ref_name}}-gha${{github.run_number}}
           OUTPUT_FILE: "sboms/atserver-gha${{github.run_number}}-sbom.cdx.json"
           AUGMENT: true
           ENRICH: true


### PR DESCRIPTION
Stable unit tests are [failing ](https://github.com/atsign-foundation/at_server/actions/runs/21197825154/job/60982165916)since upgrade to sbomify Action v0.11 as the back end now requires a unique COMPONENT_VERSION

**- What I did**

s/SBOM_VERSION/COMPONENT_VERSION/
Added `-gha{github.run_number}` as suffix

**- How I did it**

Discussion with @vpetersson

**- How to verify it**

Action will run on this being merged

**- Description for the changelog**

ci: Use a unique COMPONENT_VERSION rather than deprecated SBOM_VERSION
