### PR TITLE
fix: backwards compatibility

### DIFF
--- a/packages/at_persistence_secondary_server/CHANGELOG.md
+++ b/packages/at_persistence_secondary_server/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.3.1
+
+- fix: backwards compatibility: revert AtNotificationKeystore.currentAtSign to 
+  a non-final instance variable
+
 ## 4.3.0
 
 - feat: deprecated AtNotificationCallback class

--- a/packages/at_persistence_secondary_server/lib/src/notification/at_notification_keystore.dart
+++ b/packages/at_persistence_secondary_server/lib/src/notification/at_notification_keystore.dart
@@ -10,7 +10,7 @@ import 'package:hive/hive.dart';
 class AtNotificationKeystore
     with HiveBase<AtNotification?>
     implements SecondaryKeyStore, AtLogType<String, AtNotification> {
-  final String currentAtSign;
+  late String currentAtSign;
   late String _boxName;
   static const int maxKeyLengthWithoutCached = 248;
   late AtCompactionConfig atCompactionConfig;

--- a/packages/at_persistence_secondary_server/pubspec.yaml
+++ b/packages/at_persistence_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_persistence_secondary_server
 description: A Dart library with the implementation classes for the persistence layer of the secondary server.
-version: 4.3.0
+version: 4.3.1
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://docs.atsign.com/
 

--- a/packages/at_secondary_server/pubspec.lock
+++ b/packages/at_secondary_server/pubspec.lock
@@ -84,11 +84,10 @@ packages:
   at_persistence_secondary_server:
     dependency: "direct main"
     description:
-      name: at_persistence_secondary_server
-      sha256: "392efb813d9f44dbcadfc36e74699db07cf0b0b96bc4820970be708953c1daac"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.2.0"
+      path: "../at_persistence_secondary_server"
+      relative: true
+    source: path
+    version: "4.3.1"
   at_persistence_spec:
     dependency: "direct main"
     description:

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -8,6 +8,9 @@ publish_to: none
 environment:
   sdk: ">=3.0.0 <4.0.0"
 
+dependency_overrides:
+  at_persistence_secondary_server:
+    path: ../at_persistence_secondary_server
 dependencies:
   args: ^2.7.0
   uuid: ^4.5.3


### PR DESCRIPTION
**- What I did**
- revert AtNotificationKeystore.currentAtSign to a non-final instance variable
- update dependencies in at_secondary_server package to verify
- update CHANGELOG and pubspec.yaml for at_persistence_secondary_server 4.3.1

will publish 4.3.1 and retract 4.3.0 when this is merged

**- How I did it**

**- How to verify it**
Tests pass