### PR TITLE
fix: log the offending rawVerb and command when `InboundCommandValidator.validate` throws an InvalidSyntaxException

### DIFF
--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 3.13.1
+
+- fix: log the offending rawVerb and command when
+  `InboundCommandValidator.validate` throws an InvalidSyntaxException
+
 # 3.13.0
 
 - feat(deps): Take up at_commons ^5.10.0 to pick up new command (verb) syntax

--- a/packages/at_secondary_server/lib/src/connection/inbound/connection_util.dart
+++ b/packages/at_secondary_server/lib/src/connection/inbound/connection_util.dart
@@ -6,6 +6,7 @@ import 'package:at_commons/at_commons.dart';
 import 'package:at_secondary/src/server/at_secondary_config.dart';
 import 'package:at_secondary/src/server/server_context.dart';
 import 'package:at_server_spec/at_server_spec.dart';
+import 'package:at_utils/at_logger.dart' show AtSignLogger;
 
 import 'inbound_connection_pool.dart';
 
@@ -190,6 +191,8 @@ class InboundIdleChecker {
 }
 
 class InboundCommandValidator {
+  static final AtSignLogger logger = AtSignLogger('InboundCommandValidator');
+
   /// We only need enough of the buffer to identify the verb name (capped at 64
   /// chars below) and the optional subcommand, so for very long commands (e.g.
   /// large `update` values) we cap the decode here to a small prefix instead
@@ -242,9 +245,12 @@ class InboundCommandValidator {
     }
 
     // what verb is this?
-    final verb = AtVerb.tryParse(rawVerb) ??
-        (throw InvalidSyntaxException(
-            'Received invalid verb that does not match protocol spec'));
+    final AtVerb? verb = AtVerb.tryParse(rawVerb);
+    if (verb == null) {
+      String exMsg = 'Received invalid verb that does not match protocol spec';
+      logger.severe('$exMsg. rawVerb: $rawVerb command: $command');
+      throw InvalidSyntaxException(exMsg);
+    }
 
     // determine auth requirement - may be overridden if verb has subcommands
     bool requiresAuth = verb.requiresAuth;

--- a/packages/at_secondary_server/lib/src/connection/inbound/connection_util.dart
+++ b/packages/at_secondary_server/lib/src/connection/inbound/connection_util.dart
@@ -248,7 +248,7 @@ class InboundCommandValidator {
     final AtVerb? verb = AtVerb.tryParse(rawVerb);
     if (verb == null) {
       String exMsg = 'Received invalid verb that does not match protocol spec';
-      logger.severe('$exMsg. rawVerb: $rawVerb command: $command');
+      logger.warning('$exMsg. rawVerb: $rawVerb command: $command');
       throw InvalidSyntaxException(exMsg);
     }
 

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_secondary
 description: Implementation of secondary server.
-version: 3.13.0
+version: 3.13.1
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://www.example.com
 publish_to: none


### PR DESCRIPTION
**- What I did**
- fix: log a warning with the offending rawVerb and command when `InboundCommandValidator.validate` throws an InvalidSyntaxException

**- How I did it**
See commits

**- How to verify it**
- Tests pass
- Eyeballed the logs. `WARNING|2026-05-31 12:04:08.937748|InboundCommandValidator|Received invalid verb that does not match protocol spec. rawVerb: hello command: hello`
