### PR TITLE
feat(at_server): align enroll:listns discovery verb to the ratified WP-SS shape

### DIFF
--- a/packages/at_secondary_server/lib/src/enroll/enroll_datastore_value.dart
+++ b/packages/at_secondary_server/lib/src/enroll/enroll_datastore_value.dart
@@ -20,9 +20,14 @@ class EnrollDataStoreValue {
 
   /// Opaque per-APKAM metadata stored by the client (WP-SS).
   /// The server treats this as an opaque JSON map and returns it verbatim in
-  /// enroll:listfornamespace responses. Key packages live under
-  /// metadata['keyPackages'] by convention.
+  /// enroll:listns responses. The enrollment's single (APKAM-signed) key
+  /// package lives under metadata['keyPackage'] by convention (1:1:1 — no
+  /// format-keyed map).
   Map<String, dynamic>? metadata;
+
+  /// The signing algorithm of [apkamPublicKey] — `rsa2048` (legacy default) or
+  /// `mldsa65` (PQ). Recorded so PKAM verification can be record-authoritative.
+  String? signingAlgo;
 
   EnrollDataStoreValue(
       this.sessionId, this.appName, this.deviceName, this.apkamPublicKey);

--- a/packages/at_secondary_server/lib/src/enroll/enroll_datastore_value.g.dart
+++ b/packages/at_secondary_server/lib/src/enroll/enroll_datastore_value.g.dart
@@ -24,7 +24,8 @@ EnrollDataStoreValue _$EnrollDataStoreValueFromJson(
           json['encryptedAPKAMSymmetricKey'] as String?
       ..apkamKeysExpiryDuration =
           Duration(milliseconds: json['apkamKeysExpiryInMillis'] ?? 0)
-      ..metadata = (json['metadata'] as Map<String, dynamic>?);
+      ..metadata = (json['metadata'] as Map<String, dynamic>?)
+      ..signingAlgo = json['signingAlgo'] as String?;
 
 Map<String, dynamic> _$EnrollDataStoreValueToJson(
         EnrollDataStoreValue instance) =>
@@ -40,6 +41,7 @@ Map<String, dynamic> _$EnrollDataStoreValueToJson(
       'apkamKeysExpiryInMillis':
           instance.apkamKeysExpiryDuration.inMilliseconds,
       if (instance.metadata != null) 'metadata': instance.metadata,
+      if (instance.signingAlgo != null) 'signingAlgo': instance.signingAlgo,
     };
 
 const _$EnrollRequestTypeEnumMap = {

--- a/packages/at_secondary_server/lib/src/enroll/enrollment_manager.dart
+++ b/packages/at_secondary_server/lib/src/enroll/enrollment_manager.dart
@@ -300,9 +300,18 @@ class EnrollmentManager {
   }
 
   /// Returns all approved enrollments that have access to [namespace], as a
-  /// list of maps suitable for JSON encoding in the `enroll:listfornamespace`
-  /// response. Each entry has shape:
-  ///   `{"enrollmentId": <id>, "access": <"r"|"rw">, "metadata": <map|null>}`
+  /// flat list of maps suitable for JSON encoding in the `enroll:listns`
+  /// response (1:1:1 — one entry per enrollment, no nested `apkam[]`). Each
+  /// entry has shape:
+  ///
+  /// ```
+  /// {"enrollmentId": id, "access": "r"|"rw", "apkamPubKey": pubKey,
+  ///  "metadata": map|null}
+  /// ```
+  ///
+  /// `metadata.keyPackage` (a singular, APKAM-signed key package) is the
+  /// substrate's encapsulation target; the server stores/returns `metadata`
+  /// opaquely.
   ///
   /// The namespace match mirrors the atServer's own suffix rule:
   ///   - `*` authorises every namespace
@@ -318,9 +327,7 @@ class EnrollmentManager {
       String? access;
       for (final entry in enVal.namespaces.entries) {
         final ns = entry.key;
-        if (ns == '*' ||
-            ns == namespace ||
-            namespace.endsWith('.$ns')) {
+        if (ns == '*' || ns == namespace || namespace.endsWith('.$ns')) {
           access = entry.value;
           break;
         }
@@ -330,6 +337,7 @@ class EnrollmentManager {
       result.add({
         'enrollmentId': getIdFromKey(ek),
         'access': access,
+        'apkamPubKey': enVal.apkamPublicKey,
         'metadata': enVal.metadata,
       });
     }

--- a/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
@@ -67,20 +67,24 @@ class EnrollVerbHandler extends AbstractVerbHandler {
           'Cannot $operation enrollment without authentication');
     }
     EnrollParams? enrollVerbParams;
+    // The raw decoded enrollParams JSON map. Used to read fields the pinned
+    // at_commons EnrollParams model does not yet type (`metadata`,
+    // `signingAlgo`) — these ride the opaque JSON tail on enroll:request and
+    // are persisted verbatim onto the enrollment record.
+    Map<String, dynamic>? rawEnrollParams;
 
     // Ensure that enrollParams are present for all enroll operation.
-    // 'list' and 'listfornamespace' carry no enrollParams JSON body.
+    // 'list' and 'listns' carry no enrollParams JSON body.
     if (verbParams[AtConstants.enrollParams] == null) {
-      if (operation != 'list' &&
-          operation != 'listfornamespace' &&
-          operation != 'metadata') {
+      if (operation != 'list' && operation != 'listns') {
         logger.severe(
             'Enroll params is empty | EnrollParams: ${verbParams[AtConstants.enrollParams]}');
         throw IllegalArgumentException('Enroll parameters not provided');
       }
     } else {
-      enrollVerbParams = EnrollParams.fromJson(
-          jsonDecode(verbParams[AtConstants.enrollParams]!));
+      rawEnrollParams = jsonDecode(verbParams[AtConstants.enrollParams]!)
+          as Map<String, dynamic>;
+      enrollVerbParams = EnrollParams.fromJson(rawEnrollParams);
     }
 
     _validateParams(enrollVerbParams, operation!, atConnection);
@@ -90,6 +94,7 @@ class EnrollVerbHandler extends AbstractVerbHandler {
         await _handleEnrollmentRequest(
           enMgr,
           enrollVerbParams!,
+          rawEnrollParams,
           currentAtSign,
           responseJson,
           atConnection,
@@ -143,23 +148,13 @@ class EnrollVerbHandler extends AbstractVerbHandler {
           enrollVerbParams: enrollVerbParams,
         );
         return;
-      case 'listfornamespace':
+      case 'listns':
         response.data = await _fetchEnrollmentsForNamespace(
           enMgr,
           atConnection,
-          verbParams['namespace'] ?? '',
+          verbParams['listNamespace'] ?? '',
         );
         return;
-      case 'metadata':
-        await _storeEnrollmentMetadata(
-          enMgr,
-          atConnection,
-          verbParams['namespace'] ?? '',
-          verbParams[AtConstants.enrollParams] ?? '{}',
-          currentAtSign,
-        );
-        responseJson['status'] = 'success';
-        break;
       case 'fetch':
         response.data = await _fetchEnrollmentInfoById(
           enMgr,
@@ -226,6 +221,7 @@ class EnrollVerbHandler extends AbstractVerbHandler {
   Future<void> _handleEnrollmentRequest(
       EnrollmentManager enMgr,
       EnrollParams enrollParams,
+      Map<String, dynamic>? rawEnrollParams,
       currentAtSign,
       Map<dynamic, dynamic> responseJson,
       InboundConnection atConnection) async {
@@ -276,6 +272,20 @@ class EnrollVerbHandler extends AbstractVerbHandler {
     enrollmentValue.namespaces = enrollNamespaces;
     enrollmentValue.requestType = EnrollRequestType.newEnrollment;
 
+    // The X-Wing key package (at `metadata.keyPackage`) and the APKAM
+    // `signingAlgo` ride the opaque enrollParams JSON tail on enroll:request and
+    // are persisted verbatim onto the enrollment record — there is no separate
+    // enroll:metadata write. Read from the raw JSON: the pinned at_commons
+    // EnrollParams model does not yet type these fields.
+    final rawMetadata = rawEnrollParams?['metadata'];
+    if (rawMetadata is Map<String, dynamic>) {
+      enrollmentValue.metadata = rawMetadata;
+    }
+    final rawSigningAlgo = rawEnrollParams?['signingAlgo'];
+    if (rawSigningAlgo is String) {
+      enrollmentValue.signingAlgo = rawSigningAlgo;
+    }
+
     if (enrollParams.apkamKeysExpiryDuration != null) {
       enrollmentValue.apkamKeysExpiryDuration =
           enrollParams.apkamKeysExpiryDuration!;
@@ -296,6 +306,9 @@ class EnrollVerbHandler extends AbstractVerbHandler {
       await keyStore.put(AtConstants.atPkamPublicKey,
           AtData()..data = enrollParams.apkamPublicKey!,
           skipCommit: true);
+      // Keep the enrollment's `_apsk` signing key present for verifiers.
+      await _publishApskSigningKey(
+          newEnrollmentId, enrollParams.apkamPublicKey!, currentAtSign);
       AtData enrollData = AtData()..data = jsonEncode(enrollmentValue.toJson());
 
       await enMgr.put(newEnrollmentId, enrollData, EnrollmentStatus.approved);
@@ -397,6 +410,8 @@ class EnrollVerbHandler extends AbstractVerbHandler {
     // when enrollment is approved store the encrypted encryption keys
     if (operation == 'approve') {
       await _storeEncryptionKeys(enId, enrollParams, enVal);
+      // Keep the enrollment's `_apsk` signing key present for verifiers.
+      await _publishApskSigningKey(enId, enVal.apkamPublicKey, currentAtSign);
     }
     responseJson['enrollmentId'] = enId;
   }
@@ -476,6 +491,22 @@ class EnrollVerbHandler extends AbstractVerbHandler {
         skipCommit: true);
   }
 
+  /// Publishes the enrollment's APKAM public key as its `_apsk` signing key at
+  /// `public:_apsk.<enrollmentId>.a.__e@<atSign>` (the location the at_client
+  /// `ApkamSigning` mixin reads). The atServer keeps this key present — rather
+  /// than leaving it to the client-side `publishPublicSigningKey` — so a
+  /// verifier can always fetch it to verify APKAM signatures on `__ssenv`
+  /// envelopes and on advertised recipient keys (key package, `nskey` public,
+  /// `pqpublickey`). World-readable so a same-atSign or a peer-atSign verifier
+  /// can reach it via plookup. Idempotent: a re-publish is a harmless overwrite
+  /// with the same value.
+  Future<void> _publishApskSigningKey(
+      String enrollmentId, String apkamPublicKey, currentAtSign) async {
+    final apskKey = 'public:_apsk.$enrollmentId'
+        '.${EnrollmentConstants.perEnrollmentApproved}$currentAtSign';
+    await keyStore.put(apskKey, AtData()..data = apkamPublicKey);
+  }
+
   EnrollmentStatus _getEnrollStatusEnum(String? enrollmentOperation) {
     enrollmentOperation = enrollmentOperation?.toLowerCase();
     final operationMap = {
@@ -544,78 +575,46 @@ class EnrollVerbHandler extends AbstractVerbHandler {
     String namespace,
   ) async {
     if (namespace.isEmpty) {
-      throw IllegalArgumentException(
-          'namespace is required for enroll:listfornamespace');
+      throw IllegalArgumentException('namespace is required for enroll:listns');
     }
 
     final callerEnrollmentId =
         (atConnection.metaData as InboundConnectionMetadata).enrollmentId;
     if (callerEnrollmentId == null || callerEnrollmentId.isEmpty) {
       throw UnAuthenticatedException(
-          'enroll:listfornamespace requires APKAM authentication');
+          'enroll:listns requires APKAM authentication');
     }
 
-    // Verify the caller's own enrollment is approved and has namespace access.
+    // Verify the caller's own enrollment is approved AND holds at least read
+    // access to the requested namespace — learning a namespace's roster is
+    // gated on ≥r for that namespace, not merely on being approved.
     final callerEnVal = await enMgr.getEnrollmentById(callerEnrollmentId);
     if (callerEnVal.approval?.state != EnrollmentStatus.approved.name) {
+      throw UnAuthorizedException('Caller enrollment is not in approved state');
+    }
+    if (_accessForNamespace(callerEnVal, namespace) == null) {
       throw UnAuthorizedException(
-          'Caller enrollment is not in approved state');
+          'Caller enrollment is not authorised for namespace "$namespace"');
     }
 
     final members = await enMgr.getEnrollmentsForNamespace(namespace);
     return jsonEncode(members);
   }
 
-  /// Stores opaque [metadataJson] on the enrollment record identified by
-  /// [enrollmentId]. The caller must be authenticated via APKAM and the
-  /// [enrollmentId] must match the authenticated enrollment (a client can
-  /// only write its own metadata).
-  Future<void> _storeEnrollmentMetadata(
-    EnrollmentManager enMgr,
-    InboundConnection atConnection,
-    String enrollmentId,
-    String metadataJson,
-    String currentAtSign,
-  ) async {
-    if (enrollmentId.isEmpty) {
-      throw IllegalArgumentException(
-          'enrollmentId is required for enroll:metadata');
+  /// The caller's access (`r`|`rw`) to [namespace] under the atServer's own
+  /// suffix / `*`-wildcard rule, or null if the enrollment has no access.
+  /// Mirrors [EnrollmentManager.getEnrollmentsForNamespace]'s match; both `r`
+  /// and `rw` satisfy the ≥`r` bar the discovery verb requires.
+  String? _accessForNamespace(EnrollDataStoreValue enVal, String namespace) {
+    for (final entry in enVal.namespaces.entries) {
+      final ns = entry.key;
+      if (ns == EnrollmentConstants.allNamespaces ||
+          ns == namespace ||
+          namespace.endsWith('.$ns')) {
+        return entry.value;
+      }
     }
-
-    final callerEnrollmentId =
-        (atConnection.metaData as InboundConnectionMetadata).enrollmentId;
-    if (callerEnrollmentId == null || callerEnrollmentId.isEmpty) {
-      throw UnAuthenticatedException(
-          'enroll:metadata requires APKAM authentication');
-    }
-    if (callerEnrollmentId != enrollmentId) {
-      throw UnAuthorizedException(
-          'enroll:metadata: caller enrollment $callerEnrollmentId cannot write'
-          ' metadata for enrollment $enrollmentId');
-    }
-
-    final EnrollDataStoreValue enVal =
-        await enMgr.getEnrollmentById(enrollmentId);
-    if (enVal.approval?.state != EnrollmentStatus.approved.name) {
-      throw IllegalStateException(
-          'Cannot write metadata for a non-approved enrollment');
-    }
-
-    Map<String, dynamic> parsedMetadata;
-    try {
-      parsedMetadata = jsonDecode(metadataJson) as Map<String, dynamic>;
-    } catch (_) {
-      throw IllegalArgumentException(
-          'enroll:metadata: metadataJson is not valid JSON');
-    }
-
-    // Merge incoming metadata into any existing metadata, then persist.
-    final existing = enVal.metadata ?? {};
-    existing.addAll(parsedMetadata);
-    enVal.metadata = existing;
-
-    final atData = AtData()..data = jsonEncode(enVal.toJson());
-    await enMgr.put(enrollmentId, atData, EnrollmentStatus.approved);
+    return null;
   }
 
   bool _doesEnrollmentHaveManageNamespace(
@@ -786,8 +785,8 @@ class EnrollVerbHandler extends AbstractVerbHandler {
               'enrollmentId is mandatory for enroll:$operation');
         }
         break;
-      // listfornamespace and metadata are validated in their own handlers
-      // because their params are in the 'namespace' capture group, not enrollParams.
+      // list / listns carry no enrollParams; listns validates its namespace
+      // (from the 'listNamespace' capture group) in its own handler.
     }
   }
 

--- a/packages/at_secondary_server/test/enroll_verb_test.dart
+++ b/packages/at_secondary_server/test/enroll_verb_test.dart
@@ -2866,4 +2866,150 @@ void main() {
 
     tearDown(() async => await verbTestsTearDown());
   });
+
+  group('enroll:listns discovery + _apsk + request metadata', () {
+    final etu = ETU();
+    setUp(() async {
+      await verbTestsSetUp();
+      await etu.init();
+    });
+    tearDown(() async {
+      await verbTestsTearDown();
+    });
+
+    test(
+        'getEnrollmentsForNamespace returns apkamPubKey + metadata, '
+        'approved-only, honours suffix/* match', () async {
+      final (enIds, _) = await etu.createEnrollments(n: 2);
+      // enIds[0] = app_1 {app_1:rw, test:r}; enIds[1] = app_2 {app_2:rw, test:r}
+
+      // Attach metadata to enIds[0]'s record (models the enroll:request tail).
+      final ev0 = await enMgr.getEnrollmentById(enIds[0]);
+      ev0.metadata = {
+        'keyPackage': {'v': 1, 'keys': []}
+      };
+      await enMgr.put(enIds[0], AtData()..data = jsonEncode(ev0.toJson()),
+          EnrollmentStatus.approved);
+
+      // A pending (unapproved) enrollment authorised for 'test' — excluded.
+      final pending = await etu.createPendingEnrollment(
+          appName: 'pend',
+          deviceName: 't',
+          namespaces: {'test': 'r'},
+          apkamKeysExpiryDuration: null);
+
+      final members = await enMgr.getEnrollmentsForNamespace('test');
+      final ids = members.map((m) => m['enrollmentId']).toSet();
+      // primary(*:rw) + app_1(test:r) + app_2(test:r) authorised; pending excluded
+      expect(ids.contains(enIds[0]), true);
+      expect(ids.contains(enIds[1]), true);
+      expect(ids.contains(pending), false);
+      // every element carries apkamPubKey and access
+      for (final m in members) {
+        expect(m['apkamPubKey'], isNotNull);
+        expect(m.containsKey('access'), true);
+      }
+      final m0 = members.firstWhere((m) => m['enrollmentId'] == enIds[0]);
+      expect(m0['apkamPubKey'], 'apkam public key app_1 test');
+      expect(m0['access'], 'r');
+      expect(m0['metadata'], {
+        'keyPackage': {'v': 1, 'keys': []}
+      });
+      final m1 = members.firstWhere((m) => m['enrollmentId'] == enIds[1]);
+      expect(m1['metadata'], isNull);
+    });
+
+    test(
+        'enroll:listns serves the roster to a caller with >=r and refuses '
+        'a caller without access to the namespace', () async {
+      final (enIds, _) = await etu.createEnrollments(n: 2);
+
+      // app_1 (test:r) queries 'test' -> allowed
+      inboundConnection.metaData.isAuthenticated = true;
+      inboundConnection.metaData.enrollmentId = enIds[0];
+      final okResp = Response();
+      await etu.evh.processVerb(
+          okResp,
+          HashMap<String, String?>.from(
+              {'operation': 'listns', 'listNamespace': 'test'}),
+          inboundConnection);
+      expect(okResp.isError, false);
+      final roster = jsonDecode(okResp.data!) as List;
+      expect(roster.any((m) => m['apkamPubKey'] != null), true);
+
+      // app_2 (app_2:rw, test:r — NOT app_1) queries 'app_1' -> refused
+      inboundConnection.metaData.enrollmentId = enIds[1];
+      await expectLater(
+          etu.evh.processVerb(
+              Response(),
+              HashMap<String, String?>.from(
+                  {'operation': 'listns', 'listNamespace': 'app_1'}),
+              inboundConnection),
+          throwsA(isA<UnAuthorizedException>()));
+    });
+
+    test('_apsk signing key is published on approval (CRAM + enroll:approve)',
+        () async {
+      // primary was CRAM auto-approved in ETU.init()
+      final primaryApsk = 'public:_apsk.${etu.primaryEnId}'
+          '.${EnrollmentConstants.perEnrollmentApproved}$alice';
+      expect(await keyValueStore.exists(primaryApsk), true);
+      expect((await keyValueStore.get(primaryApsk))?.data, 'apkam public key');
+
+      // a standard enroll:approve path
+      final (enIds, _) = await etu.createEnrollments(n: 1);
+      final apsk = 'public:_apsk.${enIds[0]}'
+          '.${EnrollmentConstants.perEnrollmentApproved}$alice';
+      expect(await keyValueStore.exists(apsk), true);
+      expect(
+          (await keyValueStore.get(apsk))?.data, 'apkam public key app_1 test');
+    });
+
+    test('metadata + signingAlgo on enroll:request are persisted on the record',
+        () async {
+      inboundConnection.metaData.isAuthenticated = true;
+      final otp = await etu.getOtp();
+      // The pinned at_commons EnrollParams does not type metadata/signingAlgo,
+      // so append them to the raw request JSON tail (the server persists them).
+      final reqJson = {
+        'appName': 'metaApp',
+        'deviceName': 'd',
+        'apkamPublicKey': 'apkam meta pub',
+        'encryptedAPKAMSymmetricKey': 'enc aes',
+        'namespaces': {'wavi': 'rw'},
+        'otp': otp,
+        'signingAlgo': 'mldsa65',
+        'metadata': {
+          'keyPackage': {
+            'v': 1,
+            'keys': [
+              {'kid': 'k', 'use': 'enc', 'alg': 'x-wing', 'pub': 'p'}
+            ]
+          }
+        },
+      };
+      inboundConnection.metaData.isAuthenticated = false;
+      inboundConnection.metaData.authType = null;
+      inboundConnection.metaData.sessionID =
+          DateTime.now().millisecondsSinceEpoch.toString();
+      final r = Response();
+      await etu.evh.processVerb(
+          r,
+          getVerbParam(
+              VerbSyntax.enroll, 'enroll:request:${jsonEncode(reqJson)}'),
+          inboundConnection);
+      expect(r.isError, false);
+      final enId = jsonDecode(r.data!)['enrollmentId'];
+      final ev = await enMgr.getEnrollmentById(enId);
+      expect(ev.signingAlgo, 'mldsa65');
+      expect(ev.metadata, {
+        'keyPackage': {
+          'v': 1,
+          'keys': [
+            {'kid': 'k', 'use': 'enc', 'alg': 'x-wing', 'pub': 'p'}
+          ]
+        }
+      });
+    });
+  });
 }


### PR DESCRIPTION
Targets **`jt-wp-ss`** (PR #2685) — merge this in to bring the discovery verb onto the ratified WP-SS shape. Implements the review comments left on #2685.

**- What I did**

Reworked the `enroll:listfornamespace` discovery verb (this branch's `b33f9fe6`) to the ratified rulings in the at_client_sdk PQ docs (`docs/projects/pq/decisions.md` #B/#F + §12; docs PR atsign-foundation/at_client_sdk#2042).

**- How I did it**

- **Verb rename `enroll:listfornamespace` → `enroll:listns`** — the `case`, the namespace source (`verbParams['listNamespace']`), the guard exemption, and error messages. The Dart handler compiles against the pinned `at_commons ^5.11.0`; at runtime the verb parses only with **at_commons 5.12.0**'s `listns` regex (at_client_sdk PR #2044 into `jt-at-commons`) — the same cross-repo dependency this branch already had.
- **Removed the `enroll:metadata` write op** (`case 'metadata'` + `_storeEnrollmentMetadata` + the guard exemption) — decision #B retired it. The key package is now persisted **at `enroll:request` time**: `metadata` + `signingAlgo` are read from the raw request JSON tail (the pinned `EnrollParams` model doesn't type them yet) and stored on the enrollment record on **both** the CRAM auto-approve and pending paths.
- **Flat 1:1:1 response with `apkamPubKey`** — `getEnrollmentsForNamespace` now returns `{enrollmentId, access, apkamPubKey, metadata}`.
- **Caller gate on ≥`r`** — `_fetchEnrollmentsForNamespace` now requires the caller to hold read access to the requested namespace (mirroring the suffix / `*` match), not merely to be approved.
- **Keep `_apsk` present** — on approval (CRAM auto-approve + `enroll:approve`) the server publishes `public:_apsk.<eid>.a.__e@<atSign>` from the record's `apkamPublicKey`, so a verifier can always fetch it. (The client verifies advertised-key / envelope APKAM signatures against `_apsk` — that's the client-side SS-1c work; this is the server-side write.)
- **`EnrollDataStoreValue.signingAlgo`** added (+ hand-updated `.g.dart`); the `metadata` dartdoc uses the singular `metadata.keyPackage` (no format-keyed map).

**- How to verify it**

- `dart analyze lib test`: **no issues**.
- `dart test test/enroll_verb_test.dart test/enroll_data_store_value_test.dart --concurrency=1`: **86 tests pass** (82 existing + 4 new). New tests: `getEnrollmentsForNamespace` shape/approved-only/suffix-match; `listns` gate allow + refuse; `_apsk` published on approval; `enroll:request` metadata + `signingAlgo` persisted.
- `dart format . -o none --set-exit-if-changed`: clean.

**Deferred / for the server team**
- **Record-authoritative ML-DSA PKAM verify (DEP3)** — `signingAlgo` is now stored on the record; wiring `pkam_verb_handler` to verify against the stored algo is a follow-up (my #2685 review flagged this as optional-for-this-PR).
- **`public:_apsk` storage semantics** — I used the simplest working `keyStore.put` of a `public:`-prefixed key (committed, so it syncs to the owner's clients and serves via plookup). Please confirm the visibility/metadata match the intended serve behaviour; there is no consumer yet (client verify lands in SS-1c), so it's safe to refine.

**- Description for the changelog**

feat: `enroll:listns` discovery verb (flat 1:1:1 `{enrollmentId, access, apkamPubKey, metadata}`, caller-gated on ≥r); persist key-package `metadata` + `signingAlgo` on `enroll:request`; keep `_apsk` present on approval; remove the `enroll:metadata` op.