### PR TITLE
fix(deps): unbreak at_root deploy — restore standalone-resolvable deps

### DIFF
--- a/packages/at_root_server/pubspec.lock
+++ b/packages/at_root_server/pubspec.lock
@@ -44,23 +44,27 @@ packages:
   at_persistence_root_server:
     dependency: "direct main"
     description:
-      path: "../at_persistence_root_server"
-      relative: true
-    source: path
+      path: "packages/at_persistence_root_server"
+      ref: trunk
+      resolved-ref: b67fb3a83345f062bf21919d6c5f750aea2d3acc
+      url: "https://github.com/atsign-foundation/at_server.git"
+    source: git
     version: "2.0.7"
   at_persistence_spec:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
-      path: "../at_persistence_spec"
-      relative: true
-    source: path
-    version: "3.1.0"
+      name: at_persistence_spec
+      sha256: ea8e550368ccee9150247ae7abdc256dccf78467bb48c11d1d0d66b843b21ba7
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.14"
   at_server_spec:
     dependency: "direct main"
     description:
-      path: "../at_server_spec"
-      relative: true
-    source: path
+      name: at_server_spec
+      sha256: c128bc00c8bde819ff547b2a7baf9788723f9d87c36eddc30fd18042c64060cf
+      url: "https://pub.dev"
+    source: hosted
     version: "5.1.0"
   at_utils:
     dependency: "direct main"

--- a/packages/at_root_server/pubspec.yaml
+++ b/packages/at_root_server/pubspec.yaml
@@ -8,14 +8,6 @@ publish_to: none
 environment:
   sdk: '>=3.0.0 <4.0.0'
 
-dependency_overrides:
-  at_persistence_root_server:
-    path: ../at_persistence_root_server
-  at_persistence_spec:
-    path: ../at_persistence_spec
-  at_server_spec:
-    path: ../at_server_spec
-
 dependencies:
   args: ^2.7.0
   uuid: ^4.5.2
@@ -23,7 +15,12 @@ dependencies:
   at_commons: ^5.11.0
   at_utils: ^3.4.0
   at_server_spec: ^5.1.0
-  at_persistence_root_server: ^2.0.7
+  at_persistence_root_server:
+    git:
+      url: https://github.com/atsign-foundation/at_server.git
+      path: packages/at_persistence_root_server
+      ref: trunk
+      version: ^2.0.7
   meta: ^1.17.0
 
 dev_dependencies:


### PR DESCRIPTION
## Problem

#2675 added path-based `dependency_overrides` to `packages/at_root_server/pubspec.yaml`:

```yaml
dependency_overrides:
  at_persistence_root_server: { path: ../at_persistence_root_server }
  at_persistence_spec:        { path: ../at_persistence_spec }
  at_server_spec:             { path: ../at_server_spec }
```

The `at_root deploy` workflows build the image with `context: packages/at_root_server` (a single-package context) and `COPY . .`, so the `../` sibling packages don't exist inside the build. `dart pub get` fails with exit 66:

```
Because at_root_server depends on at_server_spec from path which doesn't exist
(could not find package at_server_spec at "../at_server_spec"), version solving failed.
```

Failing run: https://github.com/atsign-foundation/at_server/actions/runs/27682866994 (dev deploy, triggered by the merge of #2675 to trunk). `at_server_prod_deploy.yaml` shares the same `Docker_Build` and would fail identically on the next `r*.*.*` tag.

## Fix

Restore standalone-resolvable dependencies in the committed pubspec:

- `at_persistence_root_server` → **git dep on `trunk`** (it is **not** published on pub.dev, so it cannot be a hosted dependency; this is what it was before #2675).
- `at_server_spec` → hosted `^5.1.0`.
- `at_persistence_spec` → transitive hosted.

This is the resolution the last passing root-server deploy used. `pubspec.lock` is regenerated to git+hosted sources (no `path`/`relative` entries). No workflow change is required, and this fixes both the dev and prod deploys.

Monorepo local-dev path wiring stays in the melos-managed (gitignored) `pubspec_overrides.yaml`, so this does not affect local development.

> ⚠️ Note for maintainers: running `melos bootstrap` will re-resolve `pubspec.lock` with `path:` sources again — do not commit that re-poisoned lock; the committed lock must stay in the git+hosted form for the Docker build.