### PR TITLE
Fix overly aggressive InboundCommandValidator

### DIFF
--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -8,6 +8,13 @@
   on the first flow, was sent an `error:` frame, had its buffer
   cleared, and was rejected again on the second flow — two error
   frames written to the client for one command
+- fix: anchor `InboundCommandValidator`'s `scan`/`monitor`
+  short-circuit to `startsWith` (was `contains`). A value containing
+  the substring `scan ` or `monitor ` no longer skips the verb-parse
+  + auth-check path; previously, an unauthenticated client could send
+  e.g. `update:public:phone@alice scan some-text\n` and the validator
+  would early-return without enforcing the `update` verb's auth
+  requirement.
 
 # 3.13.1
 

--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 3.13.2
+
+- fix: defer `InboundCommandValidator.validate` until the buffer ends
+  with `\n` or has at least 16 bytes (the length of the longest
+  verb+subcommand, `enroll:unrevoke`, plus 1). Previously, a command arriving
+  in two TCP flows where the first carried fewer bytes than the verb
+  name (e.g. `'loo'` then `'kup:publickey@alice\n'`) failed validation
+  on the first flow, was sent an `error:` frame, had its buffer
+  cleared, and was rejected again on the second flow — two error
+  frames written to the client for one command
+
 # 3.13.1
 
 - fix: log the offending rawVerb and command when

--- a/packages/at_secondary_server/lib/src/connection/inbound/connection_util.dart
+++ b/packages/at_secondary_server/lib/src/connection/inbound/connection_util.dart
@@ -246,8 +246,13 @@ class InboundCommandValidator {
     var isAuthenticated = connection.metaData.isAuthenticated ||
         connection.metaData.isPolAuthenticated;
 
-    // why does scan delimit with a space....
-    if (command.contains('scan ') || command.contains('monitor ')) {
+    // `scan` and `monitor` are the two verbs whose arguments are
+    // delimited by a space rather than `:`, so the verb-then-colon
+    // split below can't parse them. Anchor the match to the start of
+    // the command — `contains` would also match a `scan ` or
+    // `monitor ` substring inside an `update` value, letting an
+    // unauthenticated client bypass the auth check on `update`.
+    if (command.startsWith('scan ') || command.startsWith('monitor ')) {
       return;
     }
 

--- a/packages/at_secondary_server/lib/src/connection/inbound/connection_util.dart
+++ b/packages/at_secondary_server/lib/src/connection/inbound/connection_util.dart
@@ -199,6 +199,29 @@ class InboundCommandValidator {
   /// of decoding the entire payload twice (validator + listener).
   static const int _maxBytesForValidation = 256;
 
+  /// Lower bound below which the buffer is too short to make a reliable
+  /// verb / subcommand decision: validation must be deferred until either
+  /// a terminating `\n` arrives or at least this many bytes have been
+  /// accumulated.
+  ///
+  /// Computed as `max(verb.length + 1 + max_subcommand_length + 1)` across
+  /// every [AtVerb] with `hasSubcommands == true`, where the candidate
+  /// subcommands are the [Subcommand] enum values that the validator can
+  /// match — the longest is `unrevoke` (8). The bound is
+  /// `enroll:unrevoke` (6 + 1 + 8 + 1 = 16). Verbs without subcommands and
+  /// the longest verb name (`llookup`/`plookup`/`monitor`, 7 chars) fit
+  /// inside this bound.
+  ///
+  /// Below this bound, validating against a partial prefix would
+  ///  (a) reject the legitimate first half of a fragmented command (e.g.
+  ///      `'loo'` followed in a later TCP flow by `'kup:publickey@alice\n'`)
+  ///      — `AtVerb.tryParse('loo')` returns null and we'd send a
+  ///      spurious `error:` frame plus clear the buffer; and
+  ///  (b) make the auth-required decision against a truncated subcommand
+  ///      (e.g. `'enroll:revo'` would auth-pass before the `unrevoke`
+  ///      subcommand's `requiresAuth: true` was observed).
+  static const int minBytesForValidation = 16;
+
   static final Utf8Decoder _allowMalformedUtf8 =
       Utf8Decoder(allowMalformed: true);
 

--- a/packages/at_secondary_server/lib/src/connection/inbound/inbound_message_listener.dart
+++ b/packages/at_secondary_server/lib/src/connection/inbound/inbound_message_listener.dart
@@ -170,6 +170,18 @@ class StreamableByteBuffer extends at_commons.ByteBuffer {
 
   void validate(AtConnection connection) {
     if (validated) return;
+    final len = length();
+    if (len == 0) return;
+    // Defer validation until we have either a terminating `\n` or
+    // enough bytes (see [InboundCommandValidator.minBytesForValidation])
+    // to fully cover the longest possible verb+subcommand. Validating
+    // against a shorter partial buffer would reject the first fragment
+    // of a fragmented command (e.g. `'loo'` arriving before
+    // `'kup:publickey@alice\n'`) and bin the buffer, dropping the
+    // command bytes still in flight.
+    if (!isEnd() && len < InboundCommandValidator.minBytesForValidation) {
+      return;
+    }
     InboundCommandValidator.validate(getData(), connection);
     validated = true;
   }

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_secondary
 description: Implementation of secondary server.
-version: 3.13.1
+version: 3.13.2
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://www.example.com
 publish_to: none

--- a/packages/at_secondary_server/test/inbound_message_listener_test.dart
+++ b/packages/at_secondary_server/test/inbound_message_listener_test.dart
@@ -179,6 +179,174 @@ void main() async {
         throwsA(isA<ConnectionInvalidException>()),
       );
     });
+
+    // -----------------------------------------------------------------
+    // Coverage gaps — each test below closes a specific validate()
+    // branch that wasn't otherwise exercised.
+    // -----------------------------------------------------------------
+
+    // Gap 1a: the rawVerb.length > 64 branch.
+    test('rawVerb longer than 64 chars throws InvalidSyntaxException', () {
+      when(() => connection.metaData).thenReturn(authenticatedMetadata);
+      expect(
+        () => InboundCommandValidator.validate(
+            utf8.encode('${'a' * 65}:rest\n').toList(), connection),
+        throwsA(isA<InvalidSyntaxException>()),
+      );
+    });
+
+    // Gap 1b: boundary — 64 chars exactly is NOT rejected by the
+    // length check, it falls through to tryParse-null.
+    test('rawVerb of exactly 64 chars falls through to tryParse-null', () {
+      when(() => connection.metaData).thenReturn(authenticatedMetadata);
+      expect(
+        () => InboundCommandValidator.validate(
+            utf8.encode('${'a' * 64}:rest\n').toList(), connection),
+        throwsA(isA<InvalidSyntaxException>()),
+      );
+    });
+
+    // Gap 2a/b: the isPolAuthenticated half of the auth OR — a
+    // pol-authenticated connection must satisfy auth-required verbs.
+    test('pol-authenticated connection passes auth-required top-level verbs',
+        () {
+      final pol = InboundConnectionMetadata()..isPolAuthenticated = true;
+      when(() => connection.metaData).thenReturn(pol);
+      _expectCommandsToValidate(authenticatedTopLevelCommands, connection);
+    });
+    test('pol-authenticated connection passes auth-required subcommands', () {
+      final pol = InboundConnectionMetadata()..isPolAuthenticated = true;
+      when(() => connection.metaData).thenReturn(pol);
+      _expectCommandsToValidate(subcommandsRequiringAuth, connection);
+    });
+
+    // Gap 3: Subcommand.tryParse null + verb.requiresAuth=false
+    // fallback (the unauth-default branch of the `??` operator).
+    test('unknown enroll subcommand falls back to verb.requiresAuth=false', () {
+      when(() => connection.metaData).thenReturn(unAuthenticatedMetadata);
+      expect(
+        () => InboundCommandValidator.validate(
+            utf8.encode('enroll:foobar:rest\n').toList(), connection),
+        returnsNormally,
+      );
+    });
+
+    // Gap 4a/b: hasSubcommands verb arriving with no colon at all.
+    // The secondColon lookup returns -1 and rawSubcommand is the verb
+    // name itself; Subcommand.tryParse returns null and we fall back
+    // to verb.requiresAuth.
+    test('enroll without colon falls back to verb.requiresAuth=false', () {
+      when(() => connection.metaData).thenReturn(unAuthenticatedMetadata);
+      expect(
+        () => InboundCommandValidator.validate(
+            utf8.encode('enroll\n').toList(), connection),
+        returnsNormally,
+      );
+    });
+    test('notify without colon throws UnAuth (fallback to verb.requiresAuth)',
+        () {
+      when(() => connection.metaData).thenReturn(unAuthenticatedMetadata);
+      expect(
+        () => InboundCommandValidator.validate(
+            utf8.encode('notify\n').toList(), connection),
+        throwsA(isA<UnAuthenticatedException>()),
+      );
+    });
+
+    // Gap 5: empty bytes — empty rawVerb, tryParse('') is null.
+    test('empty bytes throws InvalidSyntaxException', () {
+      when(() => connection.metaData).thenReturn(authenticatedMetadata);
+      expect(
+        () => InboundCommandValidator.validate([], connection),
+        throwsA(isA<InvalidSyntaxException>()),
+      );
+    });
+
+    // Gap 6a/b/c: trim-related edge cases.
+    test('whitespace-only input throws InvalidSyntaxException', () {
+      when(() => connection.metaData).thenReturn(authenticatedMetadata);
+      expect(
+        () => InboundCommandValidator.validate(
+            utf8.encode('   \n').toList(), connection),
+        throwsA(isA<InvalidSyntaxException>()),
+      );
+    });
+    test('leading whitespace is stripped before parsing', () {
+      when(() => connection.metaData).thenReturn(unAuthenticatedMetadata);
+      expect(
+        () => InboundCommandValidator.validate(
+            utf8.encode('   lookup:public:publickey@alice\n').toList(),
+            connection),
+        returnsNormally,
+      );
+    });
+    test('leading colon produces empty rawVerb and throws', () {
+      when(() => connection.metaData).thenReturn(authenticatedMetadata);
+      expect(
+        () => InboundCommandValidator.validate(
+            utf8.encode(':something\n').toList(), connection),
+        throwsA(isA<InvalidSyntaxException>()),
+      );
+    });
+
+    // Gap 7a/b: the prefixLen cap at _maxBytesForValidation (256).
+    test('valid verb with >256 trailing bytes still validates from prefix', () {
+      when(() => connection.metaData).thenReturn(authenticatedMetadata);
+      final big = 'update:public:phone@alice ${'x' * 400}\n';
+      expect(
+        () => InboundCommandValidator.validate(
+            utf8.encode(big).toList(), connection),
+        returnsNormally,
+      );
+    });
+    test('>256 bytes of unrecognised junk throws based on the prefix', () {
+      when(() => connection.metaData).thenReturn(authenticatedMetadata);
+      expect(
+        () => InboundCommandValidator.validate(
+            utf8.encode('${'z' * 400}\n').toList(), connection),
+        throwsA(isA<InvalidSyntaxException>()),
+      );
+    });
+
+    // Gap 8: malformed UTF-8 — the allowMalformed decoder should
+    // produce replacement chars that the validator then rejects as a
+    // non-protocol verb. The point is no FormatException leaks.
+    test('malformed UTF-8 bytes do not leak FormatException', () {
+      when(() => connection.metaData).thenReturn(authenticatedMetadata);
+      expect(
+        () => InboundCommandValidator.validate(
+            [0xFF, 0xFE, 0xFD, ...utf8.encode(':rest\n')], connection),
+        throwsA(isA<InvalidSyntaxException>()),
+      );
+    });
+
+    // Gap 9: requiresAuth=true subcommands pass when authenticated
+    // (mirror of the existing unauth test).
+    test('subcommandsRequiringAuth pass when authenticated', () {
+      when(() => connection.metaData).thenReturn(authenticatedMetadata);
+      _expectCommandsToValidate(subcommandsRequiringAuth, connection);
+    });
+
+    // Gap 10: the `scan `/`monitor ` substring short-circuit is now
+    // anchored to startsWith — values that contain those tokens no
+    // longer let an unauthenticated client bypass the auth check.
+    test(
+        '`scan `/`monitor ` substring inside a value does NOT bypass auth check',
+        () {
+      when(() => connection.metaData).thenReturn(unAuthenticatedMetadata);
+      expect(
+        () => InboundCommandValidator.validate(
+            utf8.encode('update:public:phone@alice scan some-text\n').toList(),
+            connection),
+        throwsA(isA<UnAuthenticatedException>()),
+      );
+      expect(
+        () => InboundCommandValidator.validate(
+            utf8.encode('update:public:phone@alice monitor stuff\n').toList(),
+            connection),
+        throwsA(isA<UnAuthenticatedException>()),
+      );
+    });
   });
 
   group(

--- a/packages/at_secondary_server/test/inbound_message_listener_test.dart
+++ b/packages/at_secondary_server/test/inbound_message_listener_test.dart
@@ -267,5 +267,67 @@ void main() async {
       }
       await streamFuture;
     });
+
+    test(
+        'lookup arriving in two TCP flows ("loo" + "kup:publickey@alice\\n") '
+        'reassembles into one command emission and no error frames', () async {
+      // Reproducer for a production bug. When a command's bytes arrive
+      // in two TCP flows AND the first flow's bytes are shorter than
+      // the verb name, InboundCommandValidator.validate runs against
+      // the partial prefix on the first flow, fails (AtVerb.tryParse
+      // returns null for 'loo'), the buffer is cleared, and the
+      // second flow is then validated alone (also rejected). The
+      // client sees two `error:…\n@` frames written to its connection
+      // instead of the single successful response it should get.
+      //
+      // The expected behaviour: the listener should reassemble the
+      // two flows into one command, emit it once via the callback,
+      // and write nothing to the connection in this layer.
+      var listener = InboundMessageListener(fakeConnection);
+      final emissions = <String>[];
+      final sub = sc.stream.listen(emissions.add);
+      listener.listen(callback, streamCallBack);
+
+      // GlobalExceptionHandler's _getPrompt reads
+      // AtSecondaryServerImpl.getInstance().currentAtSign — set it
+      // so that the error-handling path can actually write to the
+      // connection (otherwise it throws an unrelated `late field`
+      // error, the catch-on-Exception in the buffer listener doesn't
+      // catch the Error, and `_buffer.clear()` never runs — masking
+      // the bug as a successful reassembly).
+      AtSecondaryServerImpl.getInstance().currentAtSign = '@alice'.toAtsign();
+
+      const cmd = 'lookup:publickey@alice\n';
+      fakeConnection.socket.addData(cmd.substring(0, 3)); // 'loo'
+      // Yield to the event loop so the message + buffer listeners
+      // process the first flow BEFORE the second arrives — mirroring
+      // a real TCP flow gap. Without this, both flows land in the
+      // buffer before any listener fires and the validator sees the
+      // already-reassembled command, hiding the bug.
+      await Future.delayed(Duration(milliseconds: 10));
+      fakeConnection.socket
+          .addData(cmd.substring(3)); //    'kup:publickey@alice\n'
+
+      // Drain microtasks + give the listener a moment to process.
+      await Future.delayed(Duration(milliseconds: 50));
+      await sub.cancel();
+
+      // Pin both the emission count and the contents (per the
+      // count-emissions-not-just-the-last rule).
+      expect(emissions, [cmd.trim()],
+          reason: 'Expected one command emission with the reassembled '
+              'lookup. With the current validate-on-first-flow logic, '
+              'the prefix "loo" fails validation, the buffer is '
+              'cleared, and zero commands are emitted.');
+
+      // The listener layer shouldn't write to the connection on the
+      // success path. Any writes here indicate a `GlobalExceptionHandler`
+      // `error:…\n@` frame leaking out — the double-write the
+      // production logs show.
+      expect(fakeConnection.writes, isEmpty,
+          reason: 'Expected no error frames written; the connection saw '
+              '${fakeConnection.writes.length} write(s): '
+              '${fakeConnection.writes}');
+    });
   });
 }

--- a/packages/at_secondary_server/test/inbound_message_listener_test.dart
+++ b/packages/at_secondary_server/test/inbound_message_listener_test.dart
@@ -15,6 +15,7 @@ import 'test_utils.dart';
 StreamController<String> sc = StreamController<String>();
 
 void streamCallBack(List<int> data, InboundConnection connection) {}
+
 Future<void> callback(String value, InboundConnection connection) async {
   sc.add(value);
 }
@@ -180,12 +181,6 @@ void main() async {
       );
     });
 
-    // -----------------------------------------------------------------
-    // Coverage gaps — each test below closes a specific validate()
-    // branch that wasn't otherwise exercised.
-    // -----------------------------------------------------------------
-
-    // Gap 1a: the rawVerb.length > 64 branch.
     test('rawVerb longer than 64 chars throws InvalidSyntaxException', () {
       when(() => connection.metaData).thenReturn(authenticatedMetadata);
       expect(
@@ -195,8 +190,6 @@ void main() async {
       );
     });
 
-    // Gap 1b: boundary — 64 chars exactly is NOT rejected by the
-    // length check, it falls through to tryParse-null.
     test('rawVerb of exactly 64 chars falls through to tryParse-null', () {
       when(() => connection.metaData).thenReturn(authenticatedMetadata);
       expect(
@@ -206,8 +199,6 @@ void main() async {
       );
     });
 
-    // Gap 2a/b: the isPolAuthenticated half of the auth OR — a
-    // pol-authenticated connection must satisfy auth-required verbs.
     test('pol-authenticated connection passes auth-required top-level verbs',
         () {
       final pol = InboundConnectionMetadata()..isPolAuthenticated = true;
@@ -220,8 +211,6 @@ void main() async {
       _expectCommandsToValidate(subcommandsRequiringAuth, connection);
     });
 
-    // Gap 3: Subcommand.tryParse null + verb.requiresAuth=false
-    // fallback (the unauth-default branch of the `??` operator).
     test('unknown enroll subcommand falls back to verb.requiresAuth=false', () {
       when(() => connection.metaData).thenReturn(unAuthenticatedMetadata);
       expect(
@@ -231,10 +220,6 @@ void main() async {
       );
     });
 
-    // Gap 4a/b: hasSubcommands verb arriving with no colon at all.
-    // The secondColon lookup returns -1 and rawSubcommand is the verb
-    // name itself; Subcommand.tryParse returns null and we fall back
-    // to verb.requiresAuth.
     test('enroll without colon falls back to verb.requiresAuth=false', () {
       when(() => connection.metaData).thenReturn(unAuthenticatedMetadata);
       expect(
@@ -243,6 +228,7 @@ void main() async {
         returnsNormally,
       );
     });
+
     test('notify without colon throws UnAuth (fallback to verb.requiresAuth)',
         () {
       when(() => connection.metaData).thenReturn(unAuthenticatedMetadata);
@@ -253,7 +239,6 @@ void main() async {
       );
     });
 
-    // Gap 5: empty bytes — empty rawVerb, tryParse('') is null.
     test('empty bytes throws InvalidSyntaxException', () {
       when(() => connection.metaData).thenReturn(authenticatedMetadata);
       expect(
@@ -262,7 +247,6 @@ void main() async {
       );
     });
 
-    // Gap 6a/b/c: trim-related edge cases.
     test('whitespace-only input throws InvalidSyntaxException', () {
       when(() => connection.metaData).thenReturn(authenticatedMetadata);
       expect(
@@ -271,6 +255,7 @@ void main() async {
         throwsA(isA<InvalidSyntaxException>()),
       );
     });
+
     test('leading whitespace is stripped before parsing', () {
       when(() => connection.metaData).thenReturn(unAuthenticatedMetadata);
       expect(
@@ -280,6 +265,7 @@ void main() async {
         returnsNormally,
       );
     });
+
     test('leading colon produces empty rawVerb and throws', () {
       when(() => connection.metaData).thenReturn(authenticatedMetadata);
       expect(
@@ -289,7 +275,6 @@ void main() async {
       );
     });
 
-    // Gap 7a/b: the prefixLen cap at _maxBytesForValidation (256).
     test('valid verb with >256 trailing bytes still validates from prefix', () {
       when(() => connection.metaData).thenReturn(authenticatedMetadata);
       final big = 'update:public:phone@alice ${'x' * 400}\n';
@@ -299,6 +284,7 @@ void main() async {
         returnsNormally,
       );
     });
+
     test('>256 bytes of unrecognised junk throws based on the prefix', () {
       when(() => connection.metaData).thenReturn(authenticatedMetadata);
       expect(
@@ -308,9 +294,6 @@ void main() async {
       );
     });
 
-    // Gap 8: malformed UTF-8 — the allowMalformed decoder should
-    // produce replacement chars that the validator then rejects as a
-    // non-protocol verb. The point is no FormatException leaks.
     test('malformed UTF-8 bytes do not leak FormatException', () {
       when(() => connection.metaData).thenReturn(authenticatedMetadata);
       expect(
@@ -320,16 +303,11 @@ void main() async {
       );
     });
 
-    // Gap 9: requiresAuth=true subcommands pass when authenticated
-    // (mirror of the existing unauth test).
     test('subcommandsRequiringAuth pass when authenticated', () {
       when(() => connection.metaData).thenReturn(authenticatedMetadata);
       _expectCommandsToValidate(subcommandsRequiringAuth, connection);
     });
 
-    // Gap 10: the `scan `/`monitor ` substring short-circuit is now
-    // anchored to startsWith — values that contain those tokens no
-    // longer let an unauthenticated client bypass the auth check.
     test(
         '`scan `/`monitor ` substring inside a value does NOT bypass auth check',
         () {

--- a/packages/at_secondary_server/test/test_utils.dart
+++ b/packages/at_secondary_server/test/test_utils.dart
@@ -66,6 +66,13 @@ class MockInboundConnection extends Mock implements InboundConnection {}
 class FakeInboundConnection extends Fake implements InboundConnectionImpl {
   final FakeSocket socket;
   final InboundConnectionMetadata metadata;
+
+  /// Records every write the server-side code performs on this
+  /// connection. Tests can inspect this to assert that the connection
+  /// was (or wasn't) written to — e.g. that no `error:…\n@` frame was
+  /// sent on a path that should have succeeded.
+  final writes = <String>[];
+
   FakeInboundConnection(this.socket, this.metadata);
 
   @override
@@ -77,6 +84,11 @@ class FakeInboundConnection extends Fake implements InboundConnectionImpl {
   @override
   bool isInValid() {
     return false;
+  }
+
+  @override
+  Future<void> write(String data) async {
+    writes.add(data);
   }
 
   @override


### PR DESCRIPTION
Fixes https://github.com/atsign-foundation/at_client_sdk/issues/1953

- Defer `InboundCommandValidator.validate` until the buffer ends with `\n` or has at least 16 bytes (the length of `enroll:unrevoke` + 1) — fixes a fragmented-flow bug where a single command arriving in two TCP flows whose first carried fewer bytes than the verb name (e.g. `loo` then `kup:publickey@alice\n`) was rejected on each flow and produced two `error:` frames instead of one successful response.
- Anchor the validator's `scan`/`monitor` short-circuit from `contains('scan ' | 'monitor ')` to `startsWith` — closes a latent bypass of validation where an unauthenticated client could send e.g. `update:public:phone@alice scan some-text\n` and have it short-circuit past the validator's check. (**NB**: there was no auth issue here, the actual auth checking happens in the verb handlers themselves. Was just that an attacker could use this to bypass the intent of the validation which is to reject bad nonsense as early as possible.
- Close 16 `InboundCommandValidator` coverage gaps — `rawVerb.length > 64` (and the 64-char boundary), the `isPolAuthenticated` half of the auth OR, the `Subcommand` null + verb.requiresAuth fallback, hasSubcommands verbs arriving with no colon, empty bytes, whitespace/leading-colon edge cases, the `_maxBytesForValidation` (256) cap, malformed UTF-8, `subcommandsRequiringAuth` under authentication, and the new `startsWith` behaviour.
