### PR TITLE
chore(at_secondary_server): remove dependency override for at_server_spec

### DIFF
--- a/packages/at_secondary_server/pubspec.lock
+++ b/packages/at_secondary_server/pubspec.lock
@@ -101,10 +101,10 @@ packages:
     dependency: "direct main"
     description:
       name: at_server_spec
-      sha256: bff44167fa609ec0bcc23d57ea4929f84badf67fad90871d6a9c2972c0403eb9
+      sha256: c128bc00c8bde819ff547b2a7baf9788723f9d87c36eddc30fd18042c64060cf
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.4"
+    version: "5.1.0"
   at_utf7:
     dependency: transitive
     description:

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   at_utils: ^3.4.0
   at_chops: ^3.0.0
   at_lookup: ^3.5.0
-  at_server_spec: ^5.0.4
+  at_server_spec: ^5.1.0
   at_persistence_spec: ^3.1.0
   at_persistence_secondary_server: ^4.3.4
   intl: ^0.20.2
@@ -35,10 +35,6 @@ dependencies:
   logging: ^1.3.0
   mime: ^2.0.0
   at_base2e15: ^1.0.0
-
-dependency_overrides:
-  at_server_spec:
-    path: ../at_server_spec
 
 dev_dependencies:
   build_runner: ^2.13.0


### PR DESCRIPTION
**- What I did**
- #2614 
 -  remove dependency override for at_server_spec
 -  update pubspec.lock

**- How I did it**

**- How to verify it**

**- Description for the changelog**
chore(at_secondary_server): remove dependency override for at_server_spec