### PR TITLE
fix: more notification-related fixes / improvements

### DIFF
--- a/packages/at_persistence_secondary_server/test/hive_keystore_impl_test.dart
+++ b/packages/at_persistence_secondary_server/test/hive_keystore_impl_test.dart
@@ -728,12 +728,12 @@ void main() async {
       HiveKeystore? keystore = keyStoreManager?.getSecondaryKeyStore();
       AtData atData = AtData()
         ..data = 'dummy_value'
-        ..metaData = (AtMetaData()..ttl = 20);
+        ..metaData = (AtMetaData()..ttl = 30);
       await keystore?.put('keyabouttoexpire.wavi@test_user_1', atData);
       var expiredKeysList = await keystore?.getExpiredKeys();
       expect(expiredKeysList?.contains('keyabouttoexpire.wavi@test_user_1'),
           false);
-      await Future.delayed(Duration(milliseconds: 21));
+      await Future.delayed(Duration(milliseconds: 31));
       expiredKeysList = await keystore?.getExpiredKeys();
       expect(
           expiredKeysList?.contains('keyabouttoexpire.wavi@test_user_1'), true);
@@ -743,42 +743,40 @@ void main() async {
 
   group('A group of test related to getKeys method', () {
     String atSign = '@emoji🛠️';
-    setUp(() async => await setUpFunc(storageDir, atSign));
-    test('A test to verify getKeys does not return expired keys', () async {
+    late HiveKeystore keystore;
+
+    setUp(() async {
+      await setUpFunc(storageDir, atSign);
       SecondaryPersistenceStore? keyStoreManager =
           SecondaryPersistenceStoreFactory.getInstance()
               .getSecondaryPersistenceStore(atSign);
-      HiveKeystore? keystore = keyStoreManager?.getSecondaryKeyStore();
+      keystore = (keyStoreManager?.getSecondaryKeyStore())!;
+    });
+    tearDown(() async => await tearDownFunc(atSign));
+
+    test('A test to verify getKeys does not return expired keys', () async {
       AtData atData = AtData()
         ..data = 'value_test_4'
         // Adding TTL of 10 milliseconds
-        ..metaData = (AtMetaData()..ttl = 10);
-      await keystore?.put('expired_key.wavi$atSign', atData);
+        ..metaData = (AtMetaData()..ttl = 30);
+      await keystore.put('expired_key.wavi$atSign', atData);
       // Adding delay for the key to expire.
-      await Future.delayed(Duration(milliseconds: 20));
-      List<String>? keysList = keystore?.getKeys();
-      expect(keysList!.contains('expired_key.wavi$atSign'), false);
+      await Future.delayed(Duration(milliseconds: 31));
+      List<String>? keysList = keystore.getKeys();
+      expect(keysList.contains('expired_key.wavi$atSign'), false);
     });
 
     test('A test to verify getKeys does not return keys whose TTB is met',
         () async {
-      SecondaryPersistenceStore? keyStoreManager =
-          SecondaryPersistenceStoreFactory.getInstance()
-              .getSecondaryPersistenceStore(atSign);
-      HiveKeystore? keystore = keyStoreManager?.getSecondaryKeyStore();
       AtData atData = AtData()
         ..data = 'value_test_3'
         ..metaData = (AtMetaData()..ttb = 300000);
-      await keystore?.put('key_test_3.wavi$atSign', atData);
-      List<String>? keysList = keystore?.getKeys();
-      expect(keysList!.contains('key_test_3.wavi$atSign'), false);
+      await keystore.put('key_test_3.wavi$atSign', atData);
+      List<String>? keysList = keystore.getKeys();
+      expect(keysList.contains('key_test_3.wavi$atSign'), false);
     });
 
     test('test to verify metadata of all keys is cached', () async {
-      SecondaryPersistenceStore? keystoreManager =
-          SecondaryPersistenceStoreFactory.getInstance()
-              .getSecondaryPersistenceStore(atSign);
-      HiveKeystore? keystore = keystoreManager?.getSecondaryKeyStore();
       AtData? atData = AtData();
       AtMetaData? metaData;
       //inserting sample keys
@@ -794,68 +792,70 @@ void main() async {
 
         atData.data = 'value_test_$i';
         atData.metaData = metaData;
-        await keystore?.put('key_test_$i.wavi$atSign', atData);
+        await keystore.put('key_test_$i.wavi$atSign', atData);
       }
 
-      List<String>? keys = keystore?.getKeys();
+      List<String> keys = keystore.getKeys();
 
-      for (var key in keys!) {
-        atData = await keystore?.get(key);
+      for (var key in keys) {
+        atData = await keystore.get(key);
         metaData = atData?.metaData;
-        expect((await keystore?.getMeta(key)).toString(), metaData.toString());
+        expect((await keystore.getMeta(key)).toString(), metaData.toString());
       }
     });
 
     test('A test to verify getKeys return key with emoji', () async {
-      HiveKeystore? keystore = SecondaryPersistenceStoreFactory.getInstance()
-          .getSecondaryPersistenceStore(atSign)
-          ?.getSecondaryKeyStore();
       AtData atData = AtData()
         ..data = 'value_test_3'
         ..metaData = (AtMetaData());
-      await keystore?.put('emoji_🛠️.wavi$atSign', atData);
-      List<String>? keysList = keystore?.getKeys();
+      await keystore.put('emoji_🛠️.wavi$atSign', atData);
+      List<String> keysList = keystore.getKeys();
       print(keysList);
-      expect(keysList?.contains('emoji_🛠️.wavi$atSign'), true);
+      expect(keysList.contains('emoji_🛠️.wavi$atSign'), true);
     });
 
     test('A test to verify getKeys returns key with emoji when TTB is set',
         () async {
-      int ttb = 10;
-      HiveKeystore? keystore = SecondaryPersistenceStoreFactory.getInstance()
-          .getSecondaryPersistenceStore(atSign)
-          ?.getSecondaryKeyStore();
+      int i = 0;
+      int ttb = 30;
       AtData atData = AtData()
         ..data = 'value_test_3'
         ..metaData = (AtMetaData()..ttb = ttb);
-      await keystore?.put('emoji_🛠️.wavi$atSign', atData);
-      List<String>? keysList = keystore?.getKeys();
-      expect(keysList?.contains('emoji_🛠️.wavi$atSign'), false);
+      final k = 'emoji_🛠️.${i + 1}.wavi$atSign';
+
+      await keystore.put(k, atData, skipCommit: true);
+      List<String> keysList = keystore.getKeys();
+      expect(keysList.contains(k), false);
 
       await Future.delayed(Duration(milliseconds: ttb + 1));
-      keysList = keystore?.getKeys();
-      expect(keysList?.contains('emoji_🛠️.wavi$atSign'), true);
+
+      keysList = keystore.getKeys();
+      expect(keysList.contains(k), true);
+
+      await keystore.remove(k, skipCommit: true);
     });
 
     test(
         'A test to verify getKeys does not return key with emoji when TTL is set',
         () async {
-      int ttl = 10;
-      HiveKeystore? keystore = SecondaryPersistenceStoreFactory.getInstance()
-          .getSecondaryPersistenceStore(atSign)
-          ?.getSecondaryKeyStore();
+      int i = 0;
+      int ttl = 30;
       AtData atData = AtData()
         ..data = 'value_test_3'
         ..metaData = (AtMetaData()..ttl = ttl);
-      await keystore?.put('emoji_🛠️.wavi$atSign', atData);
-      List<String>? keysList = keystore?.getKeys();
-      expect(keysList?.contains('emoji_🛠️.wavi$atSign'), true);
-      await Future.delayed(Duration(milliseconds: ttl + 1));
-      keysList = keystore?.getKeys();
-      expect(keysList?.contains('emoji_🛠️.wavi$atSign'), false);
-    });
+      final k = 'emoji_🛠️.${i + 1}.wavi$atSign';
 
-    tearDown(() async => await tearDownFunc(atSign));
+      await keystore.put(k, atData);
+      List<String> keysList = keystore.getKeys();
+      expect(keysList.contains(k), true);
+
+      await Future.delayed(Duration(milliseconds: ttl + 1));
+
+      keysList = keystore.getKeys();
+      expect(keysList.contains(k), false);
+
+      await keystore.remove(k, skipCommit: true);
+    });
   });
 
   group('A group of tests to verify skip commit', () {

--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.10.2
+
+- fix: enforce consistent handling of notification expirations
+
 # 3.10.1
 
 - Defensive code to handle bad data in some very old atServers

--- a/packages/at_secondary_server/config/config.yaml
+++ b/packages/at_secondary_server/config/config.yaml
@@ -141,7 +141,7 @@ notification:
   # The time interval(in seconds) to notify latest commitID to monitor connections
   # To disable to the feature, set to -1.
   statsNotificationJobTimeInterval: 15
-  # The amount of time after which a notification expires in units of minutes. Defaults to 24 hours or 1440 minutes
+  # The amount of time after which a notification expires in units of minutes
   expiryInMins: 15
 
 # At refresh Job to refresh the cached keys.

--- a/packages/at_secondary_server/lib/src/server/at_secondary_config.dart
+++ b/packages/at_secondary_server/lib/src/server/at_secondary_config.dart
@@ -64,8 +64,8 @@ class AtSecondaryConfig {
   // To disable to the feature, set to -1.
   static const int _statsNotificationJobTimeInterval = 15;
 
-  // defines the time after which a notification expires in units of minutes. Notifications expire after 1440 minutes or 24 hours by default.
-  static const int _notificationExpiresAfterMins = 1440;
+  // defines the time after which a notification expires in units of minutes
+  static const int _notificationExpiresAfterMins = 15;
 
   static const int _notificationKeyStoreCompactionFrequencyMins = 5;
   static const int _notificationKeyStoreCompactionPercentage = 30;

--- a/packages/at_secondary_server/pubspec.lock
+++ b/packages/at_secondary_server/pubspec.lock
@@ -85,10 +85,10 @@ packages:
     dependency: "direct main"
     description:
       name: at_persistence_secondary_server
-      sha256: ff08a615b75ec90b3468a6fcc787e7992ecadaaabf23942e5cf3e9882aeee120
+      sha256: "526555e8fc2002f2d4e42c3d4647b63c1dca614539f16b4d7eddcff0ef75e1a9"
       url: "https://pub.dev"
     source: hosted
-    version: "4.3.1"
+    version: "4.3.3"
   at_persistence_spec:
     dependency: "direct main"
     description:

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   at_lookup: ^3.5.0
   at_server_spec: ^5.0.4
   at_persistence_spec: ^3.1.0
-  at_persistence_secondary_server: ^4.3.1
+  at_persistence_secondary_server: ^4.3.3
   intl: ^0.20.2
   json_annotation: ^4.11.0
   version: ^3.0.2

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_secondary
 description: Implementation of secondary server.
-version: 3.10.1
+version: 3.10.2
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://www.example.com
 publish_to: none

--- a/tests/at_functional_test/lib/secondary/base/pubspec.yaml
+++ b/tests/at_functional_test/lib/secondary/base/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   at_lookup: 3.0.49
   at_server_spec: 5.0.3
   at_persistence_spec: 3.0.0
-  at_persistence_secondary_server: 4.3.1
+  at_persistence_secondary_server: 4.3.3
   intl: ^0.20.2
   json_annotation: ^4.8.0
   version: 3.0.2

--- a/tests/at_functional_test/pubspec.yaml
+++ b/tests/at_functional_test/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   hex: ^0.2.0
-  at_persistence_secondary_server: ^4.3.1
+  at_persistence_secondary_server: ^4.3.3
   at_demo_data: ^1.2.0
   at_chops: ^2.2.0
   at_lookup: ^3.3.0


### PR DESCRIPTION
**- What I did**
- from #2564
  - fix: in NotificationManager.reEnqueueUndelivered, update the notification state to 'errored' if enqueuing fails
  - refactor: start using Atsign type in various places
- take up at_persistence_secondary_server 4.3.3 following completion of #2565 and #2566
- docs: correct a comment in atServer config.yaml
- fix: make default notification ttl in at_secondary_config.dart consistent with the value in config.yaml

The changes in the above PRs:
- fix: in NotificationManager.reEnqueueUndelivered, update the notification state to 'errored' if enqueuing fails
- refactor: start using Atsign type in various places
- fix: AtNotification.isExpired
- fix: AtNotification.reset was using defaultTTLInMins as an hours value, smh
- feat: make AtNotificationBuilder.defaultTTLInMins settable
- test: modified some tests to run faster
- test: added tests fully covering isExpired
- test: added tests of AtNotificationBuilder.reset
- fix: Fix the `expiresAt` and `ttl` rules in `AtNotificationBuilder.build`
- test: added bunch more tests to verify behaviour of expiresAt and ttl rules
- chore: dart format
- refactor: renamed some ttl-related static vars for readability

The rules in `AtNotificationBuilder.build` are now as follows:
```
  /// Applies the following rules, then builds the [AtNotification]
  /// 1. if [expiresAt] is null
  ///   1. If [ttl] is null or non-positive, set to [defaultTtl]
  ///   2. Ensure that [ttl] is no greater than [AtNotification.maxTtl]
  ///   3. calculate [expiresAt] by adding [ttl] to [DateTime.now]
  /// 2. Ensure that [expiresAt] is no more than [AtNotification.maxTtl] in
  /// the future
  ///
  /// Explanation of the above:
  /// - [ttl] can be supplied by AtClients when sending a notification, and
  /// [expiresAt] is calculated at that time. (Note: In future, clients will be
  /// able to specify a precise [expiresAt], and the above rules will work
  /// unchanged.)
  /// - expiresAt should be sent as-is from sending atServer to receiving
  /// - if expiresAt is set, ttl is not relevant
```


**- How I did it**
See commits

**- How to verify it**
Tests pass
