### PR TITLE
fix: Defensive code to handle bad notification data in some very old atServers

### DIFF
--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.10.1
+
+- Defensive code to handle bad data in some very old atServers
+
 # 3.10.0
 
 - Overhaul notification handling

--- a/packages/at_secondary_server/lib/src/notification/notification_manager_impl.dart
+++ b/packages/at_secondary_server/lib/src/notification/notification_manager_impl.dart
@@ -132,7 +132,12 @@ class NotificationManager {
 
   Future<void> reEnqueueUndelivered() async {
     for (final n in await getUndelivered()) {
-      enqueue(n);
+      try {
+        enqueue(n);
+      } catch (e) {
+        logger.severe('Unable to enqueue notification: $e');
+        logger.severe('Notification details: ${n.toJson().toString()}');
+      }
     }
   }
 

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_secondary
 description: Implementation of secondary server.
-version: 3.10.0
+version: 3.10.1
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://www.example.com
 publish_to: none


### PR DESCRIPTION
**- What I did**
fix: NotificationManager.reEnqueueUndelivered: handle failures to enqueue caused by ancient bad data

**- How I did it**
See commits

**- How to verify it**
Tests pass

