### PR TITLE
ci: Use Atsign fork of gChat action

### DIFF
--- a/.github/workflows/check_cacerts.yml
+++ b/.github/workflows/check_cacerts.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Google Chat Notification on failure
         if: steps.compare_cacerts.outcome == 'failure'
-        uses: Co-qn/google-chat-notification@3691ccf4763537d6e544bc6cdcccc1965799d056 # v1
+        uses: atsign-company/google-chat-notification@69f3920c9c9372c296112b25eaea0bddab9ee115 # v2.0.1
         with:
           name: Changes found in cacerts
           url: ${{ secrets.GOOGLE_CHAT_WEBHOOK }}

--- a/.github/workflows/ve_base.yaml
+++ b/.github/workflows/ve_base.yaml
@@ -70,7 +70,7 @@ jobs:
         run: echo ${{ steps.docker_build.outputs.digest }}
 
       - name: Google Chat Notification
-        uses: Co-qn/google-chat-notification@3691ccf4763537d6e544bc6cdcccc1965799d056 # v1
+        uses: atsign-company/google-chat-notification@69f3920c9c9372c296112b25eaea0bddab9ee115 # v2.0.1
         with:
           name: New Docker base image for vebase:latest
           url: ${{ secrets.GOOGLE_CHAT_WEBHOOK }}

--- a/.github/workflows/vip_rebuild.yaml
+++ b/.github/workflows/vip_rebuild.yaml
@@ -233,7 +233,7 @@ jobs:
         run: echo ${{ steps.docker_build_vip.outputs.digest }}
 
       - name: Google Chat Notification EE
-        uses: Co-qn/google-chat-notification@3691ccf4763537d6e544bc6cdcccc1965799d056 # v1
+        uses: atsign-company/google-chat-notification@69f3920c9c9372c296112b25eaea0bddab9ee115 # v2.0.1
         with:
           name: New Docker image for atsigncompany/ephemeral
           url: ${{ secrets.GOOGLE_CHAT_WEBHOOK }}


### PR DESCRIPTION
Progresses https://github.com/atsign-foundation/operations/issues/404

**- What I did**

Replaced Co-qn action (Node 16) with Atsign fork (Node 24)

**- How I did it**

Based on [self test workflow](https://github.com/atsign-company/google-chat-notification/actions/workflows/selftest.yml) in the fork repo

**- How to verify it**

:eyes: workflow logs

**- Description for the changelog**

ci: Use Atsign fork of gChat action
