### PR TITLE
fix(ve): canary_to_vip honours VIRTUALENV_BASE_PORT

### DIFF
--- a/tools/build_virtual_environment/ve/Dockerfile.canary_to_vip
+++ b/tools/build_virtual_environment/ve/Dockerfile.canary_to_vip
@@ -9,5 +9,6 @@ EXPOSE 64 443 6379 9001
 
 ENV DART_VM_OPTIONS='--use_compactor,--dontneed_on_sweep,--old_gen_growth_time_ratio=50,--old_gen_growth_space_ratio=10,--new_gen_semi_max_size=8'
 
-# Run supervisor configuration file on container startup
-CMD ["supervisord", "-n"]
+# entrypoint shifts ports if VIRTUALENV_BASE_PORT is set, then execs supervisord
+# (inherited at /atsign/entrypoint.sh from the canary base image; unset var = no-op)
+CMD ["/atsign/entrypoint.sh"]


### PR DESCRIPTION
**- What I did**

Made the published `atsigncompany/virtualenv:vip` image honour `VIRTUALENV_BASE_PORT`. `Dockerfile.canary_to_vip` (the canary→prod promotion path that actually builds the released `:vip` tag) still had `CMD ["supervisord", "-n"]`, which bypasses `/atsign/entrypoint.sh` — so the base-port feature added in #2632 was silently ignored on the promoted image. #2632 updated `Dockerfile.vip` but not `Dockerfile.canary_to_vip`.

**- How I did it**

One-line change: `CMD ["supervisord", "-n"]` → `CMD ["/atsign/entrypoint.sh"]` in `Dockerfile.canary_to_vip` (plus a clarifying comment).

No COPY/chmod is needed here because the entrypoint is inherited from the canary base image: the base `Dockerfile` does `COPY ./contents /`, and `contents/atsign/entrypoint.sh` is tracked mode `100755`, so the canary image already has an executable `/atsign/entrypoint.sh`. With `VIRTUALENV_BASE_PORT` unset the entrypoint immediately `exec`s `supervisord -n`, so the default behaviour of the `:vip` image is unchanged.

**- How to verify it**

Build the image from this branch and run it with a base port:

```bash
docker build -t vip-test \
  -f tools/build_virtual_environment/ve/Dockerfile.canary_to_vip .

# base-port run: atDirectory should bind 30000, secondaries 30001-30080, redis 30099
docker run --rm -e VIRTUALENV_BASE_PORT=30000 -p 30000-30099:30000-30099 vip-test
# connect to vip.ve.atsign.zone:30000 (root) and a shifted secondary

# default run (no var): unchanged — root 64, secondaries 25000-25999, redis 6379
docker run --rm vip-test
```

The client-side consumer is atsign-foundation/at_client_sdk#1992, which adds base-port `runLocal.sh` scripts for the functional and e2e suites. Those currently work around this by setting `entrypoint: ["/atsign/entrypoint.sh"]` in their compose files; once a `:vip` built from this change is promoted, that override becomes unnecessary (though harmless).

**- Description for the changelog**

Fix: the promoted `virtualenv:vip` image now honours `VIRTUALENV_BASE_PORT` (the canary→vip Dockerfile was bypassing the port-shifting entrypoint).
