### PR TITLE
feat: tweak the garbage collection runtime flags

### DIFF
--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.11.3
+
+- feat: tweak the garbage collection runtime flags
+
 # 3.11.2
 
 - feat: log value of Platform.executableArguments on startup

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_secondary
 description: Implementation of secondary server.
-version: 3.11.2
+version: 3.11.3
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://www.example.com
 publish_to: none

--- a/tools/build_ephemeral_environment/ee_base/Dockerfile
+++ b/tools/build_ephemeral_environment/ee_base/Dockerfile
@@ -54,7 +54,7 @@ COPY --from=buildimage --chown=atsign:atsign \
 COPY --from=buildimage --chown=atsign:atsign \
 /app/packages/at_secondary_server/pubspec.yaml /atsign/secondary/
 
-ENV DART_VM_OPTIONS="--use_compactor,--force_evacuation,--idle_duration_micros=0,--compactor_tasks=5,--marker_tasks=5,--scavenger_tasks=5,--old_gen_growth_time_ratio=50,--old_gen_growth_space_ratio=10"
+ENV DART_VM_OPTIONS="--use_compactor,--use_compactor,--idle_duration_micros=100000,--force_evacuation,--mark_when_idle,--old_gen_growth_time_ratio=50,--old_gen_growth_space_ratio=10"
 
 # Run supervisor configuration file on container startup
 CMD ["/tmp/startup.sh"]

--- a/tools/build_secondary/Dockerfile
+++ b/tools/build_secondary/Dockerfile
@@ -42,5 +42,5 @@ COPY --from=buildimage --chown=atsign:atsign /atsign /atsign/
 COPY --from=buildimage --chown=atsign:atsign /archive /archive/
 WORKDIR /atsign
 USER atsign
-ENV DART_VM_OPTIONS="--use_compactor,--force_evacuation,--idle_duration_micros=0,--compactor_tasks=5,--marker_tasks=5,--scavenger_tasks=5,--old_gen_growth_time_ratio=50,--old_gen_growth_space_ratio=10"
+ENV DART_VM_OPTIONS="--use_compactor,--use_compactor,--idle_duration_micros=100000,--force_evacuation,--mark_when_idle,--old_gen_growth_time_ratio=50,--old_gen_growth_space_ratio=10"
 ENTRYPOINT ["/usr/local/at/secondary"]

--- a/tools/build_secondary/Dockerfile.canary_to_prod
+++ b/tools/build_secondary/Dockerfile.canary_to_prod
@@ -8,6 +8,6 @@ COPY --chown=1024:1024 ./packages/at_secondary_server/pubspec.yaml $HOMEDIR/
 WORKDIR /atsign
 USER atsign
 
-ENV DART_VM_OPTIONS="--use_compactor,--force_evacuation,--idle_duration_micros=0,--compactor_tasks=5,--marker_tasks=5,--scavenger_tasks=5,--old_gen_growth_time_ratio=50,--old_gen_growth_space_ratio=10"
+ENV DART_VM_OPTIONS="--use_compactor,--use_compactor,--idle_duration_micros=100000,--force_evacuation,--mark_when_idle,--old_gen_growth_time_ratio=50,--old_gen_growth_space_ratio=10"
 
 ENTRYPOINT ["/usr/local/at/secondary"]

--- a/tools/build_secondary/Dockerfile.observe
+++ b/tools/build_secondary/Dockerfile.observe
@@ -49,5 +49,5 @@ COPY --from=buildimage /usr/lib/dart/bin/resources/devtools/ /usr/lib/dart/bin/r
 ENV PATH /usr/lib/dart/bin/
 WORKDIR /atsign
 USER atsign
-ENV DART_VM_OPTIONS="--use_compactor,--force_evacuation,--idle_duration_micros=0,--compactor_tasks=5,--marker_tasks=5,--scavenger_tasks=5,--old_gen_growth_time_ratio=50,--old_gen_growth_space_ratio=10"
+ENV DART_VM_OPTIONS="--use_compactor,--use_compactor,--idle_duration_micros=100000,--force_evacuation,--mark_when_idle,--old_gen_growth_time_ratio=50,--old_gen_growth_space_ratio=10"
 ENTRYPOINT ["/usr/lib/dart/bin/dart","run","--observe=8181/0.0.0.0","/usr/local/at/secondary.jit"]

--- a/tools/build_virtual_environment/ve/Dockerfile
+++ b/tools/build_virtual_environment/ve/Dockerfile
@@ -8,7 +8,7 @@ COPY ./contents /
 
 EXPOSE 64 443 6379 9001
 
-ENV DART_VM_OPTIONS="--use_compactor,--force_evacuation,--idle_duration_micros=0,--compactor_tasks=5,--marker_tasks=5,--scavenger_tasks=5,--old_gen_growth_time_ratio=50,--old_gen_growth_space_ratio=10"
+ENV DART_VM_OPTIONS="--use_compactor,--use_compactor,--idle_duration_micros=100000,--force_evacuation,--mark_when_idle,--old_gen_growth_time_ratio=50,--old_gen_growth_space_ratio=10"
 
 # Run supervisor configuration file on container startup
 CMD ["supervisord", "-n"]

--- a/tools/build_virtual_environment/ve/Dockerfile.canary_to_vip
+++ b/tools/build_virtual_environment/ve/Dockerfile.canary_to_vip
@@ -7,7 +7,7 @@ COPY --chown=1024:1024 ./packages/at_secondary_server/pubspec.yaml /atsign/secon
 USER root
 EXPOSE 64 443 6379 9001
 
-ENV DART_VM_OPTIONS="--use_compactor,--force_evacuation,--idle_duration_micros=0,--compactor_tasks=5,--marker_tasks=5,--scavenger_tasks=5,--old_gen_growth_time_ratio=50,--old_gen_growth_space_ratio=10"
+ENV DART_VM_OPTIONS="--use_compactor,--use_compactor,--idle_duration_micros=100000,--force_evacuation,--mark_when_idle,--old_gen_growth_time_ratio=50,--old_gen_growth_space_ratio=10"
 
 # Run supervisor configuration file on container startup
 CMD ["supervisord", "-n"]

--- a/tools/build_virtual_environment/ve/Dockerfile.vip
+++ b/tools/build_virtual_environment/ve/Dockerfile.vip
@@ -28,7 +28,7 @@ COPY --from=buildimage --chown=atsign:atsign \
 
 EXPOSE 64 443 6379 9001
 
-ENV DART_VM_OPTIONS="--use_compactor,--force_evacuation,--idle_duration_micros=0,--compactor_tasks=5,--marker_tasks=5,--scavenger_tasks=5,--old_gen_growth_time_ratio=50,--old_gen_growth_space_ratio=10"
+ENV DART_VM_OPTIONS="--use_compactor,--use_compactor,--idle_duration_micros=100000,--force_evacuation,--mark_when_idle,--old_gen_growth_time_ratio=50,--old_gen_growth_space_ratio=10"
 
 # Run supervisor configuration file on container startup
 CMD ["supervisord", "-n"]

--- a/tools/build_virtual_environment/ve_base/Dockerfile
+++ b/tools/build_virtual_environment/ve_base/Dockerfile
@@ -39,4 +39,4 @@ COPY --from=buildimage --chown=atsign:atsign \
   /app/tools/build_virtual_environment/install_PKAM_Keys/install_PKAM_Keys \
   /usr/local/bin/
 
-ENV DART_VM_OPTIONS="--use_compactor,--force_evacuation,--idle_duration_micros=0,--compactor_tasks=5,--marker_tasks=5,--scavenger_tasks=5,--old_gen_growth_time_ratio=50,--old_gen_growth_space_ratio=10"
+ENV DART_VM_OPTIONS="--use_compactor,--use_compactor,--idle_duration_micros=100000,--force_evacuation,--mark_when_idle,--old_gen_growth_time_ratio=50,--old_gen_growth_space_ratio=10"

--- a/tools/run_locally/scripts/macos/at_server
+++ b/tools/run_locally/scripts/macos/at_server
@@ -89,5 +89,4 @@ else
   observeParams="--observe=$observePort"
 fi
 
-export DART_VM_OPTIONS="--use_compactor,--force_evacuation,--idle_duration_micros=0,--compactor_tasks=5,--marker_tasks=5,--scavenger_tasks=5,--mark_when_idle,--old_gen_growth_time_ratio=50,--old_gen_growth_space_ratio=10"
-dart $observeParams "$scriptDir"/../../../../packages/at_secondary_server/bin/main.dart -a "$atSign" -p "$port" -s "$secret"
+dart --use_compactor --idle_duration_micros=100000 --use_compactor --force_evacuation --mark_when_idle --old_gen_growth_time_ratio=50 --old_gen_growth_space_ratio=10 $observeParams "$scriptDir"/../../../../packages/at_secondary_server/bin/main.dart -a "$atSign" -p "$port" -s "$secret"


### PR DESCRIPTION
**- What I did**
feat: tweak the garbage collection runtime flags

**- How I did it**

**- How to verify it**
These specific flags have been set on ssh_1 (canary), cconstab (canary) and llama atServers over the past 30 mins and the atServers are exhibiting decent memory usage

The rationale for these flags `--use_compactor,--use_compactor,--idle_duration_micros=100000,--force_evacuation,--mark_when_idle,--old_gen_growth_time_ratio=50,--old_gen_growth_space_ratio=10` is
1. to ensure that use_compactor is true (in the event that it is being ignored as potentially indicated by other experiments)
2. to set idle_duration_micros to 100ms
3. to ensure that the mark_when_idle flag is set 
4. to use the default values for compactor_tasks, marker_tasks and scavenger_tasks

Gemini's explanation of these various flags:
```
Putting it all together
You have now asked about the four "Horsemen" of Dart Memory Management. Here is how they stack up for a low-memory device:

idle_duration_micros: Sets the "When" (Wait for a gap in work).

mark_when_idle: Sets the "Prep" (Identify trash early).

force_evacuation: Sets the "Nursery Policy" (Keep the young generation empty).

use_compactor: Sets the "Deep Clean" (Keep the old generation dense).
```
