### PR TITLE
fix: monitor uses spaces in its regex

### DIFF
--- a/packages/at_secondary_server/lib/src/connection/inbound/connection_util.dart
+++ b/packages/at_secondary_server/lib/src/connection/inbound/connection_util.dart
@@ -207,7 +207,7 @@ class InboundCommandValidator {
     }
 
     // why does scan delimit with a space....
-    if (command.contains('scan ')) {
+    if (command.contains('scan ') || command.contains('monitor ')) {
       return;
     }
 

--- a/packages/at_secondary_server/test/inbound_message_listener_test.dart
+++ b/packages/at_secondary_server/test/inbound_message_listener_test.dart
@@ -145,6 +145,17 @@ void main() async {
       );
     });
 
+    test('validate monitor with trailing arguments bypasses verb parsing', () {
+      when(() => connection.metaData).thenReturn(unAuthenticatedMetadata);
+      expect(
+            () => InboundCommandValidator.validate(
+          utf8.encode('monitor this-is-accepted\n').toList(),
+          connection,
+        ),
+        returnsNormally,
+      );
+    });
+
     test('invalidate bad connection', () {
       when(() => connection.metaData).thenReturn(unAuthenticatedMetadata);
       when(() => connection.isInValid()).thenReturn(true);


### PR DESCRIPTION
**- What I did**
- [at_c functional tests catching failure in monitor regex](https://github.com/atsign-foundation/at_c/actions/runs/24349145406/job/71100104291?pr=671#step:10:182)

**- How I did it**
- included monitor in the bypass for space delimited commands

**- How to verify it**
- new tests
**- Description for the changelog**
fix: monitor uses spaces in its regex