### PR TITLE
feat: tweak http handling, log DART_VM_OPTIONS on startup

### DIFF
--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - feat: http handling tweak for more consistent behaviour for access via proxy 
   and direct access
+- feat: log the values of DART_VM_OPTIONS during startup
 
 # 3.11.0
 

--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 3.11.1
+
+- feat: http handling tweak for more consistent behaviour for access via proxy 
+  and direct access
+
 # 3.11.0
 
 - feat: make presentation of client certificates configurable for 

--- a/packages/at_secondary_server/lib/src/server/at_secondary_impl.dart
+++ b/packages/at_secondary_server/lib/src/server/at_secondary_impl.dart
@@ -68,6 +68,8 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
   }
 
   AtSecondaryServerImpl._internal() {
+    logger.info('DART_VM_OPTIONS: ${Platform.environment['DART_VM_OPTIONS']}');
+
     // TODO There's a whole lifecycle mess here that needs to be cleaned up
     // at some point. Currently we create this singleton which then has a
     // lifecycle where it can be started and stopped. When it is started, all

--- a/packages/at_secondary_server/lib/src/server/http_request_handler.dart
+++ b/packages/at_secondary_server/lib/src/server/http_request_handler.dart
@@ -94,6 +94,16 @@ class AtServerHttpRequestHandler {
     while (decodedPath.startsWith('/')) {
       decodedPath = decodedPath.substring(1);
     }
+    // For interoperability across access via proxy and direct access,
+    // we'd like to use the same URL in both cases
+    // i.e. both this URL
+    // https://proxy0001.atsign.org/@garycasey/gary/demo/blog/index.html
+    // and this one
+    // https://85d0d210-2841-59bf-a0c4-3a9a63dd42eb.canary.atsign.zone:11823/@garycasey/gary/demo/blog/index.html
+    // should both work.
+    if (decodedPath.startsWith('$currentAtSign/')) {
+      decodedPath = decodedPath.replaceFirst('$currentAtSign/', '');
+    }
     if (decodedPath.startsWith('public:')) {
       decodedPath = decodedPath.replaceFirst('public:', '');
     }

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_secondary
 description: Implementation of secondary server.
-version: 3.11.0
+version: 3.11.1
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://www.example.com
 publish_to: none

--- a/tools/run_locally/scripts/macos/at_server
+++ b/tools/run_locally/scripts/macos/at_server
@@ -89,6 +89,5 @@ else
   observeParams="--observe=$observePort"
 fi
 
-set -x
 export DART_VM_OPTIONS="--use_compactor,--force_evacuation,--idle_duration_micros=0,--compactor_tasks=5,--marker_tasks=5,--scavenger_tasks=5,--mark_when_idle,--old_gen_growth_time_ratio=50,--old_gen_growth_space_ratio=10"
 dart $observeParams "$scriptDir"/../../../../packages/at_secondary_server/bin/main.dart -a "$atSign" -p "$port" -s "$secret"


### PR DESCRIPTION
**- What I did**
- feat: http handling tweak for more consistent behaviour for access via proxy and direct access. Basically we'd like to use the same URL path in both cases
  - i.e. both this URL
    - https://proxy0001.atsign.org/@garycasey/gary/demo/blog/index.html
  - and this one
    - https://85d0d210-2841-59bf-a0c4-3a9a63dd42eb.canary.atsign.zone:11823/@garycasey/gary/demo/blog/index.html
  - should both work.
- feat: log the values of DART_VM_OPTIONS during atServer startup

**- How I did it**

**- How to verify it**

