### PR TITLE
feat(arch): cross-server to: verb (always-on inbound, outbound default off)

### DIFF
--- a/packages/at_secondary_server/config/config.yaml
+++ b/packages/at_secondary_server/config/config.yaml
@@ -35,6 +35,14 @@ security:
   # atServer
   clientCertificateRequired: true
 
+# Cross-server 'to:' verb: the first verb on an outbound peer connection
+# declares the target tenant, giving architectural flexibility for atServer
+# endpoints — e.g. atServers reached through proxies / gateways.
+# Default false. Turn on (env crossServerToVerbEnabled=true) only once every
+# atServer in the fleet understands 'to:' — a staged rollout.
+protocol:
+  crossServerToVerbEnabled: false
+
 # The atProtocol storage configurations
 hive:
   # The storage path for secondary storage.

--- a/packages/at_secondary_server/config/config.yaml
+++ b/packages/at_secondary_server/config/config.yaml
@@ -38,10 +38,16 @@ security:
 # Cross-server 'to:' verb: the first verb on an outbound peer connection
 # declares the target tenant, giving architectural flexibility for atServer
 # endpoints — e.g. atServers reached through proxies / gateways.
-# Default false. Turn on (env crossServerToVerbEnabled=true) only once every
-# atServer in the fleet understands 'to:' — a staged rollout.
+# Understanding inbound 'to:@x' is always on (unauthenticated, serves only
+# data already publicly readable via lookup). Emitting 'to:@target' on
+# outbound peer connections is gated here:
+# - toVerbOutboundEnabled (default false): emit 'to:@target' as the first
+#   verb on outbound peer connections. A peer that rejects 'to:' triggers a
+#   fallback to the legacy lookup, so enabling early costs a wasted round
+#   trip per connection to legacy peers, not an outage. Turn on (env
+#   toVerbOutboundEnabled=true) once the fleet understands 'to:'.
 protocol:
-  crossServerToVerbEnabled: false
+  toVerbOutboundEnabled: false
 
 # The atProtocol storage configurations
 hive:

--- a/packages/at_secondary_server/lib/src/connection/inbound/connection_util.dart
+++ b/packages/at_secondary_server/lib/src/connection/inbound/connection_util.dart
@@ -262,6 +262,14 @@ class InboundCommandValidator {
     final String rawVerb =
         (firstColon == -1 ? command : command.substring(0, firstColon)).trim();
 
+    // The cross-server 'to:' verb is not in the published AtVerb
+    // enum. When enabled, accept it as an unauthenticated first-verb (like from:/
+    // scan:) so it reaches ToVerbHandler; when the flag is off it falls through
+    // to the normal AtVerb.tryParse rejection, exactly as today.
+    if (rawVerb == 'to' && AtSecondaryConfig.crossServerToVerbEnabled) {
+      return;
+    }
+
     // covers 2 cases:
     // - any junk with a ':' inside, where we would try to parse the verb
     // - from the firstOrNull call, any junk that looks nothing like a command is removed.

--- a/packages/at_secondary_server/lib/src/connection/inbound/connection_util.dart
+++ b/packages/at_secondary_server/lib/src/connection/inbound/connection_util.dart
@@ -262,11 +262,10 @@ class InboundCommandValidator {
     final String rawVerb =
         (firstColon == -1 ? command : command.substring(0, firstColon)).trim();
 
-    // The cross-server 'to:' verb is not in the published AtVerb
-    // enum. When enabled, accept it as an unauthenticated first-verb (like from:/
-    // scan:) so it reaches ToVerbHandler; when the flag is off it falls through
-    // to the normal AtVerb.tryParse rejection, exactly as today.
-    if (rawVerb == 'to' && AtSecondaryConfig.crossServerToVerbEnabled) {
+    // The cross-server 'to:' verb is not in the published AtVerb enum, but is
+    // always understood. Accept it as an unauthenticated first-verb (like
+    // from:/scan:) so it reaches ToVerbHandler.
+    if (rawVerb == 'to') {
       return;
     }
 

--- a/packages/at_secondary_server/lib/src/connection/inbound/inbound_connection_metadata.dart
+++ b/packages/at_secondary_server/lib/src/connection/inbound/inbound_connection_metadata.dart
@@ -12,6 +12,10 @@ class InboundConnectionMetadata extends AtConnectionMetaData {
   /// fromOtherAtSign will be populated iff 'from' has been executed with an atSign which is NOT the atSign of this atServer
   Atsign? fromAtSign;
 
+  /// The target tenant a cross-server peer is operating on, set by the `to:@x`
+  /// verb. Single-tenant: always equals this server's atSign when set.
+  Atsign? toAtSign;
+
   /// A unique identifier to distinguish clients in the server logs.
   String? clientId;
 
@@ -30,6 +34,6 @@ class InboundConnectionMetadata extends AtConnectionMetaData {
 
   @override
   String toString() {
-    return 'InboundConnectionMetadata{self: $self, from: $from, fromAtSign: $fromAtSign, clientId: $clientId, appName: $appName, appVersion: $appVersion, platform: $platform, enrollmentId: $enrollmentId}';
+    return 'InboundConnectionMetadata{self: $self, from: $from, fromAtSign: $fromAtSign, toAtSign: $toAtSign, clientId: $clientId, appName: $appName, appVersion: $appVersion, platform: $platform, enrollmentId: $enrollmentId}';
   }
 }

--- a/packages/at_secondary_server/lib/src/connection/outbound/at_request_formatter.dart
+++ b/packages/at_secondary_server/lib/src/connection/outbound/at_request_formatter.dart
@@ -14,7 +14,7 @@ class AtRequestFormatter {
   /// The cross-server `to:@toAtSign` verb — declares the target tenant to a peer
   /// atServer and, in one round trip, returns the peer's
   /// {publickey, signing_publickey} envelope. Sent as the first verb on the
-  /// connection when [AtSecondaryConfig.crossServerToVerbEnabled] is on.
+  /// connection when [AtSecondaryConfig.toVerbOutboundEnabled] is on.
   static String createToRequest(String toAtSign) {
     return 'to:$toAtSign\n';
   }

--- a/packages/at_secondary_server/lib/src/connection/outbound/at_request_formatter.dart
+++ b/packages/at_secondary_server/lib/src/connection/outbound/at_request_formatter.dart
@@ -10,4 +10,12 @@ class AtRequestFormatter {
   static String createLookUpRequest(String key) {
     return 'lookup:$key\n';
   }
+
+  /// The cross-server `to:@toAtSign` verb — declares the target tenant to a peer
+  /// atServer and, in one round trip, returns the peer's
+  /// {publickey, signing_publickey} envelope. Sent as the first verb on the
+  /// connection when [AtSecondaryConfig.crossServerToVerbEnabled] is on.
+  static String createToRequest(String toAtSign) {
+    return 'to:$toAtSign\n';
+  }
 }

--- a/packages/at_secondary_server/lib/src/connection/outbound/outbound_client.dart
+++ b/packages/at_secondary_server/lib/src/connection/outbound/outbound_client.dart
@@ -158,21 +158,19 @@ class OutboundClient {
       doing =
           'checkRemotePublicKey parsing response from looking up $remotePublicKeyName';
       if (AtSecondaryConfig.crossServerToVerbEnabled) {
-        // 'to:' returns {"publickey":..,"signing_publickey":..}. Use the
-        // encryption public key; a null publickey means the peer has not
+        // 'to:' returns {"publickey":..,"signing_publickey":..} where each
+        // value is a {key, data, metaData} map — the same shape as a
+        // lookup:all: response. A null publickey means the peer has not
         // onboarded an encryption key yet — leave the cache untouched, exactly
         // as the KeyNotFound branch above does for the legacy lookup path.
         var envelope = jsonDecode(remoteResponse) as Map;
-        var publicKey = envelope['publickey'];
-        if (publicKey == null) {
+        var publicKeyEntry = envelope['publickey'];
+        if (publicKeyEntry == null) {
           return;
         }
-        // A non-null metaData is required — the cache put dereferences it, and the
-        // legacy fromJson path always populates one. The 'to:' envelope carries only
-        // the key string, so attach a default (public key, no TTL).
-        atData = AtData()
-          ..data = publicKey as String
-          ..metaData = AtMetaData();
+        // Same fromJson as the legacy branch below, so the peer's metadata is
+        // preserved in the cache rather than replaced with a default.
+        atData = AtData().fromJson(publicKeyEntry);
       } else {
         atData = AtData().fromJson(jsonDecode(remoteResponse));
       }

--- a/packages/at_secondary_server/lib/src/connection/outbound/outbound_client.dart
+++ b/packages/at_secondary_server/lib/src/connection/outbound/outbound_client.dart
@@ -79,22 +79,7 @@ class OutboundClient {
     }
     var result = false;
     try {
-      // 1. Find secondary url for the toAtSign
-      String secondaryUrl = await _findSecondary(toAtSign);
-      var secondaryInfo = SecondaryUtil.getSecondaryInfo(secondaryUrl);
-      String toHost = secondaryInfo[0];
-      int toPort = int.parse(secondaryInfo[1]);
-      // 2. Create an outbound connection for the host and port
-      outboundConnection = await outboundConnectionFactory
-          .createOutboundConnection(toHost, toPort, toAtSign);
-
-      // Note that the outbound connection has been created successfully
-      isConnectionCreated = true;
-      logger.finer('Outbound connection created for $toHost $toPort $toAtSign');
-
-      // 3. Listen to outbound message
-      messageListener = OutboundMessageListener(this);
-      messageListener.listen();
+      await _createConnectionAndListener();
 
       await checkRemotePublicKey();
 
@@ -114,10 +99,36 @@ class OutboundClient {
     return result;
   }
 
+  /// Resolves [toAtSign]'s atServer address, creates the outbound connection
+  /// and starts its message listener. Called by [connect], and again by
+  /// [_reconnectIfInvalid] when a peer that rejected `to:` closed the
+  /// connection.
+  Future<void> _createConnectionAndListener() async {
+    // 1. Find secondary url for the toAtSign
+    String secondaryUrl = await _findSecondary(toAtSign);
+    var secondaryInfo = SecondaryUtil.getSecondaryInfo(secondaryUrl);
+    toHost = secondaryInfo[0];
+    toPort = secondaryInfo[1];
+    // 2. Create an outbound connection for the host and port
+    outboundConnection = await outboundConnectionFactory
+        .createOutboundConnection(toHost!, int.parse(toPort!), toAtSign);
+
+    // Note that the outbound connection has been created successfully
+    isConnectionCreated = true;
+    logger.finer('Outbound connection created for $toHost $toPort $toAtSign');
+
+    // 3. Listen to outbound message
+    messageListener = OutboundMessageListener(this);
+    messageListener.listen();
+  }
+
   /// This method is called by [connect] after the connection has been established, but
   /// before the connection has been authenticated (because looking up public data on another
   /// atServer requires the connection be unauthenticated).
-  /// 1. Gets the `publickey@atSign` from the remote atServer
+  /// 1. Gets the `publickey@atSign` from the remote atServer — via the
+  ///    cross-server `to:` verb when [AtSecondaryConfig.toVerbOutboundEnabled]
+  ///    is on (falling back to the legacy lookup if the peer rejects `to:`),
+  ///    otherwise via the legacy unauthenticated lookup.
   /// 2. If got a response, calls [AtCacheManager.put]
   /// 3. If we got a KeyNotFound  from remote atServer, calls [AtCacheManager.delete]
   Future<void> checkRemotePublicKey() async {
@@ -131,16 +142,24 @@ class OutboundClient {
     AtCacheManager cacheManager =
         AtSecondaryServerImpl.getInstance().cacheManager;
 
+    if (AtSecondaryConfig.toVerbOutboundEnabled) {
+      // Try the cross-server 'to:' verb first: sent as the first verb on the
+      // connection, it declares the target tenant to the peer and returns
+      // both public keys in one round trip, so no separate lookup is needed.
+      bool handled = await _checkRemotePublicKeyViaToVerb(
+          cacheManager, cachedPublicKeyName);
+      if (handled) {
+        return;
+      }
+      // The peer did not complete the to: exchange (it may predate the verb).
+      // _checkRemotePublicKeyViaToVerb has re-established the connection if
+      // the peer closed it; fall through to the legacy lookup.
+    }
+
     String doing = 'checkRemotePublicKey looking up $remotePublicKeyName';
     try {
-      // When cross-server 'to:' is enabled, fetch the peer's public key via the
-      // 'to:@target' verb — which is ALSO the first verb on the connection,
-      // declaring the target tenant to the peer. It returns
-      // both public keys in one round trip, so no separate lookup is needed.
-      // Otherwise fall back to the legacy unauthenticated lookup, byte for byte.
-      remoteResponse = AtSecondaryConfig.crossServerToVerbEnabled
-          ? await _sendToVerb()
-          : (await lookUp('all:$remotePublicKeyName', handshake: false))!;
+      remoteResponse =
+          (await lookUp('all:$remotePublicKeyName', handshake: false))!;
     } on KeyNotFoundException {
       // Do nothing
       return;
@@ -157,23 +176,7 @@ class OutboundClient {
       }
       doing =
           'checkRemotePublicKey parsing response from looking up $remotePublicKeyName';
-      if (AtSecondaryConfig.crossServerToVerbEnabled) {
-        // 'to:' returns {"publickey":..,"signing_publickey":..} where each
-        // value is a {key, data, metaData} map — the same shape as a
-        // lookup:all: response. A null publickey means the peer has not
-        // onboarded an encryption key yet — leave the cache untouched, exactly
-        // as the KeyNotFound branch above does for the legacy lookup path.
-        var envelope = jsonDecode(remoteResponse) as Map;
-        var publicKeyEntry = envelope['publickey'];
-        if (publicKeyEntry == null) {
-          return;
-        }
-        // Same fromJson as the legacy branch below, so the peer's metadata is
-        // preserved in the cache rather than replaced with a default.
-        atData = AtData().fromJson(publicKeyEntry);
-      } else {
-        atData = AtData().fromJson(jsonDecode(remoteResponse));
-      }
+      atData = AtData().fromJson(jsonDecode(remoteResponse));
 
       doing = 'checkRemotePublicKey updating $cachedPublicKeyName in cache';
       // Note: Potentially the put here may be doing a lot more than just the put.
@@ -186,11 +189,75 @@ class OutboundClient {
     }
   }
 
+  /// Attempts the `to:` exchange with the peer and, on success, caches the
+  /// peer's public key. Returns true when the envelope was authoritative —
+  /// including when it reports that the peer has no encryption public key
+  /// yet, in which case the cache is left untouched exactly as the
+  /// KeyNotFound branch of the legacy path does. Returns false when the
+  /// caller should fall back to the legacy lookup; in that case the
+  /// connection has been re-established if the peer closed it (atServers up
+  /// to v3.0.28 close the connection on an unknown verb rather than replying
+  /// with an error).
+  Future<bool> _checkRemotePublicKeyViaToVerb(
+      AtCacheManager cacheManager, String cachedPublicKeyName) async {
+    String remoteResponse;
+    try {
+      remoteResponse = await _sendToVerb();
+    } catch (e) {
+      logger.info('to:$toAtSign was not accepted by the peer ($e);'
+          ' falling back to the legacy lookup');
+      await _reconnectIfInvalid();
+      return false;
+    }
+    try {
+      if (remoteResponse.startsWith('data:')) {
+        remoteResponse = remoteResponse.replaceFirst(_dataPrefix, '');
+      }
+      // 'to:' returns {"publickey":..,"signing_publickey":..} where each
+      // value is a {key, data, metaData} map — the same shape as a
+      // lookup:all: response.
+      var envelope = jsonDecode(remoteResponse) as Map;
+      var publicKeyEntry = envelope['publickey'];
+      if (publicKeyEntry == null) {
+        // Authoritative: the peer understands to: but has not onboarded an
+        // encryption public key yet.
+        return true;
+      }
+      // Same fromJson as the legacy path, so the peer's metadata is preserved
+      // in the cache rather than replaced with a default.
+      // Note: Potentially the put here may be doing a lot more than just the put.
+      // See AtCacheManager.put for detailed explanation.
+      await cacheManager.put(
+          cachedPublicKeyName, AtData().fromJson(publicKeyEntry));
+      return true;
+    } catch (e, st) {
+      logger.severe('Caught $e processing to: envelope from $toAtSign');
+      logger.severe(st);
+      // The peer spoke to: but the envelope was unusable. The connection is
+      // still good, so fall back to the legacy lookup rather than giving up.
+      return false;
+    }
+  }
+
+  /// The legacy-lookup fallback needs a usable connection; a peer that
+  /// rejected `to:` may have closed the connection rather than replying with
+  /// an error. Throws if the connection cannot be re-established, which fails
+  /// [connect] — the correct outcome for an unreachable peer.
+  Future<void> _reconnectIfInvalid() async {
+    if (outboundConnection != null && !outboundConnection!.isInValid()) {
+      return;
+    }
+    logger.info('Outbound connection to $toAtSign is not usable after the to:'
+        ' attempt; reconnecting');
+    await outboundConnection?.close();
+    await _createConnectionAndListener();
+  }
+
   /// Sends the cross-server `to:@toAtSign` verb and returns the peer's raw
   /// response. This is the FIRST verb on the connection (sent from
   /// [checkRemotePublicKey], which [connect] calls before the handshake), so it
   /// declares the target tenant to the peer before any `from:`.
-  /// Mirrors [scan]'s raw write/read; only used when crossServerToVerbEnabled.
+  /// Mirrors [scan]'s raw write/read; only used when toVerbOutboundEnabled.
   Future<String> _sendToVerb() async {
     var toRequest = AtRequestFormatter.createToRequest(toAtSign);
     try {

--- a/packages/at_secondary_server/lib/src/connection/outbound/outbound_client.dart
+++ b/packages/at_secondary_server/lib/src/connection/outbound/outbound_client.dart
@@ -6,6 +6,7 @@ import 'package:at_lookup/at_lookup.dart' as at_lookup;
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:at_secondary/src/caching/cache_manager.dart';
 import 'package:at_secondary/src/connection/outbound/at_request_formatter.dart';
+import 'package:at_secondary/src/server/at_secondary_config.dart';
 import 'package:at_secondary/src/connection/outbound/outbound_connection.dart';
 import 'package:at_secondary/src/connection/outbound/outbound_connection_impl.dart';
 import 'package:at_secondary/src/connection/outbound/outbound_message_listener.dart';
@@ -132,8 +133,14 @@ class OutboundClient {
 
     String doing = 'checkRemotePublicKey looking up $remotePublicKeyName';
     try {
-      remoteResponse =
-          (await lookUp('all:$remotePublicKeyName', handshake: false))!;
+      // When cross-server 'to:' is enabled, fetch the peer's public key via the
+      // 'to:@target' verb — which is ALSO the first verb on the connection,
+      // declaring the target tenant to the peer. It returns
+      // both public keys in one round trip, so no separate lookup is needed.
+      // Otherwise fall back to the legacy unauthenticated lookup, byte for byte.
+      remoteResponse = AtSecondaryConfig.crossServerToVerbEnabled
+          ? await _sendToVerb()
+          : (await lookUp('all:$remotePublicKeyName', handshake: false))!;
     } on KeyNotFoundException {
       // Do nothing
       return;
@@ -150,7 +157,25 @@ class OutboundClient {
       }
       doing =
           'checkRemotePublicKey parsing response from looking up $remotePublicKeyName';
-      atData = AtData().fromJson(jsonDecode(remoteResponse));
+      if (AtSecondaryConfig.crossServerToVerbEnabled) {
+        // 'to:' returns {"publickey":..,"signing_publickey":..}. Use the
+        // encryption public key; a null publickey means the peer has not
+        // onboarded an encryption key yet — leave the cache untouched, exactly
+        // as the KeyNotFound branch above does for the legacy lookup path.
+        var envelope = jsonDecode(remoteResponse) as Map;
+        var publicKey = envelope['publickey'];
+        if (publicKey == null) {
+          return;
+        }
+        // A non-null metaData is required — the cache put dereferences it, and the
+        // legacy fromJson path always populates one. The 'to:' envelope carries only
+        // the key string, so attach a default (public key, no TTL).
+        atData = AtData()
+          ..data = publicKey as String
+          ..metaData = AtMetaData();
+      } else {
+        atData = AtData().fromJson(jsonDecode(remoteResponse));
+      }
 
       doing = 'checkRemotePublicKey updating $cachedPublicKeyName in cache';
       // Note: Potentially the put here may be doing a lot more than just the put.
@@ -161,6 +186,30 @@ class OutboundClient {
       logger.severe(st);
       return;
     }
+  }
+
+  /// Sends the cross-server `to:@toAtSign` verb and returns the peer's raw
+  /// response. This is the FIRST verb on the connection (sent from
+  /// [checkRemotePublicKey], which [connect] calls before the handshake), so it
+  /// declares the target tenant to the peer before any `from:`.
+  /// Mirrors [scan]'s raw write/read; only used when crossServerToVerbEnabled.
+  Future<String> _sendToVerb() async {
+    var toRequest = AtRequestFormatter.createToRequest(toAtSign);
+    try {
+      await outboundConnection!.write(toRequest);
+    } on AtIOException catch (e) {
+      await outboundConnection!.close();
+      throw LookupException(
+          'Exception writing to outbound socket ${e.toString()}');
+    } on ConnectionInvalidException catch (e) {
+      logger.severe('$this | encountered $e');
+      throw OutBoundConnectionInvalidException('Outbound connection invalid');
+    }
+    var result =
+        await messageListener.read(maxWaitMilliSeconds: lookupTimeoutMillis);
+    result = result.replaceFirst(_trailingPrompt, '');
+    lastUsed = DateTime.now();
+    return result;
   }
 
   Future<String> _findSecondary(toAtSign) async {

--- a/packages/at_secondary_server/lib/src/connection/outbound/outbound_message_listener.dart
+++ b/packages/at_secondary_server/lib/src/connection/outbound/outbound_message_listener.dart
@@ -114,6 +114,19 @@ class OutboundMessageListener {
               "Unexpected response '$result' from remote secondary ${outboundClient.toAtSign} at ${outboundClient.toHost}:${outboundClient.toPort}");
         }
       }
+      // Once the connection is closed no response can ever arrive —
+      // messageHandler drops data received on a closed connection — so
+      // don't wait out the timeout. This matters when a peer closes the
+      // connection instead of replying with an error upon receiving a verb
+      // it does not understand (atServers up to v3.0.28 do this).
+      if (outboundClient.outboundConnection == null ||
+          outboundClient.outboundConnection!.metaData.isClosed) {
+        _closeOutboundClient();
+        throw AtConnectException(
+            'Connection to remote secondary ${outboundClient.toAtSign}'
+            ' at ${outboundClient.toHost}:${outboundClient.toPort}'
+            ' was closed before a response was received');
+      }
       await Future.delayed(Duration(milliseconds: loopMillis));
     }
     // No response ... that's probably bad, so in addition to throwing an exception, let's also close the connection

--- a/packages/at_secondary_server/lib/src/server/at_secondary_config.dart
+++ b/packages/at_secondary_server/lib/src/server/at_secondary_config.dart
@@ -17,12 +17,14 @@ class AtSecondaryConfig {
   static const bool _useTLS = true;
   static const bool _clientCertificateRequired = true;
 
-  // Cross-server 'to:' verb. Default OFF for safe fleet rollout.
-  // When on: the server UNDERSTANDS inbound 'to:@x' (returning the peer's
-  // {publickey, signing_publickey} envelope) and, when opening a connection to
-  // another atServer, EMITS 'to:@target' as the first verb (which also fetches
-  // the peer's public key, so no separate lookup is needed).
-  static const bool _crossServerToVerbEnabled = false;
+  // Cross-server 'to:' verb. Inbound understanding of 'to:@x' is always on
+  // (unauthenticated, serves only data that is already publicly readable via
+  // lookup) — see ToVerbHandler. Outbound emission (send 'to:@target' as the
+  // first verb on outbound peer connections, which also fetches the peer's
+  // public key so no separate lookup is needed) is gated by this flag,
+  // default OFF until every atServer understands 'to:'. OutboundClient falls
+  // back to the legacy lookup when a peer rejects 'to:'.
+  static const bool _toVerbOutboundEnabled = false;
 
   //Certificate Paths
   static const String _fullchainLocation = 'certs/fullchain.pem';
@@ -183,19 +185,21 @@ class AtSecondaryConfig {
     }
   }
 
-  /// Gates the cross-server `to:` verb. Default
-  /// false (fleet-safe: `to:` is an unknown verb and outbound connections use
-  /// the legacy `lookup:`/bare-`from:` path). Override with env
-  /// `crossServerToVerbEnabled=true` or yaml `protocol.crossServerToVerbEnabled`.
-  static bool get crossServerToVerbEnabled {
-    var result = _getBoolEnvVar('crossServerToVerbEnabled');
+  /// Gates outbound emission of the cross-server `to:` verb as the first verb
+  /// on outbound peer connections. Default false (outbound connections use the
+  /// legacy `lookup:`/bare-`from:` path, byte for byte). When on, a peer that
+  /// rejects `to:` triggers a fallback to the legacy lookup, so enabling is
+  /// safe against atServers that do not understand the verb. Override with env
+  /// `toVerbOutboundEnabled=true` or yaml `protocol.toVerbOutboundEnabled`.
+  static bool get toVerbOutboundEnabled {
+    var result = _getBoolEnvVar('toVerbOutboundEnabled');
     if (result != null) {
       return result;
     }
     try {
-      return getConfigFromYaml(['protocol', 'crossServerToVerbEnabled']);
+      return getConfigFromYaml(['protocol', 'toVerbOutboundEnabled']);
     } on ElementNotFoundException {
-      return _crossServerToVerbEnabled;
+      return _toVerbOutboundEnabled;
     }
   }
 

--- a/packages/at_secondary_server/lib/src/server/at_secondary_config.dart
+++ b/packages/at_secondary_server/lib/src/server/at_secondary_config.dart
@@ -17,6 +17,13 @@ class AtSecondaryConfig {
   static const bool _useTLS = true;
   static const bool _clientCertificateRequired = true;
 
+  // Cross-server 'to:' verb. Default OFF for safe fleet rollout.
+  // When on: the server UNDERSTANDS inbound 'to:@x' (returning the peer's
+  // {publickey, signing_publickey} envelope) and, when opening a connection to
+  // another atServer, EMITS 'to:@target' as the first verb (which also fetches
+  // the peer's public key, so no separate lookup is needed).
+  static const bool _crossServerToVerbEnabled = false;
+
   //Certificate Paths
   static const String _fullchainLocation = 'certs/fullchain.pem';
   static const String _privkeyLocation = 'certs/privkey.pem';
@@ -173,6 +180,22 @@ class AtSecondaryConfig {
       return getConfigFromYaml(['security', 'clientCertificateRequired']);
     } on ElementNotFoundException {
       return _clientCertificateRequired;
+    }
+  }
+
+  /// Gates the cross-server `to:` verb. Default
+  /// false (fleet-safe: `to:` is an unknown verb and outbound connections use
+  /// the legacy `lookup:`/bare-`from:` path). Override with env
+  /// `crossServerToVerbEnabled=true` or yaml `protocol.crossServerToVerbEnabled`.
+  static bool get crossServerToVerbEnabled {
+    var result = _getBoolEnvVar('crossServerToVerbEnabled');
+    if (result != null) {
+      return result;
+    }
+    try {
+      return getConfigFromYaml(['protocol', 'crossServerToVerbEnabled']);
+    } on ElementNotFoundException {
+      return _crossServerToVerbEnabled;
     }
   }
 

--- a/packages/at_secondary_server/lib/src/verb/handler/to_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/to_verb_handler.dart
@@ -4,7 +4,9 @@ import 'dart:convert';
 import 'package:at_commons/at_commons.dart';
 import 'package:at_secondary/src/connection/inbound/inbound_connection_metadata.dart';
 import 'package:at_secondary/src/server/at_secondary_config.dart';
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:at_secondary/src/server/at_secondary_impl.dart';
+import 'package:at_secondary/src/utils/secondary_util.dart';
 import 'package:at_secondary/src/verb/handler/abstract_verb_handler.dart';
 import 'package:at_secondary/src/verb/to.dart';
 import 'package:at_server_spec/at_server_spec.dart';
@@ -16,7 +18,9 @@ import 'package:at_server_spec/at_server_spec.dart';
 /// unknown verb — behaviour is identical to today. When on, a peer atServer
 /// declares the target tenant with `to:@x` and receives that tenant's
 /// `{publickey, signing_publickey}` envelope in one round trip (saving the peer
-/// a separate `lookup:publickey@x`).
+/// a separate `lookup:publickey@x`). Each envelope value is in exactly the
+/// `{key, data, metaData}` shape of a `lookup:all:`/`llookup:all:` response,
+/// so the peer caches the value with its metadata preserved.
 ///
 /// Single-tenant Dart hosts exactly one atSign, so `@x` must equal this server's
 /// own atSign (a multi-tenant endpoint would instead resolve which of its
@@ -51,9 +55,9 @@ class ToVerbHandler extends AbstractVerbHandler {
     // The signing public key is generated at server startup so it is present;
     // the encryption public key may be absent until the atSign onboards one.
     var encPublicKey =
-        await _getOrNull('${AtConstants.atEncryptionPublicKey}$currentAtSign');
+        await _lookupAllOrNull('${AtConstants.atEncryptionPublicKey}$currentAtSign');
     var signingPublicKey =
-        await _getOrNull('${AtConstants.atSigningPublicKey}$currentAtSign');
+        await _lookupAllOrNull('${AtConstants.atSigningPublicKey}$currentAtSign');
 
     response.data = jsonEncode({
       'publickey': encPublicKey,
@@ -61,11 +65,18 @@ class ToVerbHandler extends AbstractVerbHandler {
     });
   }
 
-  Future<String?> _getOrNull(String key) async {
+  /// Fetches [key] and returns it in the `{key, data, metaData}` shape of a
+  /// `lookup:all:`/`llookup:all:` response, via the same
+  /// [SecondaryUtil.prepareResponseData] those handlers use — so the two
+  /// formats cannot drift apart. Returns null when the key does not exist.
+  Future<Map?> _lookupAllOrNull(String key) async {
+    AtData? atData;
     try {
-      return (await keyStore.get(key))?.data;
+      atData = await keyStore.get(key);
     } on KeyNotFoundException {
       return null;
     }
+    var json = SecondaryUtil.prepareResponseData('all', atData, key: key);
+    return json == null ? null : jsonDecode(json) as Map;
   }
 }

--- a/packages/at_secondary_server/lib/src/verb/handler/to_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/to_verb_handler.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 
 import 'package:at_commons/at_commons.dart';
 import 'package:at_secondary/src/connection/inbound/inbound_connection_metadata.dart';
-import 'package:at_secondary/src/server/at_secondary_config.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:at_secondary/src/server/at_secondary_impl.dart';
 import 'package:at_secondary/src/utils/secondary_util.dart';
@@ -13,9 +12,10 @@ import 'package:at_server_spec/at_server_spec.dart';
 
 /// Handler for the cross-server `to:@x` verb.
 ///
-/// Flag-gated: [accept] returns false when
-/// [AtSecondaryConfig.crossServerToVerbEnabled] is off, so `to:` is simply an
-/// unknown verb — behaviour is identical to today. When on, a peer atServer
+/// Always understood: understanding `to:` is safe (unauthenticated, serves
+/// only data that is already publicly readable via `lookup:`), and inbound
+/// support being unconditional is what lets outbound emission of `to:` be
+/// enabled later without a flag-flip ordering problem. A peer atServer
 /// declares the target tenant with `to:@x` and receives that tenant's
 /// `{publickey, signing_publickey}` envelope in one round trip (saving the peer
 /// a separate `lookup:publickey@x`). Each envelope value is in exactly the
@@ -31,15 +31,16 @@ class ToVerbHandler extends AbstractVerbHandler {
   ToVerbHandler(super.keyStore);
 
   @override
-  bool accept(String command) =>
-      AtSecondaryConfig.crossServerToVerbEnabled && command.startsWith('to:');
+  bool accept(String command) => command.startsWith('to:');
 
   @override
   Verb getVerb() => toVerb;
 
   @override
-  Future<void> processVerb(Response response,
-      HashMap<String, String?> verbParams, InboundConnection atConnection) async {
+  Future<void> processVerb(
+      Response response,
+      HashMap<String, String?> verbParams,
+      InboundConnection atConnection) async {
     var currentAtSign = AtSecondaryServerImpl.getInstance().currentAtSign;
     Atsign target = verbParams[AtConstants.atSign]!.toAtsign();
 
@@ -54,10 +55,10 @@ class ToVerbHandler extends AbstractVerbHandler {
 
     // The signing public key is generated at server startup so it is present;
     // the encryption public key may be absent until the atSign onboards one.
-    var encPublicKey =
-        await _lookupAllOrNull('${AtConstants.atEncryptionPublicKey}$currentAtSign');
-    var signingPublicKey =
-        await _lookupAllOrNull('${AtConstants.atSigningPublicKey}$currentAtSign');
+    var encPublicKey = await _lookupAllOrNull(
+        '${AtConstants.atEncryptionPublicKey}$currentAtSign');
+    var signingPublicKey = await _lookupAllOrNull(
+        '${AtConstants.atSigningPublicKey}$currentAtSign');
 
     response.data = jsonEncode({
       'publickey': encPublicKey,

--- a/packages/at_secondary_server/lib/src/verb/handler/to_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/to_verb_handler.dart
@@ -1,0 +1,71 @@
+import 'dart:collection';
+import 'dart:convert';
+
+import 'package:at_commons/at_commons.dart';
+import 'package:at_secondary/src/connection/inbound/inbound_connection_metadata.dart';
+import 'package:at_secondary/src/server/at_secondary_config.dart';
+import 'package:at_secondary/src/server/at_secondary_impl.dart';
+import 'package:at_secondary/src/verb/handler/abstract_verb_handler.dart';
+import 'package:at_secondary/src/verb/to.dart';
+import 'package:at_server_spec/at_server_spec.dart';
+
+/// Handler for the cross-server `to:@x` verb.
+///
+/// Flag-gated: [accept] returns false when
+/// [AtSecondaryConfig.crossServerToVerbEnabled] is off, so `to:` is simply an
+/// unknown verb — behaviour is identical to today. When on, a peer atServer
+/// declares the target tenant with `to:@x` and receives that tenant's
+/// `{publickey, signing_publickey}` envelope in one round trip (saving the peer
+/// a separate `lookup:publickey@x`).
+///
+/// Single-tenant Dart hosts exactly one atSign, so `@x` must equal this server's
+/// own atSign (a multi-tenant endpoint would instead resolve which of its
+/// tenants `@x` is).
+class ToVerbHandler extends AbstractVerbHandler {
+  static To toVerb = To();
+
+  ToVerbHandler(super.keyStore);
+
+  @override
+  bool accept(String command) =>
+      AtSecondaryConfig.crossServerToVerbEnabled && command.startsWith('to:');
+
+  @override
+  Verb getVerb() => toVerb;
+
+  @override
+  Future<void> processVerb(Response response,
+      HashMap<String, String?> verbParams, InboundConnection atConnection) async {
+    var currentAtSign = AtSecondaryServerImpl.getInstance().currentAtSign;
+    Atsign target = verbParams[AtConstants.atSign]!.toAtsign();
+
+    if (target != currentAtSign) {
+      throw SecondaryNotFoundException(
+          '$target is not hosted on this atServer');
+    }
+
+    // Record the tenant the peer is operating on — informational in the
+    // single-tenant model.
+    (atConnection.metaData as InboundConnectionMetadata).toAtSign = target;
+
+    // The signing public key is generated at server startup so it is present;
+    // the encryption public key may be absent until the atSign onboards one.
+    var encPublicKey =
+        await _getOrNull('${AtConstants.atEncryptionPublicKey}$currentAtSign');
+    var signingPublicKey =
+        await _getOrNull('${AtConstants.atSigningPublicKey}$currentAtSign');
+
+    response.data = jsonEncode({
+      'publickey': encPublicKey,
+      'signing_publickey': signingPublicKey,
+    });
+  }
+
+  Future<String?> _getOrNull(String key) async {
+    try {
+      return (await keyStore.get(key))?.data;
+    } on KeyNotFoundException {
+      return null;
+    }
+  }
+}

--- a/packages/at_secondary_server/lib/src/verb/manager/verb_handler_manager.dart
+++ b/packages/at_secondary_server/lib/src/verb/manager/verb_handler_manager.dart
@@ -84,9 +84,8 @@ class DefaultVerbHandlerManager implements VerbHandlerManager {
     _verbHandlers = [];
     _verbHandlers.add(
         FromVerbHandler(keyStore, commitLog: commitLog, accessLog: accessLog));
-    // Cross-server 'to:' verb. accept() is flag-gated, so when
-    // crossServerToVerbEnabled is off this handler never matches — 'to:' stays
-    // an unknown verb, exactly as before.
+    // Cross-server 'to:' verb. Inbound understanding is always on; the
+    // handler accepts any command starting with 'to:'.
     _verbHandlers.add(ToVerbHandler(keyStore));
     _verbHandlers.add(CramVerbHandler(keyStore, accessLog: accessLog));
     _verbHandlers.add(PkamVerbHandler(keyStore));

--- a/packages/at_secondary_server/lib/src/verb/manager/verb_handler_manager.dart
+++ b/packages/at_secondary_server/lib/src/verb/manager/verb_handler_manager.dart
@@ -11,6 +11,7 @@ import 'package:at_secondary/src/verb/handler/cram_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/delete_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/enroll_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/from_verb_handler.dart';
+import 'package:at_secondary/src/verb/handler/to_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/info_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/keys_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/local_lookup_verb_handler.dart';
@@ -83,6 +84,10 @@ class DefaultVerbHandlerManager implements VerbHandlerManager {
     _verbHandlers = [];
     _verbHandlers.add(
         FromVerbHandler(keyStore, commitLog: commitLog, accessLog: accessLog));
+    // Cross-server 'to:' verb. accept() is flag-gated, so when
+    // crossServerToVerbEnabled is off this handler never matches — 'to:' stays
+    // an unknown verb, exactly as before.
+    _verbHandlers.add(ToVerbHandler(keyStore));
     _verbHandlers.add(CramVerbHandler(keyStore, accessLog: accessLog));
     _verbHandlers.add(PkamVerbHandler(keyStore));
     _verbHandlers.add(UpdateVerbHandler(

--- a/packages/at_secondary_server/lib/src/verb/to.dart
+++ b/packages/at_secondary_server/lib/src/verb/to.dart
@@ -1,0 +1,32 @@
+import 'package:at_server_spec/at_verb_spec.dart';
+
+/// The `to:` verb — cross-server, UNAUTHENTICATED, allowed as the first verb.
+///
+/// A peer atServer sends `to:@x` as the first verb after opening the socket to
+/// declare which tenant it is operating against; the server replies with the
+/// `{publickey, signing_publickey}` envelope for `@x`. Declaring the target
+/// tenant up front gives architectural flexibility for atServer endpoints —
+/// e.g. atServers reached through proxies / gateways. Single-tenant Dart:
+/// `@x` must be this server's own atSign.
+///
+/// Defined locally (rather than in at_commons/at_server_spec) so the cross-server
+/// verb can land in a single repo behind a flag; the grammar can be promoted
+/// upstream later.
+///
+/// Syntax: `to:@<atSign>`
+class To extends Verb {
+  @override
+  String name() => 'to';
+
+  @override
+  String syntax() => r'^to:(?<atSign>@?[^\s:]+)$';
+
+  @override
+  Verb? dependsOn() => null;
+
+  @override
+  String usage() => 'syntax to:@<atSign> \n e.g to:@alice';
+
+  @override
+  bool requiresAuth() => false;
+}

--- a/packages/at_secondary_server/lib/src/verb/to.dart
+++ b/packages/at_secondary_server/lib/src/verb/to.dart
@@ -4,7 +4,9 @@ import 'package:at_server_spec/at_verb_spec.dart';
 ///
 /// A peer atServer sends `to:@x` as the first verb after opening the socket to
 /// declare which tenant it is operating against; the server replies with the
-/// `{publickey, signing_publickey}` envelope for `@x`. Declaring the target
+/// `{publickey, signing_publickey}` envelope for `@x`, each value in the
+/// `{key, data, metaData}` shape of a `lookup:all:` response so the caller
+/// gets the value's metadata, not just the data. Declaring the target
 /// tenant up front gives architectural flexibility for atServer endpoints —
 /// e.g. atServers reached through proxies / gateways. Single-tenant Dart:
 /// `@x` must be this server's own atSign.

--- a/packages/at_secondary_server/test/at_request_formatter_test.dart
+++ b/packages/at_secondary_server/test/at_request_formatter_test.dart
@@ -8,7 +8,8 @@ void main() {
     });
 
     test('createFromRequest is unchanged (bare from:, no to:)', () {
-      expect(AtRequestFormatter.createFromRequest('@alice🛠'), 'from:@alice🛠\n');
+      expect(
+          AtRequestFormatter.createFromRequest('@alice🛠'), 'from:@alice🛠\n');
     });
 
     test('createLookUpRequest is unchanged', () {

--- a/packages/at_secondary_server/test/at_request_formatter_test.dart
+++ b/packages/at_secondary_server/test/at_request_formatter_test.dart
@@ -1,0 +1,23 @@
+import 'package:at_secondary/src/connection/outbound/at_request_formatter.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('AtRequestFormatter', () {
+    test('createToRequest emits to:@target with a trailing newline', () {
+      expect(AtRequestFormatter.createToRequest('@bob🛠'), 'to:@bob🛠\n');
+    });
+
+    test('createFromRequest is unchanged (bare from:, no to:)', () {
+      expect(AtRequestFormatter.createFromRequest('@alice🛠'), 'from:@alice🛠\n');
+    });
+
+    test('createLookUpRequest is unchanged', () {
+      expect(AtRequestFormatter.createLookUpRequest('all:publickey@bob🛠'),
+          'lookup:all:publickey@bob🛠\n');
+    });
+
+    test('createPolRequest is unchanged', () {
+      expect(AtRequestFormatter.createPolRequest(), 'pol\n');
+    });
+  });
+}

--- a/packages/at_secondary_server/test/outbound_to_verb_fallback_test.dart
+++ b/packages/at_secondary_server/test/outbound_to_verb_fallback_test.dart
@@ -1,0 +1,188 @@
+import 'dart:convert';
+
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_secondary/src/conf/config_util.dart';
+import 'package:at_secondary/src/server/at_secondary_config.dart';
+import 'package:at_secondary/src/utils/secondary_util.dart';
+import 'package:test/test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:yaml/yaml.dart';
+
+import 'test_utils.dart';
+
+/// Exercises [OutboundClient.checkRemotePublicKey]'s cross-server `to:` path
+/// and its fallback to the legacy `lookup:all:publickey@peer` when a peer does
+/// not understand `to:`. Driven through the shared harness (a single mock
+/// outbound connection whose `write(...)` stubs feed `socketOnDataFn`).
+void main() {
+  final String toVerbRequest = 'to:$bob\n';
+  final String legacyLookupRequest = 'lookup:all:publickey$bob\n';
+
+  setUpAll(() async {
+    await verbTestsSetUpAll();
+  });
+
+  setUp(() async {
+    await verbTestsSetUp();
+  });
+
+  tearDown(() async {
+    // Restore the real yaml in case a test replaced it to flip the flag.
+    AtSecondaryConfig.configYamlMap = ConfigUtil.getYaml();
+    await verbTestsTearDown();
+  });
+
+  void enableOutboundToVerb() {
+    AtSecondaryConfig.configYamlMap = YamlMap.wrap({
+      'protocol': {'toVerbOutboundEnabled': true}
+    });
+  }
+
+  /// A `{key, data, metaData}` entry in the shape a `lookup:all:` /  `to:`
+  /// envelope carries, with a ttr:-1 public-key metadata like the real ones.
+  Map publicKeyEntry(String keyName, String data) {
+    DateTime now = DateTime.now().toUtcMillisecondsPrecision();
+    var atData = AtData()
+      ..data = data
+      ..metaData = (AtMetaData()
+        ..ttr = -1
+        ..createdAt = now
+        ..updatedAt = now);
+    return jsonDecode(
+        SecondaryUtil.prepareResponseData('all', atData, key: keyName)!);
+  }
+
+  group('to: outbound enabled', () {
+    setUp(enableOutboundToVerb);
+
+    test(
+        'to: success caches the peer public key WITH its metadata and does'
+        ' NOT fall back to the legacy lookup', () async {
+      var envelope = jsonEncode({
+        'publickey': publicKeyEntry('public:publickey$bob', 'BOB_ENC_KEY'),
+        'signing_publickey':
+            publicKeyEntry('public:signing_publickey$bob', 'BOB_SIGN_KEY'),
+      });
+      when(() => mockOutboundConnection.write(toVerbRequest))
+          .thenAnswer((_) async {
+        socketOnDataFn('data:$envelope\n$alice@'.codeUnits);
+      });
+
+      expect(
+          await cacheManager.get(cachedBobsPublicKeyName,
+              applyMetadataRules: true),
+          isNull);
+      await outboundClientWithoutHandshake.connect();
+
+      var cached = (await cacheManager.get(cachedBobsPublicKeyName,
+          applyMetadataRules: true))!;
+      expect(cached.data, 'BOB_ENC_KEY');
+      // The peer's metadata is carried through, not replaced by a bare
+      // default — critically ttr:-1, so the cached public key is retained
+      // rather than being subject to refresh. (An empty AtMetaData would
+      // leave ttr null.)
+      expect(cached.metaData!.ttr, -1);
+      verify(() => mockOutboundConnection.write(toVerbRequest)).called(1);
+      verifyNever(() => mockOutboundConnection.write(legacyLookupRequest));
+    });
+
+    test(
+        'a peer that rejects to: with an error falls back to the legacy'
+        ' lookup on the same connection', () async {
+      when(() => mockOutboundConnection.write(toVerbRequest))
+          .thenAnswer((_) async {
+        socketOnDataFn(
+            'error:AT0003-Exception: Received invalid verb that does not match'
+                    ' protocol spec\n$alice@'
+                .codeUnits);
+      });
+      when(() => mockOutboundConnection.write(legacyLookupRequest))
+          .thenAnswer((_) async {
+        socketOnDataFn('data:$bobOriginalPublicKeyAsJson\n$alice@'.codeUnits);
+      });
+
+      await outboundClientWithoutHandshake.connect();
+
+      var cached = (await cacheManager.get(cachedBobsPublicKeyName,
+          applyMetadataRules: true))!;
+      expect(cached.data, bobOriginalPublicKeyAtData.data);
+      verify(() => mockOutboundConnection.write(toVerbRequest)).called(1);
+      verify(() => mockOutboundConnection.write(legacyLookupRequest)).called(1);
+    });
+
+    test(
+        'a peer that CLOSES the connection on to: reconnects, then falls back'
+        ' to the legacy lookup', () async {
+      var factoryCalls = 0;
+      when(() => mockOutboundConnectionFactory.createOutboundConnection(
+          bobHost, bobPort, bob)).thenAnswer((_) async {
+        factoryCalls++;
+        // The reconnect hands back a fresh (reset) connection.
+        mockOutboundConnection.metaData.isClosed = false;
+        when(() => mockOutboundConnection.isInValid()).thenReturn(false);
+        return mockOutboundConnection;
+      });
+
+      // The peer closes rather than replying: mark the connection closed so
+      // read() bails out immediately instead of waiting out the timeout.
+      when(() => mockOutboundConnection.write(toVerbRequest))
+          .thenAnswer((_) async {
+        mockOutboundConnection.metaData.isClosed = true;
+        when(() => mockOutboundConnection.isInValid()).thenReturn(true);
+      });
+      when(() => mockOutboundConnection.write(legacyLookupRequest))
+          .thenAnswer((_) async {
+        socketOnDataFn('data:$bobOriginalPublicKeyAsJson\n$alice@'.codeUnits);
+      });
+
+      await outboundClientWithoutHandshake.connect();
+
+      // One connection for the to: attempt, a second after the reconnect.
+      expect(factoryCalls, 2);
+      var cached = (await cacheManager.get(cachedBobsPublicKeyName,
+          applyMetadataRules: true))!;
+      expect(cached.data, bobOriginalPublicKeyAtData.data);
+      verify(() => mockOutboundConnection.write(legacyLookupRequest)).called(1);
+    });
+
+    test(
+        'an envelope reporting a null publickey is authoritative: no fallback,'
+        ' cache untouched', () async {
+      var envelope = jsonEncode({
+        'publickey': null,
+        'signing_publickey':
+            publicKeyEntry('public:signing_publickey$bob', 'BOB_SIGN_KEY'),
+      });
+      when(() => mockOutboundConnection.write(toVerbRequest))
+          .thenAnswer((_) async {
+        socketOnDataFn('data:$envelope\n$alice@'.codeUnits);
+      });
+
+      await outboundClientWithoutHandshake.connect();
+
+      expect(
+          await cacheManager.get(cachedBobsPublicKeyName,
+              applyMetadataRules: true),
+          isNull);
+      verify(() => mockOutboundConnection.write(toVerbRequest)).called(1);
+      verifyNever(() => mockOutboundConnection.write(legacyLookupRequest));
+    });
+  });
+
+  group('to: outbound disabled (default)', () {
+    test('the legacy lookup is used and to: is never emitted', () async {
+      when(() => mockOutboundConnection.write(legacyLookupRequest))
+          .thenAnswer((_) async {
+        socketOnDataFn('data:$bobOriginalPublicKeyAsJson\n$alice@'.codeUnits);
+      });
+
+      await outboundClientWithoutHandshake.connect();
+
+      var cached = (await cacheManager.get(cachedBobsPublicKeyName,
+          applyMetadataRules: true))!;
+      expect(cached.data, bobOriginalPublicKeyAtData.data);
+      verify(() => mockOutboundConnection.write(legacyLookupRequest)).called(1);
+      verifyNever(() => mockOutboundConnection.write(toVerbRequest));
+    });
+  });
+}

--- a/packages/at_secondary_server/test/secondary_config_test.dart
+++ b/packages/at_secondary_server/test/secondary_config_test.dart
@@ -18,6 +18,11 @@ void main() async {
           equals(logging.Level.INFO.name.trim().toUpperCase()));
     });
 
+    test('Config: crossServerToVerbEnabled defaults to false (fleet-safe)',
+        () async {
+      expect(AtSecondaryConfig.crossServerToVerbEnabled, false);
+    });
+
     test(
         'Config: check new AtSignLoggers have level set correctly, via setting AtSignLogger.root_level from a string config setting',
         () async {

--- a/packages/at_secondary_server/test/secondary_config_test.dart
+++ b/packages/at_secondary_server/test/secondary_config_test.dart
@@ -18,9 +18,9 @@ void main() async {
           equals(logging.Level.INFO.name.trim().toUpperCase()));
     });
 
-    test('Config: crossServerToVerbEnabled defaults to false (fleet-safe)',
+    test('Config: toVerbOutboundEnabled defaults to false (fleet-safe)',
         () async {
-      expect(AtSecondaryConfig.crossServerToVerbEnabled, false);
+      expect(AtSecondaryConfig.toVerbOutboundEnabled, false);
     });
 
     test(

--- a/packages/at_secondary_server/test/to_verb_test.dart
+++ b/packages/at_secondary_server/test/to_verb_test.dart
@@ -58,21 +58,32 @@ void main() {
   });
 
   group('to verb processVerb tests', () {
+    // Stored AtData always carries metadata (createdAt/updatedAt are set by
+    // AtMetadataBuilder on every put); the envelope must preserve it.
+    AtData atDataWith(String data) => AtData()
+      ..data = data
+      ..metaData = (AtMetaData()
+        ..createdBy = alice
+        ..createdAt = DateTime.utc(2026, 1, 2, 3, 4, 5)
+        ..updatedAt = DateTime.utc(2026, 1, 2, 3, 4, 5)
+        ..ttl = 86400);
+
     void stubKeys({String? enc, String? sign}) {
       when(() => mockKeyStore.get(any())).thenAnswer((inv) async {
         final key = inv.positionalArguments[0] as String;
         if (key == 'public:publickey@alice') {
-          return enc == null ? null : (AtData()..data = enc);
+          return enc == null ? null : atDataWith(enc);
         }
         if (key == 'public:signing_publickey@alice') {
-          return sign == null ? null : (AtData()..data = sign);
+          return sign == null ? null : atDataWith(sign);
         }
         return null;
       });
     }
 
-    test('returns the {publickey, signing_publickey} envelope for our atSign',
-        () async {
+    test(
+        'returns the {publickey, signing_publickey} envelope, each value in'
+        ' lookup:all: {key, data, metaData} shape', () async {
       AtSecondaryServerImpl.getInstance().currentAtSign = alice;
       stubKeys(enc: 'ENC_PUBLIC_KEY', sign: 'SIGNING_PUBLIC_KEY');
 
@@ -82,9 +93,23 @@ void main() {
       await ToVerbHandler(mockKeyStore).processVerb(response, verbParams, conn);
 
       var envelope = jsonDecode(response.data!) as Map;
-      expect(envelope['publickey'], 'ENC_PUBLIC_KEY');
-      expect(envelope['signing_publickey'], 'SIGNING_PUBLIC_KEY');
+      var publicKey = envelope['publickey'] as Map;
+      expect(publicKey['key'], 'public:publickey@alice');
+      expect(publicKey['data'], 'ENC_PUBLIC_KEY');
+      expect(publicKey['metaData']['createdBy'], alice);
+      expect(publicKey['metaData']['ttl'], 86400);
+      var signingKey = envelope['signing_publickey'] as Map;
+      expect(signingKey['key'], 'public:signing_publickey@alice');
+      expect(signingKey['data'], 'SIGNING_PUBLIC_KEY');
+      expect(signingKey['metaData']['ttl'], 86400);
       expect((conn.metaData as InboundConnectionMetadata).toAtSign, alice);
+
+      // The value round-trips through AtData().fromJson — which is what
+      // OutboundClient does with it — preserving the peer's metadata.
+      var roundTripped = AtData().fromJson(publicKey);
+      expect(roundTripped.data, 'ENC_PUBLIC_KEY');
+      expect(roundTripped.metaData!.ttl, 86400);
+      expect(roundTripped.metaData!.createdBy, alice);
     });
 
     test('a null encryption public key surfaces as null in the envelope',
@@ -99,7 +124,7 @@ void main() {
 
       var envelope = jsonDecode(response.data!) as Map;
       expect(envelope['publickey'], isNull);
-      expect(envelope['signing_publickey'], 'SIGNING_PUBLIC_KEY');
+      expect(envelope['signing_publickey']['data'], 'SIGNING_PUBLIC_KEY');
     });
 
     test('a to: for another atSign is rejected (single-tenant)', () async {

--- a/packages/at_secondary_server/test/to_verb_test.dart
+++ b/packages/at_secondary_server/test/to_verb_test.dart
@@ -45,11 +45,10 @@ void main() {
   });
 
   group('to verb accept tests', () {
-    // accept() is gated on AtSecondaryConfig.crossServerToVerbEnabled which
-    // defaults to false, so 'to:' is not accepted unless the flag is turned on
-    // — a fleet-safe default.
-    test('to: is NOT accepted when the flag is off (default)', () {
-      expect(ToVerbHandler(mockKeyStore).accept('to:@alice'), false);
+    // Inbound understanding of to: is always on — it is unauthenticated and
+    // serves only data that is already publicly readable via lookup:.
+    test('to: is accepted', () {
+      expect(ToVerbHandler(mockKeyStore).accept('to:@alice'), true);
     });
 
     test('a non-to: command is never accepted', () {

--- a/packages/at_secondary_server/test/to_verb_test.dart
+++ b/packages/at_secondary_server/test/to_verb_test.dart
@@ -1,0 +1,115 @@
+import 'dart:convert';
+
+import 'package:at_commons/at_commons.dart';
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_secondary/src/connection/inbound/inbound_connection_impl.dart';
+import 'package:at_secondary/src/connection/inbound/inbound_connection_metadata.dart';
+import 'package:at_secondary/src/server/at_secondary_impl.dart';
+import 'package:at_secondary/src/utils/handler_util.dart';
+import 'package:at_secondary/src/verb/handler/to_verb_handler.dart';
+import 'package:at_secondary/src/verb/to.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+import 'test_utils.dart';
+
+void main() {
+  late MockAtKeyValueStore mockKeyStore;
+  late FakeSocket mockSocket;
+  const inBoundSessionId = '123';
+
+  verbTestsSetUpLogging();
+
+  setUp(() {
+    mockKeyStore = MockAtKeyValueStore();
+    mockSocket = FakeSocket();
+  });
+
+  group('to verb regex tests', () {
+    test('to: with @', () {
+      expect(getVerbParam(To().syntax(), 'to:@alice')['atSign'], '@alice');
+    });
+
+    test('to: without @', () {
+      expect(getVerbParam(To().syntax(), 'to:alice')['atSign'], 'alice');
+    });
+
+    test('to: with emoji', () {
+      expect(getVerbParam(To().syntax(), 'to:@🦄')['atSign'], '@🦄');
+    });
+
+    test('to: is an unauthenticated verb named "to"', () {
+      expect(To().requiresAuth(), false);
+      expect(To().name(), 'to');
+    });
+  });
+
+  group('to verb accept tests', () {
+    // accept() is gated on AtSecondaryConfig.crossServerToVerbEnabled which
+    // defaults to false, so 'to:' is not accepted unless the flag is turned on
+    // — a fleet-safe default.
+    test('to: is NOT accepted when the flag is off (default)', () {
+      expect(ToVerbHandler(mockKeyStore).accept('to:@alice'), false);
+    });
+
+    test('a non-to: command is never accepted', () {
+      expect(ToVerbHandler(mockKeyStore).accept('from:@alice'), false);
+    });
+  });
+
+  group('to verb processVerb tests', () {
+    void stubKeys({String? enc, String? sign}) {
+      when(() => mockKeyStore.get(any())).thenAnswer((inv) async {
+        final key = inv.positionalArguments[0] as String;
+        if (key == 'public:publickey@alice') {
+          return enc == null ? null : (AtData()..data = enc);
+        }
+        if (key == 'public:signing_publickey@alice') {
+          return sign == null ? null : (AtData()..data = sign);
+        }
+        return null;
+      });
+    }
+
+    test('returns the {publickey, signing_publickey} envelope for our atSign',
+        () async {
+      AtSecondaryServerImpl.getInstance().currentAtSign = alice;
+      stubKeys(enc: 'ENC_PUBLIC_KEY', sign: 'SIGNING_PUBLIC_KEY');
+
+      var verbParams = getVerbParam(To().syntax(), 'to:@alice');
+      var conn = InboundConnectionImpl(mockSocket, inBoundSessionId);
+      var response = Response();
+      await ToVerbHandler(mockKeyStore).processVerb(response, verbParams, conn);
+
+      var envelope = jsonDecode(response.data!) as Map;
+      expect(envelope['publickey'], 'ENC_PUBLIC_KEY');
+      expect(envelope['signing_publickey'], 'SIGNING_PUBLIC_KEY');
+      expect((conn.metaData as InboundConnectionMetadata).toAtSign, alice);
+    });
+
+    test('a null encryption public key surfaces as null in the envelope',
+        () async {
+      AtSecondaryServerImpl.getInstance().currentAtSign = alice;
+      stubKeys(enc: null, sign: 'SIGNING_PUBLIC_KEY');
+
+      var verbParams = getVerbParam(To().syntax(), 'to:@alice');
+      var conn = InboundConnectionImpl(mockSocket, inBoundSessionId);
+      var response = Response();
+      await ToVerbHandler(mockKeyStore).processVerb(response, verbParams, conn);
+
+      var envelope = jsonDecode(response.data!) as Map;
+      expect(envelope['publickey'], isNull);
+      expect(envelope['signing_publickey'], 'SIGNING_PUBLIC_KEY');
+    });
+
+    test('a to: for another atSign is rejected (single-tenant)', () async {
+      AtSecondaryServerImpl.getInstance().currentAtSign = alice;
+      var verbParams = getVerbParam(To().syntax(), 'to:@bob');
+      var conn = InboundConnectionImpl(mockSocket, inBoundSessionId);
+      var response = Response();
+      await expectLater(
+          ToVerbHandler(mockKeyStore).processVerb(response, verbParams, conn),
+          throwsA(isA<SecondaryNotFoundException>()));
+    });
+  });
+}

--- a/tests/at_functional_test/test/to_verb_test.dart
+++ b/tests/at_functional_test/test/to_verb_test.dart
@@ -1,0 +1,63 @@
+import 'dart:convert';
+
+import 'package:at_functional_test/conf/config_util.dart';
+import 'package:at_functional_test/connection/outbound_connection_wrapper.dart';
+import 'package:test/test.dart';
+
+void main() {
+  String firstAtSign =
+      ConfigUtil.getYaml()!['firstAtSignServer']['firstAtSignName'];
+  String firstAtSignHost =
+      ConfigUtil.getYaml()!['firstAtSignServer']['firstAtSignUrl'];
+  int firstAtSignPort =
+      ConfigUtil.getYaml()!['firstAtSignServer']['firstAtSignPort'];
+
+  group('A group of to verb tests', () {
+    // The 'to:' verb is always understood. It is unauthenticated and must be
+    // the first verb; each fresh connection is used for a single 'to:'
+    // exchange.
+    late OutboundConnectionFactory connection;
+
+    setUp(() async {
+      connection = OutboundConnectionFactory();
+      await connection.initiateConnectionWithListener(
+          firstAtSign, firstAtSignHost, firstAtSignPort);
+    });
+
+    tearDown(() async {
+      await connection.close();
+    });
+
+    test('to: for this server returns the {publickey, signing_publickey}'
+        ' envelope in lookup:all: shape', () async {
+      String response =
+          await connection.sendRequestToServer('to:$firstAtSign');
+      expect(response, startsWith('data:'));
+
+      var envelope =
+          jsonDecode(response.replaceFirst('data:', '').trim()) as Map;
+      expect(envelope.keys, containsAll(['publickey', 'signing_publickey']));
+
+      // The signing public key is generated at startup, so it is always
+      // present and carries the {key, data, metaData} shape of a lookup:all:
+      // response.
+      var signingPublicKey = envelope['signing_publickey'] as Map;
+      expect(signingPublicKey['key'], 'public:signing_publickey$firstAtSign');
+      expect(signingPublicKey['data'], isNotNull);
+      expect(signingPublicKey['metaData'], isA<Map>());
+
+      // The encryption public key exists for an onboarded atSign, likewise in
+      // {key, data, metaData} shape.
+      var publicKey = envelope['publickey'] as Map;
+      expect(publicKey['key'], 'public:publickey$firstAtSign');
+      expect(publicKey['data'], isNotNull);
+      expect(publicKey['metaData'], isA<Map>());
+    });
+
+    test('to: for another atSign is rejected (single-tenant)', () async {
+      String response =
+          await connection.sendRequestToServer('to:@some_other_atsign');
+      expect(response, startsWith('error:'));
+    });
+  });
+}


### PR DESCRIPTION
## What I did

Added a cross-server `to:` verb to give us architectural flexibility for atServer endpoints — in particular, for atServers to be able to communicate with other atServers through proxies / gateways. As the first verb on a connection, `to:@x` declares the target tenant; the server replies with a `{publickey, signing_publickey}` envelope for `@x`.

Inbound and outbound are decoupled so the verb can roll out across the fleet safely:

- **Inbound** understanding of `to:@x` is **always on**. It is unauthenticated and serves only data that is already publicly readable via `lookup:`, so there is no reason to gate it — and having every atServer understand `to:` *before* any atServer emits it is what makes a staged rollout coherent.
- **Outbound** emission of `to:@target` is gated behind `AtSecondaryConfig.toVerbOutboundEnabled` (default **false** → outbound connections are byte-for-byte unchanged). When on, a peer that does not understand `to:` triggers an automatic fallback to the legacy lookup, so enabling it early is safe against any atServer in the fleet.

## How I did it

**Inbound (always on):** a local `To` verb + `ToVerbHandler` (unauth, first-verb; single-tenant, so `@x` must be this server's own atSign). `connection_util.validate()` special-cases `to:` (absent from the published `AtVerb` enum) as an unauthenticated first-verb. `InboundConnectionMetadata` gains `toAtSign`. Each value in the envelope is in the `{key, data, metaData}` shape of a `lookup:all:` response — built via the same `SecondaryUtil.prepareResponseData('all', …)` the lookup handlers use — so the caller gets the value's metadata (notably `ttr:-1`), not just the key string.

**Outbound (flag-gated, with fallback):** when `toVerbOutboundEnabled` is on, `OutboundClient.checkRemotePublicKey()` sends `to:@target` first and reads the peer's public key straight from the envelope (one fewer round trip than the separate `lookup:all:publickey@target`). If the peer rejects `to:` with an error, or **closes the connection** (atServers up to v3.0.28 close on an unknown verb rather than replying), it falls back to the legacy lookup — reconnecting first when the peer closed. `OutboundMessageListener.read()` now returns as soon as the connection is closed instead of waiting out the timeout, so a peer that closes on `to:` costs milliseconds, not seconds. The legacy lookup path is preserved verbatim as both the flag-off branch and the fallback. `AtRequestFormatter.createToRequest` added.

Outbound flag off ⇒ zero behaviour change (outbound uses the legacy `lookup:`/bare-`from:` path). Inbound is purely additive: a flag-off/legacy sender still emits the unchanged `lookup:` first verb, which this server handles exactly as before.

## How to verify it

- **Unit:** `dart test --concurrency=1 test/to_verb_test.dart test/at_request_formatter_test.dart test/secondary_config_test.dart test/outbound_to_verb_fallback_test.dart` — covers the `to:` grammar/handler, the `lookup:all:`-shaped envelope, the config default, and the outbound fallback (to: success caches with the peer's metadata incl. `ttr:-1`; error → fallback; peer-close → reconnect → fallback; null-publickey authoritative; outbound-off uses the legacy lookup only). Full package unit suite green; `dart analyze` clean.
- **Functional:** `tests/at_functional_test/test/to_verb_test.dart` asserts inbound `to:` works end to end by default — the server answers `to:@<self>` with the envelope in `lookup:all:` shape and rejects `to:` for another atSign. Full functional suite green via `runLocal.sh`.
- Once outbound is ready to roll out to the fleet, a follow-up PR will enable `toVerbOutboundEnabled` and cover it in e2e / functional tests.
