### PR TITLE
feat(tools): multi-instance VE/EE via base-port env var

### DIFF
--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,3 +1,9 @@
 
 # Output logs, storage directories etc are held in run_locally/runtime
 run_locally/runtime
+
+build_virtual_environment/ve/contents/atsign/root/pubspec.yaml
+build_virtual_environment/ve/contents/atsign/root/root
+
+build_virtual_environment/ve/contents/atsign/secondary/pubspec.yaml
+build_virtual_environment/ve/contents/atsign/secondary/secondary

--- a/tools/build_ephemeral_environment/README.md
+++ b/tools/build_ephemeral_environment/README.md
@@ -26,16 +26,16 @@ docker run -it -e FIRST_PORT=<start port> -p 64:64 \
 This will start the container with default certificates that are provided in
 the repo to `vip.ve.atsign.zone` in the same way as the Virtual Environment
 does. This is useful for testing but in actual use you will have to provide a
-valid certficate files for the atServers (secondaries) and map them to
+valid certificate files for the atServers (secondaries) and map them to
 `/atsign/secondary/base/certs` using the `-v` option and then map a DNS record
 to the container's IP. To tell the container the Fully Qualified DNS to
-configure the atServers use the `DNS_FQDN` environment variable. In addition
-the atDirectory (root) needs certifcates (which can be the same), and they can
+configure the atServers use the `DNS_FQDN` environment variable. In addition,
+the atDirectory (root) needs certificates (which can be the same), and they can
 be mapped via `-v` to `/atsign/root/certs`. The atDirectory/atServers need not
 have the same DNS/cert but will have the same IP, atDirectory being on port 64
-and atServers on contigious ports from `<start port>`.
+and atServers on contiguous ports from `<start port>`.
 
-Pulling this all togther an example command looks like this.
+Pulling this all together an example command looks like this.
 
 ```sh
 docker run -it -e DNS_FQDN="rainbow.crushware.com" \
@@ -45,7 +45,7 @@ docker run -it -e DNS_FQDN="rainbow.crushware.com" \
   -p 2500-2600:2500-2600 -d atsigncompany/ephemeral 
 ```
 
-The CRAM values will be printed out in the log file of the container and they
+The CRAM values will be printed out in the log file of the container, and they
 can be used to create atKeys via at_activate for example.
 
 ```sh
@@ -61,8 +61,8 @@ but with the additional argument of the new root server for example:
 sshnp --root-domain rainbow.crushware.com -f @alpha -t @bravo -d test -r @zulu
 ```
 
-By default 26 atSigns are created using the Phonetic Alphabet from @alpha to
-@zulu. This can be overidden by creating a file listing the atSigns you
+By default, 26 atSigns are created using the Phonetic Alphabet from @alpha to
+@zulu. This can be overridden by creating a file listing the atSigns you
 would like and mounting it at /tmp/setup/atsigns.
 
 For example the atsigns file could contain:
@@ -88,7 +88,7 @@ This would create the five atSigns instead of the defaults, for example:
 
 ## Monitoring and administration of the running container
 
-By default the admin interface is available via:
+By default, the admin interface is available via:
 
 [http://localhost:9001/](http://localhost:9001/)
 
@@ -96,3 +96,41 @@ Logs of each process/atSign are visible and can be restarted if required.
 
 A copy of the CRAM values for each atSign can be found inside the container
 in the file `/tmp/CRAM_keys` if the docker logs are lost.
+
+## Running multiple EEs side-by-side (`EPHEMERAL_BASE_PORT` mode)
+
+The container also supports an alternative startup mode in which every
+service it exposes is shifted into a contiguous 100-port range starting
+at a base port you choose. This lets several EEs coexist on one host
+without colliding — useful primarily for testing.
+
+Set `EPHEMERAL_BASE_PORT` to the lowest port you want to claim and the
+container will bind:
+
+| Service     | Port range                                             |
+|-------------|--------------------------------------------------------|
+| atDirectory | `EPHEMERAL_BASE_PORT`                                  |
+| atServers   | `EPHEMERAL_BASE_PORT + 1 .. EPHEMERAL_BASE_PORT + 80`  |
+| (reserved)  | `EPHEMERAL_BASE_PORT + 81 .. EPHEMERAL_BASE_PORT + 98` |
+| Redis       | `EPHEMERAL_BASE_PORT + 99`                             |
+
+When `EPHEMERAL_BASE_PORT` is unset the container behaves exactly as
+described above (atDirectory on 64, Redis on 6379, atServers from
+`FIRST_PORT`). Setting `EPHEMERAL_BASE_PORT` overrides `FIRST_PORT`.
+
+The easiest path is the `runee.sh` helper, which generates a
+per-container docker-compose file and brings the EE up:
+
+```sh
+./tools/build_ephemeral_environment/runee.sh ee-a 2500
+./tools/build_ephemeral_environment/runee.sh ee-b 2600
+```
+
+Both EEs are now running on the same host with no port conflict; ee-a's
+atDirectory is on 2500 and ee-b's is on 2600. Use `at_activate` against
+each one with the corresponding root domain / port.
+
+A sample docker-compose file is also provided at
+`tools/build_ephemeral_environment/docker-compose.yaml`; copy it as a
+starting point if you want to wire the EE into a larger compose stack
+rather than use `runee.sh`.

--- a/tools/build_ephemeral_environment/docker-compose.yaml
+++ b/tools/build_ephemeral_environment/docker-compose.yaml
@@ -1,0 +1,31 @@
+# Sample docker-compose for the ephemeral environment (EE).
+#
+# This is a starting point — copy it, set EPHEMERAL_BASE_PORT to the
+# lowest port you want to claim, and adjust the host-side port range to
+# match. Inside the container the services bind to:
+#
+#   atDirectory  -> EPHEMERAL_BASE_PORT
+#   atServers    -> EPHEMERAL_BASE_PORT+1 .. EPHEMERAL_BASE_PORT+80
+#   (reserved)   -> EPHEMERAL_BASE_PORT+81 .. EPHEMERAL_BASE_PORT+98
+#   Redis        -> EPHEMERAL_BASE_PORT+99
+#
+# For multi-EE setups prefer the runee.sh helper, which generates one of
+# these per container with a unique compose project name.
+
+name: ephemeral
+
+services:
+  ephemeral:
+    container_name: ephemeral
+    image: atsigncompany/ephemeral:latest
+    ports:
+      - '127.0.0.1:2500-2599:2500-2599'
+    extra_hosts:
+      - 'vip.ve.atsign.zone:127.0.0.1'
+    environment:
+      - EPHEMERAL_BASE_PORT=2500
+      # - DNS_FQDN=rainbow.example.com   # optional, default vip.ve.atsign.zone
+    # volumes:
+    #   - /tmp/rainbow/certs:/atsign/root/certs
+    #   - /tmp/rainbow/certs:/atsign/secondary/base/certs
+    #   - /tmp/atsigns:/tmp/setup/atsigns

--- a/tools/build_ephemeral_environment/ee_base/contents/tmp/startup.sh
+++ b/tools/build_ephemeral_environment/ee_base/contents/tmp/startup.sh
@@ -1,4 +1,35 @@
 #!/bin/bash
+#
+# Ephemeral environment container entrypoint.
+#
+# When EPHEMERAL_BASE_PORT is set (e.g. 2500) we shift every bind port
+# into the contiguous range [BASE, BASE+99]:
+#   atDirectory  -> BASE
+#   atServers    -> BASE+1 .. BASE+80
+#   (reserved)   -> BASE+81 .. BASE+98
+#   Redis        -> BASE+99
+# This lets multiple EE containers run side-by-side on one host.
+#
+# When EPHEMERAL_BASE_PORT is unset, the existing FIRST_PORT / DNS_FQDN
+# behaviour (atDirectory on 64, atServers from FIRST_PORT, redis on
+# 6379) is preserved unchanged.
+
+set -euo pipefail
+
+if [[ -n "${EPHEMERAL_BASE_PORT:-}" ]]; then
+  BASE=${EPHEMERAL_BASE_PORT}
+  ROOT_PORT=${BASE}
+  REDIS_PORT=$((BASE + 99))
+  export FIRST_PORT=$((BASE + 1))
+  export rootServerPort=${ROOT_PORT}
+
+  sed -i "s/^port .*/port ${REDIS_PORT}/" /etc/redis/redis.conf
+  sed -i "s/-p 6379/-p ${REDIS_PORT}/" /etc/supervisor/conf.d/40_root.conf
+  # /tmp/import.sh pipes records to redis-cli with no -p, so it defaults
+  # to 6379; after shifting we have to point it at the new redis port.
+  sed -i "s|redis-cli --pipe|redis-cli -p ${REDIS_PORT} --pipe|" /tmp/import.sh
+fi
+
 # Create atSign/atServers
 cd /tmp/setup/
 ./createConf.sh ./atsigns
@@ -10,4 +41,4 @@ cp /atsign/secondary/base/rootca/cacert.pem /atsign/secondary/base/certs/
 # Run supervisord as root
 sed -i '/\[supervisord\]/a user=root' /etc/supervisor/supervisord.conf
 
-supervisord  -c /etc/supervisor/supervisord.conf -n 
+supervisord -c /etc/supervisor/supervisord.conf -n

--- a/tools/build_ephemeral_environment/runee.sh
+++ b/tools/build_ephemeral_environment/runee.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# runee.sh — bring up an ephemeral environment (EE) container with port-
+# shifted services so multiple EEs can run side-by-side on one host.
+#
+# Usage: runee.sh <container-name> <base-port>
+#
+# The container will bind:
+#   atDirectory  -> <base>
+#   atServers    -> <base>+1 .. <base>+80
+#   (reserved)   -> <base>+81 .. <base>+98
+#   Redis        -> <base>+99
+# All host port mappings are bound to 127.0.0.1.
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: runee.sh <container-name> <base-port>" >&2
+  exit 2
+fi
+
+NAME=$1
+BASE=$2
+
+if [[ ! "$BASE" =~ ^[0-9]+$ ]]; then
+  echo "base-port must be numeric (got: $BASE)" >&2
+  exit 2
+fi
+if (( BASE < 1 || BASE + 99 > 65535 )); then
+  echo "base-port out of range: <base>+99 must be <= 65535" >&2
+  exit 2
+fi
+
+if docker ps --format '{{.Names}}' | grep -Fxq "$NAME"; then
+  echo "container '$NAME' is already running" >&2
+  exit 1
+fi
+
+TOP=$((BASE + 99))
+COMPOSE_FILE="docker-compose-${NAME}.yaml"
+
+cat > "$COMPOSE_FILE" <<EOF
+name: ${NAME}
+services:
+  ephemeral:
+    container_name: ${NAME}
+    image: atsigncompany/ephemeral:latest
+    ports:
+      - '127.0.0.1:${BASE}-${TOP}:${BASE}-${TOP}'
+    extra_hosts:
+      - 'vip.ve.atsign.zone:127.0.0.1'
+    environment:
+      - EPHEMERAL_BASE_PORT=${BASE}
+EOF
+
+docker compose -f "$COMPOSE_FILE" up -d

--- a/tools/build_virtual_environment/install_PKAM_Keys/bin/install_PKAM_Keys.dart
+++ b/tools/build_virtual_environment/install_PKAM_Keys/bin/install_PKAM_Keys.dart
@@ -5,7 +5,8 @@ import 'package:at_lookup/at_lookup.dart';
 import 'package:at_utils/at_utils.dart';
 
 final String rootDomain = 'vip.ve.atsign.zone';
-final int rootPort = 64;
+final int rootPort =
+    int.tryParse(Platform.environment['rootServerPort'] ?? '') ?? 64;
 final SecondaryAddressFinder saf =
     CacheableSecondaryAddressFinder(rootDomain, rootPort);
 late final AtSignLogger logger;

--- a/tools/build_virtual_environment/ve/Dockerfile.vip
+++ b/tools/build_virtual_environment/ve/Dockerfile.vip
@@ -26,9 +26,12 @@ COPY --from=buildimage --chown=atsign:atsign \
 COPY --from=buildimage --chown=atsign:atsign \
   /app/packages/at_secondary_server/pubspec.yaml /atsign/secondary/
 
+COPY tools/build_virtual_environment/ve/contents/atsign/entrypoint.sh /atsign/entrypoint.sh
+RUN chmod +x /atsign/entrypoint.sh
+
 EXPOSE 64 443 6379 9001
 
 ENV DART_VM_OPTIONS='--use_compactor,--dontneed_on_sweep,--old_gen_growth_time_ratio=50,--old_gen_growth_space_ratio=10,--new_gen_semi_max_size=8'
 
-# Run supervisor configuration file on container startup
-CMD ["supervisord", "-n"]
+# entrypoint shifts ports if VIRTUALENV_BASE_PORT is set, then execs supervisord
+CMD ["/atsign/entrypoint.sh"]

--- a/tools/build_virtual_environment/ve/contents/atsign/entrypoint.sh
+++ b/tools/build_virtual_environment/ve/contents/atsign/entrypoint.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# Virtualenv container entrypoint.
+#
+# If VIRTUALENV_BASE_PORT is unset, behaviour is unchanged: services
+# bind to their original ports (atDirectory 64, atServers 25000-25039,
+# Redis 6379) and we just exec supervisord.
+#
+# If VIRTUALENV_BASE_PORT is set (e.g. 30000), we shift every bind port
+# into the [BASE, BASE+99] range:
+#   atDirectory  -> BASE
+#   atServers    -> BASE+1 .. BASE+80
+#   Redis        -> BASE+99
+# This makes it possible to run several VE containers side-by-side on
+# one host without port collisions.
+
+set -euo pipefail
+
+if [[ -z "${VIRTUALENV_BASE_PORT:-}" ]]; then
+  exec supervisord -n
+  exit $?
+fi
+
+BASE=${VIRTUALENV_BASE_PORT}
+ROOT_PORT=${BASE}
+REDIS_PORT=$((BASE + 99))
+SECONDARY_BASE=$((BASE + 1))
+SHIFT=$((SECONDARY_BASE - 25000))
+
+# Redis bind port
+sed -i "s/^port .*/port ${REDIS_PORT}/" /etc/redis/redis.conf
+
+# root_server: redis client port (the -p arg) and bind port (env var)
+export rootServerPort="${ROOT_PORT}"
+sed -i "s/-p 6379/-p ${REDIS_PORT}/" /etc/supervisor/conf.d/30_root.conf
+
+# Secondary atServer supervisord program blocks: rewrite the -p N arg
+for f in /etc/supervisor/conf.d/[0-9]*_*.conf; do
+  grep -q '/atsign/secondary/secondary' "$f" || continue
+  old=$(grep -oE -- '-p [0-9]+' "$f" | awk '{print $2}')
+  new=$((old + SHIFT))
+  sed -i "s/-p ${old}/-p ${new}/" "$f"
+done
+
+# /tmp/records (redis seed lines): shift the vip.ve.atsign.zone:<port>
+perl -i -pe 's{vip\.ve\.atsign\.zone:(\d+)}{"vip.ve.atsign.zone:" . ($1 + '"$SHIFT"')}ge' /tmp/records
+
+# /tmp/import.sh pipes records to redis-cli with no -p, so it defaults to 6379;
+# after shifting we have to point it at the new redis port.
+sed -i "s|redis-cli --pipe|redis-cli -p ${REDIS_PORT} --pipe|" /tmp/import.sh
+
+exec supervisord -n

--- a/tools/virtualenv/runve.sh
+++ b/tools/virtualenv/runve.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# runve.sh — bring up a virtualenv container with port-shifted services so
+# multiple VEs can run side-by-side on one host.
+#
+# Usage: runve.sh <container-name> <base-port>
+#
+# The container will bind:
+#   atDirectory  -> <base>
+#   atServers    -> <base>+1 .. <base>+80
+#   (reserved)   -> <base>+81 .. <base>+98
+#   Redis        -> <base>+99
+# All host port mappings are bound to 127.0.0.1.
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: runve.sh <container-name> <base-port>" >&2
+  exit 2
+fi
+
+NAME=$1
+BASE=$2
+
+if [[ ! "$BASE" =~ ^[0-9]+$ ]]; then
+  echo "base-port must be numeric (got: $BASE)" >&2
+  exit 2
+fi
+if (( BASE < 1 || BASE + 99 > 65535 )); then
+  echo "base-port out of range: <base>+99 must be <= 65535" >&2
+  exit 2
+fi
+
+if docker ps --format '{{.Names}}' | grep -Fxq "$NAME"; then
+  echo "container '$NAME' is already running" >&2
+  exit 1
+fi
+
+TOP=$((BASE + 99))
+COMPOSE_FILE="docker-compose-${NAME}.yaml"
+
+cat > "$COMPOSE_FILE" <<EOF
+name: ${NAME}
+services:
+  virtualenv:
+    container_name: ${NAME}
+    image: atsigncompany/virtualenv:vip
+    ports:
+      - '127.0.0.1:${BASE}-${TOP}:${BASE}-${TOP}'
+    extra_hosts:
+      - 'vip.ve.atsign.zone:127.0.0.1'
+    environment:
+      - VIRTUALENV_BASE_PORT=${BASE}
+EOF
+
+docker compose -f "$COMPOSE_FILE" up -d


### PR DESCRIPTION
## Summary

- Add `VIRTUALENV_BASE_PORT` (VE) and `EPHEMERAL_BASE_PORT` (EE) env vars that shift every service in the container into the contiguous range `[BASE, BASE+99]` — atDirectory at `BASE`, atServers at `BASE+1..BASE+80`, Redis at `BASE+99`. Several containers can now coexist on one host without port collisions.
- Add `tools/virtualenv/runve.sh` and `tools/build_ephemeral_environment/runee.sh` helpers that generate a per-container docker-compose file with a unique compose project `name:` (so sibling files don't silently evict each other) and bring the container up bound to 127.0.0.1.
- When the env var is unset, behaviour is bit-for-bit unchanged: VE keeps binding 64/6379/25000-25039; EE keeps honouring `FIRST_PORT` / `DNS_FQDN`.
- `install_PKAM_Keys` now reads the `rootServerPort` env var (default 64) to match `at_root_config.dart`, so PKAM-load still reaches the atDirectory after a shift.

Ports `BASE+81..BASE+98` reserved for future services (proxy, registrar, etc).

## Test plan

- [x] `runve.sh ve-a 31000` and `runve.sh ve-b 31100` start cleanly side-by-side; both atDirectories listen on their shifted ports; both Redises hold shifted records (alice → `vip.ve.atsign.zone:31001` vs `:31101`); install_PKAM_Keys completes 40/40 against the shifted root.
- [x] `runee.sh ee-a 31000` and `runee.sh ee-b 31100` start cleanly side-by-side; alpha → `vip.ve.atsign.zone:31001` vs `:31101`; TLS handshake succeeds from host on each shifted secondary port.
- [x] Default-mode VE (no env var): atDirectory on 64, alice on 25000, redis on 6379 — unchanged.
- [x] Default-mode EE (`FIRST_PORT=2500` only): atDirectory on 64, alpha on 2500, redis on 6379 — unchanged.