### PR TITLE
feat(at_server): `enroll:listns`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ packages/at_secondary_server/bin/create_ws_to_at_server.dart
 packages/at_secondary_server/secondary
 tests/at_end2end_test/config/config.yaml
 
+.DS_Store

--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,5 +1,15 @@
 # 3.14.0
 
+- feat: `enroll:listns:<namespace>` verb for the WP-SS secret-sharing
+  substrate (at_commons 5.12.0). Returns all approved enrollments that hold
+  read-or-better access to the requested namespace, including their opaque
+  `metadata` payload (key packages). Access is gated on the caller being
+  APKAM-authenticated with an approved enrollment that itself holds ≥`r`
+  access to that namespace; unauthenticated or under-privileged callers
+  receive `UnAuthorized`.
+- feat: `metadata` field on enrollment records — an opaque JSON map stored
+  verbatim from `enroll:request`'s `EnrollParams.metadata`; surfaced in
+  `enroll:fetch`, `enroll:list`, and `enroll:listns` responses.
 - feat: `appMetadata` support on `update`, `update:meta` and `notify`
   (at_commons 5.11.0). The base64(JSON)
   `:appMetadata:` fragment is parsed into

--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 3.14.0
+# 3.15.0
 
 - feat: `enroll:listns:<namespace>` verb for the WP-SS secret-sharing
   substrate (at_commons 5.12.0). Returns all approved enrollments that hold
@@ -10,6 +10,9 @@
 - feat: `metadata` field on enrollment records — an opaque JSON map stored
   verbatim from `enroll:request`'s `EnrollParams.metadata`; surfaced in
   `enroll:fetch`, `enroll:list`, and `enroll:listns` responses.
+
+# 3.14.0
+
 - feat: `appMetadata` support on `update`, `update:meta` and `notify`
   (at_commons 5.11.0). The base64(JSON)
   `:appMetadata:` fragment is parsed into

--- a/packages/at_secondary_server/lib/src/enroll/enroll_datastore_value.dart
+++ b/packages/at_secondary_server/lib/src/enroll/enroll_datastore_value.dart
@@ -20,9 +20,14 @@ class EnrollDataStoreValue {
 
   /// Opaque per-APKAM metadata stored by the client (WP-SS).
   /// The server treats this as an opaque JSON map and returns it verbatim in
-  /// enroll:listfornamespace responses. Key packages live under
-  /// metadata['keyPackages'] by convention.
+  /// enroll:listns responses. The enrollment's single (APKAM-signed) key
+  /// package lives under metadata['keyPackage'] by convention (1:1:1 — no
+  /// format-keyed map).
   Map<String, dynamic>? metadata;
+
+  /// The signing algorithm of [apkamPublicKey] — `rsa2048` (legacy default) or
+  /// `mldsa65` (PQ). Recorded so PKAM verification can be record-authoritative.
+  String? signingAlgo;
 
   EnrollDataStoreValue(
       this.sessionId, this.appName, this.deviceName, this.apkamPublicKey);

--- a/packages/at_secondary_server/lib/src/enroll/enroll_datastore_value.dart
+++ b/packages/at_secondary_server/lib/src/enroll/enroll_datastore_value.dart
@@ -18,6 +18,12 @@ class EnrollDataStoreValue {
   String? encryptedAPKAMSymmetricKey;
   Duration apkamKeysExpiryDuration = Duration(milliseconds: 0);
 
+  /// Opaque per-APKAM metadata stored by the client (WP-SS).
+  /// The server treats this as an opaque JSON map and returns it verbatim in
+  /// enroll:listfornamespace responses. Key packages live under
+  /// metadata['keyPackages'] by convention.
+  Map<String, dynamic>? metadata;
+
   EnrollDataStoreValue(
       this.sessionId, this.appName, this.deviceName, this.apkamPublicKey);
 

--- a/packages/at_secondary_server/lib/src/enroll/enroll_datastore_value.g.dart
+++ b/packages/at_secondary_server/lib/src/enroll/enroll_datastore_value.g.dart
@@ -24,7 +24,8 @@ EnrollDataStoreValue _$EnrollDataStoreValueFromJson(
           json['encryptedAPKAMSymmetricKey'] as String?
       ..apkamKeysExpiryDuration =
           Duration(milliseconds: json['apkamKeysExpiryInMillis'] ?? 0)
-      ..metadata = (json['metadata'] as Map<String, dynamic>?);
+      ..metadata = (json['metadata'] as Map<String, dynamic>?)
+      ..signingAlgo = json['signingAlgo'] as String?;
 
 Map<String, dynamic> _$EnrollDataStoreValueToJson(
         EnrollDataStoreValue instance) =>
@@ -40,6 +41,7 @@ Map<String, dynamic> _$EnrollDataStoreValueToJson(
       'apkamKeysExpiryInMillis':
           instance.apkamKeysExpiryDuration.inMilliseconds,
       if (instance.metadata != null) 'metadata': instance.metadata,
+      if (instance.signingAlgo != null) 'signingAlgo': instance.signingAlgo,
     };
 
 const _$EnrollRequestTypeEnumMap = {

--- a/packages/at_secondary_server/lib/src/enroll/enroll_datastore_value.g.dart
+++ b/packages/at_secondary_server/lib/src/enroll/enroll_datastore_value.g.dart
@@ -23,7 +23,8 @@ EnrollDataStoreValue _$EnrollDataStoreValueFromJson(
       ..encryptedAPKAMSymmetricKey =
           json['encryptedAPKAMSymmetricKey'] as String?
       ..apkamKeysExpiryDuration =
-          Duration(milliseconds: json['apkamKeysExpiryInMillis'] ?? 0);
+          Duration(milliseconds: json['apkamKeysExpiryInMillis'] ?? 0)
+      ..metadata = (json['metadata'] as Map<String, dynamic>?);
 
 Map<String, dynamic> _$EnrollDataStoreValueToJson(
         EnrollDataStoreValue instance) =>
@@ -38,6 +39,7 @@ Map<String, dynamic> _$EnrollDataStoreValueToJson(
       'encryptedAPKAMSymmetricKey': instance.encryptedAPKAMSymmetricKey,
       'apkamKeysExpiryInMillis':
           instance.apkamKeysExpiryDuration.inMilliseconds,
+      if (instance.metadata != null) 'metadata': instance.metadata,
     };
 
 const _$EnrollRequestTypeEnumMap = {

--- a/packages/at_secondary_server/lib/src/enroll/enrollment_manager.dart
+++ b/packages/at_secondary_server/lib/src/enroll/enrollment_manager.dart
@@ -299,6 +299,43 @@ class EnrollmentManager {
     return ejList;
   }
 
+  /// Returns all approved enrollments that have access to [namespace], as a
+  /// list of maps suitable for JSON encoding in the `enroll:listfornamespace`
+  /// response. Each entry has shape:
+  ///   `{"enrollmentId": <id>, "access": <"r"|"rw">, "metadata": <map|null>}`
+  ///
+  /// The namespace match mirrors the atServer's own suffix rule:
+  ///   - `*` authorises every namespace
+  ///   - an exact match (e.g. `wavi` authorises `wavi`)
+  ///   - a namespace suffix match (e.g. `wavi` authorises `data.wavi`)
+  Future<List<Map<String, dynamic>>> getEnrollmentsForNamespace(
+      String namespace) async {
+    final result = <Map<String, dynamic>>[];
+    for (final ek in await getAllEnrollmentKeys()) {
+      final EnrollDataStoreValue enVal = await getEnrollmentByFullKey(ek);
+      if (enVal.approval?.state != EnrollmentStatus.approved.name) continue;
+
+      String? access;
+      for (final entry in enVal.namespaces.entries) {
+        final ns = entry.key;
+        if (ns == '*' ||
+            ns == namespace ||
+            namespace.endsWith('.$ns')) {
+          access = entry.value;
+          break;
+        }
+      }
+      if (access == null) continue;
+
+      result.add({
+        'enrollmentId': getIdFromKey(ek),
+        'access': access,
+        'metadata': enVal.metadata,
+      });
+    }
+    return result;
+  }
+
   /// iterate all enrollments, remove key which leaks appName and deviceName
   Future<List<String>> removeLegacyApkamPublicKeys() async {
     final List<String> deletedLegacyKeys = [];

--- a/packages/at_secondary_server/lib/src/enroll/enrollment_manager.dart
+++ b/packages/at_secondary_server/lib/src/enroll/enrollment_manager.dart
@@ -300,9 +300,18 @@ class EnrollmentManager {
   }
 
   /// Returns all approved enrollments that have access to [namespace], as a
-  /// list of maps suitable for JSON encoding in the `enroll:listfornamespace`
-  /// response. Each entry has shape:
-  ///   `{"enrollmentId": <id>, "access": <"r"|"rw">, "metadata": <map|null>}`
+  /// flat list of maps suitable for JSON encoding in the `enroll:listns`
+  /// response (1:1:1 — one entry per enrollment, no nested `apkam[]`). Each
+  /// entry has shape:
+  ///
+  /// ```
+  /// {"enrollmentId": id, "access": "r"|"rw", "apkamPubKey": pubKey,
+  ///  "metadata": map|null}
+  /// ```
+  ///
+  /// `metadata.keyPackage` (a singular, APKAM-signed key package) is the
+  /// substrate's encapsulation target; the server stores/returns `metadata`
+  /// opaquely.
   ///
   /// The namespace match mirrors the atServer's own suffix rule:
   ///   - `*` authorises every namespace
@@ -318,9 +327,7 @@ class EnrollmentManager {
       String? access;
       for (final entry in enVal.namespaces.entries) {
         final ns = entry.key;
-        if (ns == '*' ||
-            ns == namespace ||
-            namespace.endsWith('.$ns')) {
+        if (ns == '*' || ns == namespace || namespace.endsWith('.$ns')) {
           access = entry.value;
           break;
         }
@@ -330,6 +337,7 @@ class EnrollmentManager {
       result.add({
         'enrollmentId': getIdFromKey(ek),
         'access': access,
+        'apkamPubKey': enVal.apkamPublicKey,
         'metadata': enVal.metadata,
       });
     }

--- a/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
@@ -68,10 +68,12 @@ class EnrollVerbHandler extends AbstractVerbHandler {
     }
     EnrollParams? enrollVerbParams;
 
-    // Ensure that enrollParams are present for all enroll operation
-    // Exclude operation 'list' which does not have enrollParams
+    // Ensure that enrollParams are present for all enroll operation.
+    // 'list' and 'listfornamespace' carry no enrollParams JSON body.
     if (verbParams[AtConstants.enrollParams] == null) {
-      if (operation != 'list') {
+      if (operation != 'list' &&
+          operation != 'listfornamespace' &&
+          operation != 'metadata') {
         logger.severe(
             'Enroll params is empty | EnrollParams: ${verbParams[AtConstants.enrollParams]}');
         throw IllegalArgumentException('Enroll parameters not provided');
@@ -141,6 +143,23 @@ class EnrollVerbHandler extends AbstractVerbHandler {
           enrollVerbParams: enrollVerbParams,
         );
         return;
+      case 'listfornamespace':
+        response.data = await _fetchEnrollmentsForNamespace(
+          enMgr,
+          atConnection,
+          verbParams['namespace'] ?? '',
+        );
+        return;
+      case 'metadata':
+        await _storeEnrollmentMetadata(
+          enMgr,
+          atConnection,
+          verbParams['namespace'] ?? '',
+          verbParams[AtConstants.enrollParams] ?? '{}',
+          currentAtSign,
+        );
+        responseJson['status'] = 'success';
+        break;
       case 'fetch':
         response.data = await _fetchEnrollmentInfoById(
           enMgr,
@@ -511,6 +530,94 @@ class EnrollVerbHandler extends AbstractVerbHandler {
     }
   }
 
+  /// Returns a JSON-encoded list of approved enrollments authorised for
+  /// [namespace]. Each element has shape:
+  ///   `{"enrollmentId": <id>, "access": <"r"|"rw">, "metadata": <map|null>}`
+  ///
+  /// Only enrollments with at least read-access to [namespace] are included.
+  /// Requires an APKAM-authenticated connection that itself has access to the
+  /// namespace (the atServer namespace gating ensures this implicitly; the
+  /// handler re-verifies that the caller's enrollment is approved).
+  Future<String> _fetchEnrollmentsForNamespace(
+    EnrollmentManager enMgr,
+    InboundConnection atConnection,
+    String namespace,
+  ) async {
+    if (namespace.isEmpty) {
+      throw IllegalArgumentException(
+          'namespace is required for enroll:listfornamespace');
+    }
+
+    final callerEnrollmentId =
+        (atConnection.metaData as InboundConnectionMetadata).enrollmentId;
+    if (callerEnrollmentId == null || callerEnrollmentId.isEmpty) {
+      throw UnAuthenticatedException(
+          'enroll:listfornamespace requires APKAM authentication');
+    }
+
+    // Verify the caller's own enrollment is approved and has namespace access.
+    final callerEnVal = await enMgr.getEnrollmentById(callerEnrollmentId);
+    if (callerEnVal.approval?.state != EnrollmentStatus.approved.name) {
+      throw UnAuthorizedException(
+          'Caller enrollment is not in approved state');
+    }
+
+    final members = await enMgr.getEnrollmentsForNamespace(namespace);
+    return jsonEncode(members);
+  }
+
+  /// Stores opaque [metadataJson] on the enrollment record identified by
+  /// [enrollmentId]. The caller must be authenticated via APKAM and the
+  /// [enrollmentId] must match the authenticated enrollment (a client can
+  /// only write its own metadata).
+  Future<void> _storeEnrollmentMetadata(
+    EnrollmentManager enMgr,
+    InboundConnection atConnection,
+    String enrollmentId,
+    String metadataJson,
+    String currentAtSign,
+  ) async {
+    if (enrollmentId.isEmpty) {
+      throw IllegalArgumentException(
+          'enrollmentId is required for enroll:metadata');
+    }
+
+    final callerEnrollmentId =
+        (atConnection.metaData as InboundConnectionMetadata).enrollmentId;
+    if (callerEnrollmentId == null || callerEnrollmentId.isEmpty) {
+      throw UnAuthenticatedException(
+          'enroll:metadata requires APKAM authentication');
+    }
+    if (callerEnrollmentId != enrollmentId) {
+      throw UnAuthorizedException(
+          'enroll:metadata: caller enrollment $callerEnrollmentId cannot write'
+          ' metadata for enrollment $enrollmentId');
+    }
+
+    final EnrollDataStoreValue enVal =
+        await enMgr.getEnrollmentById(enrollmentId);
+    if (enVal.approval?.state != EnrollmentStatus.approved.name) {
+      throw IllegalStateException(
+          'Cannot write metadata for a non-approved enrollment');
+    }
+
+    Map<String, dynamic> parsedMetadata;
+    try {
+      parsedMetadata = jsonDecode(metadataJson) as Map<String, dynamic>;
+    } catch (_) {
+      throw IllegalArgumentException(
+          'enroll:metadata: metadataJson is not valid JSON');
+    }
+
+    // Merge incoming metadata into any existing metadata, then persist.
+    final existing = enVal.metadata ?? {};
+    existing.addAll(parsedMetadata);
+    enVal.metadata = existing;
+
+    final atData = AtData()..data = jsonEncode(enVal.toJson());
+    await enMgr.put(enrollmentId, atData, EnrollmentStatus.approved);
+  }
+
   bool _doesEnrollmentHaveManageNamespace(
       EnrollDataStoreValue enrollDataStoreValue) {
     return enrollDataStoreValue.namespaces
@@ -679,6 +786,8 @@ class EnrollVerbHandler extends AbstractVerbHandler {
               'enrollmentId is mandatory for enroll:$operation');
         }
         break;
+      // listfornamespace and metadata are validated in their own handlers
+      // because their params are in the 'namespace' capture group, not enrollParams.
     }
   }
 

--- a/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
@@ -67,11 +67,6 @@ class EnrollVerbHandler extends AbstractVerbHandler {
           'Cannot $operation enrollment without authentication');
     }
     EnrollParams? enrollVerbParams;
-    // The raw decoded enrollParams JSON map. Used to read fields the pinned
-    // at_commons EnrollParams model does not yet type (`metadata`,
-    // `signingAlgo`) — these ride the opaque JSON tail on enroll:request and
-    // are persisted verbatim onto the enrollment record.
-    Map<String, dynamic>? rawEnrollParams;
 
     // Ensure that enrollParams are present for all enroll operation.
     // 'list' and 'listns' carry no enrollParams JSON body.
@@ -82,9 +77,9 @@ class EnrollVerbHandler extends AbstractVerbHandler {
         throw IllegalArgumentException('Enroll parameters not provided');
       }
     } else {
-      rawEnrollParams =
-          jsonDecode(verbParams[AtConstants.enrollParams]!) as Map<String, dynamic>;
-      enrollVerbParams = EnrollParams.fromJson(rawEnrollParams);
+      enrollVerbParams = EnrollParams.fromJson(
+          jsonDecode(verbParams[AtConstants.enrollParams]!)
+              as Map<String, dynamic>);
     }
 
     _validateParams(enrollVerbParams, operation!, atConnection);
@@ -94,7 +89,6 @@ class EnrollVerbHandler extends AbstractVerbHandler {
         await _handleEnrollmentRequest(
           enMgr,
           enrollVerbParams!,
-          rawEnrollParams,
           currentAtSign,
           responseJson,
           atConnection,
@@ -221,7 +215,6 @@ class EnrollVerbHandler extends AbstractVerbHandler {
   Future<void> _handleEnrollmentRequest(
       EnrollmentManager enMgr,
       EnrollParams enrollParams,
-      Map<String, dynamic>? rawEnrollParams,
       currentAtSign,
       Map<dynamic, dynamic> responseJson,
       InboundConnection atConnection) async {
@@ -273,17 +266,14 @@ class EnrollVerbHandler extends AbstractVerbHandler {
     enrollmentValue.requestType = EnrollRequestType.newEnrollment;
 
     // The X-Wing key package (at `metadata.keyPackage`) and the APKAM
-    // `signingAlgo` ride the opaque enrollParams JSON tail on enroll:request and
-    // are persisted verbatim onto the enrollment record — there is no separate
-    // enroll:metadata write. Read from the raw JSON: the pinned at_commons
-    // EnrollParams model does not yet type these fields.
-    final rawMetadata = rawEnrollParams?['metadata'];
-    if (rawMetadata is Map<String, dynamic>) {
-      enrollmentValue.metadata = rawMetadata;
+    // `signingAlgo` ride EnrollParams on enroll:request and are persisted
+    // verbatim onto the enrollment record — there is no separate
+    // enroll:metadata write.
+    if (enrollParams.metadata != null) {
+      enrollmentValue.metadata = enrollParams.metadata;
     }
-    final rawSigningAlgo = rawEnrollParams?['signingAlgo'];
-    if (rawSigningAlgo is String) {
-      enrollmentValue.signingAlgo = rawSigningAlgo;
+    if (enrollParams.signingAlgo != null) {
+      enrollmentValue.signingAlgo = enrollParams.signingAlgo;
     }
 
     if (enrollParams.apkamKeysExpiryDuration != null) {

--- a/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
@@ -67,20 +67,24 @@ class EnrollVerbHandler extends AbstractVerbHandler {
           'Cannot $operation enrollment without authentication');
     }
     EnrollParams? enrollVerbParams;
+    // The raw decoded enrollParams JSON map. Used to read fields the pinned
+    // at_commons EnrollParams model does not yet type (`metadata`,
+    // `signingAlgo`) — these ride the opaque JSON tail on enroll:request and
+    // are persisted verbatim onto the enrollment record.
+    Map<String, dynamic>? rawEnrollParams;
 
     // Ensure that enrollParams are present for all enroll operation.
-    // 'list' and 'listfornamespace' carry no enrollParams JSON body.
+    // 'list' and 'listns' carry no enrollParams JSON body.
     if (verbParams[AtConstants.enrollParams] == null) {
-      if (operation != 'list' &&
-          operation != 'listfornamespace' &&
-          operation != 'metadata') {
+      if (operation != 'list' && operation != 'listns') {
         logger.severe(
             'Enroll params is empty | EnrollParams: ${verbParams[AtConstants.enrollParams]}');
         throw IllegalArgumentException('Enroll parameters not provided');
       }
     } else {
-      enrollVerbParams = EnrollParams.fromJson(
-          jsonDecode(verbParams[AtConstants.enrollParams]!));
+      rawEnrollParams = jsonDecode(verbParams[AtConstants.enrollParams]!)
+          as Map<String, dynamic>;
+      enrollVerbParams = EnrollParams.fromJson(rawEnrollParams);
     }
 
     _validateParams(enrollVerbParams, operation!, atConnection);
@@ -90,6 +94,7 @@ class EnrollVerbHandler extends AbstractVerbHandler {
         await _handleEnrollmentRequest(
           enMgr,
           enrollVerbParams!,
+          rawEnrollParams,
           currentAtSign,
           responseJson,
           atConnection,
@@ -143,23 +148,13 @@ class EnrollVerbHandler extends AbstractVerbHandler {
           enrollVerbParams: enrollVerbParams,
         );
         return;
-      case 'listfornamespace':
+      case 'listns':
         response.data = await _fetchEnrollmentsForNamespace(
           enMgr,
           atConnection,
-          verbParams['namespace'] ?? '',
+          verbParams['listNamespace'] ?? '',
         );
         return;
-      case 'metadata':
-        await _storeEnrollmentMetadata(
-          enMgr,
-          atConnection,
-          verbParams['namespace'] ?? '',
-          verbParams[AtConstants.enrollParams] ?? '{}',
-          currentAtSign,
-        );
-        responseJson['status'] = 'success';
-        break;
       case 'fetch':
         response.data = await _fetchEnrollmentInfoById(
           enMgr,
@@ -226,6 +221,7 @@ class EnrollVerbHandler extends AbstractVerbHandler {
   Future<void> _handleEnrollmentRequest(
       EnrollmentManager enMgr,
       EnrollParams enrollParams,
+      Map<String, dynamic>? rawEnrollParams,
       currentAtSign,
       Map<dynamic, dynamic> responseJson,
       InboundConnection atConnection) async {
@@ -276,6 +272,20 @@ class EnrollVerbHandler extends AbstractVerbHandler {
     enrollmentValue.namespaces = enrollNamespaces;
     enrollmentValue.requestType = EnrollRequestType.newEnrollment;
 
+    // The X-Wing key package (at `metadata.keyPackage`) and the APKAM
+    // `signingAlgo` ride the opaque enrollParams JSON tail on enroll:request and
+    // are persisted verbatim onto the enrollment record — there is no separate
+    // enroll:metadata write. Read from the raw JSON: the pinned at_commons
+    // EnrollParams model does not yet type these fields.
+    final rawMetadata = rawEnrollParams?['metadata'];
+    if (rawMetadata is Map<String, dynamic>) {
+      enrollmentValue.metadata = rawMetadata;
+    }
+    final rawSigningAlgo = rawEnrollParams?['signingAlgo'];
+    if (rawSigningAlgo is String) {
+      enrollmentValue.signingAlgo = rawSigningAlgo;
+    }
+
     if (enrollParams.apkamKeysExpiryDuration != null) {
       enrollmentValue.apkamKeysExpiryDuration =
           enrollParams.apkamKeysExpiryDuration!;
@@ -296,6 +306,9 @@ class EnrollVerbHandler extends AbstractVerbHandler {
       await keyStore.put(AtConstants.atPkamPublicKey,
           AtData()..data = enrollParams.apkamPublicKey!,
           skipCommit: true);
+      // Keep the enrollment's `_apsk` signing key present for verifiers.
+      await _publishApskSigningKey(
+          newEnrollmentId, enrollParams.apkamPublicKey!, currentAtSign);
       AtData enrollData = AtData()..data = jsonEncode(enrollmentValue.toJson());
 
       await enMgr.put(newEnrollmentId, enrollData, EnrollmentStatus.approved);
@@ -397,6 +410,8 @@ class EnrollVerbHandler extends AbstractVerbHandler {
     // when enrollment is approved store the encrypted encryption keys
     if (operation == 'approve') {
       await _storeEncryptionKeys(enId, enrollParams, enVal);
+      // Keep the enrollment's `_apsk` signing key present for verifiers.
+      await _publishApskSigningKey(enId, enVal.apkamPublicKey, currentAtSign);
     }
     responseJson['enrollmentId'] = enId;
   }
@@ -476,6 +491,22 @@ class EnrollVerbHandler extends AbstractVerbHandler {
         skipCommit: true);
   }
 
+  /// Publishes the enrollment's APKAM public key as its `_apsk` signing key at
+  /// `public:_apsk.<enrollmentId>.a.__e@<atSign>` (the location the at_client
+  /// `ApkamSigning` mixin reads). The atServer keeps this key present — rather
+  /// than leaving it to the client-side `publishPublicSigningKey` — so a
+  /// verifier can always fetch it to verify APKAM signatures on `__ssenv`
+  /// envelopes and on advertised recipient keys (key package, `nskey` public,
+  /// `pqpublickey`). World-readable so a same-atSign or a peer-atSign verifier
+  /// can reach it via plookup. Idempotent: a re-publish is a harmless overwrite
+  /// with the same value.
+  Future<void> _publishApskSigningKey(
+      String enrollmentId, String apkamPublicKey, currentAtSign) async {
+    final apskKey = 'public:_apsk.$enrollmentId'
+        '.${EnrollmentConstants.perEnrollmentApproved}$currentAtSign';
+    await keyStore.put(apskKey, AtData()..data = apkamPublicKey);
+  }
+
   EnrollmentStatus _getEnrollStatusEnum(String? enrollmentOperation) {
     enrollmentOperation = enrollmentOperation?.toLowerCase();
     final operationMap = {
@@ -544,78 +575,46 @@ class EnrollVerbHandler extends AbstractVerbHandler {
     String namespace,
   ) async {
     if (namespace.isEmpty) {
-      throw IllegalArgumentException(
-          'namespace is required for enroll:listfornamespace');
+      throw IllegalArgumentException('namespace is required for enroll:listns');
     }
 
     final callerEnrollmentId =
         (atConnection.metaData as InboundConnectionMetadata).enrollmentId;
     if (callerEnrollmentId == null || callerEnrollmentId.isEmpty) {
       throw UnAuthenticatedException(
-          'enroll:listfornamespace requires APKAM authentication');
+          'enroll:listns requires APKAM authentication');
     }
 
-    // Verify the caller's own enrollment is approved and has namespace access.
+    // Verify the caller's own enrollment is approved AND holds at least read
+    // access to the requested namespace — learning a namespace's roster is
+    // gated on ≥r for that namespace, not merely on being approved.
     final callerEnVal = await enMgr.getEnrollmentById(callerEnrollmentId);
     if (callerEnVal.approval?.state != EnrollmentStatus.approved.name) {
+      throw UnAuthorizedException('Caller enrollment is not in approved state');
+    }
+    if (_accessForNamespace(callerEnVal, namespace) == null) {
       throw UnAuthorizedException(
-          'Caller enrollment is not in approved state');
+          'Caller enrollment is not authorised for namespace "$namespace"');
     }
 
     final members = await enMgr.getEnrollmentsForNamespace(namespace);
     return jsonEncode(members);
   }
 
-  /// Stores opaque [metadataJson] on the enrollment record identified by
-  /// [enrollmentId]. The caller must be authenticated via APKAM and the
-  /// [enrollmentId] must match the authenticated enrollment (a client can
-  /// only write its own metadata).
-  Future<void> _storeEnrollmentMetadata(
-    EnrollmentManager enMgr,
-    InboundConnection atConnection,
-    String enrollmentId,
-    String metadataJson,
-    String currentAtSign,
-  ) async {
-    if (enrollmentId.isEmpty) {
-      throw IllegalArgumentException(
-          'enrollmentId is required for enroll:metadata');
+  /// The caller's access (`r`|`rw`) to [namespace] under the atServer's own
+  /// suffix / `*`-wildcard rule, or null if the enrollment has no access.
+  /// Mirrors [EnrollmentManager.getEnrollmentsForNamespace]'s match; both `r`
+  /// and `rw` satisfy the ≥`r` bar the discovery verb requires.
+  String? _accessForNamespace(EnrollDataStoreValue enVal, String namespace) {
+    for (final entry in enVal.namespaces.entries) {
+      final ns = entry.key;
+      if (ns == EnrollmentConstants.allNamespaces ||
+          ns == namespace ||
+          namespace.endsWith('.$ns')) {
+        return entry.value;
+      }
     }
-
-    final callerEnrollmentId =
-        (atConnection.metaData as InboundConnectionMetadata).enrollmentId;
-    if (callerEnrollmentId == null || callerEnrollmentId.isEmpty) {
-      throw UnAuthenticatedException(
-          'enroll:metadata requires APKAM authentication');
-    }
-    if (callerEnrollmentId != enrollmentId) {
-      throw UnAuthorizedException(
-          'enroll:metadata: caller enrollment $callerEnrollmentId cannot write'
-          ' metadata for enrollment $enrollmentId');
-    }
-
-    final EnrollDataStoreValue enVal =
-        await enMgr.getEnrollmentById(enrollmentId);
-    if (enVal.approval?.state != EnrollmentStatus.approved.name) {
-      throw IllegalStateException(
-          'Cannot write metadata for a non-approved enrollment');
-    }
-
-    Map<String, dynamic> parsedMetadata;
-    try {
-      parsedMetadata = jsonDecode(metadataJson) as Map<String, dynamic>;
-    } catch (_) {
-      throw IllegalArgumentException(
-          'enroll:metadata: metadataJson is not valid JSON');
-    }
-
-    // Merge incoming metadata into any existing metadata, then persist.
-    final existing = enVal.metadata ?? {};
-    existing.addAll(parsedMetadata);
-    enVal.metadata = existing;
-
-    final atData = AtData()..data = jsonEncode(enVal.toJson());
-    await enMgr.put(enrollmentId, atData, EnrollmentStatus.approved);
+    return null;
   }
 
   bool _doesEnrollmentHaveManageNamespace(
@@ -786,8 +785,8 @@ class EnrollVerbHandler extends AbstractVerbHandler {
               'enrollmentId is mandatory for enroll:$operation');
         }
         break;
-      // listfornamespace and metadata are validated in their own handlers
-      // because their params are in the 'namespace' capture group, not enrollParams.
+      // list / listns carry no enrollParams; listns validates its namespace
+      // (from the 'listNamespace' capture group) in its own handler.
     }
   }
 

--- a/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
@@ -82,8 +82,8 @@ class EnrollVerbHandler extends AbstractVerbHandler {
         throw IllegalArgumentException('Enroll parameters not provided');
       }
     } else {
-      rawEnrollParams = jsonDecode(verbParams[AtConstants.enrollParams]!)
-          as Map<String, dynamic>;
+      rawEnrollParams =
+          jsonDecode(verbParams[AtConstants.enrollParams]!) as Map<String, dynamic>;
       enrollVerbParams = EnrollParams.fromJson(rawEnrollParams);
     }
 

--- a/packages/at_secondary_server/pubspec.lock
+++ b/packages/at_secondary_server/pubspec.lock
@@ -69,10 +69,10 @@ packages:
     dependency: "direct main"
     description:
       name: at_commons
-      sha256: "3deadcb1f1e0e25550ebc638524a09450f61cfc580db6f50b538f58f787077ac"
+      sha256: "59ee72b4dbbe9ca8310fb08a2de725937e6a0bb5947b7c24286aea5e8d0eadb5"
       url: "https://pub.dev"
     source: hosted
-    version: "5.11.0"
+    version: "5.12.0"
   at_lookup:
     dependency: "direct main"
     description:

--- a/packages/at_secondary_server/pubspec.lock
+++ b/packages/at_secondary_server/pubspec.lock
@@ -84,16 +84,18 @@ packages:
   at_persistence_secondary_server:
     dependency: "direct main"
     description:
-      path: "../at_persistence_secondary_server"
-      relative: true
-    source: path
+      name: at_persistence_secondary_server
+      sha256: e4386ee5aab1c6cda7ca9f2baf1f7273fc8e4b669f7aa477260693c8ba84d08b
+      url: "https://pub.dev"
+    source: hosted
     version: "5.1.0"
   at_server_spec:
     dependency: "direct main"
     description:
-      path: "../at_server_spec"
-      relative: true
-    source: path
+      name: at_server_spec
+      sha256: c128bc00c8bde819ff547b2a7baf9788723f9d87c36eddc30fd18042c64060cf
+      url: "https://pub.dev"
+    source: hosted
     version: "5.1.0"
   at_utf7:
     dependency: transitive

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_secondary
 description: Implementation of secondary server.
-version: 3.14.0
+version: 3.15.0
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://www.example.com
 publish_to: none

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   basic_utils: ^5.7.0
   ecdsa: ^0.1.2
   encrypt: ^5.0.3
-  at_commons: ^5.11.0
+  at_commons: ^5.12.0
   at_utils: ^3.4.0
   at_chops: ^3.3.0
   at_lookup: ^3.5.0

--- a/packages/at_secondary_server/test/enroll_verb_test.dart
+++ b/packages/at_secondary_server/test/enroll_verb_test.dart
@@ -2866,4 +2866,150 @@ void main() {
 
     tearDown(() async => await verbTestsTearDown());
   });
+
+  group('enroll:listns discovery + _apsk + request metadata', () {
+    final etu = ETU();
+    setUp(() async {
+      await verbTestsSetUp();
+      await etu.init();
+    });
+    tearDown(() async {
+      await verbTestsTearDown();
+    });
+
+    test(
+        'getEnrollmentsForNamespace returns apkamPubKey + metadata, '
+        'approved-only, honours suffix/* match', () async {
+      final (enIds, _) = await etu.createEnrollments(n: 2);
+      // enIds[0] = app_1 {app_1:rw, test:r}; enIds[1] = app_2 {app_2:rw, test:r}
+
+      // Attach metadata to enIds[0]'s record (models the enroll:request tail).
+      final ev0 = await enMgr.getEnrollmentById(enIds[0]);
+      ev0.metadata = {
+        'keyPackage': {'v': 1, 'keys': []}
+      };
+      await enMgr.put(enIds[0], AtData()..data = jsonEncode(ev0.toJson()),
+          EnrollmentStatus.approved);
+
+      // A pending (unapproved) enrollment authorised for 'test' — excluded.
+      final pending = await etu.createPendingEnrollment(
+          appName: 'pend',
+          deviceName: 't',
+          namespaces: {'test': 'r'},
+          apkamKeysExpiryDuration: null);
+
+      final members = await enMgr.getEnrollmentsForNamespace('test');
+      final ids = members.map((m) => m['enrollmentId']).toSet();
+      // primary(*:rw) + app_1(test:r) + app_2(test:r) authorised; pending excluded
+      expect(ids.contains(enIds[0]), true);
+      expect(ids.contains(enIds[1]), true);
+      expect(ids.contains(pending), false);
+      // every element carries apkamPubKey and access
+      for (final m in members) {
+        expect(m['apkamPubKey'], isNotNull);
+        expect(m.containsKey('access'), true);
+      }
+      final m0 = members.firstWhere((m) => m['enrollmentId'] == enIds[0]);
+      expect(m0['apkamPubKey'], 'apkam public key app_1 test');
+      expect(m0['access'], 'r');
+      expect(m0['metadata'], {
+        'keyPackage': {'v': 1, 'keys': []}
+      });
+      final m1 = members.firstWhere((m) => m['enrollmentId'] == enIds[1]);
+      expect(m1['metadata'], isNull);
+    });
+
+    test(
+        'enroll:listns serves the roster to a caller with >=r and refuses '
+        'a caller without access to the namespace', () async {
+      final (enIds, _) = await etu.createEnrollments(n: 2);
+
+      // app_1 (test:r) queries 'test' -> allowed
+      inboundConnection.metaData.isAuthenticated = true;
+      inboundConnection.metaData.enrollmentId = enIds[0];
+      final okResp = Response();
+      await etu.evh.processVerb(
+          okResp,
+          HashMap<String, String?>.from(
+              {'operation': 'listns', 'listNamespace': 'test'}),
+          inboundConnection);
+      expect(okResp.isError, false);
+      final roster = jsonDecode(okResp.data!) as List;
+      expect(roster.any((m) => m['apkamPubKey'] != null), true);
+
+      // app_2 (app_2:rw, test:r — NOT app_1) queries 'app_1' -> refused
+      inboundConnection.metaData.enrollmentId = enIds[1];
+      await expectLater(
+          etu.evh.processVerb(
+              Response(),
+              HashMap<String, String?>.from(
+                  {'operation': 'listns', 'listNamespace': 'app_1'}),
+              inboundConnection),
+          throwsA(isA<UnAuthorizedException>()));
+    });
+
+    test('_apsk signing key is published on approval (CRAM + enroll:approve)',
+        () async {
+      // primary was CRAM auto-approved in ETU.init()
+      final primaryApsk = 'public:_apsk.${etu.primaryEnId}'
+          '.${EnrollmentConstants.perEnrollmentApproved}$alice';
+      expect(await keyValueStore.exists(primaryApsk), true);
+      expect((await keyValueStore.get(primaryApsk))?.data, 'apkam public key');
+
+      // a standard enroll:approve path
+      final (enIds, _) = await etu.createEnrollments(n: 1);
+      final apsk = 'public:_apsk.${enIds[0]}'
+          '.${EnrollmentConstants.perEnrollmentApproved}$alice';
+      expect(await keyValueStore.exists(apsk), true);
+      expect(
+          (await keyValueStore.get(apsk))?.data, 'apkam public key app_1 test');
+    });
+
+    test('metadata + signingAlgo on enroll:request are persisted on the record',
+        () async {
+      inboundConnection.metaData.isAuthenticated = true;
+      final otp = await etu.getOtp();
+      // The pinned at_commons EnrollParams does not type metadata/signingAlgo,
+      // so append them to the raw request JSON tail (the server persists them).
+      final reqJson = {
+        'appName': 'metaApp',
+        'deviceName': 'd',
+        'apkamPublicKey': 'apkam meta pub',
+        'encryptedAPKAMSymmetricKey': 'enc aes',
+        'namespaces': {'wavi': 'rw'},
+        'otp': otp,
+        'signingAlgo': 'mldsa65',
+        'metadata': {
+          'keyPackage': {
+            'v': 1,
+            'keys': [
+              {'kid': 'k', 'use': 'enc', 'alg': 'x-wing', 'pub': 'p'}
+            ]
+          }
+        },
+      };
+      inboundConnection.metaData.isAuthenticated = false;
+      inboundConnection.metaData.authType = null;
+      inboundConnection.metaData.sessionID =
+          DateTime.now().millisecondsSinceEpoch.toString();
+      final r = Response();
+      await etu.evh.processVerb(
+          r,
+          getVerbParam(
+              VerbSyntax.enroll, 'enroll:request:${jsonEncode(reqJson)}'),
+          inboundConnection);
+      expect(r.isError, false);
+      final enId = jsonDecode(r.data!)['enrollmentId'];
+      final ev = await enMgr.getEnrollmentById(enId);
+      expect(ev.signingAlgo, 'mldsa65');
+      expect(ev.metadata, {
+        'keyPackage': {
+          'v': 1,
+          'keys': [
+            {'kid': 'k', 'use': 'enc', 'alg': 'x-wing', 'pub': 'p'}
+          ]
+        }
+      });
+    });
+  });
 }

--- a/packages/at_server_spec/CHANGELOG.md
+++ b/packages/at_server_spec/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.2.0
+- chore: dependency bump — `at_commons` to `^5.12.0`
+
 ## 5.1.0
 - feat: introduce enum AtVerb for better preparsing of verbs
 

--- a/packages/at_server_spec/lib/src/verb/enroll.dart
+++ b/packages/at_server_spec/lib/src/verb/enroll.dart
@@ -1,4 +1,5 @@
 import 'package:at_server_spec/src/verb/verb.dart';
+import 'package:at_commons/at_commons.dart';
 
 /// Enroll verb enables a new app or client to request new enrollment to a secondary server
 /// Secondary server will notify the new enrollment request to already enrolled apps which have access to __manage namespace.
@@ -10,26 +11,12 @@ import 'package:at_server_spec/src/verb/verb.dart';
 /// namespaces - List of namespaces the requesting app or client needs access e.g [wavi,r;buzz,rw]
 /// otp - timebased OTP which has to fetched from an already enrolled app
 /// apkamPublicKey - new pkam public key from the requesting app/client
-///
-/// Extended operations (WP-SS):
-/// enroll:listfornamespace:<namespace>
-///   Returns all approved enrollments with namespace access plus their key packages.
-/// enroll:metadata:<enrollmentId>:<jsonMetadata>
-///   Stores opaque metadata (key packages) on the caller's own enrollment record.
 class Enroll extends Verb {
-  /// Extended regex that adds `listfornamespace` and `metadata` to the allowed
-  /// operations, and captures an optional `namespace` segment after the
-  /// operation (used by both new verbs: namespace name for listfornamespace,
-  /// enrollmentId for metadata).
-  static const String extendedSyntax =
-      r'^enroll:(?<operation>(?:(request|approve|deny|revoke|list|listfornamespace|fetch|unrevoke|delete|metadata)))'
-      r'(:(?<force>force))?(:(?<namespace>[^:{\n]+))?(?::)?((?<enrollParams>.+)|(<=list:)<enrollParams>.?)?$';
-
   @override
   String name() => 'enroll';
 
   @override
-  String syntax() => extendedSyntax;
+  String syntax() => VerbSyntax.enroll;
 
   @override
   Verb? dependsOn() {

--- a/packages/at_server_spec/lib/src/verb/enroll.dart
+++ b/packages/at_server_spec/lib/src/verb/enroll.dart
@@ -1,5 +1,4 @@
 import 'package:at_server_spec/src/verb/verb.dart';
-import 'package:at_commons/at_commons.dart';
 
 /// Enroll verb enables a new app or client to request new enrollment to a secondary server
 /// Secondary server will notify the new enrollment request to already enrolled apps which have access to __manage namespace.
@@ -11,12 +10,26 @@ import 'package:at_commons/at_commons.dart';
 /// namespaces - List of namespaces the requesting app or client needs access e.g [wavi,r;buzz,rw]
 /// otp - timebased OTP which has to fetched from an already enrolled app
 /// apkamPublicKey - new pkam public key from the requesting app/client
+///
+/// Extended operations (WP-SS):
+/// enroll:listfornamespace:<namespace>
+///   Returns all approved enrollments with namespace access plus their key packages.
+/// enroll:metadata:<enrollmentId>:<jsonMetadata>
+///   Stores opaque metadata (key packages) on the caller's own enrollment record.
 class Enroll extends Verb {
+  /// Extended regex that adds `listfornamespace` and `metadata` to the allowed
+  /// operations, and captures an optional `namespace` segment after the
+  /// operation (used by both new verbs: namespace name for listfornamespace,
+  /// enrollmentId for metadata).
+  static const String extendedSyntax =
+      r'^enroll:(?<operation>(?:(request|approve|deny|revoke|list|listfornamespace|fetch|unrevoke|delete|metadata)))'
+      r'(:(?<force>force))?(:(?<namespace>[^:{\n]+))?(?::)?((?<enrollParams>.+)|(<=list:)<enrollParams>.?)?$';
+
   @override
   String name() => 'enroll';
 
   @override
-  String syntax() => VerbSyntax.enroll;
+  String syntax() => extendedSyntax;
 
   @override
   Verb? dependsOn() {

--- a/packages/at_server_spec/pubspec.yaml
+++ b/packages/at_server_spec/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   meta: ^1.11.0
-  at_commons: ^5.11.0
+  at_commons: ^5.12.0
 
 dev_dependencies:
   lints: ^5.0.0

--- a/packages/at_server_spec/pubspec.yaml
+++ b/packages/at_server_spec/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_server_spec
 description: A Dart library containing abstract classes that defines what implementations of the root and secondary servers are responsible for.
-version: 5.1.0
+version: 5.2.0
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://docs.atsign.com
 documentation: https://docs.atsign.com/atplatform/secondaryserver

--- a/tests/at_functional_test/lib/conf/config_util.dart
+++ b/tests/at_functional_test/lib/conf/config_util.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:at_utils/at_utils.dart';
 import 'package:yaml/yaml.dart';
 
@@ -5,7 +7,32 @@ class ConfigUtil {
   static final ApplicationConfiguration appConfig =
       ApplicationConfiguration('config/config.yaml');
 
+  /// The functional-test config from `config/config.yaml`.
+  ///
+  /// When the `VIRTUALENV_BASE_PORT` environment variable is set, the first
+  /// atSign's port is overlaid with the value the ve entrypoint assigns to the
+  /// first atServer (`BASE + 1`), so tests run against a virtualenv launched on
+  /// a shifted port range without editing the config file. Unset => the config
+  /// file's ports are used unchanged.
   static YamlMap? getYaml() {
-    return appConfig.getYaml();
+    final yaml = appConfig.getYaml();
+    final basePort =
+        int.tryParse(Platform.environment['VIRTUALENV_BASE_PORT'] ?? '');
+    if (yaml == null || basePort == null) {
+      return yaml;
+    }
+    final overlaid = _deepCopy(yaml) as Map;
+    (overlaid['firstAtSignServer'] as Map)['firstAtSignPort'] = basePort + 1;
+    return YamlMap.wrap(overlaid);
+  }
+
+  static dynamic _deepCopy(dynamic node) {
+    if (node is Map) {
+      return {for (final e in node.entries) e.key: _deepCopy(e.value)};
+    }
+    if (node is List) {
+      return [for (final e in node) _deepCopy(e)];
+    }
+    return node;
   }
 }

--- a/tests/at_functional_test/runLocal.sh
+++ b/tests/at_functional_test/runLocal.sh
@@ -5,6 +5,28 @@ cd "$(dirname -- "$0")"
 cd ../../
 repoDir=$(pwd)
 
+# Optional VE base port. Set VIRTUALENV_BASE_PORT (env) or pass it as the first
+# argument to run the virtualenv on a shifted port range, so it doesn't clash
+# with another VE already running on the default ports. The ve entrypoint binds
+# atDirectory to BASE, atServers to BASE+1.., Redis to BASE+99
+# (tools/build_virtual_environment/ve/contents/atsign/entrypoint.sh). The Dart
+# harness reads VIRTUALENV_BASE_PORT too (config_util, the readiness checks), so
+# tests target the shifted ports without editing config.yaml. Unset => original
+# ports (atDirectory 64, atServers 25000.., Redis 6379).
+VIRTUALENV_BASE_PORT="${1:-${VIRTUALENV_BASE_PORT:-}}"
+if [[ -n "$VIRTUALENV_BASE_PORT" ]]; then
+  export VIRTUALENV_BASE_PORT
+  export rootServerPort="$VIRTUALENV_BASE_PORT" # install_PKAM_Keys reads this
+  veEnvArgs="-e VIRTUALENV_BASE_PORT=${VIRTUALENV_BASE_PORT}"
+  vePortArgs="-p ${VIRTUALENV_BASE_PORT}-$((VIRTUALENV_BASE_PORT + 99)):${VIRTUALENV_BASE_PORT}-$((VIRTUALENV_BASE_PORT + 99))"
+  veCmd="bash /atsign/entrypoint.sh"
+  echo "Using VE base port ${VIRTUALENV_BASE_PORT} (atServers ${VIRTUALENV_BASE_PORT}+1.., Redis +99)"
+else
+  veEnvArgs=""
+  vePortArgs="-p 6379:6379 -p 25000-25040:25000-25040 -p 64:64 -p 443:443"
+  veCmd=""
+fi
+
 echo "Generate atDirectory binary (root) [in dart:3.11.2 Linux container]"
 # Compile the binaries inside a Linux Dart container so they run inside the
 # Linux at_virtual_env container we build below. Compiling on the host
@@ -45,8 +67,8 @@ docker stop at_server_func_cont
 echo "Run docker container"
 docker run -d --rm --name at_server_func_cont \
   -e testingMode="true" -e httpsEnabled="true" \
-  -p 6379:6379 -p 25000-25040:25000-25040 -p 64:64 -p 443:443 \
-  at_virtual_env:local || exit 1
+  $veEnvArgs $vePortArgs \
+  at_virtual_env:local $veCmd || exit 1
 
 echo "Check docker readiness to load PKAM keys"
 cd ${repoDir}/tests/at_functional_test

--- a/tests/at_functional_test/test/check_docker_readiness.dart
+++ b/tests/at_functional_test/test/check_docker_readiness.dart
@@ -5,7 +5,14 @@ import 'package:test/test.dart';
 
 void main() {
   var atsign = '@sitaram🛠';
-  var atsignPort = 25017;
+  // Match the port the ve entrypoint assigns to @sitaram🛠 when the VE runs on a
+  // shifted base port (VIRTUALENV_BASE_PORT); default 25017 otherwise.
+  const defaultAtsignPort = 25017;
+  final basePort =
+      int.tryParse(Platform.environment['VIRTUALENV_BASE_PORT'] ?? '');
+  final atsignPort = basePort != null
+      ? defaultAtsignPort + (basePort + 1 - 25000)
+      : defaultAtsignPort;
   var rootServer = 'vip.ve.atsign.zone';
   String response = '';
 

--- a/tests/at_functional_test/test/check_root_server_readiness.dart
+++ b/tests/at_functional_test/test/check_root_server_readiness.dart
@@ -10,7 +10,10 @@ Queue rootServerResponseQueue = Queue();
 
 void main() {
   var atSign = 'sitaram🛠';
-  var rootServerPort = 64;
+  // Root/atDirectory binds to VIRTUALENV_BASE_PORT when the VE runs on a shifted
+  // base port; default 64 otherwise.
+  final rootServerPort =
+      int.tryParse(Platform.environment['VIRTUALENV_BASE_PORT'] ?? '') ?? 64;
   var rootServer = 'vip.ve.atsign.zone';
 
   late SecureSocket secureSocket;

--- a/tests/at_functional_test/test/check_test_env.dart
+++ b/tests/at_functional_test/test/check_test_env.dart
@@ -7,7 +7,14 @@ void main() {
   SecureSocket secureSocket;
   var rootServer = 'vip.ve.atsign.zone';
   var atsign = '@sitaram🛠';
-  var atsignPort = 25017;
+  // Match the port the ve entrypoint assigns to @sitaram🛠 when the VE runs on a
+  // shifted base port (VIRTUALENV_BASE_PORT); default 25017 otherwise.
+  const defaultAtsignPort = 25017;
+  final basePort =
+      int.tryParse(Platform.environment['VIRTUALENV_BASE_PORT'] ?? '');
+  final atsignPort = basePort != null
+      ? defaultAtsignPort + (basePort + 1 - 25000)
+      : defaultAtsignPort;
   int maxRetryCount = 10;
   int retryCount = 1;
 

--- a/tests/at_functional_test/test/enroll_listns_test.dart
+++ b/tests/at_functional_test/test/enroll_listns_test.dart
@@ -1,0 +1,159 @@
+import 'dart:convert';
+
+import 'package:at_demo_data/at_demo_data.dart' as at_demos;
+import 'package:at_functional_test/conf/config_util.dart';
+import 'package:at_functional_test/connection/outbound_connection_wrapper.dart';
+import 'package:at_functional_test/utils/encryption_util.dart';
+import 'package:test/test.dart';
+import 'package:uuid/uuid.dart';
+
+/// Functional tests for the `enroll:listns:<namespace>` discovery verb and the
+/// `metadata` / `signingAlgo` fields that now ride an `enroll:request`.
+///
+/// `enroll:listns` returns every approved enrollment that holds read-or-better
+/// access to the requested namespace, as a flat list of
+/// `{enrollmentId, access, apkamPubKey, metadata}`. The caller must be
+/// APKAM-authenticated with an approved enrollment that itself holds >=r on the
+/// namespace, otherwise the server refuses with UnAuthorized.
+void main() {
+  final firstAtSign =
+      ConfigUtil.getYaml()!['firstAtSignServer']['firstAtSignName'];
+  final firstAtSignHost =
+      ConfigUtil.getYaml()!['firstAtSignServer']['firstAtSignUrl'];
+  final firstAtSignPort =
+      ConfigUtil.getYaml()!['firstAtSignServer']['firstAtSignPort'];
+
+  // Encrypted-key bundle the enroll flow needs: the two default keys wrapped for
+  // enroll:approve, and the APKAM symmetric key for a second (OTP) enrollment.
+  final apkamEncryptedKeysMap = <String, String>{
+    'encryptedDefaultEncPrivateKey': EncryptionUtil.encryptValue(
+        at_demos.encryptionPrivateKeyMap[firstAtSign]!,
+        at_demos.apkamSymmetricKeyMap[firstAtSign]!),
+    'encryptedSelfEncKey': EncryptionUtil.encryptValue(
+        at_demos.aesKeyMap[firstAtSign]!,
+        at_demos.apkamSymmetricKeyMap[firstAtSign]!),
+    'encryptedAPKAMSymmetricKey': EncryptionUtil.encryptKey(
+        at_demos.apkamSymmetricKeyMap[firstAtSign]!,
+        at_demos.encryptionPublicKeyMap[firstAtSign]!),
+  };
+
+  final firstAtSignConnection = OutboundConnectionFactory();
+
+  setUp(() async {
+    await firstAtSignConnection.initiateConnectionWithListener(
+        firstAtSign, firstAtSignHost, firstAtSignPort);
+  });
+
+  tearDown(() async {
+    await firstAtSignConnection.close();
+  });
+
+  group('enroll:listns discovery + request metadata', () {
+    test(
+        'listns returns an approved enrollment carrying its apkamPubKey and '
+        'metadata', () async {
+      await firstAtSignConnection.authenticateConnection(
+          authType: AuthType.cram);
+
+      // A namespace unique to this run so the assertions are unambiguous.
+      final namespace = 'listns${Uuid().v4().hashCode}';
+      final apkamPublicKey = at_demos.pkamPublicKeyMap[firstAtSign]!;
+      final keyPackage = {
+        'v': 1,
+        'keys': [
+          {'kid': 'k', 'use': 'enc', 'alg': 'x-wing', 'pub': 'p'}
+        ]
+      };
+
+      // enroll:request on a CRAM connection is auto-approved. metadata and
+      // signingAlgo ride the request and are persisted on the record.
+      final enrollRequest = 'enroll:request:${jsonEncode({
+            'appName': 'listns-app',
+            'deviceName': 'device-${Uuid().v4().hashCode}',
+            'namespaces': {namespace: 'rw'},
+            'apkamPublicKey': apkamPublicKey,
+            'signingAlgo': 'mldsa65',
+            'metadata': {'keyPackage': keyPackage},
+          })}\n';
+      final enrollJson = jsonDecode(
+          (await firstAtSignConnection.sendRequestToServer(enrollRequest))
+              .replaceFirst('data:', ''));
+      final enrollmentId = enrollJson['enrollmentId'];
+      expect(enrollmentId, isNotEmpty);
+      expect(enrollJson['status'], 'approved');
+
+      // APKAM-authenticate as the new enrollment, then query the roster.
+      await firstAtSignConnection.authenticateConnection(
+          authType: AuthType.pkam, enrollmentId: enrollmentId);
+
+      final roster = jsonDecode(
+          (await firstAtSignConnection
+                  .sendRequestToServer('enroll:listns:$namespace\n'))
+              .replaceFirst('data:', '')) as List;
+
+      final mine = roster.firstWhere((m) => m['enrollmentId'] == enrollmentId,
+          orElse: () => null);
+      expect(mine, isNotNull,
+          reason: 'the enrollment should appear in the listns roster for the '
+              'namespace it was granted');
+      expect(mine['access'], 'rw');
+      expect(mine['apkamPubKey'], apkamPublicKey);
+      expect(mine['metadata'], {'keyPackage': keyPackage});
+    });
+
+    test(
+        'listns refuses a caller whose enrollment lacks access to the '
+        'namespace', () async {
+      await firstAtSignConnection.authenticateConnection(
+          authType: AuthType.cram);
+
+      final grantedNamespace = 'buzz${Uuid().v4().hashCode}';
+      final otherNamespace = 'wavi${Uuid().v4().hashCode}';
+
+      // Second enrollment via OTP, scoped to grantedNamespace only.
+      final otp = (await firstAtSignConnection.sendRequestToServer('otp:get'))
+          .replaceAll('data:', '')
+          .trim();
+      final secondConnection = await OutboundConnectionFactory()
+          .initiateConnectionWithListener(
+              firstAtSign, firstAtSignHost, firstAtSignPort);
+      final secondEnrollRequest = 'enroll:request:${jsonEncode({
+            'appName': 'buzz',
+            'deviceName': 'device-${Uuid().v4().hashCode}',
+            'namespaces': {grantedNamespace: 'rw'},
+            'otp': otp,
+            'apkamPublicKey': at_demos.pkamPublicKeyMap[firstAtSign],
+            'encryptedAPKAMSymmetricKey':
+                apkamEncryptedKeysMap['encryptedAPKAMSymmetricKey'],
+          })}\n';
+      final pendingJson = jsonDecode(
+          (await secondConnection.sendRequestToServer(secondEnrollRequest))
+              .replaceFirst('data:', ''));
+      expect(pendingJson['status'], 'pending');
+      final secondEnrollId = pendingJson['enrollmentId'];
+
+      // Approve it from the CRAM (owner) connection.
+      final approveJson = jsonDecode((await firstAtSignConnection
+              .sendRequestToServer('enroll:approve:${jsonEncode({
+                    'enrollmentId': secondEnrollId,
+                    'encryptedDefaultEncryptionPrivateKey':
+                        apkamEncryptedKeysMap['encryptedDefaultEncPrivateKey'],
+                    'encryptedDefaultSelfEncryptionKey':
+                        apkamEncryptedKeysMap['encryptedSelfEncKey'],
+                  })}'))
+          .replaceFirst('data:', ''));
+      expect(approveJson['status'], 'approved');
+
+      // APKAM-authenticate as the second enrollment and query a namespace it
+      // was NOT granted -> the server refuses.
+      await secondConnection.authenticateConnection(
+          authType: AuthType.apkam, enrollmentId: secondEnrollId);
+      final refusal = await secondConnection
+          .sendRequestToServer('enroll:listns:$otherNamespace\n');
+      expect(refusal, startsWith('error:'),
+          reason: 'a caller without >=r on the namespace must be refused');
+
+      await secondConnection.close();
+    });
+  });
+}

--- a/tests/at_functional_test/test/http_test.dart
+++ b/tests/at_functional_test/test/http_test.dart
@@ -18,12 +18,16 @@ void main() {
 
   AtSignLogger.root_level = 'shout';
   final root = 'vip.ve.atsign.zone';
+  // atDirectory binds to VIRTUALENV_BASE_PORT when the VE runs on a shifted base
+  // port; default 64 otherwise.
+  final rootPort =
+      int.tryParse(Platform.environment['VIRTUALENV_BASE_PORT'] ?? '') ?? 64;
 
   group('basic atDirectory tests', () {
     test('lookup existing atSign via 64', () async {
       List<Future> futures = [];
       for (final atSign in atSigns) {
-        final saf = CacheableSecondaryAddressFinder(root, 64);
+        final saf = CacheableSecondaryAddressFinder(root, rootPort);
         futures.add(saf.findSecondary(atSign));
       }
       final responses = await Future.wait(futures);
@@ -33,7 +37,7 @@ void main() {
     test('lookup non-existent atSign avia 64', () async {
       List<Future> futures = [];
       for (final atSign in atSigns.map((e) => '${e}_nope')) {
-        final saf = CacheableSecondaryAddressFinder(root, 64);
+        final saf = CacheableSecondaryAddressFinder(root, rootPort);
         futures.add(expectLater(saf.findSecondary(atSign),
             throwsA(isA<SecondaryNotFoundException>())));
       }
@@ -71,7 +75,7 @@ void main() {
   group('atDirectory redirect tests', () {
     Future<bool> getAndCompareServerSigningKeyData(String atSign) async {
       final String command = 'lookup:signing_publickey$atSign';
-      final atLookup = AtLookupImpl(atSign, root, 64);
+      final atLookup = AtLookupImpl(atSign, root, rootPort);
       String pskFromAtLookup;
       try {
         pskFromAtLookup = (await atLookup.executeCommand('$command\n'))!;
@@ -93,7 +97,7 @@ void main() {
 
     Future<bool> getAndCompareServerSigningKeyMetadata(String atSign) async {
       final String command = 'lookup:meta:signing_publickey$atSign';
-      final atLookup = AtLookupImpl(atSign, root, 64);
+      final atLookup = AtLookupImpl(atSign, root, rootPort);
       String atMetaDataFromAtLookup = '';
       try {
         atMetaDataFromAtLookup = (await atLookup.executeCommand('$command\n'))!;

--- a/tests/at_functional_test/test/http_test.dart
+++ b/tests/at_functional_test/test/http_test.dart
@@ -18,10 +18,13 @@ void main() {
 
   AtSignLogger.root_level = 'shout';
   final root = 'vip.ve.atsign.zone';
-  // atDirectory binds to VIRTUALENV_BASE_PORT when the VE runs on a shifted base
-  // port; default 64 otherwise.
-  final rootPort =
-      int.tryParse(Platform.environment['VIRTUALENV_BASE_PORT'] ?? '') ?? 64;
+  // When the VE runs on a shifted base port (VIRTUALENV_BASE_PORT), the
+  // atDirectory binds to BASE and serves HTTPS on BASE + 98 (see the ve
+  // entrypoint); otherwise the defaults 64 / 443.
+  final basePort =
+      int.tryParse(Platform.environment['VIRTUALENV_BASE_PORT'] ?? '');
+  final rootPort = basePort ?? 64;
+  final httpsPort = basePort != null ? basePort + 98 : 443;
 
   group('basic atDirectory tests', () {
     test('lookup existing atSign via 64', () async {
@@ -48,7 +51,7 @@ void main() {
     test('lookup existing atSign via https', () async {
       List<Future> futures = [];
       for (final atSign in atSigns) {
-        final Uri url = Uri.https(root, atSign);
+        final Uri url = Uri.https('$root:$httpsPort', atSign);
         futures.add(expectLater(
           http.get(url).then((response) => response.statusCode),
           completion(HttpStatus.ok),
@@ -61,7 +64,7 @@ void main() {
     test('lookup non-existent atSign via https', () async {
       List<Future> futures = [];
       for (final atSign in atSigns.map((e) => '${e}_nope')) {
-        final Uri url = Uri.https(root, atSign);
+        final Uri url = Uri.https('$root:$httpsPort', atSign);
         futures.add(expectLater(
           http.get(url).then((response) => response.statusCode),
           completion(HttpStatus.notFound),
@@ -87,7 +90,7 @@ void main() {
       }
 
       final (statusCode, pskFromHttpRedirect) = await dartIoHttpClientGet(
-          Uri.https(root, '/$atSign/signing_publickey'));
+          Uri.https('$root:$httpsPort', '/$atSign/signing_publickey'));
 
       expect(statusCode, HttpStatus.ok);
       expect(pskFromHttpRedirect, pskFromAtLookup);
@@ -112,7 +115,7 @@ void main() {
       }
 
       final (statusCode, atMetaDataFromHttpGet) = await dartIoHttpClientGet(
-          Uri.https(root, '/$atSign/signing_publickey', {'at_rt': 'meta'}));
+          Uri.https('$root:$httpsPort', '/$atSign/signing_publickey', {'at_rt': 'meta'}));
 
       expect(statusCode, HttpStatus.ok);
       expect(atMetaDataFromHttpGet, atMetaDataFromAtLookup);

--- a/tools/build_virtual_environment/ve/contents/atsign/entrypoint.sh
+++ b/tools/build_virtual_environment/ve/contents/atsign/entrypoint.sh
@@ -10,6 +10,7 @@
 # into the [BASE, BASE+99] range:
 #   atDirectory  -> BASE
 #   atServers    -> BASE+1 .. BASE+80
+#   HTTPS        -> BASE+98
 #   Redis        -> BASE+99
 # This makes it possible to run several VE containers side-by-side on
 # one host without port collisions.
@@ -24,6 +25,7 @@ fi
 BASE=${VIRTUALENV_BASE_PORT}
 ROOT_PORT=${BASE}
 REDIS_PORT=$((BASE + 99))
+HTTPS_PORT=$((BASE + 98))
 SECONDARY_BASE=$((BASE + 1))
 SHIFT=$((SECONDARY_BASE - 25000))
 
@@ -32,6 +34,8 @@ sed -i "s/^port .*/port ${REDIS_PORT}/" /etc/redis/redis.conf
 
 # root_server: redis client port (the -p arg) and bind port (env var)
 export rootServerPort="${ROOT_PORT}"
+# root_server: HTTPS bind port (env var read by AtRootConfig.httpsPort)
+export httpsPort="${HTTPS_PORT}"
 sed -i "s/-p 6379/-p ${REDIS_PORT}/" /etc/supervisor/conf.d/30_root.conf
 
 # Secondary atServer supervisord program blocks: rewrite the -p N arg


### PR DESCRIPTION
Related to https://github.com/atsign-foundation/at_client_sdk/issues/2008

  **- What I did**

  Implements the atServer half of the WP-SS secret-sharing substrate — the gated
  discovery verb the client's `EnrollmentDirectory` seam talks to, plus verbatim
  storage of per-enrollment key-package metadata.

  - **`enroll:listns:<namespace>`** — returns all *approved* enrollments that hold
    read-or-better access to the requested namespace, as a **flattened** list of
    `{enrollmentId, access, apkamPubKey, metadata}` (no nested `apkam[]` array).
  - **`metadata` on enrollment records** — an opaque JSON map stored verbatim from
    `EnrollParams.metadata` on `enroll:request` (the client's X-Wing key package
    rides here under `metadata['keyPackage']`; `signingAlgo` likewise). Read from
    the raw request JSON, so no at_commons grammar change is required. Surfaced in
    `enroll:fetch`, `enroll:list`, and `enroll:listns` responses.
  - **`_apsk` signing-key publication** — on new-enrollment and on `enroll:approve`,
    the enrollment's APKAM public key is published to
    `public:_apsk.<enrollmentId>.a.__e@<atSign>` so a same-atSign or peer-atSign
    verifier can always fetch it (via plookup) to verify APKAM signatures on
    `__ssenv` envelopes and advertised recipient keys. Idempotent re-publish.

  **- How I did it**

  - `enroll_verb_handler.dart` — new `listns` case (`_fetchEnrollmentsForNamespace`);
    reads `metadata`/`signingAlgo` from the raw decoded `enrollParams` JSON tail
    (the pinned at_commons `EnrollParams` model doesn't type these yet); adds
    `_publishApskSigningKey` on the new-enrollment and approve paths.
  - `enrollment_manager.dart` — `getEnrollmentsForNamespace()` with the suffix/`*`
    namespace match (both `r` and `rw` satisfy the ≥`r` bar).
  - `enroll_datastore_value.dart` (+ `.g.dart`) — `metadata` and `signingAlgo`
    fields on the record.
  - Access gate: the caller must be APKAM-authenticated with an approved
    enrollment that itself holds ≥`r` on the namespace; unauthenticated or
    under-privileged callers get `UnAuthorized`, and an empty namespace is rejected.
  - Bumps `at_secondary_server` to 3.14.0 and `at_server_spec` to 5.1.0, both on
    `at_commons ^5.12.0`.

  **- How to verify it**

  dart test packages/at_secondary_server/test/enroll_verb_test.dart
  Four new tests in the `enroll:listns discovery + _apsk + request metadata` group
  cover the flat roster shape + `apkamPubKey`/`metadata`, the ≥`r` gating (serves a
  caller with access, refuses one without), `_apsk` publication on approval, and
  `metadata`/`signingAlgo` persistence. Also verified live end-to-end: a
  virtualenv built from this branch drives an `enroll:listns` round-trip and passes
  the full at_client_sdk `at_functional_test` suite (see at_client_sdk#2037).

  **- Description for the changelog**

  `enroll:listns:<namespace>` discovery verb + opaque per-enrollment `metadata`
  for the WP-SS secret-sharing substrate.

---
**PQ plan conformance (§10(e)):** project **SS-1b** — [implementation-plan.md](https://github.com/atsign-foundation/at_client_sdk/blob/trunk/docs/projects/pq/implementation-plan.md), tracking epic atsign-foundation/at_client_sdk#1889.
