### PR TITLE
feat: make presentation of client certificates configurable for atServer-to-atServer communication

### DIFF
--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 3.11.0
+
+- feat: make presentation of client certificates configurable for 
+  atServer-to-atServer communication
+
 # 3.10.3
 
 - chore: remove obsolete configuration

--- a/packages/at_secondary_server/config/config.yaml
+++ b/packages/at_secondary_server/config/config.yaml
@@ -28,8 +28,11 @@ security:
   trustedCertificateLocation: '/etc/cacert/cacert.pem'
 
   # Whether to require a client certificate when another atServer
-  # connects to us. This should NEVER be set to false except in exceptional
-  # circumstances, and then probably only for testing purposes.
+  # connects to us. This should NEVER be set to false except in
+  # very specific circumstances, such as a self-contained ephemeral
+  # environment, or for testing purposes. This flag also controls
+  # whether we present a client certificate when connecting to another
+  # atServer
   clientCertificateRequired: true
 
 # The atProtocol storage configurations

--- a/packages/at_secondary_server/lib/src/connection/outbound/outbound_client.dart
+++ b/packages/at_secondary_server/lib/src/connection/outbound/outbound_client.dart
@@ -353,29 +353,38 @@ class DefaultOutboundConnectionFactory implements OutboundConnectionFactory {
   final AtSecurityContextImpl atSecurityContext = AtSecurityContextImpl();
   final SecurityContext securityContext =
       SecurityContext(withTrustedRoots: true);
-  final bool requireCerts;
+  final bool clientCertificateRequired;
 
-  DefaultOutboundConnectionFactory({required this.requireCerts}) {
+  DefaultOutboundConnectionFactory({required this.clientCertificateRequired}) {
+    // always set the trustedCertificatePath, we need to verify the TLS
+    // connection as a client
+    if (File(atSecurityContext.trustedCertificatePath).existsSync()) {
+      securityContext
+          .setTrustedCertificates(atSecurityContext.trustedCertificatePath);
+    } else if (clientCertificateRequired) {
+      throw StateError(
+          '${atSecurityContext.trustedCertificatePath} is required but not found');
+    }
+
+    // If we're not required to present certs, then do nothing further
+    if (!clientCertificateRequired) {
+      return;
+    }
+    // We are required to present certificates
+    // If we have separate mtls certs, use them
     if (File(atSecurityContext.privateKeyPathMtls).existsSync() &&
         File(atSecurityContext.publicKeyPathMtls).existsSync()) {
       logger.info('Using MTLS cert when making outbound client connections');
       securityContext.useCertificateChain(atSecurityContext.publicKeyPathMtls);
       securityContext.usePrivateKey(atSecurityContext.privateKeyPathMtls);
-    } else if (File(atSecurityContext.privateKeyPath).existsSync() &&
+    } else // otherwise, (legacy) present our server cert as a client cert
+    if (File(atSecurityContext.privateKeyPath).existsSync() &&
         File(atSecurityContext.publicKeyPath).existsSync()) {
       logger.info('Using server cert when making outbound client connections');
       securityContext.useCertificateChain(atSecurityContext.publicKeyPath);
       securityContext.usePrivateKey(atSecurityContext.privateKeyPath);
-    } else if (requireCerts) {
+    } else {
       throw StateError('SSL Certificates are required, but none were found');
-    }
-
-    if (File(atSecurityContext.trustedCertificatePath).existsSync()) {
-      securityContext
-          .setTrustedCertificates(atSecurityContext.trustedCertificatePath);
-    } else if (requireCerts) {
-      throw StateError(
-          '${atSecurityContext.trustedCertificatePath} is required but not found');
     }
   }
 

--- a/packages/at_secondary_server/lib/src/server/at_secondary_config.dart
+++ b/packages/at_secondary_server/lib/src/server/at_secondary_config.dart
@@ -183,7 +183,16 @@ class AtSecondaryConfig {
     }
   }
 
-  static bool? get clientCertificateRequired {
+  /// Whether to require a client certificate when another atServer
+  /// connects to us. This should NEVER be set to false except in
+  /// very specific circumstances, such as a self-contained ephemeral
+  /// environment, or for testing purposes.
+  ///
+  /// This flag also controls whether we present a client certificate
+  /// when connecting to another atServer
+  ///
+  /// - To override from env: `clientCertificateRequired=false`
+  static bool get clientCertificateRequired {
     var result = _getBoolEnvVar('clientCertificateRequired');
     if (result != null) {
       return result;

--- a/packages/at_secondary_server/lib/src/server/at_secondary_impl.dart
+++ b/packages/at_secondary_server/lib/src/server/at_secondary_impl.dart
@@ -53,8 +53,6 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
   static final int? accessLogCompactionPercentage =
       AtSecondaryConfig.accessLogCompactionPercentage;
   static final int? accessLogSizeInKB = AtSecondaryConfig.accessLogSizeInKB;
-  static final bool? clientCertificateRequired =
-      AtSecondaryConfig.clientCertificateRequired;
   static final skipCommitsForExpiredKeys =
       AtSecondaryConfig.skipCommitsForExpiredKeys;
 
@@ -93,7 +91,7 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
       socketConfig: socketConfig,
     );
     outboundConnectionFactory = DefaultOutboundConnectionFactory(
-      requireCerts: false, // so unit tests can work
+      clientCertificateRequired: false, // so unit tests can work
     );
     outboundClientManager = OutboundClientManager(
       secondaryAddressFinder,
@@ -256,7 +254,7 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
       socketConfig: socketConfig,
     );
     outboundConnectionFactory = DefaultOutboundConnectionFactory(
-      requireCerts: true,
+      clientCertificateRequired: AtSecondaryConfig.clientCertificateRequired,
     );
     outboundClientManager = OutboundClientManager(
       secondaryAddressFinder,
@@ -272,9 +270,6 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
           outboundConnectionFactory,
           poolSize: serverContext!.outboundConnectionLimit,
         ));
-
-    // Scan and re-enqueue the notifications undelivered to other atSigns
-    await notificationManager.reEnqueueUndelivered();
 
     // Refresh Cached Keys
     cacheManager = AtCacheManager(serverContext!.currentAtSign!,
@@ -384,16 +379,11 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
       } else {
         await _startUnSecuredServer();
       }
-    } on Exception catch (e, stacktrace) {
+    } catch (e, stacktrace) {
       _isRunning = false;
-      logger.severe('AtSecondaryServer().start exception: ${e.toString()}');
+      logger.severe('AtSecondaryServer().start : ${e.toString()}');
       logger.severe(stacktrace);
       throw AtServerException(e.toString());
-    } catch (error, stacktrace) {
-      _isRunning = false;
-      logger.severe('AtSecondaryServer().start error: ${error.toString()}');
-      logger.severe(stacktrace);
-      throw AtServerException(error.toString());
     }
 
     if (serverContext!.trainingMode) {
@@ -408,6 +398,9 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
       logger.warning('Training mode set - exiting');
       exit(0);
     }
+
+    // Enqueue any undelivered notifications for delivery to other atServers
+    await notificationManager.reEnqueueUndelivered();
 
     resume();
   }

--- a/packages/at_secondary_server/lib/src/verb/handler/from_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/from_verb_handler.dart
@@ -19,8 +19,6 @@ class FromVerbHandler extends AbstractVerbHandler {
   static From from = From();
   static final _rootDomain = AtSecondaryConfig.rootServerUrl;
   static final _rootPort = AtSecondaryConfig.rootServerPort;
-  static final bool? clientCertificateRequired =
-      AtSecondaryConfig.clientCertificateRequired;
 
   FromVerbHandler(super.keyStore);
 
@@ -75,7 +73,7 @@ class FromVerbHandler extends AbstractVerbHandler {
     }
 
     if (fromAtSign != AtSecondaryServerImpl.getInstance().currentAtSign &&
-        clientCertificateRequired!) {
+        AtSecondaryConfig.clientCertificateRequired) {
       var result = await _verifyFromAtSign(fromAtSign, atConnection);
       logger.finer('_verifyFromAtSign result : $result');
       if (!result) {
@@ -127,7 +125,7 @@ class FromVerbHandler extends AbstractVerbHandler {
       return atConnection.metaData.isStream;
     }
 
-    if (clientCertificateRequired!) {
+    if (AtSecondaryConfig.clientCertificateRequired) {
       var result = _verifyClientCerts(cn, host);
       return result;
     }
@@ -135,25 +133,26 @@ class FromVerbHandler extends AbstractVerbHandler {
   }
 
   bool _verifyClientCerts(X509Certificate cn, String host) {
-    var subject = cn.subject;
     logger.info(
-        'Connected from: $cn $subject issued by ${cn.issuer} valid from ${cn.startValidity} to ${cn.endValidity}');
-    if (subject.contains(host)) {
+        'Connected from: $cn ${cn.subject} issued by ${cn.issuer} valid from ${cn.startValidity} to ${cn.endValidity}');
+
+    X509CertificateData certData = X509Utils.x509CertificateFromPem(cn.pem);
+    List<String> subjectAlternativeNames =
+        certData.tbsCertificate?.extensions?.subjectAlternativNames ?? [];
+    logger.info('SAN: $subjectAlternativeNames');
+
+    String commonName = certData.tbsCertificate?.subject['2.5.4.3'] ?? '';
+    logger.info('CN: $commonName');
+
+    if (cn.subject.contains(host)) {
       // TODO Dig in to the possible values of subject
       return true;
     }
-    // If you would like to see the cert
-    var x509Pem = cn.pem;
-    // test with an internet available certificate to ensure we are picking out the SAN and not the CN
-    var data = X509Utils.x509CertificateFromPem(x509Pem);
-    List<String> subjectAlternativeNames =
-        data.tbsCertificate?.extensions?.subjectAlternativNames ?? [];
-    logger.info('SAN: $subjectAlternativeNames');
+
     if (subjectAlternativeNames.contains(host)) {
       return true;
     }
-    String commonName = data.tbsCertificate?.subject['2.5.4.3'] ?? '';
-    logger.info('CN: $commonName');
+
     if (commonName.contains(host)) {
       // Probably should be an equality test
       return true;

--- a/packages/at_secondary_server/pubspec.lock
+++ b/packages/at_secondary_server/pubspec.lock
@@ -301,10 +301,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "6f6b30cba0301e7b38f32bdc9a6bdae6f5921a55f0a1eb9450e1e6515645dbb2"
+      sha256: "29f7ecc274a86d32920b1d9cfc7502fa87220da41ec60b55f329559d5732e2b2"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.6"
+    version: "3.1.7"
   ecdsa:
     dependency: "direct main"
     description:

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_secondary
 description: Implementation of secondary server.
-version: 3.10.3
+version: 3.11.0
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://www.example.com
 publish_to: none

--- a/packages/at_secondary_server/test/outbound_client_pool_test.dart
+++ b/packages/at_secondary_server/test/outbound_client_pool_test.dart
@@ -27,7 +27,7 @@ void main() async {
     AtSecondaryServerImpl.getInstance().serverContext = serverContext;
     outboundClientPool = OutboundClientPool();
     notifyConnectionsPool = NotifyConnectionsPool(MockSecondaryAddressFinder(),
-        DefaultOutboundConnectionFactory(requireCerts: false));
+        DefaultOutboundConnectionFactory(clientCertificateRequired: false));
 
     notifyConnectionsPool.size = 2;
   });
@@ -39,7 +39,7 @@ void main() async {
 
   group('A group of outbound client pool test', () {
     OutboundConnectionFactory outboundConnectionFactory =
-        DefaultOutboundConnectionFactory(requireCerts: false);
+        DefaultOutboundConnectionFactory(clientCertificateRequired: false);
     test('test outbound client pool init', () {
       outboundClientPool.size = 5;
       expect(outboundClientPool.getCapacity(), 5);

--- a/packages/at_secondary_server/test/outbound_client_test.dart
+++ b/packages/at_secondary_server/test/outbound_client_test.dart
@@ -12,7 +12,7 @@ import 'test_utils.dart';
 void main() {
   late FakeSocket mockSocket;
   OutboundConnectionFactory outboundConnectionFactory =
-      DefaultOutboundConnectionFactory(requireCerts: false);
+      DefaultOutboundConnectionFactory(clientCertificateRequired: false);
 
   verbTestsSetUpLogging();
 


### PR DESCRIPTION
**- What I did**
- resolves #2550 
- feat: make presentation of client certificates configurable for atServer-to-atServer communication
- fix: on startup, enqueue undelivered notifications AFTER opening the serverSocket, not before
- build: update pubspec and changelog for 3.11.0

**- How I did it**
See commits

**- How to verify it**
Tests pass
