### PR TITLE
build: update dependencies before releasing atServer canary c3.14.0

### DIFF
--- a/packages/at_root_server/pubspec.lock
+++ b/packages/at_root_server/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "8d7ff3948166b8ec5da0fbb5962000926b8e02f2ed9b3e51d1738905fbd4c98d"
+      sha256: "1b0e6a07425a3e460666e88bf1c949ccc7bb0116ad562ce94a1eca60fe820725"
       url: "https://pub.dev"
     source: hosted
-    version: "93.0.0"
+    version: "103.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: de7148ed2fcec579b19f122c1800933dfa028f6d9fd38a152b04b1516cec120b
+      sha256: "61c04d0c1bfed555c681ea079519933f071a5a026578ff73c4ff0df2d3462e5e"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.1"
+    version: "13.3.0"
   args:
     dependency: "direct main"
     description:
@@ -29,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      sha256: e2eb0491ba5ddb6177742d2da23904574082139b07c1e33b8503b9f46f3e1a37
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.13.1"
   at_commons:
     dependency: "direct main"
     description:
@@ -44,27 +44,23 @@ packages:
   at_persistence_root_server:
     dependency: "direct main"
     description:
-      path: "packages/at_persistence_root_server"
-      ref: trunk
-      resolved-ref: "6ac89dfb7d078dda843a954c70d7bf28d66748c7"
-      url: "https://github.com/atsign-foundation/at_server.git"
-    source: git
+      path: "../at_persistence_root_server"
+      relative: true
+    source: path
     version: "2.0.7"
   at_persistence_spec:
     dependency: "direct overridden"
     description:
-      name: at_persistence_spec
-      sha256: ea8e550368ccee9150247ae7abdc256dccf78467bb48c11d1d0d66b843b21ba7
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.14"
+      path: "../at_persistence_spec"
+      relative: true
+    source: path
+    version: "3.1.0"
   at_server_spec:
     dependency: "direct main"
     description:
-      name: at_server_spec
-      sha256: c128bc00c8bde819ff547b2a7baf9788723f9d87c36eddc30fd18042c64060cf
-      url: "https://pub.dev"
-    source: hosted
+      path: "../at_server_spec"
+      relative: true
+    source: path
     version: "5.1.0"
   at_utils:
     dependency: "direct main"
@@ -86,10 +82,10 @@ packages:
     dependency: transitive
     description:
       name: chalkdart
-      sha256: "7ffc6bd39c81453fb9ba8dbce042a9c960219b75ea1c07196a7fa41c2fab9e86"
+      sha256: "7dcf37e0b3d8dcec8c4ae0420d85aad9b3167d6a759601fd5b0f2b1958746581"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.1.0"
   cli_config:
     dependency: transitive
     description:
@@ -190,10 +186,10 @@ packages:
     dependency: transitive
     description:
       name: json_annotation
-      sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
+      sha256: "2a743920d81b7910627f68ee2c9ac1fc0bfee32b9fc3403587d7c6791ca12f80"
       url: "https://pub.dev"
     source: hosted
-    version: "4.9.0"
+    version: "4.12.0"
   lints:
     dependency: "direct dev"
     description:
@@ -214,10 +210,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.20"
   meta:
     dependency: "direct main"
     description:
@@ -334,10 +330,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
+      sha256: "56a02f1f4cd1a2d96303c0144c93bd6d909eea6bee6bf5a0e0b685edbd4c47ab"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.1"
+    version: "1.10.2"
   stack_trace:
     dependency: transitive
     description:
@@ -414,10 +410,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60"
+      sha256: "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.2"
+    version: "15.2.0"
   watcher:
     dependency: transitive
     description:
@@ -467,4 +463,4 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.10.0 <4.0.0"
+  dart: ">=3.11.0 <4.0.0"

--- a/packages/at_root_server/pubspec.yaml
+++ b/packages/at_root_server/pubspec.yaml
@@ -8,19 +8,22 @@ publish_to: none
 environment:
   sdk: '>=3.0.0 <4.0.0'
 
+dependency_overrides:
+  at_persistence_root_server:
+    path: ../at_persistence_root_server
+  at_persistence_spec:
+    path: ../at_persistence_spec
+  at_server_spec:
+    path: ../at_server_spec
+
 dependencies:
   args: ^2.7.0
   uuid: ^4.5.2
   yaml: ^3.1.3
-  at_commons: ^5.10.0
+  at_commons: ^5.11.0
   at_utils: ^3.4.0
-  at_server_spec: ^5.0.4
-  at_persistence_root_server:
-    git:
-      url: https://github.com/atsign-foundation/at_server.git
-      path: packages/at_persistence_root_server
-      ref: trunk
-      version: ^2.0.7
+  at_server_spec: ^5.1.0
+  at_persistence_root_server: ^2.0.7
   meta: ^1.17.0
 
 dev_dependencies:

--- a/packages/at_secondary_server/pubspec.lock
+++ b/packages/at_secondary_server/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: cd6add6f846f35fb79f3c315296703c1a24f3cfd7f4739d91a74961c1c7e9f1b
+      sha256: "1b0e6a07425a3e460666e88bf1c949ccc7bb0116ad562ce94a1eca60fe820725"
       url: "https://pub.dev"
     source: hosted
-    version: "100.0.0"
+    version: "103.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "6ba98576948803398b69e3a444df24eacdbe12ed699c7014e120ea38552debbf"
+      sha256: "61c04d0c1bfed555c681ea079519933f071a5a026578ff73c4ff0df2d3462e5e"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "13.3.0"
   archive:
     dependency: transitive
     description:
@@ -61,10 +61,10 @@ packages:
     dependency: "direct main"
     description:
       name: at_chops
-      sha256: "71d55c906177443995d175a5d33784243abd21ed0456f3463b16e3f803eb0db9"
+      sha256: f53505b62169c0c3d8226ee8fbe4b2b837bff68be33496946e54d680986192a7
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "3.2.0"
   at_commons:
     dependency: "direct main"
     description:
@@ -543,6 +543,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.5.0"
+  pqcrypto:
+    dependency: transitive
+    description:
+      name: pqcrypto
+      sha256: "36fc4126fb18e841127bfcc6c0c3ed85e1a1b04dc333737eeab7a505683e0ac4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0"
   process:
     dependency: transitive
     description:

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -8,12 +8,6 @@ publish_to: none
 environment:
   sdk: ">=3.0.0 <4.0.0"
 
-dependency_overrides:
-  at_persistence_secondary_server:
-    path: ../at_persistence_secondary_server
-  at_server_spec:
-    path: ../at_server_spec
-
 dependencies:
   args: ^2.7.0
   uuid: ^4.5.3
@@ -30,7 +24,7 @@ dependencies:
   at_chops: ^3.0.0
   at_lookup: ^3.5.0
   at_server_spec: ^5.1.0
-  at_persistence_secondary_server: ^4.3.5
+  at_persistence_secondary_server: ^5.1.0
   intl: ^0.20.2
   json_annotation: ^4.12.0
   version: ^3.0.2


### PR DESCRIPTION
**- What I did**
- build(deps): removed dependency override for at_secondary_server; now directly depends on published version 5.1.0 of at_persistence_secondary_server
- build(deps): modded at_root_server pubspec to always depend on relative paths for the three at_* packages it depends on

Didn't need to bump pubspec/changelog version to 3.14.0, that was already done in a previous PR

**- How I did it**

**- How to verify it**

**- Description for the changelog**
