### PR TITLE
fix: auth check for `config: set` commands was too strict

### DIFF
--- a/packages/at_secondary_server/lib/src/verb/handler/abstract_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/abstract_verb_handler.dart
@@ -372,6 +372,7 @@ abstract class AbstractVerbHandler implements VerbHandler {
   bool _isReadAllowed(Verb verb, String access) {
     return (verb is LocalLookup ||
             verb is Lookup ||
+            verb is Config ||
             verb is NotifyFetch ||
             verb is NotifyStatus ||
             verb is NotifyList ||
@@ -384,6 +385,7 @@ abstract class AbstractVerbHandler implements VerbHandler {
   bool _isWriteAllowed(Verb verb, String access) {
     return (verb is Update ||
             verb is Delete ||
+            verb is Config ||
             verb is Notify ||
             verb is NotifyAll ||
             verb is NotifyRemove ||


### PR DESCRIPTION

**- What I did**
fix: Since the recent elimination of "testingMode", the ConfigVerbHandler relies on the standard auth checker in AbstractVerbHandler. However the Config verb was never added to the lists in _isReadAllowed and _isWriteAllowed; now it has.

**- How I did it**

**- How to verify it**
- Tests pass
- Issue was discovered in https://github.com/atsign-foundation/at_client_sdk/pull/1920 ... I have verified manually that this change allows a a clean test run.