### PR TITLE
fix: Fix the `expiresAt` and `ttl` rules in `AtNotificationBuilder.build`

### DIFF
--- a/packages/at_persistence_secondary_server/CHANGELOG.md
+++ b/packages/at_persistence_secondary_server/CHANGELOG.md
@@ -1,7 +1,11 @@
+## 4.3.3
+
+- fix: Fix the `expiresAt` and `ttl` rules in `AtNotificationBuilder.build`
+
 ## 4.3.2
 
 - fix: fixes to `AtNotification.isExpired`
-- fix: fixed use of defaulTTLInMins in `AtNotificationBuilder.reset` 
+- fix: fixed use of `defaulTtl` in `AtNotificationBuilder.reset` 
 
 ## 4.3.1
 

--- a/packages/at_persistence_secondary_server/lib/src/notification/at_notification.dart
+++ b/packages/at_persistence_secondary_server/lib/src/notification/at_notification.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:at_persistence_secondary_server/src/utils/type_adapter_util.dart';
 import 'package:hive/hive.dart';
@@ -141,15 +143,20 @@ class AtNotification {
         'atValue:$atValue';
   }
 
-  /// If notificationDateTime is before now minus this duration,
+  /// 1. A notification may have an expiration no more than this duration into
+  /// the future.
+  /// 2. If notificationDateTime is before now minus this duration,
   /// then the notification is considered to be expired.
-  static Duration notificationDateTimeExpiryTimeout = Duration(days: 8);
+  static Duration maxTtl = Duration(days: 8);
+
+  /// The default used by [AtNotificationBuilder.build] to calculate expiresAt
+  static Duration defaultTtl = Duration(minutes: 15);
 
   /// true if
   /// - [notificationStatus] is [NotificationStatus.expired]
   /// - or [expiresAt] is null, or before now
   /// - or [notificationDateTime] is null, or more than
-  ///   [notificationDateTimeExpiryTimeout] ago
+  ///   [maxTtl] ago
   ///
   /// The reason for the check on [notificationDateTime] is to help with
   /// cleaning out old bad data from a time when there were no guards on [ttl]
@@ -160,8 +167,7 @@ class AtNotification {
         expiresAt == null ||
         expiresAt!.isBefore(DateTime.now().toUtc()) ||
         notificationDateTime == null ||
-        notificationDateTime!.isBefore(
-            DateTime.now().subtract(notificationDateTimeExpiryTimeout));
+        notificationDateTime!.isBefore(DateTime.now().subtract(maxTtl));
   }
 }
 
@@ -440,8 +446,6 @@ class MessageTypeAdapter extends TypeAdapter<MessageType?> {
 
 /// AtNotificationBuilder class to build [AtNotification] object
 class AtNotificationBuilder {
-  static int defaultTTLInMins = 15;
-
   String? id = Uuid().v4();
 
   String? fromAtSign;
@@ -474,17 +478,48 @@ class AtNotificationBuilder {
 
   String? atValue;
 
-  int? ttl = Duration(minutes: defaultTTLInMins).inMilliseconds;
+  int? ttl = AtNotification.defaultTtl.inMilliseconds;
 
   AtMetaData? atMetaData;
 
+  /// Applies the following rules, then builds the [AtNotification]
+  /// 1. if [expiresAt] is null
+  ///   1. If [ttl] is null or non-positive, set to [defaultTtl]
+  ///   2. Ensure that [ttl] is no greater than [AtNotification.maxTtl]
+  ///   3. calculate [expiresAt] by adding [ttl] to [DateTime.now]
+  /// 2. Ensure that [expiresAt] is no more than [AtNotification.maxTtl] in
+  /// the future
+  ///
+  /// Explanation of the above:
+  /// - [ttl] can be supplied by AtClients when sending a notification, and
+  /// [expiresAt] is calculated at that time. (Note: In future, clients will be
+  /// able to specify a precise [expiresAt], and the above rules will work
+  /// unchanged.)
+  /// - expiresAt should be sent as-is from sending atServer to receiving
+  /// - if expiresAt is set, ttl is not relevant
   AtNotification build() {
-    ttl ??= Duration(minutes: defaultTTLInMins).inMilliseconds;
-    if ((ttl != null && ttl! > 0) && expiresAt == null) {
-      expiresAt = DateTime.now()
-          .toUtcMillisecondsPrecision()
-          .add(Duration(milliseconds: ttl!));
+    final now = DateTime.now().toUtcMillisecondsPrecision();
+    final maxExpiresAt = now.add(AtNotification.maxTtl);
+
+    // 1.1 - set ttl to default if null or non-positive
+    if (ttl == null || ttl! <= 0) {
+      ttl = AtNotification.defaultTtl.inMilliseconds;
     }
+    // 1.2 - enforce max ttl value
+    ttl = min(ttl!, AtNotification.maxTtl.inMilliseconds);
+
+    // ignore: prefer_conditional_assignment
+    if (expiresAt == null) {
+      // 1.3 - calculate expiresAt
+      expiresAt ??= now.add(Duration(milliseconds: ttl!));
+    }
+
+    // 2. ensure no later than maxExpiresAt
+    if (expiresAt!.millisecondsSinceEpoch >
+        maxExpiresAt.millisecondsSinceEpoch) {
+      expiresAt = maxExpiresAt;
+    }
+
     return AtNotification._builder(this);
   }
 
@@ -506,7 +541,7 @@ class AtNotificationBuilder {
       ..notifier = 'system'
       ..depth = 1
       ..atValue = null
-      ..ttl = Duration(minutes: defaultTTLInMins).inMilliseconds
+      ..ttl = AtNotification.defaultTtl.inMilliseconds
       ..atMetaData = null;
   }
 }

--- a/packages/at_persistence_secondary_server/pubspec.yaml
+++ b/packages/at_persistence_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_persistence_secondary_server
 description: A Dart library with the implementation classes for the persistence layer of the secondary server.
-version: 4.3.2
+version: 4.3.3
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://docs.atsign.com/
 

--- a/packages/at_persistence_secondary_server/test/at_notification_keystore_test.dart
+++ b/packages/at_persistence_secondary_server/test/at_notification_keystore_test.dart
@@ -80,7 +80,7 @@ void main() async {
       await keyStore.deleteExpiredKeys();
       expect((await keyStore.get(atNotification.id))?.toAtSign, '@bob');
 
-      sleep(Duration(milliseconds: ttl+1));
+      sleep(Duration(milliseconds: ttl + 1));
       await keyStore.deleteExpiredKeys();
       expect(await keyStore.get(atNotification.id), isNull);
     });

--- a/packages/at_persistence_secondary_server/test/at_notification_test.dart
+++ b/packages/at_persistence_secondary_server/test/at_notification_test.dart
@@ -4,6 +4,176 @@ import 'package:at_persistence_secondary_server/at_persistence_secondary_server.
 import 'package:test/test.dart';
 
 void main() async {
+  group('AtNotificationBuilder tests of ttl and expiresAt', () {
+    test('expiresAt null, ttl 0', () {
+      final b = AtNotificationBuilder()..ttl = 0;
+      expect(b.ttl, 0);
+      expect(b.expiresAt, null);
+
+      b.build();
+      expect(b.ttl, AtNotification.defaultTtl.inMilliseconds);
+      expect(
+          b.expiresAt!.millisecondsSinceEpoch,
+          closeTo(
+              DateTime.now().millisecondsSinceEpoch +
+                  AtNotification.defaultTtl.inMilliseconds,
+              2));
+      final n = b.build();
+      expect(n.ttl, b.ttl);
+      expect(n.expiresAt, b.expiresAt);
+    });
+
+    test('expiresAt null, ttl negative', () {
+      final b = AtNotificationBuilder()..ttl = -1000;
+      expect(b.ttl, -1000);
+      expect(b.expiresAt, null);
+
+      b.build();
+      expect(b.ttl, AtNotification.defaultTtl.inMilliseconds);
+      expect(
+          b.expiresAt!.millisecondsSinceEpoch,
+          closeTo(
+              DateTime.now().millisecondsSinceEpoch +
+                  AtNotification.defaultTtl.inMilliseconds,
+              2));
+      final n = b.build();
+      expect(n.ttl, b.ttl);
+      expect(n.expiresAt, b.expiresAt);
+    });
+    test('expiresAt null, ttl null', () {
+      final b = AtNotificationBuilder()..ttl = null;
+      expect(b.ttl, null);
+      expect(b.expiresAt, null);
+
+      b.build();
+      expect(
+          b.expiresAt!.millisecondsSinceEpoch,
+          closeTo(
+              DateTime.now().millisecondsSinceEpoch +
+                  AtNotification.defaultTtl.inMilliseconds,
+              2));
+      final n = b.build();
+      expect(n.ttl, b.ttl);
+      expect(n.expiresAt, b.expiresAt);
+    });
+    test('expiresAt null, ttl set to < max', () {
+      int testTtl = (AtNotification.maxTtl.inMilliseconds / 2).floor();
+      final b = AtNotificationBuilder()..ttl = testTtl;
+      expect(b.expiresAt, null);
+      b.build();
+      expect(b.expiresAt!.millisecondsSinceEpoch,
+          closeTo(DateTime.now().millisecondsSinceEpoch + testTtl, 2));
+      final n = b.build();
+      expect(n.ttl, b.ttl);
+      expect(n.expiresAt, b.expiresAt);
+    });
+    test('expiresAt null, ttl set to == max', () {
+      int testTtl = AtNotification.maxTtl.inMilliseconds;
+      final b = AtNotificationBuilder()..ttl = testTtl;
+      expect(b.expiresAt, null);
+      b.build();
+      expect(b.expiresAt!.millisecondsSinceEpoch,
+          closeTo(DateTime.now().millisecondsSinceEpoch + testTtl, 2));
+      final n = b.build();
+      expect(b.ttl, AtNotification.maxTtl.inMilliseconds);
+      expect(n.ttl, b.ttl);
+      expect(n.expiresAt, b.expiresAt);
+    });
+    test('expiresAt null, ttl set to max plus 1ms', () {
+      int testTtl = AtNotification.maxTtl.inMilliseconds + 1;
+      final b = AtNotificationBuilder()..ttl = testTtl;
+      expect(b.expiresAt, null);
+      b.build();
+      expect(
+          b.expiresAt!.millisecondsSinceEpoch,
+          closeTo(
+              DateTime.now().millisecondsSinceEpoch +
+                  AtNotification.maxTtl.inMilliseconds,
+              2));
+      final n = b.build();
+      expect(b.ttl, AtNotification.maxTtl.inMilliseconds);
+      expect(n.ttl, b.ttl);
+      expect(n.expiresAt, b.expiresAt);
+    });
+    test('expiresAt null, ttl set to max plus 5 seconds', () {
+      int testTtl = AtNotification.maxTtl.inMilliseconds + 5000;
+      final b = AtNotificationBuilder()..ttl = testTtl;
+      expect(b.expiresAt, null);
+      b.build();
+      expect(
+          b.expiresAt!.millisecondsSinceEpoch,
+          closeTo(
+              DateTime.now().millisecondsSinceEpoch +
+                  AtNotification.maxTtl.inMilliseconds,
+              2));
+      final n = b.build();
+      expect(b.ttl, AtNotification.maxTtl.inMilliseconds);
+      expect(n.ttl, b.ttl);
+      expect(n.expiresAt, b.expiresAt);
+      expect(n.isExpired(), false);
+    });
+
+    test('expiresAt in the past', () {
+      final testVal = DateTime.now()
+          .toUtcMillisecondsPrecision()
+          .subtract(Duration(milliseconds: 1));
+      final b = AtNotificationBuilder()
+        ..ttl = null
+        ..expiresAt = testVal;
+      final n = b.build();
+      expect(n.expiresAt, testVal);
+      expect(n.isExpired(), true);
+      // Even though ttl is not relevant here, we do want to make sure it is
+      // non-null since this was expected behaviour up until now
+      expect(n.ttl, AtNotification.defaultTtl.inMilliseconds);
+    });
+    test('expiresAt in the future < max', () {
+      final testVal =
+          DateTime.now().toUtcMillisecondsPrecision().add(Duration(minutes: 5));
+      final b = AtNotificationBuilder()
+        ..ttl = null
+        ..expiresAt = testVal;
+      final n = b.build();
+      expect(n.expiresAt, testVal);
+      expect(n.isExpired(), false);
+      // Even though ttl is not relevant here, we do want to make sure it is
+      // non-null since this was expected behaviour up until now
+      expect(n.ttl, AtNotification.defaultTtl.inMilliseconds);
+    });
+    test('expiresAt in the future == max', () {
+      final testVal = DateTime.now()
+          .toUtcMillisecondsPrecision()
+          .add(AtNotification.maxTtl);
+      final b = AtNotificationBuilder()
+        ..ttl = null
+        ..expiresAt = testVal;
+      final n = b.build();
+      expect(n.expiresAt, testVal);
+      expect(n.isExpired(), false);
+      // Even though ttl is not relevant here, we do want to make sure it is
+      // non-null since this was expected behaviour up until now
+      expect(n.ttl, AtNotification.defaultTtl.inMilliseconds);
+    });
+    test('expiresAt in the future > max', () {
+      final maxVal = DateTime.now()
+          .toUtcMillisecondsPrecision()
+          .add(AtNotification.maxTtl);
+      final testVal = maxVal.add(Duration(minutes: 5));
+      final b = AtNotificationBuilder()
+        ..ttl = null
+        ..expiresAt = testVal;
+      final n = b.build();
+      expect(n.expiresAt, isNot(testVal));
+      expect(n.expiresAt!.millisecondsSinceEpoch,
+          isNot(closeTo(testVal.millisecondsSinceEpoch, 5)));
+      expect(n.expiresAt!.millisecondsSinceEpoch,
+          closeTo(maxVal.millisecondsSinceEpoch, 5));
+      expect(n.isExpired(), false);
+      // Even though ttl is not relevant here, we do want to make sure it is
+      // non-null since this was expected behaviour up until now
+      expect(n.ttl, AtNotification.defaultTtl.inMilliseconds);
+    });
+  });
   group('Notification expirations', () {
     test('test notification expired via ttl', () async {
       final notificationBuilder = AtNotificationBuilder()..ttl = 1;
@@ -40,7 +210,7 @@ void main() async {
 
       n = (AtNotificationBuilder()
             ..notificationDateTime = DateTime.now()
-                .subtract(AtNotification.notificationDateTimeExpiryTimeout)
+                .subtract(AtNotification.maxTtl)
                 .subtract(Duration(milliseconds: 1)))
           .build();
       expect(n.isExpired(), true);
@@ -67,10 +237,7 @@ void main() async {
 
     test('test builder reset', () async {
       final b = AtNotificationBuilder();
-      expect(
-          b.ttl,
-          Duration(minutes: AtNotificationBuilder.defaultTTLInMins)
-              .inMilliseconds);
+      expect(b.ttl, AtNotification.defaultTtl.inMilliseconds);
       expect(b.notificationDateTime!.millisecondsSinceEpoch,
           closeTo(DateTime.now().millisecondsSinceEpoch, 2));
       b.ttl = 333333;
@@ -80,10 +247,7 @@ void main() async {
 
       await Future.delayed(Duration(milliseconds: 10));
       b.reset();
-      expect(
-          b.ttl,
-          Duration(minutes: AtNotificationBuilder.defaultTTLInMins)
-              .inMilliseconds);
+      expect(b.ttl, AtNotification.defaultTtl.inMilliseconds);
       expect(b.notificationDateTime!.millisecondsSinceEpoch,
           closeTo(DateTime.now().millisecondsSinceEpoch, 2));
       expect(b.notificationDateTime!.millisecondsSinceEpoch,

--- a/packages/at_persistence_secondary_server/test/hive_keystore_impl_test.dart
+++ b/packages/at_persistence_secondary_server/test/hive_keystore_impl_test.dart
@@ -832,7 +832,7 @@ void main() async {
       List<String>? keysList = keystore?.getKeys();
       expect(keysList?.contains('emoji_🛠️.wavi$atSign'), false);
 
-      await Future.delayed(Duration(milliseconds: ttb+1));
+      await Future.delayed(Duration(milliseconds: ttb + 1));
       keysList = keystore?.getKeys();
       expect(keysList?.contains('emoji_🛠️.wavi$atSign'), true);
     });
@@ -840,7 +840,7 @@ void main() async {
     test(
         'A test to verify getKeys does not return key with emoji when TTL is set',
         () async {
-          int ttl = 10;
+      int ttl = 10;
       HiveKeystore? keystore = SecondaryPersistenceStoreFactory.getInstance()
           .getSecondaryPersistenceStore(atSign)
           ?.getSecondaryKeyStore();
@@ -850,7 +850,7 @@ void main() async {
       await keystore?.put('emoji_🛠️.wavi$atSign', atData);
       List<String>? keysList = keystore?.getKeys();
       expect(keysList?.contains('emoji_🛠️.wavi$atSign'), true);
-      await Future.delayed(Duration(milliseconds: ttl+1));
+      await Future.delayed(Duration(milliseconds: ttl + 1));
       keysList = keystore?.getKeys();
       expect(keysList?.contains('emoji_🛠️.wavi$atSign'), false);
     });


### PR DESCRIPTION
**- What I did**
- fix: Fix the `expiresAt` and `ttl` rules in `AtNotificationBuilder.build`
- test: added bunch more tests to verify behaviour of expiresAt and ttl rules
- chore: dart format
- refactor: renamed some ttl-related static vars for readability

The rules in `AtNotificationBuilder.build` are now as follows:
```
  /// Applies the following rules, then builds the [AtNotification]
  /// 1. if [expiresAt] is null
  ///   1. If [ttl] is null or non-positive, set to [defaultTtl]
  ///   2. Ensure that [ttl] is no greater than [AtNotification.maxTtl]
  ///   3. calculate [expiresAt] by adding [ttl] to [DateTime.now]
  /// 2. Ensure that [expiresAt] is no more than [AtNotification.maxTtl] in
  /// the future
  ///
  /// Explanation of the above:
  /// - [ttl] can be supplied by AtClients when sending a notification, and
  /// [expiresAt] is calculated at that time. (Note: In future, clients will be
  /// able to specify a precise [expiresAt], and the above rules will work
  /// unchanged.)
  /// - expiresAt should be sent as-is from sending atServer to receiving
  /// - if expiresAt is set, ttl is not relevant
```

**- How I did it**
See commits

**- How to verify it**
Tests pass
