### PR TITLE
feat(persistence): SQLite persistence backend + Hive↔SQLite migration + dual-mode validation

### DIFF
--- a/.github/workflows/functional_dual_verify.yaml
+++ b/.github/workflows/functional_dual_verify.yaml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - trunk
-      - gkc-sqlite-impl
   pull_request:
     branches:
       - trunk

--- a/.github/workflows/functional_dual_verify.yaml
+++ b/.github/workflows/functional_dual_verify.yaml
@@ -1,0 +1,136 @@
+name: functional_dual_verify
+# Runs the functional test pack against an atServer in dual persistence mode
+# (Hive primary, every write mirrored into SQLite), then verifies that each
+# atSign's Hive and SQLite DB sets are logically identical. This gates the
+# SQLite backend + dual-write mirror against a real end-to-end workload.
+on:
+  push:
+    branches:
+      - trunk
+      - gkc-sqlite-impl
+  pull_request:
+    branches:
+      - trunk
+
+permissions:
+  contents: read
+
+env:
+  root-working-directory: ./packages/at_root_server
+  psecondary-working-directory: ./packages/at_persistence_secondary_server
+  secondary-working-directory: ./packages/at_secondary_server
+  ftest-working-directory: ./tests/at_functional_test
+  install-pkam-working-directory: ./tools/build_virtual_environment/install_PKAM_Keys
+
+jobs:
+  functional_dual_verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
+        with:
+          sdk: stable
+
+      - name: Install dependencies (functional test)
+        working-directory: ${{ env.ftest-working-directory }}
+        run: dart pub get
+
+      # The compare tool (tool/dual_compare_ve.dart) needs the persistence
+      # package's deps resolved.
+      - name: Install dependencies (persistence)
+        working-directory: ${{ env.psecondary-working-directory }}
+        run: dart pub get
+
+      - name: Add entry to hosts file
+        run: echo "127.0.0.1    vip.ve.atsign.zone" | sudo tee -a /etc/hosts
+
+      - name: Generate atDirectory binary (root)
+        working-directory: ${{ env.root-working-directory }}
+        run: dart pub get && dart compile exe bin/main.dart -o root
+
+      - name: Generate atServer binary (secondary)
+        working-directory: ${{ env.secondary-working-directory }}
+        run: dart pub get && dart compile exe bin/main.dart -o secondary
+
+      - name: Copy root and secondary binaries to the virtualenv
+        run: |
+          mkdir -p tools/build_virtual_environment/ve/contents/atsign/root
+          cp packages/at_root_server/root tools/build_virtual_environment/ve/contents/atsign/root/
+          cp packages/at_root_server/pubspec.yaml tools/build_virtual_environment/ve/contents/atsign/root/
+          chmod 755 tools/build_virtual_environment/ve/contents/atsign/root/root
+          rm -rf tools/build_virtual_environment/ve/contents/atsign/secondary
+          mkdir -p tools/build_virtual_environment/ve/contents/atsign/secondary
+          cp packages/at_secondary_server/secondary tools/build_virtual_environment/ve/contents/atsign/secondary/
+          cp packages/at_secondary_server/pubspec.yaml tools/build_virtual_environment/ve/contents/atsign/secondary/
+          chmod 755 tools/build_virtual_environment/ve/contents/atsign/secondary/secondary
+
+      - name: Build virtualenv docker image (with libsqlite3)
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          file: tools/build_virtual_environment/ve/Dockerfile
+          context: tools/build_virtual_environment/ve
+          tags: at_virtual_env:dual
+
+      - name: Run docker container in DUAL persistence mode
+        run: |
+          docker run -d --rm --name at_virtual_env_dual_cont \
+            -e testingMode="true" -e httpsEnabled="true" -e persistenceBackend="dual" \
+            -p 6379:6379 -p 25000-25099:25000-25099 -p 64:64 -p 443:443 \
+            at_virtual_env:dual
+
+      - name: Check docker readiness to load PKAM keys
+        working-directory: ${{ env.ftest-working-directory }}
+        run: dart run test/check_docker_readiness.dart
+
+      - name: Check root server readiness to load PKAM keys
+        working-directory: ${{ env.ftest-working-directory }}
+        run: dart run test/check_root_server_readiness.dart
+
+      - name: Load PKAM Keys
+        working-directory: ${{ env.install-pkam-working-directory }}
+        run: |
+          dart pub get
+          dart bin/install_PKAM_Keys.dart
+
+      - name: Check test environment readiness
+        working-directory: ${{ env.ftest-working-directory }}
+        run: dart run test/check_test_env.dart
+
+      - name: Run functional pack (dual mode)
+        working-directory: ${{ env.ftest-working-directory }}
+        run: dart run test --concurrency=1
+
+      - name: Verify every atSign's Hive and SQLite DB sets are identical
+        run: |
+          CONT=at_virtual_env_dual_cont
+          OUT=$(mktemp -d)
+          fail=0
+          total=0
+          dbs=$(docker exec "$CONT" sh -c "find / -name atsign.db 2>/dev/null" | tr -d '\r')
+          if [ -z "$dbs" ]; then
+            echo "::error::dual mode produced no SQLite databases"
+            exit 1
+          fi
+          for db in $dbs; do
+            secdir=$(echo "$db" | sed 's|/storage/sqlite/.*||')
+            atSign=$(basename "$(dirname "$db")")
+            dest="$OUT/$(echo "$secdir" | md5sum | cut -c1-12)"
+            docker cp "$CONT:$secdir/." "$dest" >/dev/null
+            res=$(cd packages/at_persistence_secondary_server && \
+              dart run tool/dual_compare_ve.dart "$dest" "$atSign" 2>/dev/null \
+              | grep -vE '^(SHOUT|INFO|WARNING|FINE)')
+            echo "$res"
+            echo "$res" | grep -q '^IDENTICAL' || fail=1
+            total=$((total+1))
+            rm -rf "$dest"
+          done
+          echo "compared $total atSign(s)"
+          if [ "$fail" != "0" ]; then
+            echo "::error::Hive and SQLite DB sets diverged in dual mode"
+            exit 1
+          fi
+
+      - name: Stop container
+        if: always()
+        run: docker stop at_virtual_env_dual_cont || true

--- a/packages/at_persistence_secondary_server/CHANGELOG.md
+++ b/packages/at_persistence_secondary_server/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 5.1.0
+## 5.2.0
 
 - feat: dual-write persistence layer (`lib/dual.dart`) — serves reads from a
   primary backend while mirroring every write byte-exactly into a secondary
@@ -30,6 +30,9 @@
   entries and live unexpired-key entries are always compared, so real mirror
   data loss still fails. Makes the dual-write Hive-vs-SQLite DB-set comparison
   deterministic under a real functional workload, so it can gate CI.
+
+## 5.1.0
+
 - feat: new persistence field `AtMetaData.appMetadata` carrying the
   provider-owned `AppMetadata` from at_commons (opaque to the
   server). Stored by `AtMetaDataAdapter` as a JSON-encoded string

--- a/packages/at_persistence_secondary_server/CHANGELOG.md
+++ b/packages/at_persistence_secondary_server/CHANGELOG.md
@@ -1,5 +1,35 @@
 ## 5.1.0
 
+- feat: dual-write persistence layer (`lib/dual.dart`) — serves reads from a
+  primary backend while mirroring every write byte-exactly into a secondary
+  (via `restore`/`replay`, not operation-replay, so server-stamped timestamps
+  and commit ids stay identical). Run a real workload once, compare after.
+- feat: `bin/compare_persistence.dart` — compares two DB sets (backend +
+  storage root) for one atSign across all four stores and reports every
+  inconsistency; exit 0 identical / 1 differences / 2 error. Backed by
+  `PersistenceSnapshot.differencesFrom` (all differences, not just the first).
+- feat: SQLite persistence backend (`lib/sqlite.dart`) implementing the
+  same spec interfaces as Hive — `SqliteAtKeyValueStore` (with full-
+  fidelity `supportsSnapshots` / `supportsPathQueries` / true
+  transactions), `SqliteAtCommitLog` (dense/gapless `counters`-based
+  commit ids), `SqliteAtNotificationKeystore`, `SqliteAtAccessLog`,
+  `SqliteAtPersistenceFactory`. One `atsign.db` per atSign; the schema
+  is a stable per-atSign interchange contract.
+- feat: migrator-only verbatim primitives — `AtKeyValueStore.restore`
+  and `AtAccessLog.replay` (symmetric to `AtCommitLog.replay`) — plus
+  `PersistenceMigrator` (backend-agnostic Hive↔SQLite copy) and
+  `PersistenceSnapshot` (canonical bundle comparator). `AtPersistenceBackendId`
+  gains `sqlite`. Covered by a conversion-integrity gate:
+  hive→sqlite→hive→sqlite→hive→sqlite round-trips byte-identically.
+- fix: `PersistenceSnapshot` tolerates Hive's non-deterministic commit-log
+  orphans — a non-delete commit entry whose key is absent or expired is skipped.
+  After a TTL-expiry `skipCommit` sweep, Hive can leave a stale commit entry in
+  its box (its cache-based `getLatestCommitEntry` purge misses the box entry —
+  a cache/box inconsistency); a faithful SQLite mirror carries no such entry.
+  Such an entry is sync-benign, so it is excluded from both snapshots. DELETE
+  entries and live unexpired-key entries are always compared, so real mirror
+  data loss still fails. Makes the dual-write Hive-vs-SQLite DB-set comparison
+  deterministic under a real functional workload, so it can gate CI.
 - feat: new persistence field `AtMetaData.appMetadata` carrying the
   provider-owned `AppMetadata` from at_commons (opaque to the
   server). Stored by `AtMetaDataAdapter` as a JSON-encoded string

--- a/packages/at_persistence_secondary_server/bin/compare_persistence.dart
+++ b/packages/at_persistence_secondary_server/bin/compare_persistence.dart
@@ -1,0 +1,147 @@
+import 'dart:io';
+
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_persistence_secondary_server/hive.dart';
+import 'package:at_persistence_secondary_server/sqlite.dart';
+import 'package:path/path.dart' as p;
+
+/// Compares two persistence "DB sets" (backend + storage root) for one atSign
+/// and reports every inconsistency across all four stores (keystore, commit
+/// log, access log, notifications).
+///
+/// Exit codes:
+///   0  the two sets are byte-identical (under the canonical snapshot)
+///   1  differences were found (each printed)
+///   2  usage / runtime error
+///
+/// Usage:
+///   # hive vs sqlite under the same storage root (e.g. after a dual-write run):
+///   dart bin/compare_persistence.dart --atsign @alice --root storage
+///
+///   # two explicit sets:
+///   dart bin/compare_persistence.dart --atsign @alice \
+///     --a-backend hive   --a-root /data/before \
+///     --b-backend sqlite --b-root /data/after  [--max N]
+Future<void> main(List<String> args) async {
+  final opts = _parseArgs(args);
+  if (opts == null) {
+    _usage();
+    exit(2);
+  }
+
+  final aFactory = _factoryFor(opts.aBackend);
+  final bFactory = _factoryFor(opts.bBackend);
+  try {
+    final aBundle = await aFactory.initialize(
+        opts.atSign, _configFor(opts.aBackend, opts.aRoot));
+    final bBundle = await bFactory.initialize(
+        opts.atSign, _configFor(opts.bBackend, opts.bRoot));
+
+    final aSnap = await PersistenceSnapshot.capture(aBundle);
+    final bSnap = await PersistenceSnapshot.capture(bBundle);
+
+    stdout.writeln('A = ${opts.aBackend}@${opts.aRoot}  counts=${aSnap.counts}');
+    stdout.writeln('B = ${opts.bBackend}@${opts.bRoot}  counts=${bSnap.counts}');
+
+    final diffs = aSnap.differencesFrom(bSnap);
+    if (diffs.isEmpty) {
+      stdout.writeln('IDENTICAL — the two DB sets match for ${opts.atSign}.');
+      exit(0);
+    }
+
+    stdout.writeln('DIFFERENCES: ${diffs.length} found for ${opts.atSign}');
+    final shown = diffs.take(opts.max).toList();
+    for (final d in shown) {
+      stdout.writeln('  - $d');
+    }
+    if (diffs.length > shown.length) {
+      stdout.writeln('  ... and ${diffs.length - shown.length} more '
+          '(raise --max to see them all)');
+    }
+    exit(1);
+  } catch (e, st) {
+    stderr.writeln('ERROR: $e\n$st');
+    exit(2);
+  } finally {
+    await aFactory.close();
+    await bFactory.close();
+  }
+}
+
+AtPersistenceFactory _factoryFor(String backend) => backend == 'sqlite'
+    ? SqliteAtPersistenceFactory()
+    : HiveAtPersistenceFactory();
+
+AtPersistenceConfig _configFor(String backend, String root) =>
+    backend == 'sqlite'
+        ? SqlitePersistenceConfig.serverDefaults(
+            storagePath: p.join(root, 'sqlite'))
+        : HivePersistenceConfig.serverDefaults(
+            storagePath: p.join(root, 'hive'),
+            commitLogPath: p.join(root, 'commitLog'),
+            accessLogPath: p.join(root, 'accessLog'),
+            notificationStoragePath: p.join(root, 'notificationLog.v1'),
+          );
+
+class _Opts {
+  final String atSign;
+  final String aBackend, aRoot, bBackend, bRoot;
+  final int max;
+  _Opts(this.atSign, this.aBackend, this.aRoot, this.bBackend, this.bRoot,
+      this.max);
+}
+
+_Opts? _parseArgs(List<String> args) {
+  String? atSign, root, aBackend, aRoot, bBackend, bRoot;
+  var max = 100;
+  String? next(int i) => i < args.length ? args[i] : null;
+  for (var i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case '--atsign':
+        atSign = next(++i);
+      case '--root':
+        root = next(++i);
+      case '--a-backend':
+        aBackend = next(++i);
+      case '--a-root':
+        aRoot = next(++i);
+      case '--b-backend':
+        bBackend = next(++i);
+      case '--b-root':
+        bRoot = next(++i);
+      case '--max':
+        max = int.tryParse(next(++i) ?? '') ?? max;
+      case '-h':
+      case '--help':
+        return null;
+    }
+  }
+  if (atSign == null) return null;
+  // Convenience mode: --root compares hive vs sqlite under one root.
+  if (root != null) {
+    aBackend ??= 'hive';
+    aRoot ??= root;
+    bBackend ??= 'sqlite';
+    bRoot ??= root;
+  }
+  if (aBackend == null || aRoot == null || bBackend == null || bRoot == null) {
+    return null;
+  }
+  if (!_valid(aBackend) || !_valid(bBackend)) return null;
+  return _Opts(atSign, aBackend, aRoot, bBackend, bRoot, max);
+}
+
+bool _valid(String b) => b == 'hive' || b == 'sqlite';
+
+void _usage() {
+  stderr.writeln('''
+Compare two persistence DB sets for one atSign.
+
+Usage:
+  compare_persistence.dart --atsign @alice --root <dir>
+  compare_persistence.dart --atsign @alice \\
+    --a-backend hive --a-root <dir> --b-backend sqlite --b-root <dir> [--max N]
+
+Backends: hive | sqlite
+Exit: 0 identical, 1 differences, 2 error''');
+}

--- a/packages/at_persistence_secondary_server/lib/at_persistence_secondary_server.dart
+++ b/packages/at_persistence_secondary_server/lib/at_persistence_secondary_server.dart
@@ -2,3 +2,5 @@ export 'package:at_persistence_secondary_server/src/spec/at_persistence_config.d
 export 'package:at_persistence_secondary_server/src/spec/at_persistence_factory.dart';
 export 'package:at_persistence_secondary_server/src/utils/date_time_extensions.dart';
 export 'package:at_persistence_secondary_server/src/spec/spec.dart';
+export 'package:at_persistence_secondary_server/src/migration/persistence_migrator.dart';
+export 'package:at_persistence_secondary_server/src/migration/persistence_snapshot.dart';

--- a/packages/at_persistence_secondary_server/lib/dual.dart
+++ b/packages/at_persistence_secondary_server/lib/dual.dart
@@ -1,0 +1,7 @@
+/// A dual-write persistence layer: serve reads from a primary backend while
+/// mirroring every write byte-exactly into a secondary backend. Run a real
+/// workload once (e.g. the functional pack) and compare the two resulting DB
+/// sets for logical identity afterwards.
+library;
+
+export 'package:at_persistence_secondary_server/src/dual/dual_write_persistence.dart';

--- a/packages/at_persistence_secondary_server/lib/sqlite.dart
+++ b/packages/at_persistence_secondary_server/lib/sqlite.dart
@@ -1,0 +1,17 @@
+/// The SQLite persistence backend for at_server. Depends only on the
+/// abstract spec surface exported by
+/// `package:at_persistence_secondary_server/at_persistence_secondary_server.dart`.
+///
+/// One database per atSign (`<storagePath>/<atSign>/atsign.db`); the
+/// per-atSign schema is a stable interchange contract. See [SqliteSchema]
+/// for the canonical DDL.
+library;
+
+export 'package:at_persistence_secondary_server/src/impl/sqlite/sqlite_persistence_config.dart';
+export 'package:at_persistence_secondary_server/src/impl/sqlite/sqlite_at_persistence_factory.dart';
+export 'package:at_persistence_secondary_server/src/impl/sqlite/sqlite_at_keyvalue_store.dart';
+export 'package:at_persistence_secondary_server/src/impl/sqlite/sqlite_at_commit_log.dart';
+export 'package:at_persistence_secondary_server/src/impl/sqlite/sqlite_at_access_log.dart';
+export 'package:at_persistence_secondary_server/src/impl/sqlite/sqlite_at_notification_keystore.dart';
+export 'package:at_persistence_secondary_server/src/impl/sqlite/sqlite_database.dart';
+export 'package:at_persistence_secondary_server/src/impl/sqlite/sqlite_schema.dart';

--- a/packages/at_persistence_secondary_server/lib/src/dual/dual_write_persistence.dart
+++ b/packages/at_persistence_secondary_server/lib/src/dual/dual_write_persistence.dart
@@ -1,0 +1,503 @@
+import 'dart:async';
+
+import 'package:at_commons/at_commons.dart';
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+
+/// A persistence layer that serves all reads from a **primary** backend while
+/// mirroring every write into a **secondary** backend, so a real workload
+/// (e.g. the functional pack) can be run once and the two resulting DB sets
+/// compared for logical identity afterwards.
+///
+/// The mirror is byte-exact, not operation-replayed: each write is applied to
+/// the primary, then the primary's resulting per-key state (data + metadata
+/// with its server-stamped createdAt/updatedAt, and its commit entry with its
+/// commit id) is copied verbatim into the secondary via `restore` / `replay`.
+/// Replaying the *operation* on the secondary instead would let each backend
+/// stamp its own timestamps and diverge.
+///
+/// Reads, capability flags, snapshots, and change events all come from the
+/// primary, so the server behaves exactly as if it were running on the
+/// primary backend alone.
+
+class DualWritePersistenceConfig implements AtPersistenceConfig {
+  final AtPersistenceConfig primary;
+  final AtPersistenceConfig secondary;
+
+  DualWritePersistenceConfig({required this.primary, required this.secondary});
+
+  @override
+  AtPersistenceBackendId get backend => primary.backend;
+  @override
+  String get storagePath => primary.storagePath;
+  @override
+  String get commitLogPath => primary.commitLogPath;
+  @override
+  String get accessLogPath => primary.accessLogPath;
+  @override
+  String get notificationStoragePath => primary.notificationStoragePath;
+  @override
+  String get backendMarkerPath => primary.backendMarkerPath;
+  @override
+  bool get enableAccessLog => primary.enableAccessLog;
+  @override
+  bool get enableNotificationKeystore => primary.enableNotificationKeystore;
+  @override
+  bool get enableCommitLog => primary.enableCommitLog;
+}
+
+class DualWriteAtPersistenceFactory implements AtPersistenceFactory {
+  final AtPersistenceFactory primaryFactory;
+  final AtPersistenceFactory secondaryFactory;
+
+  final Map<String, DualWriteBundle> _bundles = {};
+
+  DualWriteAtPersistenceFactory(this.primaryFactory, this.secondaryFactory);
+
+  @override
+  AtPersistenceBackendId get backendId => primaryFactory.backendId;
+
+  @override
+  Future<AtPersistenceBundle> initialize(
+      String atSign, AtPersistenceConfig config) async {
+    if (config is! DualWritePersistenceConfig) {
+      throw ArgumentError('DualWriteAtPersistenceFactory expects '
+          'DualWritePersistenceConfig, got ${config.runtimeType}');
+    }
+    final existing = _bundles[atSign];
+    if (existing != null && !existing.isClosed) return existing;
+
+    final primary = await primaryFactory.initialize(atSign, config.primary);
+    final secondary =
+        await secondaryFactory.initialize(atSign, config.secondary);
+    final bundle = DualWriteBundle._(atSign, primary, secondary);
+    _bundles[atSign] = bundle;
+    return bundle;
+  }
+
+  @override
+  AtPersistenceBundle? bundleFor(String atSign) {
+    final b = _bundles[atSign];
+    return (b == null || b.isClosed) ? null : b;
+  }
+
+  @override
+  Future<void> closeFor(String atSign) async {
+    await _bundles.remove(atSign)?.close();
+  }
+
+  @override
+  Future<void> close() async {
+    for (final b in _bundles.values.toList()) {
+      await b.close();
+    }
+    _bundles.clear();
+    await primaryFactory.close();
+    await secondaryFactory.close();
+  }
+}
+
+class DualWriteBundle implements AtPersistenceBundle {
+  @override
+  final String atSign;
+
+  final AtPersistenceBundle primary;
+  final AtPersistenceBundle secondary;
+
+  @override
+  late final AtKeyValueStore<String, AtData, AtMetaData?> keyValueStore;
+  @override
+  late final AtAccessLog? accessLog;
+  @override
+  late final AtNotificationKeystore? notificationKeystore;
+
+  bool _closed = false;
+
+  DualWriteBundle._(this.atSign, this.primary, this.secondary) {
+    keyValueStore =
+        _DualWriteKeyStore(primary.keyValueStore, secondary.keyValueStore);
+    accessLog = (primary.accessLog != null && secondary.accessLog != null)
+        ? _DualWriteAccessLog(primary.accessLog!, secondary.accessLog!)
+        : primary.accessLog;
+    notificationKeystore = (primary.notificationKeystore != null &&
+            secondary.notificationKeystore != null)
+        ? _DualWriteNotificationKeystore(
+            primary.notificationKeystore!, secondary.notificationKeystore!)
+        : primary.notificationKeystore;
+  }
+
+  @override
+  AtPersistenceBackendId get backendId => primary.backendId;
+
+  @override
+  bool get isClosed => _closed;
+
+  @override
+  Future<void> clear() async {
+    await primary.clear();
+    await secondary.clear();
+  }
+
+  @override
+  Future<void> close() async {
+    if (_closed) return;
+    _closed = true;
+    await primary.close();
+    await secondary.close();
+  }
+}
+
+/// Keystore wrapper: writes to primary, then mirrors the affected key's exact
+/// resulting state into secondary. Reads/capabilities delegate to primary.
+class _DualWriteKeyStore implements AtKeyValueStore<String, AtData, AtMetaData?> {
+  final AtKeyValueStore<String, AtData, AtMetaData?> _primary;
+  final AtKeyValueStore<String, AtData, AtMetaData?> _secondary;
+
+  _DualWriteKeyStore(this._primary, this._secondary);
+
+  Future<AtData?> _tryGet(
+      AtKeyValueStore<String, AtData, AtMetaData?> ks, String key) async {
+    try {
+      return await ks.get(key);
+    } on KeyNotFoundException {
+      return null;
+    }
+  }
+
+  /// Makes secondary's state for [key] identical to primary's: same row
+  /// (data + metadata) and same commit entry (id, op, opTime), or same
+  /// absence.
+  Future<void> _mirror(String key) async {
+    final data = await _tryGet(_primary, key);
+    if (data != null) {
+      await _secondary.restore(key, data);
+    } else {
+      // Absent in primary → delete the row and purge any commit entry.
+      await _secondary.remove(key, skipCommit: true);
+    }
+    final entry = _primary.commitLog?.getLatestCommitEntry(key);
+    if (entry != null) {
+      await _secondary.commitLog?.replay(entry);
+    }
+  }
+
+  @override
+  Future<int?> put(String key, AtData value, {bool skipCommit = false}) async {
+    final id = await _primary.put(key, value, skipCommit: skipCommit);
+    await _mirror(key);
+    return id;
+  }
+
+  @override
+  Future<int?> create(String key, AtData value,
+      {bool skipCommit = false}) async {
+    final id = await _primary.create(key, value, skipCommit: skipCommit);
+    await _mirror(key);
+    return id;
+  }
+
+  @override
+  Future<int?> putAll(String key, AtData value, AtMetaData? metadata) async {
+    final id = await _primary.putAll(key, value, metadata);
+    await _mirror(key);
+    return id;
+  }
+
+  @override
+  Future<int?> putMeta(String key, AtMetaData? metadata) async {
+    final id = await _primary.putMeta(key, metadata);
+    await _mirror(key);
+    return id;
+  }
+
+  @override
+  Future<void> restore(String key, AtData value) async {
+    await _primary.restore(key, value);
+    await _mirror(key);
+  }
+
+  @override
+  Future<int?> remove(String key, {bool skipCommit = false}) async {
+    final id = await _primary.remove(key, skipCommit: skipCommit);
+    await _mirror(key);
+    return id;
+  }
+
+  @override
+  Future<int> removeMany(List<String> keys, {bool skipCommit = false}) async {
+    final n = await _primary.removeMany(keys, skipCommit: skipCommit);
+    for (final k in keys) {
+      await _mirror(k);
+    }
+    return n;
+  }
+
+  @override
+  Future<bool> deleteExpiredKeys() async {
+    final expired = await (await _primary.getExpiredKeys()).toList();
+    final result = await _primary.deleteExpiredKeys();
+    for (final k in expired) {
+      await _mirror(k);
+    }
+    return result;
+  }
+
+  // ---- reads / capabilities: primary ----
+  @override
+  Future<void> initialize() => _primary.initialize();
+  @override
+  AtCommitLog? get commitLog => _primary.commitLog;
+  @override
+  set commitLog(AtCommitLog? log) => _primary.commitLog = log;
+  @override
+  Future<AtData?> get(String key) => _primary.get(key);
+  @override
+  Future<AtMetaData?> getMeta(String key) => _primary.getMeta(key);
+  @override
+  Future<Map<String, AtData>> getMany(List<String> keys) =>
+      _primary.getMany(keys);
+  @override
+  Future<bool> exists(String key) => _primary.exists(key);
+  @override
+  Future<Stream<String>> getKeys({String? regex}) =>
+      _primary.getKeys(regex: regex);
+  @override
+  Future<Stream<String>> getExpiredKeys() => _primary.getExpiredKeys();
+  @override
+  Future<DateTime?> nextExpiresAt() => _primary.nextExpiresAt();
+  @override
+  Future<Stream<String>> peekExpired({DateTime? asOf, int? limit}) =>
+      _primary.peekExpired(asOf: asOf, limit: limit);
+  @override
+  Future<DateTime?> nextAvailableAt({DateTime? asOf}) =>
+      _primary.nextAvailableAt(asOf: asOf);
+  @override
+  Future<Stream<String>> peekNewlyAvailable(
+          {required DateTime since, DateTime? asOf, int? limit}) =>
+      _primary.peekNewlyAvailable(since: since, asOf: asOf, limit: limit);
+  @override
+  Future<Stream<String>> scanKeys(KeyPattern pattern,
+          {bool includeExpired = false,
+          OrderByKey? orderBy,
+          int? limit,
+          int? skip}) =>
+      _primary.scanKeys(pattern,
+          includeExpired: includeExpired,
+          orderBy: orderBy,
+          limit: limit,
+          skip: skip);
+  @override
+  List<Future<void> Function(String key, {required bool skipCommit})>
+      get preRemoveHooks => _primary.preRemoveHooks;
+  @override
+  List<Future<void> Function(String key, {required bool skipCommit})>
+      get postRemoveHooks => _primary.postRemoveHooks;
+  @override
+  Stream<KeyStoreChange> get changes => _primary.changes;
+  @override
+  bool get supportsSnapshots => _primary.supportsSnapshots;
+  @override
+  Future<AtKeyValueStoreSnapshot<String, AtData, AtMetaData?>> snapshot() =>
+      _primary.snapshot();
+  @override
+  bool get supportsPathQueries => _primary.supportsPathQueries;
+  @override
+  Stream<KeyEntry<String, AtData, AtMetaData?>> queryByPath(
+          {required KeyPattern keyPattern,
+          required Predicate predicate,
+          OrderByKey? orderBy,
+          int? limit,
+          int? skip}) =>
+      _primary.queryByPath(
+          keyPattern: keyPattern,
+          predicate: predicate,
+          orderBy: orderBy,
+          limit: limit,
+          skip: skip);
+  @override
+  Future<KeyStoreStats> stats() => _primary.stats();
+  @override
+  Stream<Object> compact(bool dryRun) => _primary.compact(dryRun);
+
+  @override
+  Future<R> transaction<R>(
+      Future<R> Function(KeyStoreTxn<String, AtData, dynamic> txn) body) {
+    // Server verb handlers do not use keystore transactions; delegating to
+    // primary (unmirrored) keeps the contract without a bespoke handle.
+    return _primary.transaction(body);
+  }
+}
+
+/// Notification wrapper: notifications carry no server-stamped write-time
+/// fields, so a straight tee keeps the two stores identical.
+class _DualWriteNotificationKeystore implements AtNotificationKeystore {
+  final AtNotificationKeystore _primary;
+  final AtNotificationKeystore _secondary;
+
+  _DualWriteNotificationKeystore(this._primary, this._secondary);
+
+  @override
+  Future<int?> put(String key, AtNotification value,
+      {bool skipCommit = false}) async {
+    final id = await _primary.put(key, value, skipCommit: skipCommit);
+    await _secondary.put(key, value, skipCommit: skipCommit);
+    return id;
+  }
+
+  @override
+  Future<int?> create(String key, AtNotification value,
+          {bool skipCommit = false}) =>
+      put(key, value, skipCommit: skipCommit);
+
+  @override
+  Future<int?> remove(String key, {bool skipCommit = false}) async {
+    final id = await _primary.remove(key, skipCommit: skipCommit);
+    await _secondary.remove(key, skipCommit: skipCommit);
+    return id;
+  }
+
+  @override
+  Future<int> removeMany(List<String> keys, {bool skipCommit = false}) async {
+    final n = await _primary.removeMany(keys, skipCommit: skipCommit);
+    await _secondary.removeMany(keys, skipCommit: skipCommit);
+    return n;
+  }
+
+  @override
+  Future<bool> deleteExpiredKeys() async {
+    final expired = await (await _primary.getExpiredKeys()).toList();
+    final result = await _primary.deleteExpiredKeys();
+    if (expired.isNotEmpty) await _secondary.removeMany(expired, skipCommit: true);
+    return result;
+  }
+
+  @override
+  Future<void> init(String path) async {
+    await _primary.init(path);
+    await _secondary.init(path);
+  }
+
+  @override
+  Future<void> initialize() => _primary.initialize();
+  @override
+  Future<AtNotification?> get(String key) => _primary.get(key);
+  @override
+  Future<Map<String, AtNotification>> getMany(List<String> keys) =>
+      _primary.getMany(keys);
+  @override
+  Future<bool> exists(String key) => _primary.exists(key);
+  @override
+  Future<Stream<String>> getKeys({String? regex}) =>
+      _primary.getKeys(regex: regex);
+  @override
+  Future<Stream<String>> getExpiredKeys() => _primary.getExpiredKeys();
+  @override
+  Future<DateTime?> nextExpiresAt() => _primary.nextExpiresAt();
+  @override
+  Future<Stream<String>> peekExpired({DateTime? asOf, int? limit}) =>
+      _primary.peekExpired(asOf: asOf, limit: limit);
+  @override
+  List<Future<void> Function(String key, {required bool skipCommit})>
+      get preRemoveHooks => _primary.preRemoveHooks;
+  @override
+  List<Future<void> Function(String key, {required bool skipCommit})>
+      get postRemoveHooks => _primary.postRemoveHooks;
+  @override
+  Stream<KeyStoreChange> get changes => _primary.changes;
+  @override
+  bool get supportsSnapshots => _primary.supportsSnapshots;
+  @override
+  Future<KeyStoreSnapshot<String, AtNotification, dynamic>> snapshot() =>
+      _primary.snapshot();
+  @override
+  Future<KeyStoreStats> stats() => _primary.stats();
+  @override
+  Future<R> transaction<R>(
+          Future<R> Function(KeyStoreTxn<String, AtNotification, dynamic> txn)
+              body) =>
+      _primary.transaction(body);
+  @override
+  Stream<AtNotification> iterate() => _primary.iterate();
+  @override
+  int entriesCount() => _primary.entriesCount();
+  @override
+  int getSize() => _primary.getSize();
+  @override
+  Future<void> close() async {
+    await _primary.close();
+    await _secondary.close();
+  }
+
+  @override
+  Stream<String> compact(bool dryRun) async* {
+    final removed = <String>[];
+    await for (final id in _primary.compact(dryRun)) {
+      removed.add(id);
+      yield id;
+    }
+    if (!dryRun && removed.isNotEmpty) {
+      await _secondary.removeMany(removed, skipCommit: true);
+    }
+  }
+}
+
+/// Access-log wrapper: `insert` stamps `now` per backend, so mirror the exact
+/// entry the primary just wrote via `replay`.
+class _DualWriteAccessLog implements AtAccessLog {
+  final AtAccessLog _primary;
+  final AtAccessLog _secondary;
+
+  _DualWriteAccessLog(this._primary, this._secondary);
+
+  @override
+  Future<int?> insert(String fromAtSign, String verbName,
+      {String? lookupKey}) async {
+    // Build the entry once and replay the SAME entry to both logs. Using
+    // primary.insert + getLastAccessLogEntry would race: a concurrent insert
+    // could advance "last" between the two calls, mirroring the wrong entry.
+    final entry = AccessLogEntry(
+        fromAtSign, DateTime.now().toUtc(), verbName, lookupKey);
+    await _primary.replay(entry);
+    await _secondary.replay(entry);
+    return null;
+  }
+
+  @override
+  Future<void> replay(AccessLogEntry entry) async {
+    await _primary.replay(entry);
+    await _secondary.replay(entry);
+  }
+
+  @override
+  Future<Map<String, int>> mostVisitedAtSigns(int length) =>
+      _primary.mostVisitedAtSigns(length);
+  @override
+  Future<Map<String, int>> mostVisitedKeys(int length) =>
+      _primary.mostVisitedKeys(length);
+  @override
+  Future<AccessLogEntry> getLastAccessLogEntry() =>
+      _primary.getLastAccessLogEntry();
+  @override
+  Future<AccessLogEntry?> getLastPkamAccessLogEntry() =>
+      _primary.getLastPkamAccessLogEntry();
+  @override
+  Stream<AccessLogEntry> iterate() => _primary.iterate();
+  @override
+  int entriesCount() => _primary.entriesCount();
+  @override
+  int getSize() => _primary.getSize();
+  @override
+  Future<void> close() async {
+    await _primary.close();
+    await _secondary.close();
+  }
+
+  @override
+  Stream<int> compact(bool dryRun) async* {
+    // Both logs hold the same content in the same order and use the same
+    // percentage, so compacting each independently drops the same entries.
+    yield* _primary.compact(dryRun);
+    if (!dryRun) {
+      await _secondary.compact(false).drain<void>();
+    }
+  }
+}

--- a/packages/at_persistence_secondary_server/lib/src/impl/hive/hive_at_access_log.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/hive/hive_at_access_log.dart
@@ -70,6 +70,21 @@ class HiveAtAccessLog implements AtAccessLog {
     return await _accessLogKeyStore.getLastPkamEntry();
   }
 
+  /// Appends [entry] verbatim, preserving its `requestDateTime`.
+  /// See [AtAccessLog.replay].
+  @override
+  Future<void> replay(AccessLogEntry entry) async {
+    try {
+      await _accessLogKeyStore.add(entry);
+    } on Exception catch (e) {
+      throw DataStoreException(
+          'Exception replaying to access log:${e.toString()}');
+    } on HiveError catch (e) {
+      throw DataStoreException(
+          'Hive error replaying to access log:${e.toString()}');
+    }
+  }
+
   @override
   Stream<AccessLogEntry> iterate() async* {
     // Access log uses a LazyBox; fetch each value asynchronously

--- a/packages/at_persistence_secondary_server/lib/src/impl/hive/hive_at_keyvalue_store.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/hive/hive_at_keyvalue_store.dart
@@ -400,6 +400,34 @@ class HiveAtKeyValueStore
     }
   }
 
+  /// Writes [value] verbatim — no metadata builder, no commit-log
+  /// append, no change event. See [AtKeyValueStore.restore]. Used by
+  /// the persistence migrator to reproduce a source keystore's
+  /// records exactly (preserving createdAt/updatedAt/version and
+  /// every other field).
+  @override
+  Future<void> restore(String key, AtData value) async {
+    key = key.toLowerCase();
+    final atKey = AtKey.getKeyType(key, enforceNameSpace: false);
+    if (atKey == KeyType.invalidKey) {
+      logger.warning('Key $key is invalid');
+      throw InvalidAtKeyException('Key $key is invalid');
+    }
+    String hiveKey = HiveKeyStoreHelper.prepareKey(key);
+    _checkMaxLength(hiveKey);
+    try {
+      await getBox().put(hiveKey, value);
+      _updateMetadataCache(key, value.metaData);
+    } on Exception catch (exception) {
+      logger.severe('HiveAtKeyValueStore restore exception: $exception');
+      throw DataStoreException('exception in restore: ${exception.toString()}');
+    } on HiveError catch (error) {
+      await _restartHiveBox(error);
+      logger.severe('HiveAtKeyValueStore error: $error');
+      throw DataStoreException(error.message);
+    }
+  }
+
   /// Returns an integer if the key to be deleted is present in keystore or cache.
   @override
   Future<int?> remove(String key, {bool skipCommit = false}) async {

--- a/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_at_access_log.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_at_access_log.dart
@@ -1,0 +1,148 @@
+import 'dart:io';
+
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:sqlite3/sqlite3.dart';
+
+import 'sqlite_database.dart';
+
+/// SQLite-backed [AtAccessLog] (`access_log` table). Insert-only verb /
+/// connection audit; `seq` is the rowid alias, so insertion order is id
+/// order.
+class SqliteAtAccessLog implements AtAccessLog {
+  final SqliteDatabase _db;
+
+  /// Percentage of oldest entries dropped per compaction pass.
+  final int compactionPercentage;
+
+  SqliteAtAccessLog(this._db, {this.compactionPercentage = 30});
+
+  @override
+  Future<int?> insert(String fromAtSign, String verbName,
+      {String? lookupKey}) async {
+    return _db.runInTransaction(() {
+      _db.raw.execute(
+        'INSERT INTO access_log (from_atsign, request_at, verb_name, lookup_key) '
+        'VALUES (?, ?, ?, ?);',
+        [
+          fromAtSign,
+          DateTime.now().toUtc().millisecondsSinceEpoch,
+          verbName,
+          lookupKey
+        ],
+      );
+      return _db.raw.select('SELECT last_insert_rowid() r;').first['r'] as int;
+    });
+  }
+
+  @override
+  Future<void> replay(AccessLogEntry entry) async {
+    _db.raw.execute(
+      'INSERT INTO access_log (from_atsign, request_at, verb_name, lookup_key) '
+      'VALUES (?, ?, ?, ?);',
+      [
+        entry.fromAtSign,
+        entry.requestDateTime?.toUtc().millisecondsSinceEpoch,
+        entry.verbName,
+        entry.lookupKey
+      ],
+    );
+  }
+
+  @override
+  Future<Map<String, int>> mostVisitedAtSigns(int length) async {
+    final rows = _db.raw.select(
+        "SELECT from_atsign a, COUNT(*) c FROM access_log WHERE verb_name = 'pol' "
+        'AND from_atsign IS NOT NULL GROUP BY from_atsign ORDER BY c DESC LIMIT ?;',
+        [length]);
+    return {for (final r in rows) r['a'] as String: r['c'] as int};
+  }
+
+  @override
+  Future<Map<String, int>> mostVisitedKeys(int length) async {
+    final rows = _db.raw.select(
+        "SELECT lookup_key k, COUNT(*) c FROM access_log WHERE verb_name = 'lookup' "
+        'AND lookup_key IS NOT NULL GROUP BY lookup_key ORDER BY c DESC LIMIT ?;',
+        [length]);
+    return {for (final r in rows) r['k'] as String: r['c'] as int};
+  }
+
+  @override
+  Future<AccessLogEntry> getLastAccessLogEntry() async {
+    final rows = _db.raw.select(
+        'SELECT from_atsign, request_at, verb_name, lookup_key FROM access_log '
+        'ORDER BY seq DESC LIMIT 1;');
+    if (rows.isEmpty) {
+      throw StateError('access_log is empty');
+    }
+    return _entryFromRow(rows.first);
+  }
+
+  @override
+  Future<AccessLogEntry?> getLastPkamAccessLogEntry() async {
+    final rows = _db.raw.select(
+        "SELECT from_atsign, request_at, verb_name, lookup_key FROM access_log "
+        "WHERE verb_name = 'pkam' ORDER BY request_at DESC, seq DESC LIMIT 1;");
+    return rows.isEmpty ? null : _entryFromRow(rows.first);
+  }
+
+  @override
+  Stream<AccessLogEntry> iterate() async* {
+    final rows = _db.raw.select(
+        'SELECT from_atsign, request_at, verb_name, lookup_key FROM access_log '
+        'ORDER BY seq;');
+    for (final r in rows) {
+      yield _entryFromRow(r);
+    }
+  }
+
+  @override
+  int entriesCount() =>
+      _db.raw.select('SELECT COUNT(*) c FROM access_log;').first['c'] as int;
+
+  @override
+  int getSize() {
+    final f = File(_db.path);
+    return f.existsSync() ? f.lengthSync() : 0;
+  }
+
+  @override
+  Future<void> close() async {}
+
+  /// Drops all rows (keeping the connection open) for test isolation.
+  Future<void> clear() async {
+    _db.raw.execute('DELETE FROM access_log;');
+  }
+
+  @override
+  Stream<int> compact(bool dryRun) async* {
+    final total = entriesCount();
+    final firstN = (total * (compactionPercentage / 100)).toInt();
+    if (firstN <= 0) return;
+    final ids = _db.raw
+        .select('SELECT seq FROM access_log ORDER BY seq LIMIT ?;', [firstN])
+        .map((r) => r['seq'] as int)
+        .toList();
+    if (dryRun) {
+      yield* Stream.fromIterable(ids);
+      return;
+    }
+    _db.runInTransaction(() {
+      for (final id in ids) {
+        _db.raw.execute('DELETE FROM access_log WHERE seq = ?;', [id]);
+      }
+    });
+    yield* Stream.fromIterable(ids);
+  }
+
+  AccessLogEntry _entryFromRow(Row row) {
+    final millis = row['request_at'] as int?;
+    return AccessLogEntry(
+      row['from_atsign'] as String?,
+      millis == null
+          ? null
+          : DateTime.fromMillisecondsSinceEpoch(millis, isUtc: true),
+      row['verb_name'] as String?,
+      row['lookup_key'] as String?,
+    );
+  }
+}

--- a/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_at_commit_log.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_at_commit_log.dart
@@ -1,0 +1,190 @@
+import 'dart:io';
+
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:sqlite3/sqlite3.dart';
+
+import 'sqlite_database.dart';
+
+/// SQLite-backed [AtCommitLog]. One row per atKey, newest-wins, with a
+/// dense/gapless `commit_id` allocated from the `counters` table in the
+/// same transaction as the keystore write (see [commitSync]).
+class SqliteAtCommitLog extends AtCommitLog {
+  final SqliteDatabase _db;
+
+  SqliteAtCommitLog(this._db);
+
+  /// True for atKeys that never get a commit-log row (and so never
+  /// consume a commit id): `private:` / `privatekey:` / `public:_`
+  /// (single underscore) / `local:` — EXCEPT `public:__` (double
+  /// underscore), which IS synced. Mirrors `hive_at_commit_log.dart`.
+  static final RegExp _elidedPrefixes =
+      RegExp('^(private:|privatekey:|public:_|local:)');
+
+  bool _isElided(String key) =>
+      !key.startsWith('public:__') && _elidedPrefixes.hasMatch(key);
+
+  /// Synchronous commit used inside a keystore write's transaction so
+  /// the value row and its commit entry are one atomic unit. Returns the
+  /// allocated commit id, or `-1` for an elided key. Re-entrant via
+  /// [SqliteDatabase.runInTransaction]: joins the caller's transaction
+  /// when there is one, else opens its own.
+  int? commitSync(String atKey, CommitOp operation) {
+    if (_isElided(atKey)) return -1;
+    return _db.runInTransaction(() {
+      _db.raw.execute(
+          "UPDATE counters SET value = value + 1 WHERE name = 'last_commit_id';");
+      final commitId = _db.raw
+          .select("SELECT value FROM counters WHERE name = 'last_commit_id';")
+          .first
+          .values
+          .first as int;
+      _db.raw.execute(
+        'INSERT INTO commit_log (atkey, commit_id, operation, op_time) '
+        'VALUES (?, ?, ?, ?) '
+        'ON CONFLICT(atkey) DO UPDATE SET '
+        'commit_id = excluded.commit_id, operation = excluded.operation, '
+        'op_time = excluded.op_time;',
+        [
+          atKey,
+          commitId,
+          operation.name,
+          DateTime.now().toUtcMillisecondsPrecision().millisecondsSinceEpoch,
+        ],
+      );
+      return commitId;
+    });
+  }
+
+  /// Delete the commit-log row for [atKey] (expiry / skipCommit path).
+  /// No counter bump. Re-entrant. An expired key must not be
+  /// resurrectable by a sync client replaying an old commit entry.
+  void purgeSync(String atKey) {
+    _db.raw.execute('DELETE FROM commit_log WHERE atkey = ?;', [atKey]);
+  }
+
+  @override
+  Future<int?> commit(String key, CommitOp operation) async =>
+      commitSync(key, operation);
+
+  @override
+  Future<void> replay(CommitEntry entry) async {
+    if (entry.commitId == null) {
+      throw DataStoreException('replay requires a non-null commitId');
+    }
+    _db.runInTransaction(() {
+      _db.raw.execute(
+        'INSERT INTO commit_log (atkey, commit_id, operation, op_time) '
+        'VALUES (?, ?, ?, ?) '
+        'ON CONFLICT(atkey) DO UPDATE SET '
+        'commit_id = excluded.commit_id, operation = excluded.operation, '
+        'op_time = excluded.op_time;',
+        [
+          entry.atKey,
+          entry.commitId,
+          entry.operation.name,
+          entry.opTime?.toUtc().millisecondsSinceEpoch,
+        ],
+      );
+      // Keep the allocator ahead of every replayed id so subsequent live
+      // commits stay monotonic and never collide with a migrated id.
+      _db.raw.execute(
+          "UPDATE counters SET value = MAX(value, ?) WHERE name = 'last_commit_id';",
+          [entry.commitId]);
+    });
+  }
+
+  @override
+  Stream<CommitEntry> iterate({
+    int? fromCommitId,
+    bool Function(CommitEntry)? where,
+  }) async* {
+    final rows = fromCommitId == null
+        ? _db.raw.select(
+            'SELECT atkey, commit_id, operation, op_time FROM commit_log '
+            'ORDER BY commit_id;')
+        : _db.raw.select(
+            'SELECT atkey, commit_id, operation, op_time FROM commit_log '
+            'WHERE commit_id >= ? ORDER BY commit_id;',
+            [fromCommitId]);
+    for (final row in rows) {
+      final entry = _entryFromRow(row);
+      if (where == null || where(entry)) yield entry;
+    }
+  }
+
+  @override
+  int? lastCommittedSequenceNumber() => _minMax('MAX');
+
+  @override
+  int? firstCommittedSequenceNumber() => _minMax('MIN');
+
+  @override
+  CommitEntry? getLatestCommitEntry(String key) {
+    final rows = _db.raw.select(
+        'SELECT atkey, commit_id, operation, op_time FROM commit_log '
+        'WHERE atkey = ?;',
+        [key]);
+    return rows.isEmpty ? null : _entryFromRow(rows.first);
+  }
+
+  @override
+  int entriesCount() =>
+      _db.raw.select('SELECT COUNT(*) c FROM commit_log;').first['c'] as int;
+
+  @override
+  int getSize() => _dbFileSize(_db.path);
+
+  @override
+  Future<void> close() async {
+    // The connection is owned by the shared SqliteDatabase and closed by
+    // the bundle; individual stores do not close it.
+  }
+
+  @override
+  Stream<int> compact(bool dryRun) async* {
+    // One row per atKey by construction — there are no duplicate entries
+    // to prune, so compaction is a no-op on this backend.
+  }
+
+  int? _minMax(String fn) {
+    final v = _db.raw
+        .select('SELECT $fn(commit_id) v FROM commit_log;')
+        .first['v'];
+    return v as int?;
+  }
+
+  CommitEntry _entryFromRow(Row row) {
+    final op = _opFromSymbol(row['operation'] as String);
+    final opTimeMillis = row['op_time'] as int?;
+    final opTime = opTimeMillis == null
+        ? null
+        : DateTime.fromMillisecondsSinceEpoch(opTimeMillis, isUtc: true);
+    return CommitEntry(row['atkey'] as String, op, opTime)
+      ..commitId = row['commit_id'] as int?;
+  }
+
+  static CommitOp _opFromSymbol(String symbol) {
+    switch (symbol) {
+      case '+':
+        return CommitOp.UPDATE;
+      case '#':
+        return CommitOp.UPDATE_META;
+      case '*':
+        return CommitOp.UPDATE_ALL;
+      case '-':
+        return CommitOp.DELETE;
+      default:
+        throw DataStoreException('Unknown commit operation symbol: $symbol');
+    }
+  }
+}
+
+/// Approximate on-disk size: the main db file plus any `-wal` sidecar.
+int _dbFileSize(String path) {
+  var total = 0;
+  for (final suffix in ['', '-wal']) {
+    final f = File('$path$suffix');
+    if (f.existsSync()) total += f.lengthSync();
+  }
+  return total;
+}

--- a/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_at_keyvalue_store.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_at_keyvalue_store.dart
@@ -1,0 +1,694 @@
+import 'dart:async';
+
+import 'package:at_commons/at_commons.dart';
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:sqlite3/sqlite3.dart';
+
+import 'sqlite_at_commit_log.dart';
+import 'sqlite_database.dart';
+import 'sqlite_metadata_codec.dart';
+import 'sqlite_query_translator.dart';
+
+/// SQLite-backed [AtKeyValueStore] — the main keystore (`at_data` table).
+///
+/// Mirrors the Hive keystore's semantics (metadata-builder-on-write,
+/// commit-op selection, TTL/TTB visibility, skipCommit purge) while
+/// answering expiry / availability from indexed columns rather than an
+/// in-memory cache, and lighting up the SQL-only capabilities
+/// (`supportsSnapshots` / `supportsPathQueries` / true transactions).
+class SqliteAtKeyValueStore
+    implements AtKeyValueStore<String, AtData, AtMetaData?> {
+  final SqliteDatabase _db;
+
+  /// The atSign owning this store — the `createdBy`/`updatedBy` audit
+  /// value the metadata builder stamps.
+  final String atSign;
+
+  AtCommitLog? _commitLog;
+
+  final StreamController<KeyStoreChange> _changes =
+      StreamController<KeyStoreChange>.broadcast();
+
+  @override
+  final List<Future<void> Function(String key, {required bool skipCommit})>
+      preRemoveHooks = [];
+  @override
+  final List<Future<void> Function(String key, {required bool skipCommit})>
+      postRemoveHooks = [];
+
+  static const int maxKeyLength = 255;
+  static const int maxKeyLengthWithoutCached = 248;
+
+  SqliteAtKeyValueStore(this._db, this.atSign);
+
+  @override
+  Future<void> initialize() async {
+    // The database is opened and schema-applied by the factory; nothing
+    // to do here.
+  }
+
+  @override
+  AtCommitLog? get commitLog => _commitLog;
+  @override
+  set commitLog(AtCommitLog? log) => _commitLog = log;
+
+  SqliteAtCommitLog? get _sqliteCommitLog {
+    final cl = _commitLog;
+    return cl is SqliteAtCommitLog ? cl : null;
+  }
+
+  // ---------------------------------------------------------------
+  // Single-key reads / writes
+  // ---------------------------------------------------------------
+
+  @override
+  Future<AtData?> get(String key) async {
+    final k = _normalize(key);
+    final rows = _db.raw
+        .select('SELECT value, metadata FROM at_data WHERE atkey = ?;', [k]);
+    if (rows.isEmpty) {
+      throw KeyNotFoundException('$key does not exist in keystore');
+    }
+    return _atDataFromRow(rows.first, k);
+  }
+
+  @override
+  Future<int?> put(String key, AtData value, {bool skipCommit = false}) async {
+    final k = _validateAndNormalize(key);
+    if (!_existsSync(k)) {
+      return create(key, value, skipCommit: skipCommit);
+    }
+    final existing = _getSync(k);
+    final toStore = AtData()
+      ..data = value.data
+      ..metaData = AtMetadataBuilder(
+        atSign: atSign,
+        newAtMetaData: value.metaData,
+        existingMetaData: existing?.metaData,
+      ).build();
+    final result = _db.runInTransaction(() {
+      _upsertAtData(k, toStore);
+      return skipCommit ? -1 : _commitOrNull(k, CommitOp.UPDATE_ALL);
+    });
+    _changes.add(KeyUpdated(k));
+    return result;
+  }
+
+  @override
+  Future<int?> create(String key, AtData value,
+      {bool skipCommit = false}) async {
+    final k = _validateAndNormalize(key);
+    _checkMaxLength(k);
+    final toStore = AtData()
+      ..data = value.data
+      ..metaData =
+          AtMetadataBuilder(atSign: atSign, newAtMetaData: value.metaData)
+              .build();
+    final commitOp = _commitOpForNewWrite(value.metaData);
+    final result = _db.runInTransaction(() {
+      _upsertAtData(k, toStore);
+      return skipCommit ? -1 : _commitOrNull(k, commitOp);
+    });
+    _changes.add(KeyAdded(k));
+    return result;
+  }
+
+  @override
+  Future<int?> putAll(String key, AtData value, AtMetaData? metadata) async {
+    final k = _validateAndNormalize(key);
+    final existing = _existsSync(k) ? _getSync(k) : null;
+    final toStore = AtData()
+      ..data = value.data
+      ..metaData = AtMetadataBuilder(
+        atSign: atSign,
+        newAtMetaData: metadata,
+        existingMetaData: existing?.metaData,
+      ).build();
+    final result = _db.runInTransaction(() {
+      _upsertAtData(k, toStore);
+      return _commitOrNull(k, CommitOp.UPDATE_ALL);
+    });
+    _changes.add(existing == null ? KeyAdded(k) : KeyUpdated(k));
+    return result;
+  }
+
+  @override
+  Future<int?> putMeta(String key, AtMetaData? metadata) async {
+    final k = _validateAndNormalize(key);
+    final existing = _existsSync(k) ? _getSync(k)! : AtData();
+    final toStore = AtData()
+      ..data = existing.data
+      ..metaData = AtMetadataBuilder(
+        atSign: atSign,
+        newAtMetaData: metadata,
+        existingMetaData: existing.metaData,
+      ).build();
+    final result = _db.runInTransaction(() {
+      _upsertAtData(k, toStore);
+      return _commitOrNull(k, CommitOp.UPDATE_META);
+    });
+    _changes.add(KeyUpdated(k));
+    return result;
+  }
+
+  @override
+  Future<AtMetaData?> getMeta(String key) async {
+    try {
+      return (await get(key))?.metaData;
+    } on KeyNotFoundException {
+      return null;
+    }
+  }
+
+  @override
+  Future<void> restore(String key, AtData value) async {
+    final k = _validateAndNormalize(key);
+    _checkMaxLength(k);
+    // Verbatim: store value as-is (its own metadata), no builder pass,
+    // no commit-log append, no change event.
+    _db.runInTransaction(() => _upsertAtData(k, value));
+  }
+
+  @override
+  Future<int?> remove(String key, {bool skipCommit = false}) async {
+    final lowered = key.toLowerCase();
+    for (final hook in preRemoveHooks) {
+      await hook(lowered, skipCommit: skipCommit);
+    }
+    final k = _normalize(key);
+    final result = _db.runInTransaction(() {
+      _db.raw.execute('DELETE FROM at_data WHERE atkey = ?;', [k]);
+      if (skipCommit) {
+        _sqliteCommitLog?.purgeSync(k);
+        return -1;
+      }
+      return _commitOrNull(k, CommitOp.DELETE);
+    });
+    _changes.add(KeyRemoved(k));
+    for (final hook in postRemoveHooks) {
+      await hook(lowered, skipCommit: skipCommit);
+    }
+    return result;
+  }
+
+  @override
+  Future<int> removeMany(List<String> keys, {bool skipCommit = false}) async {
+    final normalized = keys.map(_normalize).toSet().toList();
+    var removed = 0;
+    final toFire = <String>[];
+    _db.runInTransaction(() {
+      for (final k in normalized) {
+        if (!_existsSync(k)) continue;
+        _db.raw.execute('DELETE FROM at_data WHERE atkey = ?;', [k]);
+        if (skipCommit) {
+          _sqliteCommitLog?.purgeSync(k);
+        } else {
+          _commitOrNull(k, CommitOp.DELETE);
+        }
+        removed++;
+        toFire.add(k);
+      }
+    });
+    for (final k in toFire) {
+      _changes.add(KeyRemoved(k));
+    }
+    return removed;
+  }
+
+  @override
+  Future<Map<String, AtData>> getMany(List<String> keys) async {
+    if (keys.isEmpty) return {};
+    final normalized = keys.map(_normalize).toList();
+    final placeholders = List.filled(normalized.length, '?').join(',');
+    final rows = _db.raw.select(
+        'SELECT atkey, value, metadata FROM at_data WHERE atkey IN ($placeholders);',
+        normalized);
+    final result = <String, AtData>{};
+    for (final row in rows) {
+      final atkey = row['atkey'] as String;
+      result[atkey] = _atDataFromRow(row, atkey);
+    }
+    return result;
+  }
+
+  @override
+  Future<bool> exists(String key) async => _existsSync(_normalize(key));
+
+  // ---------------------------------------------------------------
+  // Expiry / availability
+  // ---------------------------------------------------------------
+
+  @override
+  Future<Stream<String>> getExpiredKeys() async {
+    final now = _nowMillis();
+    final rows = _db.raw.select(
+        'SELECT atkey FROM at_data WHERE expires_at IS NOT NULL AND expires_at <= ?;',
+        [now]);
+    return Stream.fromIterable(rows.map((r) => r['atkey'] as String));
+  }
+
+  @override
+  Future<bool> deleteExpiredKeys() async {
+    final expired =
+        (await getExpiredKeys()).asBroadcastStream(); // materialize below
+    final keys = <String>[];
+    await for (final k in expired) {
+      keys.add(k);
+    }
+    for (final k in keys) {
+      // Expiry deletes are local-only maintenance: purge the row and its
+      // commit entry, never advance the commit id.
+      await remove(k, skipCommit: true);
+    }
+    return true;
+  }
+
+  @override
+  Future<DateTime?> nextExpiresAt() async {
+    final v = _db.raw
+        .select(
+            'SELECT MIN(expires_at) m FROM at_data WHERE expires_at IS NOT NULL;')
+        .first['m'];
+    return v == null
+        ? null
+        : DateTime.fromMillisecondsSinceEpoch(v as int, isUtc: true);
+  }
+
+  @override
+  Future<Stream<String>> peekExpired({DateTime? asOf, int? limit}) async {
+    final cutoff = (asOf ?? DateTime.now()).toUtc().millisecondsSinceEpoch;
+    var sql =
+        'SELECT atkey FROM at_data WHERE expires_at IS NOT NULL AND expires_at <= ? ORDER BY expires_at';
+    final params = <Object?>[cutoff];
+    if (limit != null) {
+      sql += ' LIMIT ?';
+      params.add(limit);
+    }
+    final rows = _db.raw.select('$sql;', params);
+    return Stream.fromIterable(rows.map((r) => r['atkey'] as String));
+  }
+
+  @override
+  Future<DateTime?> nextAvailableAt({DateTime? asOf}) async {
+    final now = (asOf ?? DateTime.now()).toUtc().millisecondsSinceEpoch;
+    final v = _db.raw.select(
+        'SELECT MIN(available_at) m FROM at_data WHERE available_at IS NOT NULL AND available_at > ?;',
+        [now]).first['m'];
+    return v == null
+        ? null
+        : DateTime.fromMillisecondsSinceEpoch(v as int, isUtc: true);
+  }
+
+  @override
+  Future<Stream<String>> peekNewlyAvailable({
+    required DateTime since,
+    DateTime? asOf,
+    int? limit,
+  }) async {
+    final lo = since.toUtc().millisecondsSinceEpoch;
+    final hi = (asOf ?? DateTime.now()).toUtc().millisecondsSinceEpoch;
+    var sql =
+        'SELECT atkey FROM at_data WHERE available_at IS NOT NULL AND available_at > ? AND available_at <= ? ORDER BY available_at';
+    final params = <Object?>[lo, hi];
+    if (limit != null) {
+      sql += ' LIMIT ?';
+      params.add(limit);
+    }
+    final rows = _db.raw.select('$sql;', params);
+    return Stream.fromIterable(rows.map((r) => r['atkey'] as String));
+  }
+
+  // ---------------------------------------------------------------
+  // Listing
+  // ---------------------------------------------------------------
+
+  @override
+  Future<Stream<String>> getKeys({String? regex}) async {
+    // Eager validation: a bad regex rejects the Future, not the Stream.
+    final re = RegExp(regex ?? '.*');
+    final now = _nowMillis();
+    final rows = _db.raw.select(
+        'SELECT atkey FROM at_data WHERE (available_at IS NULL OR available_at <= ?) '
+        'AND (expires_at IS NULL OR expires_at > ?);',
+        [now, now]);
+    final matched =
+        rows.map((r) => r['atkey'] as String).where(re.hasMatch).toList();
+    return Stream.fromIterable(matched);
+  }
+
+  @override
+  Future<Stream<String>> scanKeys(
+    KeyPattern pattern, {
+    bool includeExpired = false,
+    OrderByKey? orderBy,
+    int? limit,
+    int? skip,
+  }) async {
+    var where = '1=1';
+    final params = <Object?>[];
+    if (!includeExpired) {
+      final now = _nowMillis();
+      where +=
+          ' AND (available_at IS NULL OR available_at <= ?) AND (expires_at IS NULL OR expires_at > ?)';
+      params
+        ..add(now)
+        ..add(now);
+    }
+    final order = switch (orderBy) {
+      OrderByKey.byKey => ' ORDER BY atkey',
+      OrderByKey.byExpiresAt =>
+        ' ORDER BY (expires_at IS NULL), expires_at', // nulls last
+      OrderByKey.byCreatedAt =>
+        " ORDER BY json_extract(metadata, '\$.createdAt')",
+      null => '',
+    };
+    final rows = _db.raw
+        .select('SELECT atkey FROM at_data WHERE $where$order;', params);
+    // KeyPattern filter, then skip/limit (limit is post-filter, matching
+    // the Hive semantics).
+    var matched = rows
+        .map((r) => r['atkey'] as String)
+        .where((k) => SqliteQueryTranslator.matchesKeyPattern(k, pattern));
+    if (skip != null) matched = matched.skip(skip);
+    if (limit != null) matched = matched.take(limit);
+    return Stream.fromIterable(matched.toList());
+  }
+
+  // ---------------------------------------------------------------
+  // Reactive / transactional / diagnostic
+  // ---------------------------------------------------------------
+
+  @override
+  Stream<KeyStoreChange> get changes => _changes.stream;
+
+  @override
+  Future<R> transaction<R>(
+      Future<R> Function(KeyStoreTxn<String, AtData, dynamic> txn) body) async {
+    final txn = _SqliteKeyStoreTxn(this);
+    final result = await body(txn);
+    // Apply buffered ops atomically, in body order.
+    final fired = <KeyStoreChange>[];
+    _db.runInTransaction(() {
+      for (final op in txn._ops) {
+        if (op.isRemove) {
+          if (_existsSync(op.key)) {
+            _db.raw.execute('DELETE FROM at_data WHERE atkey = ?;', [op.key]);
+            _commitOrNull(op.key, CommitOp.DELETE);
+            fired.add(KeyRemoved(op.key));
+          }
+        } else {
+          final existed = _existsSync(op.key);
+          final toStore = AtData()
+            ..data = op.value!.data
+            ..metaData = AtMetadataBuilder(
+              atSign: atSign,
+              newAtMetaData: op.metadata,
+              existingMetaData: existed ? _getSync(op.key)?.metaData : null,
+            ).build();
+          _upsertAtData(op.key, toStore);
+          _commitOrNull(op.key, CommitOp.UPDATE_ALL);
+          fired.add(existed ? KeyUpdated(op.key) : KeyAdded(op.key));
+        }
+      }
+    });
+    for (final change in fired) {
+      _changes.add(change);
+    }
+    return result;
+  }
+
+  @override
+  bool get supportsSnapshots => true;
+
+  @override
+  Future<AtKeyValueStoreSnapshot<String, AtData, AtMetaData?>> snapshot() async {
+    return _SqliteSnapshot.open(_db.path);
+  }
+
+  @override
+  bool get supportsPathQueries => true;
+
+  @override
+  Stream<KeyEntry<String, AtData, AtMetaData?>> queryByPath({
+    required KeyPattern keyPattern,
+    required Predicate predicate,
+    OrderByKey? orderBy,
+    int? limit,
+    int? skip,
+  }) async* {
+    final translated = SqliteQueryTranslator.predicateToSql(predicate, 'value');
+    final where = '(${translated.sql})';
+    final params = <Object?>[...translated.params];
+    final order = switch (orderBy) {
+      OrderByKey.byKey => ' ORDER BY atkey',
+      OrderByKey.byExpiresAt => ' ORDER BY (expires_at IS NULL), expires_at',
+      OrderByKey.byCreatedAt =>
+        " ORDER BY json_extract(metadata, '\$.createdAt')",
+      null => '',
+    };
+    final rows = _db.raw.select(
+        'SELECT atkey, value, metadata FROM at_data WHERE $where$order;',
+        params);
+    var entries = rows
+        .where((r) => SqliteQueryTranslator.matchesKeyPattern(
+            r['atkey'] as String, keyPattern))
+        .map((r) {
+      final atkey = r['atkey'] as String;
+      final atData = _atDataFromRow(r, atkey);
+      return KeyEntry<String, AtData, AtMetaData?>(
+          atkey, atData, atData.metaData);
+    });
+    if (skip != null) entries = entries.skip(skip);
+    if (limit != null) entries = entries.take(limit);
+    for (final e in entries) {
+      yield e;
+    }
+  }
+
+  @override
+  Future<KeyStoreStats> stats() async {
+    final row = _db.raw.select('SELECT '
+        'COUNT(*) total, '
+        'SUM(CASE WHEN expires_at IS NOT NULL THEN 1 ELSE 0 END) ttl, '
+        'SUM(CASE WHEN available_at IS NOT NULL THEN 1 ELSE 0 END) ttb, '
+        "MIN(json_extract(metadata, '\$.createdAt')) oldest, "
+        "MAX(json_extract(metadata, '\$.createdAt')) newest "
+        'FROM at_data;').first;
+    DateTime? parse(Object? v) =>
+        v == null ? null : DateTime.tryParse(v as String);
+    return KeyStoreStats(
+      totalKeys: (row['total'] as int?) ?? 0,
+      ttlKeys: (row['ttl'] as int?) ?? 0,
+      ttbKeys: (row['ttb'] as int?) ?? 0,
+      sizeBytes: _db.raw
+              .select('PRAGMA page_count;')
+              .first
+              .values
+              .first as int? ??
+          0,
+      oldestCreatedAt: parse(row['oldest']),
+      newestCreatedAt: parse(row['newest']),
+    );
+  }
+
+  @override
+  Stream<Object> compact(bool dryRun) =>
+      _commitLog?.compact(dryRun) ?? const Stream.empty();
+
+  /// Drops all rows (keeping the connection open) for test isolation.
+  Future<void> clear() async {
+    _db.raw.execute('DELETE FROM at_data;');
+  }
+
+  /// No-op: the shared connection is closed by the bundle.
+  Future<void> close() async {}
+
+  // ---------------------------------------------------------------
+  // Internals
+  // ---------------------------------------------------------------
+
+  String _normalize(String key) =>
+      key.trim().toLowerCase().replaceAll(' ', '');
+
+  String _validateAndNormalize(String key) {
+    final normalized = _normalize(key);
+    if (AtKey.getKeyType(normalized, enforceNameSpace: false) ==
+        KeyType.invalidKey) {
+      throw InvalidAtKeyException('Key $key is invalid');
+    }
+    return normalized;
+  }
+
+  void _checkMaxLength(String key) {
+    final maxLength =
+        key.startsWith('cached:') ? maxKeyLength : maxKeyLengthWithoutCached;
+    if (key.length > maxLength) {
+      throw DataStoreException(
+          'key length ${key.length} is greater than max allowed $maxLength chars');
+    }
+  }
+
+  int _nowMillis() => DateTime.now().toUtc().millisecondsSinceEpoch;
+
+  bool _existsSync(String normalizedKey) => _db.raw
+      .select('SELECT 1 FROM at_data WHERE atkey = ? LIMIT 1;', [normalizedKey])
+      .isNotEmpty;
+
+  AtData? _getSync(String normalizedKey) {
+    final rows = _db.raw.select(
+        'SELECT value, metadata FROM at_data WHERE atkey = ?;',
+        [normalizedKey]);
+    return rows.isEmpty ? null : _atDataFromRow(rows.first, normalizedKey);
+  }
+
+  void _upsertAtData(String atkey, AtData data) {
+    final m = data.metaData ?? AtMetaData();
+    _db.raw.execute(
+      'INSERT INTO at_data (atkey, value, metadata, expires_at, available_at, refresh_at) '
+      'VALUES (?, ?, ?, ?, ?, ?) '
+      'ON CONFLICT(atkey) DO UPDATE SET value = excluded.value, '
+      'metadata = excluded.metadata, expires_at = excluded.expires_at, '
+      'available_at = excluded.available_at, refresh_at = excluded.refresh_at;',
+      [
+        atkey,
+        data.data,
+        SqliteMetadataCodec.encode(m),
+        SqliteMetadataCodec.expiresAtMillis(m),
+        SqliteMetadataCodec.availableAtMillis(m),
+        SqliteMetadataCodec.refreshAtMillis(m),
+      ],
+    );
+  }
+
+  int? _commitOrNull(String atkey, CommitOp op) =>
+      _sqliteCommitLog?.commitSync(atkey, op);
+
+  AtData _atDataFromRow(Row row, String atkey) => AtData()
+    ..data = row['value'] as String?
+    ..metaData = SqliteMetadataCodec.decode(row['metadata'] as String)
+    ..key = atkey;
+
+  /// Sets [CommitOp.UPDATE_ALL] when any metadata field is present (a
+  /// value+metadata write), else [CommitOp.UPDATE]. Mirrors the Hive
+  /// create path's null-check chain.
+  CommitOp _commitOpForNewWrite(AtMetaData? m) {
+    if (m != null &&
+        (m.ttl != null ||
+            m.ttb != null ||
+            m.ttr != null ||
+            m.isCascade != null ||
+            m.isBinary != null ||
+            m.isEncrypted != null ||
+            m.dataSignature != null ||
+            m.sharedKeyEnc != null ||
+            m.pubKeyCS != null ||
+            m.encoding != null ||
+            m.encKeyName != null ||
+            m.encAlgo != null ||
+            m.ivNonce != null ||
+            m.skeEncKeyName != null ||
+            m.skeEncAlgo != null ||
+            m.pubKeyHash != null ||
+            m.immutable != null)) {
+      return CommitOp.UPDATE_ALL;
+    }
+    return CommitOp.UPDATE;
+  }
+}
+
+/// Buffered transaction handle — reads see buffered writes over live
+/// state; buffered ops are applied atomically by
+/// [SqliteAtKeyValueStore.transaction].
+class _SqliteKeyStoreTxn implements KeyStoreTxn<String, AtData, dynamic> {
+  final SqliteAtKeyValueStore _store;
+  final List<_BufferedOp> _ops = [];
+
+  _SqliteKeyStoreTxn(this._store);
+
+  @override
+  Future<void> put(String key, AtData value, dynamic metadata) async {
+    _ops.add(_BufferedOp.put(
+        _store._normalize(key), value, metadata as AtMetaData?));
+  }
+
+  @override
+  Future<void> remove(String key) async {
+    _ops.add(_BufferedOp.remove(_store._normalize(key)));
+  }
+
+  @override
+  Future<AtData?> get(String key) async {
+    final k = _store._normalize(key);
+    // Last buffered op for this key wins over live state.
+    for (final op in _ops.reversed) {
+      if (op.key == k) {
+        return op.isRemove ? null : op.value;
+      }
+    }
+    return _store._getSync(k);
+  }
+
+  @override
+  Future<bool> exists(String key) async => (await get(key)) != null;
+}
+
+class _BufferedOp {
+  final String key;
+  final bool isRemove;
+  final AtData? value;
+  final AtMetaData? metadata;
+
+  _BufferedOp.put(this.key, this.value, this.metadata) : isRemove = false;
+  _BufferedOp.remove(this.key)
+      : isRemove = true,
+        value = null,
+        metadata = null;
+}
+
+/// A WAL read-transaction snapshot on a second connection: reads observe
+/// the database as of snapshot creation, independent of concurrent
+/// writes on the main connection.
+class _SqliteSnapshot
+    implements AtKeyValueStoreSnapshot<String, AtData, AtMetaData?> {
+  final Database _conn;
+  bool _released = false;
+
+  _SqliteSnapshot._(this._conn);
+
+  static _SqliteSnapshot open(String path) {
+    final conn = sqlite3.open(path);
+    conn.execute('BEGIN DEFERRED;');
+    // Touch a row to pin the WAL read snapshot.
+    conn.select('SELECT 1 FROM at_data LIMIT 1;');
+    return _SqliteSnapshot._(conn);
+  }
+
+  @override
+  Future<AtData?> get(String key) async {
+    final k = key.trim().toLowerCase().replaceAll(' ', '');
+    final rows = _conn
+        .select('SELECT value, metadata FROM at_data WHERE atkey = ?;', [k]);
+    if (rows.isEmpty) return null;
+    return AtData()
+      ..data = rows.first['value'] as String?
+      ..metaData = SqliteMetadataCodec.decode(rows.first['metadata'] as String)
+      ..key = k;
+  }
+
+  @override
+  Stream<String> scanKeys(KeyPattern pattern) async* {
+    final rows = _conn.select('SELECT atkey FROM at_data;');
+    for (final r in rows) {
+      final k = r['atkey'] as String;
+      if (SqliteQueryTranslator.matchesKeyPattern(k, pattern)) yield k;
+    }
+  }
+
+  @override
+  Future<void> release() async {
+    if (_released) return;
+    _released = true;
+    _conn.execute('ROLLBACK;');
+    _conn.dispose();
+  }
+}

--- a/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_at_notification_keystore.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_at_notification_keystore.dart
@@ -1,0 +1,265 @@
+import 'dart:async';
+
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+
+import 'sqlite_database.dart';
+import 'sqlite_notification_codec.dart';
+
+/// SQLite-backed [AtNotificationKeystore] (`notifications` table). A
+/// `KeyValueStore<String, AtNotification>` — no commit log, no metadata
+/// triplet — plus the notification-specific `init` / `iterate` surface.
+class SqliteAtNotificationKeystore
+    implements AtNotificationKeystore {
+  final SqliteDatabase _db;
+
+  final StreamController<KeyStoreChange> _changes =
+      StreamController<KeyStoreChange>.broadcast();
+
+  @override
+  final List<Future<void> Function(String key, {required bool skipCommit})>
+      preRemoveHooks = [];
+  @override
+  final List<Future<void> Function(String key, {required bool skipCommit})>
+      postRemoveHooks = [];
+
+  SqliteAtNotificationKeystore(this._db);
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Future<void> init(String path) async {
+    // The shared database is opened by the factory; nothing to do.
+  }
+
+  @override
+  Future<int?> put(String key, AtNotification value,
+      {bool skipCommit = false}) async {
+    final existed = await exists(key);
+    _db.runInTransaction(() {
+      _db.raw.execute(
+        'INSERT INTO notifications (id, payload, notification_datetime, type, status, expires_at) '
+        'VALUES (?, ?, ?, ?, ?, ?) '
+        'ON CONFLICT(id) DO UPDATE SET payload = excluded.payload, '
+        'notification_datetime = excluded.notification_datetime, '
+        'type = excluded.type, status = excluded.status, '
+        'expires_at = excluded.expires_at;',
+        [
+          key,
+          SqliteNotificationCodec.encode(value),
+          SqliteNotificationCodec.notificationDateTimeMillis(value) ?? 0,
+          SqliteNotificationCodec.typeExtract(value),
+          SqliteNotificationCodec.statusExtract(value),
+          SqliteNotificationCodec.expiresAtMillis(value),
+        ],
+      );
+    });
+    _changes.add(existed ? KeyUpdated(key) : KeyAdded(key));
+    return null; // notifications carry no commit id
+  }
+
+  @override
+  Future<int?> create(String key, AtNotification value,
+          {bool skipCommit = false}) =>
+      put(key, value, skipCommit: skipCommit);
+
+  @override
+  Future<AtNotification?> get(String key) async {
+    final rows =
+        _db.raw.select('SELECT payload FROM notifications WHERE id = ?;', [key]);
+    if (rows.isEmpty) return null;
+    return SqliteNotificationCodec.decode(rows.first['payload'] as String);
+  }
+
+  @override
+  Future<int?> remove(String key, {bool skipCommit = false}) async {
+    for (final hook in preRemoveHooks) {
+      await hook(key, skipCommit: skipCommit);
+    }
+    _db.raw.execute('DELETE FROM notifications WHERE id = ?;', [key]);
+    _changes.add(KeyRemoved(key));
+    for (final hook in postRemoveHooks) {
+      await hook(key, skipCommit: skipCommit);
+    }
+    return null;
+  }
+
+  @override
+  Future<bool> exists(String key) async => _db.raw
+      .select('SELECT 1 FROM notifications WHERE id = ? LIMIT 1;', [key])
+      .isNotEmpty;
+
+  @override
+  Future<Map<String, AtNotification>> getMany(List<String> keys) async {
+    final result = <String, AtNotification>{};
+    for (final k in keys) {
+      final n = await get(k);
+      if (n != null) result[k] = n;
+    }
+    return result;
+  }
+
+  @override
+  Future<int> removeMany(List<String> keys, {bool skipCommit = false}) async {
+    var removed = 0;
+    _db.runInTransaction(() {
+      for (final k in keys) {
+        if (_db.raw
+            .select('SELECT 1 FROM notifications WHERE id = ? LIMIT 1;', [k])
+            .isEmpty) {
+          continue;
+        }
+        _db.raw.execute('DELETE FROM notifications WHERE id = ?;', [k]);
+        removed++;
+      }
+    });
+    return removed;
+  }
+
+  @override
+  Future<Stream<String>> getKeys({String? regex}) async {
+    final re = RegExp(regex ?? '.*');
+    final rows = _db.raw.select('SELECT id FROM notifications;');
+    return Stream.fromIterable(
+        rows.map((r) => r['id'] as String).where(re.hasMatch));
+  }
+
+  @override
+  Future<Stream<String>> getExpiredKeys() async {
+    final now = DateTime.now().toUtc().millisecondsSinceEpoch;
+    final maxTtlMillis = AtNotification.maxTtl.inMilliseconds;
+    final rows = _db.raw.select(
+        "SELECT id FROM notifications WHERE status = 'expired' "
+        'OR (expires_at IS NOT NULL AND expires_at <= ?) '
+        'OR notification_datetime <= ?;',
+        [now, now - maxTtlMillis]);
+    return Stream.fromIterable(rows.map((r) => r['id'] as String));
+  }
+
+  @override
+  Future<bool> deleteExpiredKeys() async {
+    final keys = await (await getExpiredKeys()).toList();
+    for (final k in keys) {
+      await remove(k, skipCommit: true);
+    }
+    return true;
+  }
+
+  @override
+  Future<DateTime?> nextExpiresAt() async {
+    final v = _db.raw
+        .select(
+            'SELECT MIN(expires_at) m FROM notifications WHERE expires_at IS NOT NULL;')
+        .first['m'];
+    return v == null
+        ? null
+        : DateTime.fromMillisecondsSinceEpoch(v as int, isUtc: true);
+  }
+
+  @override
+  Future<Stream<String>> peekExpired({DateTime? asOf, int? limit}) async {
+    final cutoff = (asOf ?? DateTime.now()).toUtc().millisecondsSinceEpoch;
+    var sql =
+        'SELECT id FROM notifications WHERE expires_at IS NOT NULL AND expires_at <= ? ORDER BY expires_at';
+    final params = <Object?>[cutoff];
+    if (limit != null) {
+      sql += ' LIMIT ?';
+      params.add(limit);
+    }
+    final rows = _db.raw.select('$sql;', params);
+    return Stream.fromIterable(rows.map((r) => r['id'] as String));
+  }
+
+  @override
+  Stream<KeyStoreChange> get changes => _changes.stream;
+
+  @override
+  Future<R> transaction<R>(
+      Future<R> Function(KeyStoreTxn<String, AtNotification, dynamic> txn)
+          body) async {
+    // Notifications are appended one-at-a-time in practice; a minimal
+    // buffered transaction keeps the contract without a bespoke handle.
+    throw UnsupportedError(
+        'transaction() is not used on the notification keystore');
+  }
+
+  @override
+  bool get supportsSnapshots => false;
+
+  @override
+  Future<KeyStoreSnapshot<String, AtNotification, dynamic>> snapshot() async {
+    return _LiveNotificationSnapshot(this);
+  }
+
+  @override
+  Future<KeyStoreStats> stats() async {
+    final total =
+        _db.raw.select('SELECT COUNT(*) c FROM notifications;').first['c']
+            as int;
+    return KeyStoreStats(
+      totalKeys: total,
+      ttlKeys: 0,
+      ttbKeys: 0,
+      sizeBytes: 0,
+      oldestCreatedAt: null,
+      newestCreatedAt: null,
+    );
+  }
+
+  @override
+  Stream<AtNotification> iterate() async* {
+    final rows =
+        _db.raw.select('SELECT payload FROM notifications ORDER BY id;');
+    for (final r in rows) {
+      yield SqliteNotificationCodec.decode(r['payload'] as String);
+    }
+  }
+
+  @override
+  int entriesCount() =>
+      _db.raw.select('SELECT COUNT(*) c FROM notifications;').first['c'] as int;
+
+  @override
+  int getSize() {
+    final pageCount =
+        _db.raw.select('PRAGMA page_count;').first.values.first as int? ?? 0;
+    final pageSize =
+        _db.raw.select('PRAGMA page_size;').first.values.first as int? ?? 0;
+    return pageCount * pageSize;
+  }
+
+  @override
+  Future<void> close() async {}
+
+  /// Drops all rows (keeping the connection open) for test isolation.
+  Future<void> clear() async {
+    _db.raw.execute('DELETE FROM notifications;');
+  }
+
+  @override
+  Stream<String> compact(bool dryRun) async* {
+    final expired = await (await getExpiredKeys()).toList();
+    if (dryRun) {
+      yield* Stream.fromIterable(expired);
+      return;
+    }
+    for (final id in expired) {
+      await remove(id, skipCommit: true);
+      yield id;
+    }
+  }
+}
+
+/// A live-reading snapshot: `supportsSnapshots` is false, so reads reflect
+/// current state (parity with the Hive notification keystore).
+class _LiveNotificationSnapshot
+    implements KeyStoreSnapshot<String, AtNotification, dynamic> {
+  final SqliteAtNotificationKeystore _store;
+  _LiveNotificationSnapshot(this._store);
+
+  @override
+  Future<AtNotification?> get(String key) => _store.get(key);
+
+  @override
+  Future<void> release() async {}
+}

--- a/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_at_persistence_factory.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_at_persistence_factory.dart
@@ -1,0 +1,146 @@
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_utils/at_logger.dart';
+
+import 'sqlite_at_access_log.dart';
+import 'sqlite_at_commit_log.dart';
+import 'sqlite_at_keyvalue_store.dart';
+import 'sqlite_at_notification_keystore.dart';
+import 'sqlite_database.dart';
+import 'sqlite_persistence_config.dart';
+
+/// SQLite-backed [AtPersistenceFactory]. Produces one
+/// [SqliteAtPersistenceBundle] per atSign, each wrapping a single shared
+/// [SqliteDatabase] (`<storagePath>/<atSign>/atsign.db`) — so every store
+/// for an atSign transacts against the same connection.
+class SqliteAtPersistenceFactory implements AtPersistenceFactory {
+  final _logger = AtSignLogger('SqliteAtPersistenceFactory');
+
+  final Map<String, SqliteAtPersistenceBundle> _bundles = {};
+
+  @override
+  AtPersistenceBackendId get backendId => AtPersistenceBackendId.sqlite;
+
+  @override
+  Future<AtPersistenceBundle> initialize(
+      String atSign, AtPersistenceConfig config) async {
+    if (config is! SqlitePersistenceConfig) {
+      throw ArgumentError(
+          'SqliteAtPersistenceFactory expects SqlitePersistenceConfig, '
+          'got ${config.runtimeType}');
+    }
+
+    final existing = _bundles[atSign];
+    if (existing != null) {
+      if (!existing.isClosed) return existing;
+      _bundles.remove(atSign);
+    }
+
+    _logger.info('Initialising SQLite persistence for $atSign');
+
+    final db = SqliteDatabase.open(atSign, config.dbPathFor(atSign));
+
+    final commitLog = config.enableCommitLog ? SqliteAtCommitLog(db) : null;
+    final accessLog = config.enableAccessLog ? SqliteAtAccessLog(db) : null;
+    final notificationKeystore =
+        config.enableNotificationKeystore ? SqliteAtNotificationKeystore(db) : null;
+
+    final keyValueStore = SqliteAtKeyValueStore(db, atSign)
+      ..commitLog = commitLog;
+    await keyValueStore.initialize();
+
+    final bundle = SqliteAtPersistenceBundle._(
+      atSign: atSign,
+      db: db,
+      keyValueStore: keyValueStore,
+      accessLog: accessLog,
+      notificationKeystore: notificationKeystore,
+    );
+    _bundles[atSign] = bundle;
+    return bundle;
+  }
+
+  @override
+  AtPersistenceBundle? bundleFor(String atSign) {
+    final bundle = _bundles[atSign];
+    if (bundle == null) return null;
+    if (bundle.isClosed) {
+      _bundles.remove(atSign);
+      return null;
+    }
+    return bundle;
+  }
+
+  @override
+  Future<void> closeFor(String atSign) async {
+    final bundle = _bundles.remove(atSign);
+    if (bundle == null) return;
+    try {
+      await bundle.close();
+    } catch (e, st) {
+      _logger.warning('Error closing bundle for $atSign: $e\n$st');
+    }
+  }
+
+  @override
+  Future<void> close() async {
+    final bundles = _bundles.values.toList();
+    _bundles.clear();
+    for (final b in bundles) {
+      try {
+        await b.close();
+      } catch (e, st) {
+        _logger.warning('Error closing bundle for ${b.atSign}: $e\n$st');
+      }
+    }
+  }
+}
+
+/// SQLite-backed [AtPersistenceBundle]. All stores share the one
+/// [SqliteDatabase]; the bundle owns its lifecycle.
+class SqliteAtPersistenceBundle implements AtPersistenceBundle {
+  @override
+  final String atSign;
+
+  final SqliteDatabase _db;
+
+  @override
+  final SqliteAtKeyValueStore keyValueStore;
+
+  @override
+  final SqliteAtAccessLog? accessLog;
+
+  @override
+  final SqliteAtNotificationKeystore? notificationKeystore;
+
+  bool _closed = false;
+
+  @override
+  bool get isClosed => _closed;
+
+  SqliteAtPersistenceBundle._({
+    required this.atSign,
+    required SqliteDatabase db,
+    required this.keyValueStore,
+    required this.accessLog,
+    required this.notificationKeystore,
+  }) : _db = db;
+
+  @override
+  AtPersistenceBackendId get backendId => AtPersistenceBackendId.sqlite;
+
+  @override
+  Future<void> clear() async {
+    if (_closed) {
+      throw StateError(
+          'Cannot clear a closed SqliteAtPersistenceBundle for $atSign');
+    }
+    _db.clear();
+  }
+
+  @override
+  Future<void> close() async {
+    if (_closed) return;
+    _closed = true;
+    _db.close();
+  }
+}

--- a/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_database.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_database.dart
@@ -1,0 +1,138 @@
+import 'dart:ffi';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:sqlite3/open.dart' as sqlite_open;
+import 'package:sqlite3/sqlite3.dart';
+
+import 'sqlite_schema.dart';
+
+/// A single per-atSign SQLite database file. All four stores for an
+/// atSign (keystore, commit log, notification keystore, access log) share
+/// one instance — one open connection to one `atsign.db` — so a value
+/// write and its commit-log row commit atomically in one transaction.
+///
+/// sqlite3's API is synchronous; the store methods wrap these calls in
+/// `Future`-returning signatures to satisfy the async interface. A call
+/// blocks the isolate for the duration of the file I/O (the same tradeoff
+/// Hive's synchronous box operations make).
+class SqliteDatabase {
+  /// The atSign this database belongs to.
+  final String atSign;
+
+  /// Absolute or relative path to the `.db` file.
+  final String path;
+
+  final Database _db;
+
+  /// Nesting depth of [runInTransaction] — only the outermost call
+  /// issues `BEGIN`/`COMMIT`, so stores can compose (keystore.put wraps
+  /// commitLog.commit) without nested-transaction errors.
+  int _txnDepth = 0;
+
+  bool _rollbackPending = false;
+
+  SqliteDatabase._(this.atSign, this.path, this._db);
+
+  static bool _libraryConfigured = false;
+
+  /// On Linux, point `package:sqlite3` at the versioned soname
+  /// `libsqlite3.so.0` shipped by the runtime `libsqlite3-0` package — its
+  /// default (`libsqlite3.so`) only exists in the `-dev` package. No-op on
+  /// macOS/Windows, where the default resolution works. Runs once, before
+  /// the first `sqlite3.open`.
+  static void _configureLibrary() {
+    if (_libraryConfigured) return;
+    _libraryConfigured = true;
+    if (!Platform.isLinux) return;
+    sqlite_open.open
+        .overrideFor(sqlite_open.OperatingSystem.linux, () {
+      try {
+        return DynamicLibrary.open('libsqlite3.so.0');
+      } on ArgumentError {
+        return DynamicLibrary.open('libsqlite3.so');
+      }
+    });
+  }
+
+  /// Opens (creating parent directories and the file if needed) the
+  /// database at [dbPath], applies [SqliteSchema], and returns the
+  /// context.
+  static SqliteDatabase open(String atSign, String dbPath) {
+    _configureLibrary();
+    final dir = p.dirname(dbPath);
+    if (dir.isNotEmpty) {
+      Directory(dir).createSync(recursive: true);
+    }
+    final db = sqlite3.open(dbPath);
+    try {
+      SqliteSchema.apply(db);
+    } catch (_) {
+      db.dispose();
+      rethrow;
+    }
+    return SqliteDatabase._(atSign, dbPath, db);
+  }
+
+  /// The underlying sqlite3 handle. Stores use it for `select` / `execute`
+  /// / `prepare`. Prefer routing mutations through [runInTransaction].
+  Database get raw => _db;
+
+  /// Runs [body] inside a single transaction. Re-entrant: a nested call
+  /// joins the outer transaction rather than starting its own, and a
+  /// rollback anywhere aborts the whole outermost transaction. On any
+  /// thrown error the (outermost) transaction rolls back and the error
+  /// propagates.
+  T runInTransaction<T>(T Function() body) {
+    if (_txnDepth > 0) {
+      // Already inside a transaction — join it. A throw here sets the
+      // rollback flag so the outermost frame rolls the whole thing back.
+      try {
+        return body();
+      } catch (_) {
+        _rollbackPending = true;
+        rethrow;
+      }
+    }
+    _db.execute('BEGIN IMMEDIATE;');
+    _txnDepth++;
+    _rollbackPending = false;
+    try {
+      final result = body();
+      if (_rollbackPending) {
+        _db.execute('ROLLBACK;');
+      } else {
+        _db.execute('COMMIT;');
+      }
+      return result;
+    } catch (_) {
+      _db.execute('ROLLBACK;');
+      rethrow;
+    } finally {
+      _txnDepth--;
+      _rollbackPending = false;
+    }
+  }
+
+  /// `true` while a [runInTransaction] body is executing.
+  bool get inTransaction => _txnDepth > 0;
+
+  /// Drops all rows from every table and re-seeds the counter, keeping
+  /// the connection open. Backs [AtPersistenceBundle.clear] for cheap
+  /// per-test isolation.
+  void clear() {
+    runInTransaction(() {
+      _db.execute('DELETE FROM at_data;');
+      _db.execute('DELETE FROM commit_log;');
+      _db.execute('DELETE FROM notifications;');
+      _db.execute('DELETE FROM access_log;');
+      _db.execute("UPDATE counters SET value = 0 WHERE name = 'last_commit_id';");
+    });
+  }
+
+  /// Closes the connection. Idempotent-safe for the bundle's close path
+  /// (callers must not use the context afterwards).
+  void close() {
+    _db.dispose();
+  }
+}

--- a/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_metadata_codec.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_metadata_codec.dart
@@ -1,0 +1,45 @@
+import 'dart:convert';
+
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+
+/// Encodes / decodes the `at_data.metadata` column and derives its indexed
+/// extract columns (`expires_at` / `available_at` / `refresh_at`).
+///
+/// The column stores the **canonical** `AtMetaData` JSON — the exact wire
+/// (`llookup:all`) form: `AtMetaData.toJson()` in its declared field order,
+/// with null-valued keys stripped (readers treat absent == null; the
+/// unguarded `createdAt`/`updatedAt` are always present on stored data).
+/// This is the canonical interchange form.
+class SqliteMetadataCodec {
+  SqliteMetadataCodec._();
+
+  /// The metadata column value for [metaData]: null-stripped canonical JSON.
+  static String encode(AtMetaData metaData) =>
+      jsonEncode(_stripNulls(metaData.toJson()));
+
+  /// Reconstructs an [AtMetaData] from a stored [metadataJson] column.
+  static AtMetaData decode(String metadataJson) =>
+      AtMetaData().fromJson(jsonDecode(metadataJson) as Map);
+
+  /// The `expires_at` extract (epoch millis, UTC) — the metadata's derived
+  /// `expiresAt` (populated by [AtMetadataBuilder] on write, or carried
+  /// verbatim on restore). `null` when the key never expires.
+  static int? expiresAtMillis(AtMetaData m) =>
+      m.expiresAt?.toUtc().millisecondsSinceEpoch;
+
+  /// The `available_at` extract (epoch millis, UTC).
+  static int? availableAtMillis(AtMetaData m) =>
+      m.availableAt?.toUtc().millisecondsSinceEpoch;
+
+  /// The `refresh_at` extract (epoch millis, UTC).
+  static int? refreshAtMillis(AtMetaData m) =>
+      m.refreshAt?.toUtc().millisecondsSinceEpoch;
+
+  static Map<String, dynamic> _stripNulls(Map map) {
+    final out = <String, dynamic>{};
+    for (final entry in map.entries) {
+      if (entry.value != null) out[entry.key as String] = entry.value;
+    }
+    return out;
+  }
+}

--- a/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_notification_codec.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_notification_codec.dart
@@ -1,0 +1,112 @@
+import 'dart:convert';
+
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+
+/// Encodes / decodes an [AtNotification] to the `notifications.payload`
+/// column and derives its indexed extract columns.
+///
+/// [AtNotification.toJson] is not directly `jsonEncode`-able (it embeds
+/// enum and `DateTime` values), so this codec maps every field to a
+/// JSON-safe form (enum → `.name`, `DateTime` → ISO-8601 UTC string,
+/// metadata → `AtMetaData.toJson()`). [decode] reconstructs through
+/// [AtNotificationBuilder.build], matching the Hive adapter's read-time
+/// normalization exactly (ttl/expiresAt re-derivation), so both backends
+/// return byte-identical notifications for the same stored row.
+class SqliteNotificationCodec {
+  SqliteNotificationCodec._();
+
+  static String encode(AtNotification n) => jsonEncode({
+        'id': n.id,
+        'fromAtSign': n.fromAtSign,
+        'notificationDateTime': n.notificationDateTime?.toUtc().toString(),
+        'toAtSign': n.toAtSign,
+        'notification': n.notification,
+        'type': n.type?.name,
+        'opType': n.opType?.name,
+        'messageType': n.messageType?.name,
+        'priority': n.priority?.name,
+        'notificationStatus': n.notificationStatus?.name,
+        'retryCount': n.retryCount,
+        'strategy': n.strategy,
+        'depth': n.depth,
+        'notifier': n.notifier,
+        'expiresAt': n.expiresAt?.toUtc().toString(),
+        'atValue': n.atValue,
+        'atMetadata': n.atMetadata?.toJson(),
+        'ttl': n.ttl,
+      });
+
+  static AtNotification decode(String payloadJson) {
+    final m = jsonDecode(payloadJson) as Map;
+    final builder = AtNotificationBuilder()
+      ..id = m['id'] as String?
+      ..fromAtSign = m['fromAtSign'] as String?
+      ..notificationDateTime = _parseDate(m['notificationDateTime'])
+      ..toAtSign = m['toAtSign'] as String?
+      ..notification = m['notification'] as String?
+      ..type = _enum(NotificationType.values, m['type'])
+      ..opType = _enum(OperationType.values, m['opType'])
+      ..messageType = _enum(MessageType.values, m['messageType'])
+      ..priority = _enum(NotificationPriority.values, m['priority'])
+      ..notificationStatus = _enum(NotificationStatus.values, m['notificationStatus'])
+      ..retryCount = (m['retryCount'] as int?) ?? 1
+      ..strategy = m['strategy'] as String?
+      ..depth = m['depth'] as int?
+      ..notifier = m['notifier'] as String?
+      ..expiresAt = _parseDate(m['expiresAt'])
+      ..atValue = m['atValue'] as String?
+      ..atMetaData = _decodeAtMetadata(m['atMetadata'] as Map?)
+      ..ttl = m['ttl'] as int?;
+    return builder.build();
+  }
+
+  /// A notification's embedded metadata — unlike stored keystore metadata —
+  /// can have a null `createdAt`/`updatedAt` (it is not run through
+  /// [AtMetadataBuilder]). [AtMetaData.fromJson] calls `DateTime.parse` on
+  /// those two fields with no null guard, so decode tolerantly: parse with
+  /// placeholder dates, then restore the true (nullable) values — matching
+  /// how Hive's binary adapter preserves the nulls.
+  static AtMetaData? _decodeAtMetadata(Map? m) {
+    if (m == null) return null;
+    final createdAt = _parseDate(m['createdAt']);
+    final updatedAt = _parseDate(m['updatedAt']);
+    final placeholder =
+        DateTime.fromMillisecondsSinceEpoch(0, isUtc: true).toString();
+    final patched = Map.of(m)
+      ..['createdAt'] = createdAt?.toUtc().toString() ?? placeholder
+      ..['updatedAt'] = updatedAt?.toUtc().toString() ?? placeholder;
+    // fromJson also coerces a null version to 0; restore the true nullable
+    // value so a notification's metadata round-trips exactly as Hive's binary
+    // adapter preserves it.
+    return AtMetaData().fromJson(patched)
+      ..createdAt = createdAt
+      ..updatedAt = updatedAt
+      ..version = m['version'] as int?;
+  }
+
+  /// The `notification_datetime` extract (epoch millis, UTC).
+  static int? notificationDateTimeMillis(AtNotification n) =>
+      n.notificationDateTime?.toUtc().millisecondsSinceEpoch;
+
+  /// The `type` extract (`sent` / `received` / `self`).
+  static String typeExtract(AtNotification n) => n.type?.name ?? '';
+
+  /// The `status` extract (`delivered` / `errored` / `queued` / `expired`).
+  static String statusExtract(AtNotification n) =>
+      n.notificationStatus?.name ?? '';
+
+  /// The `expires_at` extract (epoch millis, UTC).
+  static int? expiresAtMillis(AtNotification n) =>
+      n.expiresAt?.toUtc().millisecondsSinceEpoch;
+
+  static DateTime? _parseDate(Object? v) =>
+      (v == null || v == 'null') ? null : DateTime.parse(v as String).toUtc();
+
+  static T? _enum<T extends Enum>(List<T> values, Object? name) {
+    if (name == null) return null;
+    for (final v in values) {
+      if (v.name == name) return v;
+    }
+    return null;
+  }
+}

--- a/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_persistence_config.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_persistence_config.dart
@@ -1,0 +1,81 @@
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:path/path.dart' as p;
+
+/// SQLite-specific persistence configuration.
+///
+/// Unlike Hive (which spreads the keystore / commit log / access log /
+/// notifications across four storage directories), the SQLite backend
+/// keeps all of an atSign's data in a single `atsign.db` file under a
+/// per-atSign directory: `<storagePath>/<atSign>/atsign.db`. The four
+/// path getters the [AtPersistenceConfig] contract requires therefore all
+/// resolve to the one storage root — they are vestigial for a single-file
+/// backend but kept for interface conformance.
+class SqlitePersistenceConfig implements AtPersistenceConfig {
+  @override
+  AtPersistenceBackendId get backend => AtPersistenceBackendId.sqlite;
+
+  /// The SQLite storage root. Per-atSign databases live at
+  /// `<storagePath>/<atSign>/atsign.db`, so this is typically a
+  /// `.../sqlite` directory sibling to the Hive tree.
+  @override
+  final String storagePath;
+
+  // Single-file backend: these all resolve to the storage root.
+  @override
+  String get commitLogPath => storagePath;
+  @override
+  String get accessLogPath => storagePath;
+  @override
+  String get notificationStoragePath => storagePath;
+
+  @override
+  final String backendMarkerPath;
+
+  @override
+  final bool enableAccessLog;
+
+  @override
+  final bool enableNotificationKeystore;
+
+  @override
+  final bool enableCommitLog;
+
+  SqlitePersistenceConfig({
+    required this.storagePath,
+    String? backendMarkerPath,
+    this.enableAccessLog = true,
+    this.enableNotificationKeystore = true,
+    this.enableCommitLog = true,
+  }) : backendMarkerPath =
+            backendMarkerPath ?? p.join(storagePath, '.persistence_backend');
+
+  /// The `.db` file path for [atSign]: `<storagePath>/<atSign>/atsign.db`.
+  String dbPathFor(String atSign) =>
+      p.join(storagePath, atSign, 'atsign.db');
+
+  /// atSecondary server config: all optional capabilities on.
+  factory SqlitePersistenceConfig.serverDefaults({
+    required String storagePath,
+    String? backendMarkerPath,
+  }) =>
+      SqlitePersistenceConfig(
+        storagePath: storagePath,
+        backendMarkerPath: backendMarkerPath,
+        enableAccessLog: true,
+        enableNotificationKeystore: true,
+        enableCommitLog: true,
+      );
+
+  /// at_client-shaped config: keystore only, commit-log-free.
+  factory SqlitePersistenceConfig.clientDefaults({
+    required String storagePath,
+    String? backendMarkerPath,
+  }) =>
+      SqlitePersistenceConfig(
+        storagePath: storagePath,
+        backendMarkerPath: backendMarkerPath,
+        enableAccessLog: false,
+        enableNotificationKeystore: false,
+        enableCommitLog: false,
+      );
+}

--- a/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_query_translator.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_query_translator.dart
@@ -1,0 +1,83 @@
+import 'package:at_commons/at_commons.dart';
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+
+/// Translates the backend-agnostic [KeyPattern] / [Predicate] query types
+/// into SQLite. [matchesKeyPattern] mirrors the Hive keystore's
+/// `_matchesPattern` exactly (atKey-structure filtering); [predicateToSql]
+/// lowers a value-field [Predicate] AST to a `json_extract` WHERE clause.
+class SqliteQueryTranslator {
+  SqliteQueryTranslator._();
+
+  /// True if [keyString] matches [pattern]. Same semantics as the Hive
+  /// keystore: parse the atKey and compare sharedBy / sharedWith
+  /// (case-insensitive, `@`-tolerant) / namespace / idPrefix. A malformed
+  /// key matches nothing.
+  static bool matchesKeyPattern(String keyString, KeyPattern pattern) {
+    if (pattern.isUnrestricted) return true;
+    final AtKey atKey;
+    try {
+      atKey = AtKey.fromString(keyString);
+    } on Exception {
+      return false;
+    }
+    if (pattern.sharedBy != null &&
+        !_atSignEquals(atKey.sharedBy, pattern.sharedBy!)) {
+      return false;
+    }
+    if (pattern.sharedWith != null &&
+        !_atSignEquals(atKey.sharedWith, pattern.sharedWith!)) {
+      return false;
+    }
+    if (pattern.namespace != null && atKey.namespace != pattern.namespace) {
+      return false;
+    }
+    if (pattern.idPrefix != null && !atKey.key.startsWith(pattern.idPrefix!)) {
+      return false;
+    }
+    return true;
+  }
+
+  static bool _atSignEquals(String? actual, String expected) {
+    if (actual == null) return false;
+    final a = actual.startsWith('@') ? actual.substring(1) : actual;
+    final e = expected.startsWith('@') ? expected.substring(1) : expected;
+    return a.toLowerCase() == e.toLowerCase();
+  }
+
+  /// Lowers [predicate] to a SQL boolean expression over `json_extract`
+  /// of [column]. Returns the SQL fragment and its positional params.
+  static ({String sql, List<Object?> params}) predicateToSql(
+      Predicate predicate, String column) {
+    switch (predicate) {
+      case PathEquals p:
+        final path = "\$.${p.path.join('.')}";
+        if (p.expected == null) {
+          return (sql: "json_extract($column, ?) IS NULL", params: [path]);
+        }
+        final expected = p.expected;
+        final bound = expected is bool ? (expected ? 1 : 0) : expected;
+        return (
+          sql: "json_extract($column, ?) = ?",
+          params: [path, bound]
+        );
+      case And a:
+        if (a.children.isEmpty) return (sql: '1=1', params: []);
+        return _combine(a.children, 'AND', column);
+      case Or o:
+        if (o.children.isEmpty) return (sql: '1=0', params: []);
+        return _combine(o.children, 'OR', column);
+    }
+  }
+
+  static ({String sql, List<Object?> params}) _combine(
+      List<Predicate> children, String op, String column) {
+    final parts = <String>[];
+    final params = <Object?>[];
+    for (final child in children) {
+      final t = predicateToSql(child, column);
+      parts.add('(${t.sql})');
+      params.addAll(t.params);
+    }
+    return (sql: parts.join(' $op '), params: params);
+  }
+}

--- a/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_schema.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_schema.dart
@@ -1,0 +1,165 @@
+import 'package:sqlite3/sqlite3.dart';
+
+/// The per-atSign SQLite schema — a stable interchange contract. One
+/// database per atSign; every store (keystore, commit log, notifications,
+/// access log) lives in the same `atsign.db` file so a value write and its
+/// commit entry can share one transaction.
+///
+/// The DDL, PRAGMAs, and [contractVersion] here are the canonical
+/// definition of that contract.
+class SqliteSchema {
+  SqliteSchema._();
+
+  /// `PRAGMA user_version`. A reader hard-fails on a database whose
+  /// stored version is HIGHER than this (it cannot know the newer shape)
+  /// and migrates-forward from a lower one.
+  static const int contractVersion = 1;
+
+  /// One row per live atKey. Deletes remove the row (sync-visible
+  /// deletion state lives in [commitLog], not here as a tombstone).
+  /// `metadata` is the canonical `AtMetaData` JSON (the wire `llookup:all`
+  /// form); `expires_at`/`available_at`/`refresh_at` are indexed extracts
+  /// of the same-named derived metadata fields (epoch millis, UTC).
+  static const String atData = '''
+CREATE TABLE IF NOT EXISTS at_data (
+  atkey        TEXT PRIMARY KEY NOT NULL,
+  value        TEXT,
+  metadata     TEXT NOT NULL,
+  expires_at   INTEGER,
+  available_at INTEGER,
+  refresh_at   INTEGER
+) WITHOUT ROWID;
+''';
+
+  static const List<String> atDataIndexes = [
+    'CREATE INDEX IF NOT EXISTS at_data_expires_at ON at_data (expires_at) WHERE expires_at IS NOT NULL;',
+    'CREATE INDEX IF NOT EXISTS at_data_available_at ON at_data (available_at) WHERE available_at IS NOT NULL;',
+    'CREATE INDEX IF NOT EXISTS at_data_refresh_at ON at_data (refresh_at) WHERE refresh_at IS NOT NULL;',
+  ];
+
+  /// One row per atKey, newest-wins: a new commit for an atKey replaces
+  /// that atKey's row (the canonical `CommitLogKeyStore` collapse — the
+  /// log answers "each key's latest commit", not the history).
+  static const String commitLog = '''
+CREATE TABLE IF NOT EXISTS commit_log (
+  atkey     TEXT PRIMARY KEY NOT NULL,
+  commit_id INTEGER NOT NULL,
+  operation TEXT NOT NULL CHECK (operation IN ('+', '#', '*', '-')),
+  op_time   INTEGER
+) WITHOUT ROWID;
+''';
+
+  static const List<String> commitLogIndexes = [
+    'CREATE UNIQUE INDEX IF NOT EXISTS commit_log_commit_id ON commit_log (commit_id);',
+  ];
+
+  /// Monotonic allocators. `last_commit_id` is bumped in the same
+  /// transaction as each synced write, giving a dense, gapless commit id
+  /// per database. (A `MAX(commit_log.commit_id)` allocator is unsafe:
+  /// expiry purges a key's commit row and could reissue the max id.)
+  static const String counters = '''
+CREATE TABLE IF NOT EXISTS counters (
+  name  TEXT PRIMARY KEY NOT NULL,
+  value INTEGER NOT NULL
+) WITHOUT ROWID;
+''';
+
+  static const String seedCounters =
+      "INSERT OR IGNORE INTO counters (name, value) VALUES ('last_commit_id', 0);";
+
+  /// Durable notification delivery queue + inbox. `payload` is the
+  /// canonical `AtNotification` JSON; the other columns are indexed
+  /// extracts for the three query shapes (since-time monitor scans,
+  /// startup re-enqueue of `queued`, expiry sweep).
+  static const String notifications = '''
+CREATE TABLE IF NOT EXISTS notifications (
+  id                    TEXT PRIMARY KEY NOT NULL,
+  payload               TEXT NOT NULL,
+  notification_datetime INTEGER NOT NULL,
+  type                  TEXT NOT NULL,
+  status                TEXT NOT NULL,
+  expires_at            INTEGER
+) WITHOUT ROWID;
+''';
+
+  static const List<String> notificationIndexes = [
+    'CREATE INDEX IF NOT EXISTS notifications_datetime ON notifications (notification_datetime);',
+    'CREATE INDEX IF NOT EXISTS notifications_status ON notifications (status);',
+    'CREATE INDEX IF NOT EXISTS notifications_expires_at ON notifications (expires_at) WHERE expires_at IS NOT NULL;',
+  ];
+
+  /// Insert-only connection/verb audit feeding the `stats` verbs. `seq`
+  /// is the implicit rowid alias (insertion order == id order).
+  static const String accessLog = '''
+CREATE TABLE IF NOT EXISTS access_log (
+  seq         INTEGER PRIMARY KEY,
+  from_atsign TEXT,
+  request_at  INTEGER NOT NULL,
+  verb_name   TEXT,
+  lookup_key  TEXT
+);
+''';
+
+  static const List<String> accessLogIndexes = [
+    'CREATE INDEX IF NOT EXISTS access_log_request_at ON access_log (request_at);',
+  ];
+
+  /// Open-time PRAGMAs. WAL + synchronous=NORMAL survives process kill
+  /// (only power loss can drop the WAL tail); both servers tolerate
+  /// opening a database left in either journal mode.
+  static const List<String> pragmas = [
+    'PRAGMA journal_mode = WAL;',
+    'PRAGMA synchronous = NORMAL;',
+    'PRAGMA busy_timeout = 5000;',
+  ];
+
+  /// Applies PRAGMAs, creates every table/index (idempotent), seeds the
+  /// counters, and reconciles `user_version`. Safe to call on an existing
+  /// database (nothing is dropped).
+  ///
+  /// Throws [StateError] if the database's stored `user_version` is newer
+  /// than [contractVersion] — this reader cannot safely touch a
+  /// forward-versioned file.
+  static void apply(Database db) {
+    for (final p in pragmas) {
+      db.execute(p);
+    }
+
+    final storedVersion = _userVersion(db);
+    if (storedVersion > contractVersion) {
+      throw StateError(
+          'SQLite database is at contract version $storedVersion, newer than '
+          'this server understands ($contractVersion). Refusing to open.');
+    }
+
+    db.execute(atData);
+    for (final ix in atDataIndexes) {
+      db.execute(ix);
+    }
+    db.execute(commitLog);
+    for (final ix in commitLogIndexes) {
+      db.execute(ix);
+    }
+    db.execute(counters);
+    db.execute(seedCounters);
+    db.execute(notifications);
+    for (final ix in notificationIndexes) {
+      db.execute(ix);
+    }
+    db.execute(accessLog);
+    for (final ix in accessLogIndexes) {
+      db.execute(ix);
+    }
+
+    if (storedVersion < contractVersion) {
+      // Forward-migrate marker. (v1 is the initial contract, so there is
+      // no data reshaping to do; future bumps add migration steps here.)
+      db.execute('PRAGMA user_version = $contractVersion;');
+    }
+  }
+
+  static int _userVersion(Database db) {
+    final rs = db.select('PRAGMA user_version;');
+    return rs.isEmpty ? 0 : (rs.first.values.first as int);
+  }
+}

--- a/packages/at_persistence_secondary_server/lib/src/migration/persistence_migrator.dart
+++ b/packages/at_persistence_secondary_server/lib/src/migration/persistence_migrator.dart
@@ -1,0 +1,91 @@
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+
+/// Per-store counts produced by a [PersistenceMigrator.migrate] run.
+class MigrationReport {
+  final int keys;
+  final int commitEntries;
+  final int accessEntries;
+  final int notifications;
+
+  MigrationReport({
+    required this.keys,
+    required this.commitEntries,
+    required this.accessEntries,
+    required this.notifications,
+  });
+
+  @override
+  String toString() =>
+      'MigrationReport{keys: $keys, commitEntries: $commitEntries, '
+      'accessEntries: $accessEntries, notifications: $notifications}';
+}
+
+/// Copies every store from one [AtPersistenceBundle] to another, backend-
+/// agnostically, using the verbatim primitives so nothing is re-derived:
+///   * keystore   — `scanKeys(includeExpired) + get → restore`
+///   * commit log — `iterate → replay` (preserving `commitId`, and the
+///                   allocator is bumped past every replayed id)
+///   * access log — `iterate → replay` (preserving `requestDateTime`)
+///   * notifications — `iterate → put`
+///
+/// The result is byte-identical to the source under
+/// [PersistenceSnapshot]. The target should be freshly initialised (empty)
+/// — the migrator does not clear it first.
+class PersistenceMigrator {
+  static Future<MigrationReport> migrate(
+      AtPersistenceBundle source, AtPersistenceBundle target) async {
+    // 1. Keystore — every key, including expired / not-yet-born.
+    var keys = 0;
+    final keyList = await (await source.keyValueStore
+            .scanKeys(KeyPattern(), includeExpired: true))
+        .toList();
+    for (final k in keyList) {
+      final data = await source.keyValueStore.get(k);
+      if (data == null) continue;
+      await target.keyValueStore.restore(k, data);
+      keys++;
+    }
+
+    // 2. Commit log — preserve commit ids and sync identity.
+    var commitEntries = 0;
+    final srcCommitLog = source.keyValueStore.commitLog;
+    final tgtCommitLog = target.keyValueStore.commitLog;
+    if (srcCommitLog != null && tgtCommitLog != null) {
+      await for (final entry in srcCommitLog.iterate()) {
+        await tgtCommitLog.replay(entry);
+        commitEntries++;
+      }
+    }
+
+    // 3. Access log — preserve timestamps and order.
+    var accessEntries = 0;
+    final srcAccessLog = source.accessLog;
+    final tgtAccessLog = target.accessLog;
+    if (srcAccessLog != null && tgtAccessLog != null) {
+      await for (final entry in srcAccessLog.iterate()) {
+        await tgtAccessLog.replay(entry);
+        accessEntries++;
+      }
+    }
+
+    // 4. Notifications — put stores verbatim; read normalises both sides.
+    var notifications = 0;
+    final srcNotif = source.notificationKeystore;
+    final tgtNotif = target.notificationKeystore;
+    if (srcNotif != null && tgtNotif != null) {
+      await for (final n in srcNotif.iterate()) {
+        final id = n.id;
+        if (id == null) continue;
+        await tgtNotif.put(id, n);
+        notifications++;
+      }
+    }
+
+    return MigrationReport(
+      keys: keys,
+      commitEntries: commitEntries,
+      accessEntries: accessEntries,
+      notifications: notifications,
+    );
+  }
+}

--- a/packages/at_persistence_secondary_server/lib/src/migration/persistence_snapshot.dart
+++ b/packages/at_persistence_secondary_server/lib/src/migration/persistence_snapshot.dart
@@ -1,0 +1,185 @@
+import 'dart:convert';
+
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+
+/// A backend-agnostic, canonical snapshot of everything an
+/// [AtPersistenceBundle] holds — used to assert that two bundles carry
+/// identical data (the migration verify step, and the conversion-integrity
+/// harness), regardless of backend.
+///
+/// Canonicalisation choices that make the comparison backend-neutral:
+///   * keystore entries are keyed by atKey → `{data, metaData.toJson()}`;
+///     the transient `AtData.key` (Hive's on-disk key vs SQLite's atKey)
+///     is excluded.
+///   * timestamps are reduced to epoch millis (Hive stores ms precision;
+///     both backends normalise to it).
+///   * commit-log / access-log entries are ordered lists (order is
+///     load-bearing); keystore / notifications are maps (order is not).
+class PersistenceSnapshot {
+  /// atKey → canonical `{data, metaData}` JSON.
+  final Map<String, String> keystore;
+
+  /// Ordered `commitId|atKey|op|opTimeMillis` lines.
+  final List<String> commitLog;
+
+  /// Ordered `fromAtSign|requestAtMillis|verb|lookupKey` lines.
+  final List<String> accessLog;
+
+  /// notification id → canonical field JSON.
+  final Map<String, String> notifications;
+
+  PersistenceSnapshot._(
+      this.keystore, this.commitLog, this.accessLog, this.notifications);
+
+  /// Captures a canonical snapshot of [bundle]. Reads every key
+  /// (including expired / not-yet-born) so the snapshot reflects stored
+  /// state, not query-time visibility.
+  static Future<PersistenceSnapshot> capture(AtPersistenceBundle bundle) async {
+    final keystore = <String, String>{};
+    // Lower-cased atKeys whose row is present AND not past its expiry. Only such
+    // a key's non-delete commit entry is sync-relevant — see the commit-log note.
+    final liveUnexpired = <String>{};
+    final now = DateTime.now().toUtc();
+    final keys = await (await bundle.keyValueStore
+            .scanKeys(KeyPattern(), includeExpired: true))
+        .toList();
+    for (final k in keys) {
+      final d = await bundle.keyValueStore.get(k);
+      if (d == null) continue;
+      keystore[k] =
+          jsonEncode({'data': d.data, 'metaData': d.metaData?.toJson()});
+      final exp = d.metaData?.expiresAt?.toUtc();
+      if (exp == null || exp.isAfter(now)) {
+        liveUnexpired.add(k.toLowerCase());
+      }
+    }
+
+    final commitLog = <String>[];
+    final cl = bundle.keyValueStore.commitLog;
+    if (cl != null) {
+      await for (final e in cl.iterate()) {
+        // Tolerate a divergence Hive produces but a faithful SQLite mirror does
+        // not. After a TTL-expiry `skipCommit` sweep, Hive can leave a stale
+        // non-delete commit entry in its box for an expired key: the sweep tries
+        // to purge the entry via the cache-based getLatestCommitEntry, and on a
+        // cache miss the box entry survives orphaned (a Hive cache/box
+        // inconsistency). SQLite carries no such stale entry. A commit entry for
+        // a key that is absent or expired is sync-benign — its value is gone or
+        // will not sync live — so skip non-delete entries whose key is not
+        // present-and-unexpired. DELETE entries, and entries for live unexpired
+        // keys, are always compared: real mirror data loss still fails here.
+        if (e.operation != CommitOp.DELETE &&
+            !liveUnexpired.contains(e.atKey?.toLowerCase())) {
+          continue;
+        }
+        commitLog.add('${e.commitId}|${e.atKey}|${e.operation.name}|'
+            '${e.opTime?.toUtc().millisecondsSinceEpoch}');
+      }
+    }
+
+    final accessLog = <String>[];
+    final al = bundle.accessLog;
+    if (al != null) {
+      await for (final e in al.iterate()) {
+        accessLog.add('${e.fromAtSign}|'
+            '${e.requestDateTime?.toUtc().millisecondsSinceEpoch}|'
+            '${e.verbName}|${e.lookupKey}');
+      }
+      // The access log is an audit trail; its cross-backend insertion order
+      // is not load-bearing (and interleaves under concurrent dual-write), so
+      // compare it as a multiset. Migration preserves order, so sorting is a
+      // no-op there.
+      accessLog.sort();
+    }
+
+    final notifications = <String, String>{};
+    final nk = bundle.notificationKeystore;
+    if (nk != null) {
+      await for (final n in nk.iterate()) {
+        notifications[n.id ?? ''] = _canonicalNotification(n);
+      }
+    }
+
+    return PersistenceSnapshot._(keystore, commitLog, accessLog, notifications);
+  }
+
+  /// Returns `null` if [other] is identical, else a short human-readable
+  /// description of the first difference found (for test failures and the
+  /// server-side migration verify log).
+  String? describeDifferenceFrom(PersistenceSnapshot other) {
+    final diffs = differencesFrom(other);
+    return diffs.isEmpty ? null : diffs.first;
+  }
+
+  /// Returns EVERY difference from [other] (empty when identical), across
+  /// all four stores — for a full reconciliation report (the compare CLI).
+  List<String> differencesFrom(PersistenceSnapshot other) {
+    final diffs = <String>[];
+    _collectMapDiffs('keystore', keystore, other.keystore, diffs);
+    _collectListDiffs('commitLog', commitLog, other.commitLog, diffs);
+    _collectListDiffs('accessLog', accessLog, other.accessLog, diffs);
+    _collectMapDiffs(
+        'notifications', notifications, other.notifications, diffs);
+    return diffs;
+  }
+
+  bool matches(PersistenceSnapshot other) =>
+      differencesFrom(other).isEmpty;
+
+  /// Per-store row counts, for the compare CLI's summary line.
+  Map<String, int> get counts => {
+        'keystore': keystore.length,
+        'commitLog': commitLog.length,
+        'accessLog': accessLog.length,
+        'notifications': notifications.length,
+      };
+
+  static String _canonicalNotification(AtNotification n) => jsonEncode({
+        'id': n.id,
+        'fromAtSign': n.fromAtSign,
+        'toAtSign': n.toAtSign,
+        'notification': n.notification,
+        'type': n.type?.name,
+        'opType': n.opType?.name,
+        'messageType': n.messageType?.name,
+        'priority': n.priority?.name,
+        'notificationStatus': n.notificationStatus?.name,
+        'retryCount': n.retryCount,
+        'strategy': n.strategy,
+        'depth': n.depth,
+        'notifier': n.notifier,
+        'notificationDateTime':
+            n.notificationDateTime?.toUtc().millisecondsSinceEpoch,
+        'expiresAt': n.expiresAt?.toUtc().millisecondsSinceEpoch,
+        'atValue': n.atValue,
+        'atMetadata': n.atMetadata?.toJson(),
+        'ttl': n.ttl,
+      });
+
+  static void _collectMapDiffs(String label, Map<String, String> a,
+      Map<String, String> b, List<String> out) {
+    for (final key in a.keys) {
+      if (!b.containsKey(key)) {
+        out.add('$label: key only in A: $key');
+      } else if (a[key] != b[key]) {
+        out.add('$label: value differs for $key\n    A=${a[key]}\n    B=${b[key]}');
+      }
+    }
+    for (final key in b.keys) {
+      if (!a.containsKey(key)) out.add('$label: key only in B: $key');
+    }
+  }
+
+  static void _collectListDiffs(
+      String label, List<String> a, List<String> b, List<String> out) {
+    if (a.length != b.length) {
+      out.add('$label: length ${a.length} (A) != ${b.length} (B)');
+    }
+    final n = a.length < b.length ? a.length : b.length;
+    for (var i = 0; i < n; i++) {
+      if (a[i] != b[i]) {
+        out.add('$label[$i] differs:\n    A=${a[i]}\n    B=${b[i]}');
+      }
+    }
+  }
+}

--- a/packages/at_persistence_secondary_server/lib/src/spec/accesslog/at_access_log.dart
+++ b/packages/at_persistence_secondary_server/lib/src/spec/accesslog/at_access_log.dart
@@ -35,6 +35,13 @@ abstract class AtAccessLog implements Compactable {
   /// backend to another.
   Stream<AccessLogEntry> iterate();
 
+  /// Append [entry] **verbatim**, preserving its `requestDateTime`
+  /// (unlike [insert], which stamps the current instant). The
+  /// keystore counterpart to [iterate] for the persistence migrator:
+  /// replaying every iterated entry into a fresh backend reproduces
+  /// the same insertion-ordered log.
+  Future<void> replay(AccessLogEntry entry);
+
   /// Total entry count. Used by operators / metrics; not on any
   /// hot path.
   int entriesCount();

--- a/packages/at_persistence_secondary_server/lib/src/spec/at_persistence_config.dart
+++ b/packages/at_persistence_secondary_server/lib/src/spec/at_persistence_config.dart
@@ -1,8 +1,8 @@
 /// Identifies which persistence backend an [AtPersistenceFactory]
-/// produces. Only [hive] ships today; future backends (e.g. SQLite,
+/// produces. [hive] and [sqlite] ship today; future backends (e.g.
 /// Postgres) will add others without changing the enum's existing
 /// values.
-enum AtPersistenceBackendId { hive }
+enum AtPersistenceBackendId { hive, sqlite }
 
 /// Open base class for backend-specific configuration. Future
 /// backends subclass to add backend-specific fields without breaking

--- a/packages/at_persistence_secondary_server/lib/src/spec/keystore/at_keyvalue_store.dart
+++ b/packages/at_persistence_secondary_server/lib/src/spec/keystore/at_keyvalue_store.dart
@@ -97,6 +97,20 @@ abstract interface class AtKeyValueStore<K, V, T>
   /// Returns the metadata associated with [key].
   Future<T> getMeta(K key);
 
+  /// Write [value] for [key] **verbatim** — no [AtMetadataBuilder]
+  /// pass, no `version`/`updatedAt` mutation, no commit-log append,
+  /// no change-event. The stored record is byte-for-byte what
+  /// [value] carries (its data and its metadata).
+  ///
+  /// This is the keystore counterpart to [AtCommitLog.replay]: it
+  /// exists for the persistence migrator to copy keystore content
+  /// from one backend to another while preserving every field
+  /// exactly. It is NOT a general write path — application writes go
+  /// through [put] / [create] / [putAll], which derive metadata.
+  /// Idempotent: restoring the same (key, value) twice leaves the
+  /// same stored record.
+  Future<void> restore(K key, V value);
+
   /// Stream the keystore keys that match [pattern]. Backend-
   /// portable successor to [KeyValueStore.getKeys] for callers
   /// that want structured filtering rather than building regular

--- a/packages/at_persistence_secondary_server/pubspec.yaml
+++ b/packages/at_persistence_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_persistence_secondary_server
 description: A Dart library with the implementation classes for the persistence layer of the secondary server.
-version: 5.1.0
+version: 5.2.0
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://docs.atsign.com/
 

--- a/packages/at_persistence_secondary_server/pubspec.yaml
+++ b/packages/at_persistence_secondary_server/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 dependencies:
   path: ^1.8.2
   hive: ^2.2.3
+  sqlite3: ^2.4.0
   cron: ^0.5.0
   crypto: ^3.0.3
   uuid: ^4.0.0

--- a/packages/at_persistence_secondary_server/test/conversion_integrity_test.dart
+++ b/packages/at_persistence_secondary_server/test/conversion_integrity_test.dart
@@ -1,0 +1,193 @@
+import 'dart:io';
+
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_persistence_secondary_server/hive.dart';
+import 'package:at_persistence_secondary_server/sqlite.dart';
+import 'package:test/test.dart';
+
+/// The conversion-integrity gate:
+///
+///   hive1 → sqlite1 → hive2 → sqlite2 → hive3 → sqlite3
+///
+/// asserting all three Hive snapshots are identical, and all three SQLite
+/// snapshots are identical. Because the migrator uses verbatim primitives
+/// (no metadata builder, preserved commit ids), a lossless backend
+/// round-trips a rich fixture unchanged; any lossy field would surface as
+/// a snapshot difference.
+void main() {
+  const atSign = '@alice';
+  final root = '${Directory.current.path}/test/conversion_tmp';
+
+  final hiveFactory = HiveAtPersistenceFactory();
+  final sqliteFactory = SqliteAtPersistenceFactory();
+
+  tearDown(() async {
+    await hiveFactory.close();
+    await sqliteFactory.close();
+    final dir = Directory(root);
+    if (dir.existsSync()) dir.deleteSync(recursive: true);
+  });
+
+  Future<AtPersistenceBundle> hiveBundle(String name) => hiveFactory.initialize(
+      '$atSign-$name-key', // distinct atSign so boxes don't collide in-process
+      HivePersistenceConfig.serverDefaults(
+        storagePath: '$root/hive/$name',
+        commitLogPath: '$root/hive/$name',
+        accessLogPath: '$root/hive/$name',
+        notificationStoragePath: '$root/hive/$name',
+      ));
+
+  Future<AtPersistenceBundle> sqliteBundle(String name) =>
+      sqliteFactory.initialize(
+          '$atSign-$name-key',
+          SqlitePersistenceConfig.serverDefaults(
+              storagePath: '$root/sqlite/$name'));
+
+  AtData atData(String? v, AtMetaData m) => AtData()
+    ..data = v
+    ..metaData = m;
+
+  // ms-precision so Hive's ms-truncation and SQLite's JSON string form agree.
+  DateTime t(int y, [int mo = 1, int d = 1, int h = 0, int mi = 0, int s = 0, int ms = 0]) =>
+      DateTime.utc(y, mo, d, h, mi, s, ms);
+
+  /// Seeds a bundle with a fixture exercising every field/edge the round
+  /// trip must preserve.
+  Future<void> seed(AtPersistenceBundle b) async {
+    final ks = b.keyValueStore;
+    final owner = b.atSign;
+
+    // 1. A fully-populated metadata record (via verbatim restore so the
+    //    audit fields are fixed and comparable).
+    await ks.restore('public:publickey$owner', atData('RSA_PUB', AtMetaData()
+      ..createdBy = owner
+      ..updatedBy = owner
+      ..createdAt = t(2021, 1, 2, 3, 4, 5, 678)
+      ..updatedAt = t(2021, 1, 2, 3, 4, 5, 678)
+      ..version = 0
+      ..ttr = -1
+      ..isBinary = false
+      ..isEncrypted = false
+      ..dataSignature = 'sig-data'
+      ..sharedKeyEnc = 'shared-enc'
+      ..pubKeyCS = 'cs123'
+      ..encoding = 'base64'
+      ..encKeyName = 'ek'
+      ..encAlgo = 'AES/GCM'
+      ..ivNonce = 'iv123'
+      ..skeEncKeyName = 'ske'
+      ..skeEncAlgo = 'RSA'));
+
+    // 2. A normal write (goes through the builder → commit entry).
+    await ks.create('phone.wavi$owner', atData('+1234', AtMetaData()));
+
+    // 3. A shared key.
+    await ks.create('@bob:location.wavi$owner',
+        atData('encrypted-loc', AtMetaData()..isEncrypted = true));
+
+    // 4. A TTL key already expired. (version is always set on real
+    //    stored data — the builder stamps it — so the fixture sets it too;
+    //    AtMetaData.fromJson coerces a null version to 0, which would
+    //    otherwise diverge from Hive's binary adapter that preserves null.)
+    await ks.restore('temp.wavi$owner', atData('gone', AtMetaData()
+      ..createdAt = t(2020)
+      ..updatedAt = t(2020)
+      ..version = 3
+      ..ttl = 1000
+      ..expiresAt = t(2020, 1, 1, 0, 0, 1)));
+
+    // 5. A TTB key not yet born.
+    await ks.restore('future.wavi$owner', atData('later', AtMetaData()
+      ..createdAt = t(2021)
+      ..updatedAt = t(2021)
+      ..version = 0
+      ..ttb = 999999999
+      ..availableAt = t(2099)));
+
+    // 6. An elided key (no commit entry).
+    await ks.create('private:secret.wavi$owner', atData('hush', AtMetaData()));
+
+    // 7. A public:__ (double underscore) key — IS synced.
+    await ks.create('public:__internal.wavi$owner', atData('vis', AtMetaData()));
+
+    // 8. A unicode atKey.
+    await ks.create('emoji.wavi$owner', atData('🎉', AtMetaData()));
+
+    // 9. A create-then-delete (leaves a `-` commit entry, no at_data row).
+    await ks.create('goodbye.wavi$owner', atData('bye', AtMetaData()));
+    await ks.remove('goodbye.wavi$owner');
+
+    // Access log.
+    await b.accessLog!.replay(
+        AccessLogEntry(owner, t(2022, 5, 5, 1, 2, 3), 'pkam', null));
+    await b.accessLog!
+        .replay(AccessLogEntry('@bob', t(2022, 5, 5, 1, 2, 4), 'lookup', 'phone.wavi$owner'));
+    await b.accessLog!
+        .replay(AccessLogEntry('@bob', t(2022, 5, 5, 1, 2, 5), 'pol', null));
+
+    // Notifications in different statuses.
+    for (final status in NotificationStatus.values) {
+      final n = (AtNotificationBuilder()
+            ..id = 'notif-${status.name}'
+            ..fromAtSign = '@bob'
+            ..toAtSign = owner
+            ..type = NotificationType.received
+            ..opType = OperationType.update
+            ..notification = 'phone.wavi$owner'
+            ..notificationStatus = status
+            ..notificationDateTime = t(2022, 6, 6, 7, 8, 9)
+            ..expiresAt = t(2099, 1, 1)
+            ..ttl = 3600000
+            ..atValue = 'payload-${status.name}')
+          .build();
+      await b.notificationKeystore!.put(n.id!, n);
+    }
+  }
+
+  test('hive1 → sqlite1 → hive2 → sqlite2 → hive3 → sqlite3 are identical',
+      () async {
+    final hive1 = await hiveBundle('h1');
+    await seed(hive1);
+
+    final sqlite1 = await sqliteBundle('s1');
+    final r1 = await PersistenceMigrator.migrate(hive1, sqlite1);
+
+    final hive2 = await hiveBundle('h2');
+    await PersistenceMigrator.migrate(sqlite1, hive2);
+
+    final sqlite2 = await sqliteBundle('s2');
+    await PersistenceMigrator.migrate(hive2, sqlite2);
+
+    final hive3 = await hiveBundle('h3');
+    await PersistenceMigrator.migrate(sqlite2, hive3);
+
+    final sqlite3 = await sqliteBundle('s3');
+    await PersistenceMigrator.migrate(hive3, sqlite3);
+
+    // Migration actually moved data.
+    expect(r1.keys, greaterThan(5));
+    expect(r1.commitEntries, greaterThan(3));
+    expect(r1.accessEntries, 3);
+    expect(r1.notifications, NotificationStatus.values.length);
+
+    final snapH1 = await PersistenceSnapshot.capture(hive1);
+    final snapH2 = await PersistenceSnapshot.capture(hive2);
+    final snapH3 = await PersistenceSnapshot.capture(hive3);
+    final snapS1 = await PersistenceSnapshot.capture(sqlite1);
+    final snapS2 = await PersistenceSnapshot.capture(sqlite2);
+    final snapS3 = await PersistenceSnapshot.capture(sqlite3);
+
+    expect(snapH1.describeDifferenceFrom(snapH2), isNull,
+        reason: 'hive1 vs hive2');
+    expect(snapH1.describeDifferenceFrom(snapH3), isNull,
+        reason: 'hive1 vs hive3');
+    expect(snapS1.describeDifferenceFrom(snapS2), isNull,
+        reason: 'sqlite1 vs sqlite2');
+    expect(snapS1.describeDifferenceFrom(snapS3), isNull,
+        reason: 'sqlite1 vs sqlite3');
+
+    // And the two backends agree with each other (the interchange goal).
+    expect(snapH1.describeDifferenceFrom(snapS1), isNull,
+        reason: 'hive1 vs sqlite1');
+  });
+}

--- a/packages/at_persistence_secondary_server/test/dual_write_test.dart
+++ b/packages/at_persistence_secondary_server/test/dual_write_test.dart
@@ -1,0 +1,106 @@
+import 'dart:io';
+
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_persistence_secondary_server/dual.dart';
+import 'package:at_persistence_secondary_server/hive.dart';
+import 'package:at_persistence_secondary_server/sqlite.dart';
+import 'package:test/test.dart';
+
+/// Drives a realistic operation sequence through the dual-write bundle
+/// (Hive primary + SQLite secondary) and asserts the two underlying DB sets
+/// end up byte-identical — the property the functional-pack run relies on.
+void main() {
+  const atSign = '@dual_alice';
+  final root = '${Directory.current.path}/test/dual_tmp';
+
+  late DualWriteAtPersistenceFactory factory;
+  late DualWriteBundle bundle;
+
+  setUp(() async {
+    factory = DualWriteAtPersistenceFactory(
+        HiveAtPersistenceFactory(), SqliteAtPersistenceFactory());
+    bundle = await factory.initialize(
+        atSign,
+        DualWritePersistenceConfig(
+          primary: HivePersistenceConfig.serverDefaults(
+            storagePath: '$root/hive',
+            commitLogPath: '$root/commitLog',
+            accessLogPath: '$root/accessLog',
+            notificationStoragePath: '$root/notif',
+          ),
+          secondary: SqlitePersistenceConfig.serverDefaults(
+              storagePath: '$root/sqlite'),
+        )) as DualWriteBundle;
+  });
+
+  tearDown(() async {
+    await factory.close();
+    final dir = Directory(root);
+    if (dir.existsSync()) dir.deleteSync(recursive: true);
+  });
+
+  AtData d(String v, [AtMetaData? m]) => AtData()
+    ..data = v
+    ..metaData = m;
+
+  test('every write is mirrored byte-exactly; the two DB sets are identical',
+      () async {
+    final ks = bundle.keyValueStore;
+
+    // Value writes (the metadata builder stamps createdAt/updatedAt — the
+    // mirror must copy the primary's stamps, not let sqlite stamp its own).
+    await ks.create('phone.wavi$atSign', d('111'));
+    await ks.put('phone.wavi$atSign', d('222')); // update → version bump
+    await ks.create('email.wavi$atSign', d('a@b', AtMetaData()..isEncrypted = true));
+    await ks.putMeta('email.wavi$atSign', AtMetaData()..ttr = 3600);
+
+    // Shared + elided + public:__ keys.
+    await ks.create('@bob:loc.wavi$atSign', d('enc'));
+    await ks.create('private:secret.wavi$atSign', d('hush'));
+    await ks.create('public:__vis.wavi$atSign', d('shown'));
+
+    // Delete (leaves a `-` commit entry).
+    await ks.create('bye.wavi$atSign', d('later'));
+    await ks.remove('bye.wavi$atSign');
+
+    // Expired TTL key swept via deleteExpiredKeys.
+    await ks.restore('exp.wavi$atSign', d('gone', AtMetaData()
+      ..createdAt = DateTime.utc(2020)
+      ..updatedAt = DateTime.utc(2020)
+      ..version = 0
+      ..ttl = 1
+      ..expiresAt = DateTime.utc(2020, 1, 1, 0, 0, 1)));
+    await ks.deleteExpiredKeys();
+
+    // Notifications — including one whose embedded metadata has null
+    // createdAt/updatedAt/version (as real wire notifications do), which the
+    // SQLite codec must round-trip exactly as Hive's binary adapter does.
+    final n = (AtNotificationBuilder()
+          ..id = 'notif-1'
+          ..fromAtSign = '@bob'
+          ..toAtSign = atSign
+          ..notification = 'phone.wavi$atSign'
+          ..type = NotificationType.received
+          ..notificationStatus = NotificationStatus.delivered
+          ..atMetaData = (AtMetaData()
+            ..createdBy = atSign
+            ..isEncrypted = true
+            ..ttl = 0)) // no createdAt / updatedAt / version set
+        .build();
+    await bundle.notificationKeystore!.put(n.id!, n);
+
+    // Access log.
+    await bundle.accessLog!.insert('@bob', 'lookup', lookupKey: 'phone.wavi$atSign');
+    await bundle.accessLog!.insert(atSign, 'pkam');
+
+    // The two underlying DB sets must be byte-identical.
+    final primarySnap = await PersistenceSnapshot.capture(bundle.primary);
+    final secondarySnap = await PersistenceSnapshot.capture(bundle.secondary);
+    final diffs = primarySnap.differencesFrom(secondarySnap);
+    expect(diffs, isEmpty, reason: diffs.join('\n'));
+
+    // Sanity: the data actually landed (reads come from primary).
+    expect((await ks.get('phone.wavi$atSign'))!.data, '222');
+    expect(await ks.exists('exp.wavi$atSign'), false);
+  });
+}

--- a/packages/at_persistence_secondary_server/test/persistence_snapshot_test.dart
+++ b/packages/at_persistence_secondary_server/test/persistence_snapshot_test.dart
@@ -1,0 +1,104 @@
+import 'dart:io';
+
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_persistence_secondary_server/sqlite.dart';
+import 'package:test/test.dart';
+
+/// Verifies the commit-log tolerance in [PersistenceSnapshot]. Hive can leave a
+/// stale non-delete commit entry in its box for an expired (or removed) key
+/// after a TTL-expiry `skipCommit` sweep — its cache-based purge misses the box
+/// entry — while a faithful SQLite mirror carries no such entry. Such an entry
+/// is sync-benign, so the snapshot skips non-delete commit entries whose key is
+/// not present-and-unexpired. DELETE entries and live-unexpired-key entries are
+/// always compared, so real mirror data loss still fails the comparison.
+void main() {
+  final root = '${Directory.current.path}/test/snapshot_tmp';
+  late SqliteAtPersistenceFactory fa, fb;
+
+  AtData live(String v) => AtData()
+    ..data = v
+    ..metaData = (AtMetaData()
+      ..createdAt = DateTime.utc(2021)
+      ..updatedAt = DateTime.utc(2021)
+      ..version = 0);
+
+  AtData expired(String v) => AtData()
+    ..data = v
+    ..metaData = (AtMetaData()
+      ..createdAt = DateTime.utc(2021)
+      ..updatedAt = DateTime.utc(2021)
+      ..version = 0
+      ..ttl = 200
+      ..expiresAt = DateTime.utc(2021, 1, 1, 0, 0, 0, 200));
+
+  setUp(() {
+    fa = SqliteAtPersistenceFactory();
+    fb = SqliteAtPersistenceFactory();
+  });
+  tearDown(() async {
+    await fa.close();
+    await fb.close();
+    final d = Directory(root);
+    if (d.existsSync()) d.deleteSync(recursive: true);
+  });
+
+  Future<List<AtPersistenceBundle>> two() async => [
+        await fa.initialize(
+            '@a', SqlitePersistenceConfig.serverDefaults(storagePath: '$root/a')),
+        await fb.initialize(
+            '@a', SqlitePersistenceConfig.serverDefaults(storagePath: '$root/b')),
+      ];
+
+  Future<List<String>> diffs(AtPersistenceBundle a, AtPersistenceBundle b) async =>
+      (await PersistenceSnapshot.capture(a))
+          .differencesFrom(await PersistenceSnapshot.capture(b));
+
+  test('non-delete commit for an expired key is tolerated', () async {
+    final bs = await two();
+    final a = bs[0], b = bs[1];
+
+    // Both hold the same live key (row + commit) and the same expired key row.
+    for (final bundle in bs) {
+      await bundle.keyValueStore.restore('k.wavi@a', live('v'));
+      await bundle.keyValueStore.commitLog!.replay(
+          CommitEntry('k.wavi@a', CommitOp.UPDATE_ALL, DateTime.utc(2021))
+            ..commitId = 1);
+      await bundle.keyValueStore.restore('ttlkey.wavi@a', expired('x'));
+    }
+    expect(await diffs(a, b), isEmpty);
+
+    // Only A carries the expired key's stale commit entry (the Hive orphan).
+    await a.keyValueStore.commitLog!.replay(
+        CommitEntry('ttlkey.wavi@a', CommitOp.UPDATE_ALL, DateTime.utc(2021))
+          ..commitId = 50);
+    expect(await diffs(a, b), isEmpty,
+        reason: 'a non-delete commit for an expired key must be tolerated');
+  });
+
+  test('non-delete commit for a live unexpired key is compared', () async {
+    final bs = await two();
+    final a = bs[0], b = bs[1];
+
+    // Both hold the same live key row (unexpired), but only A has its commit.
+    for (final bundle in bs) {
+      await bundle.keyValueStore.restore('live.wavi@a', live('v'));
+    }
+    await a.keyValueStore.commitLog!.replay(
+        CommitEntry('live.wavi@a', CommitOp.UPDATE_ALL, DateTime.utc(2021))
+          ..commitId = 7);
+    expect(await diffs(a, b), isNotEmpty,
+        reason: 'a live unexpired key\'s commit entry must be compared');
+  });
+
+  test('DELETE commit is always compared', () async {
+    final bs = await two();
+    final a = bs[0], b = bs[1];
+
+    // A DELETE entry legitimately has no keystore row; it must still be compared.
+    await a.keyValueStore.commitLog!.replay(
+        CommitEntry('gone.wavi@a', CommitOp.DELETE, DateTime.utc(2021))
+          ..commitId = 9);
+    expect(await diffs(a, b), isNotEmpty,
+        reason: 'delete entries must always be compared');
+  });
+}

--- a/packages/at_persistence_secondary_server/test/sqlite/sqlite_keystore_test.dart
+++ b/packages/at_persistence_secondary_server/test/sqlite/sqlite_keystore_test.dart
@@ -1,0 +1,248 @@
+import 'dart:io';
+
+import 'package:at_commons/at_commons.dart';
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_persistence_secondary_server/src/impl/sqlite/sqlite_at_commit_log.dart';
+import 'package:at_persistence_secondary_server/src/impl/sqlite/sqlite_at_keyvalue_store.dart';
+import 'package:at_persistence_secondary_server/src/impl/sqlite/sqlite_database.dart';
+import 'package:test/test.dart';
+
+void main() {
+  const atSign = '@alice';
+  final root = '${Directory.current.path}/test/sqlite/ks_tmp';
+  late SqliteDatabase db;
+  late SqliteAtCommitLog commitLog;
+  late SqliteAtKeyValueStore ks;
+
+  setUp(() {
+    db = SqliteDatabase.open(atSign, '$root/$atSign/atsign.db');
+    commitLog = SqliteAtCommitLog(db);
+    ks = SqliteAtKeyValueStore(db, atSign)..commitLog = commitLog;
+  });
+
+  tearDown(() {
+    db.close();
+    final dir = Directory(root);
+    if (dir.existsSync()) dir.deleteSync(recursive: true);
+  });
+
+  AtData data(String v, [AtMetaData? m]) => AtData()
+    ..data = v
+    ..metaData = m;
+
+  group('CRUD', () {
+    test('create / get / exists', () async {
+      final id = await ks.create('phone.wavi@alice', data('123'));
+      expect(id, isNotNull);
+      expect((await ks.get('phone.wavi@alice'))!.data, '123');
+      expect(await ks.exists('phone.wavi@alice'), true);
+      expect(await ks.exists('nope.wavi@alice'), false);
+    });
+
+    test('get on absent key throws KeyNotFoundException', () async {
+      expect(() => ks.get('nope.wavi@alice'),
+          throwsA(isA<KeyNotFoundException>()));
+    });
+
+    test('put creates then updates; builder bumps version + updatedAt',
+        () async {
+      await ks.put('loc.wavi@alice', data('india'));
+      final v0 = await ks.get('loc.wavi@alice');
+      expect(v0!.data, 'india');
+      expect(v0.metaData!.version, 0);
+      expect(v0.metaData!.createdBy, atSign);
+
+      await ks.put('loc.wavi@alice', data('usa'));
+      final v1 = await ks.get('loc.wavi@alice');
+      expect(v1!.data, 'usa');
+      expect(v1.metaData!.version, 1);
+    });
+
+    test('putMeta keeps value, bumps meta', () async {
+      await ks.create('k.wavi@alice', data('val'));
+      await ks.putMeta('k.wavi@alice', AtMetaData()..ttl = 60000);
+      final got = await ks.get('k.wavi@alice');
+      expect(got!.data, 'val');
+      expect(got.metaData!.ttl, 60000);
+    });
+
+    test('getMany returns only present keys', () async {
+      await ks.create('a.wavi@alice', data('1'));
+      await ks.create('b.wavi@alice', data('2'));
+      final many = await ks.getMany(
+          ['a.wavi@alice', 'b.wavi@alice', 'missing.wavi@alice']);
+      expect(many.keys.toSet(), {'a.wavi@alice', 'b.wavi@alice'});
+    });
+
+    test('remove then removeMany', () async {
+      await ks.create('a.wavi@alice', data('1'));
+      await ks.create('b.wavi@alice', data('2'));
+      await ks.create('c.wavi@alice', data('3'));
+      await ks.remove('a.wavi@alice');
+      expect(await ks.exists('a.wavi@alice'), false);
+      final n = await ks.removeMany(['b.wavi@alice', 'c.wavi@alice', 'x@alice']);
+      expect(n, 2);
+    });
+  });
+
+  group('commit log semantics', () {
+    test('commit ids are monotonic and dense', () async {
+      await ks.create('a.wavi@alice', data('1'));
+      await ks.create('b.wavi@alice', data('2'));
+      expect(commitLog.firstCommittedSequenceNumber(), 1);
+      expect(commitLog.lastCommittedSequenceNumber(), 2);
+    });
+
+    test('one entry per atKey, newest-wins', () async {
+      await ks.put('a.wavi@alice', data('1'));
+      await ks.put('a.wavi@alice', data('2'));
+      expect(commitLog.entriesCount(), 1);
+      expect(commitLog.getLatestCommitEntry('a.wavi@alice')!.operation,
+          CommitOp.UPDATE_ALL);
+    });
+
+    test('delete records a - operation', () async {
+      await ks.create('a.wavi@alice', data('1'));
+      await ks.remove('a.wavi@alice');
+      final e = commitLog.getLatestCommitEntry('a.wavi@alice');
+      expect(e!.operation, CommitOp.DELETE);
+    });
+
+    test('elided keys (private/privatekey/public:_/local) get no commit id',
+        () async {
+      expect(
+          await commitLog.commit('private:testkey@alice', CommitOp.UPDATE), -1);
+      expect(
+          await commitLog.commit('privatekey:testkey@alice', CommitOp.UPDATE),
+          -1);
+      expect(await commitLog.commit('public:_loc@alice', CommitOp.UPDATE), -1);
+      expect(await commitLog.commit('local:foo@alice', CommitOp.UPDATE), -1);
+      // public:__ (double underscore) IS synced.
+      expect(await commitLog.commit('public:__loc@alice', CommitOp.UPDATE),
+          isNot(-1));
+    });
+
+    test('skipCommit purges the stale commit entry', () async {
+      await ks.create('a.wavi@alice', data('1'));
+      expect(commitLog.getLatestCommitEntry('a.wavi@alice'), isNotNull);
+      await ks.remove('a.wavi@alice', skipCommit: true);
+      expect(commitLog.getLatestCommitEntry('a.wavi@alice'), isNull);
+    });
+  });
+
+  group('restore is verbatim', () {
+    test('preserves version/createdAt, no commit appended', () async {
+      final meta = AtMetaData()
+        ..createdBy = '@other'
+        ..createdAt = DateTime.utc(2020, 1, 1, 0, 0, 0, 5)
+        ..updatedAt = DateTime.utc(2020, 1, 2, 0, 0, 0, 7)
+        ..version = 42
+        ..ttr = -1;
+      await ks.restore('cached:public:publickey@bob', data('KEY', meta));
+      final got = await ks.get('cached:public:publickey@bob');
+      expect(got!.data, 'KEY');
+      expect(got.metaData!.version, 42);
+      expect(got.metaData!.createdBy, '@other');
+      expect(got.metaData!.createdAt, DateTime.utc(2020, 1, 1, 0, 0, 0, 5));
+      expect(commitLog.lastCommittedSequenceNumber(), isNull);
+    });
+  });
+
+  group('TTL / TTB', () {
+    test('expiry: getExpiredKeys / nextExpiresAt / deleteExpiredKeys',
+        () async {
+      // ttl already elapsed → expires_at in the past.
+      final past = AtMetaData()
+        ..ttl = 1
+        ..expiresAt = DateTime.now().toUtc().subtract(Duration(minutes: 1));
+      await ks.restore('exp.wavi@alice', data('x', past));
+      await ks.create('live.wavi@alice', data('y'));
+
+      final expired = await (await ks.getExpiredKeys()).toList();
+      expect(expired, contains('exp.wavi@alice'));
+      expect(await ks.deleteExpiredKeys(), true);
+      expect(await ks.exists('exp.wavi@alice'), false);
+      expect(await ks.exists('live.wavi@alice'), true);
+    });
+
+    test('not-yet-born keys are hidden from getKeys, surfaced by peek',
+        () async {
+      final future = DateTime.now().toUtc().add(Duration(hours: 1));
+      final meta = AtMetaData()
+        ..ttb = 3600000
+        ..availableAt = future;
+      await ks.restore('born.wavi@alice', data('z', meta));
+
+      final keys = await (await ks.getKeys()).toList();
+      expect(keys, isNot(contains('born.wavi@alice')));
+      final na = await ks.nextAvailableAt();
+      expect(na, isNotNull);
+    });
+  });
+
+  group('scanKeys / queryByPath', () {
+    test('scanKeys filters by KeyPattern', () async {
+      await ks.create('phone.wavi@alice', data('1'));
+      await ks.create('email.buzz@alice', data('2'));
+      final wavi = await (await ks.scanKeys(KeyPattern(namespace: 'wavi')))
+          .toList();
+      expect(wavi, ['phone.wavi@alice']);
+    });
+
+    test('queryByPath matches a JSON value field', () async {
+      await ks.create('a.wavi@alice', data('{"city":"paris"}'));
+      await ks.create('b.wavi@alice', data('{"city":"london"}'));
+      final hits = await ks
+          .queryByPath(
+            keyPattern: KeyPattern(),
+            predicate: PathEquals(['city'], 'paris'),
+          )
+          .toList();
+      expect(hits.map((e) => e.key), ['a.wavi@alice']);
+    });
+  });
+
+  group('snapshot isolation', () {
+    test('snapshot reads state at creation, ignoring later writes', () async {
+      await ks.create('a.wavi@alice', data('before'));
+      final snap = await ks.snapshot();
+      await ks.put('a.wavi@alice', data('after'));
+      expect((await snap.get('a.wavi@alice'))!.data, 'before');
+      await snap.release();
+      expect((await ks.get('a.wavi@alice'))!.data, 'after');
+    });
+  });
+
+  group('transaction', () {
+    test('all-or-nothing: a throw rolls back every buffered write', () async {
+      await expectLater(
+          ks.transaction((txn) async {
+            await txn.put('a.wavi@alice', data('1'), null);
+            await txn.put('b.wavi@alice', data('2'), null);
+            throw StateError('boom');
+          }),
+          throwsA(isA<StateError>()));
+      expect(await ks.exists('a.wavi@alice'), false);
+      expect(await ks.exists('b.wavi@alice'), false);
+    });
+
+    test('commits buffered writes on success', () async {
+      await ks.transaction((txn) async {
+        await txn.put('a.wavi@alice', data('1'), null);
+        expect((await txn.get('a.wavi@alice'))!.data, '1'); // reads own write
+      });
+      expect((await ks.get('a.wavi@alice'))!.data, '1');
+    });
+  });
+
+  test('changes stream emits add/update/remove', () async {
+    final events = <String>[];
+    final sub = ks.changes.listen((c) => events.add(c.runtimeType.toString()));
+    await ks.create('a.wavi@alice', data('1'));
+    await ks.put('a.wavi@alice', data('2'));
+    await ks.remove('a.wavi@alice');
+    await Future.delayed(Duration(milliseconds: 10));
+    await sub.cancel();
+    expect(events, ['KeyAdded', 'KeyUpdated', 'KeyRemoved']);
+  });
+}

--- a/packages/at_persistence_secondary_server/test/sqlite/sqlite_schema_test.dart
+++ b/packages/at_persistence_secondary_server/test/sqlite/sqlite_schema_test.dart
@@ -1,0 +1,170 @@
+import 'dart:io';
+
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_persistence_secondary_server/src/impl/sqlite/sqlite_database.dart';
+import 'package:at_persistence_secondary_server/src/impl/sqlite/sqlite_persistence_config.dart';
+import 'package:at_persistence_secondary_server/src/impl/sqlite/sqlite_schema.dart';
+import 'package:sqlite3/sqlite3.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final root = '${Directory.current.path}/test/sqlite/tmp';
+
+  tearDown(() {
+    final dir = Directory(root);
+    if (dir.existsSync()) dir.deleteSync(recursive: true);
+  });
+
+  group('SqlitePersistenceConfig', () {
+    test('derives per-atSign db path under storagePath', () {
+      final config = SqlitePersistenceConfig.serverDefaults(storagePath: root);
+      expect(config.backend, AtPersistenceBackendId.sqlite);
+      expect(config.dbPathFor('@alice🛠'), '$root/@alice🛠/atsign.db');
+      expect(config.enableCommitLog, true);
+      expect(config.enableAccessLog, true);
+      expect(config.enableNotificationKeystore, true);
+    });
+
+    test('clientDefaults disables the optional capabilities', () {
+      final config = SqlitePersistenceConfig.clientDefaults(storagePath: root);
+      expect(config.enableCommitLog, false);
+      expect(config.enableAccessLog, false);
+      expect(config.enableNotificationKeystore, false);
+    });
+  });
+
+  group('SqliteDatabase / SqliteSchema', () {
+    test('open creates the file, all tables, seed counter, user_version', () {
+      final config = SqlitePersistenceConfig.serverDefaults(storagePath: root);
+      final path = config.dbPathFor('@alice');
+      final db = SqliteDatabase.open('@alice', path);
+
+      expect(File(path).existsSync(), true);
+
+      final tables = db.raw
+          .select(
+              "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name;")
+          .map((r) => r['name'] as String)
+          .toList();
+      expect(
+          tables,
+          containsAll(
+              ['at_data', 'commit_log', 'counters', 'notifications', 'access_log']));
+
+      final ver = db.raw.select('PRAGMA user_version;').first.values.first;
+      expect(ver, SqliteSchema.contractVersion);
+
+      final counter = db.raw.select(
+          "SELECT value FROM counters WHERE name = 'last_commit_id';");
+      expect(counter.first['value'], 0);
+
+      final journal =
+          db.raw.select('PRAGMA journal_mode;').first.values.first;
+      expect((journal as String).toLowerCase(), 'wal');
+
+      db.close();
+    });
+
+    test('re-opening an existing db is idempotent (no data loss)', () {
+      final path =
+          SqlitePersistenceConfig.serverDefaults(storagePath: root)
+              .dbPathFor('@bob');
+      var db = SqliteDatabase.open('@bob', path);
+      db.raw.execute(
+          "INSERT INTO at_data (atkey, value, metadata) VALUES ('k@bob','v','{}');");
+      db.close();
+
+      db = SqliteDatabase.open('@bob', path);
+      final rows = db.raw.select('SELECT atkey, value FROM at_data;');
+      expect(rows.length, 1);
+      expect(rows.first['value'], 'v');
+      db.close();
+    });
+
+    test('runInTransaction rolls back on throw', () {
+      final path =
+          SqlitePersistenceConfig.serverDefaults(storagePath: root)
+              .dbPathFor('@carol');
+      final db = SqliteDatabase.open('@carol', path);
+
+      expect(
+          () => db.runInTransaction(() {
+                db.raw.execute(
+                    "INSERT INTO at_data (atkey, value, metadata) VALUES ('k@carol','v','{}');");
+                throw StateError('boom');
+              }),
+          throwsA(isA<StateError>()));
+
+      expect(db.raw.select('SELECT COUNT(*) c FROM at_data;').first['c'], 0);
+      db.close();
+    });
+
+    test('nested runInTransaction commits once; inner throw rolls back all',
+        () {
+      final path =
+          SqlitePersistenceConfig.serverDefaults(storagePath: root)
+              .dbPathFor('@dave');
+      final db = SqliteDatabase.open('@dave', path);
+
+      // Happy path: nested join commits the whole thing.
+      db.runInTransaction(() {
+        db.raw.execute(
+            "INSERT INTO at_data (atkey, value, metadata) VALUES ('a@dave','1','{}');");
+        db.runInTransaction(() {
+          db.raw.execute(
+              "INSERT INTO at_data (atkey, value, metadata) VALUES ('b@dave','2','{}');");
+        });
+      });
+      expect(db.raw.select('SELECT COUNT(*) c FROM at_data;').first['c'], 2);
+
+      // Inner throw aborts the whole outer transaction.
+      expect(
+          () => db.runInTransaction(() {
+                db.raw.execute(
+                    "INSERT INTO at_data (atkey, value, metadata) VALUES ('c@dave','3','{}');");
+                db.runInTransaction(() {
+                  throw StateError('inner boom');
+                });
+              }),
+          throwsA(isA<StateError>()));
+      expect(db.raw.select('SELECT COUNT(*) c FROM at_data;').first['c'], 2);
+      db.close();
+    });
+
+    test('clear drops rows and resets the counter, keeping the db open', () {
+      final path =
+          SqlitePersistenceConfig.serverDefaults(storagePath: root)
+              .dbPathFor('@erin');
+      final db = SqliteDatabase.open('@erin', path);
+      db.raw.execute(
+          "INSERT INTO at_data (atkey, value, metadata) VALUES ('k@erin','v','{}');");
+      db.raw.execute(
+          "UPDATE counters SET value = 7 WHERE name = 'last_commit_id';");
+
+      db.clear();
+
+      expect(db.raw.select('SELECT COUNT(*) c FROM at_data;').first['c'], 0);
+      expect(
+          db.raw
+              .select("SELECT value FROM counters WHERE name='last_commit_id';")
+              .first['value'],
+          0);
+      db.close();
+    });
+
+    test('refuses to open a forward-versioned database', () {
+      final path =
+          SqlitePersistenceConfig.serverDefaults(storagePath: root)
+              .dbPathFor('@frank');
+      // Create the db normally (dir + file + schema at v1), then stamp it
+      // with a newer contract version to simulate a forward-versioned file.
+      SqliteDatabase.open('@frank', path).close();
+      final raw = sqlite3.open(path);
+      raw.execute('PRAGMA user_version = 999;');
+      raw.dispose();
+
+      expect(() => SqliteDatabase.open('@frank', path),
+          throwsA(isA<StateError>()));
+    });
+  });
+}

--- a/packages/at_persistence_secondary_server/test/verbatim_restore_test.dart
+++ b/packages/at_persistence_secondary_server/test/verbatim_restore_test.dart
@@ -1,0 +1,105 @@
+import 'dart:io';
+
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:test/test.dart';
+
+import 'test_utils.dart';
+
+/// Tests for the migrator-only verbatim primitives added in the SQLite
+/// backend work: [AtKeyValueStore.restore] and [AtAccessLog.replay].
+/// The defining property is that they do NOT run the metadata builder /
+/// timestamp stamping that the normal write paths do.
+void main() {
+  final storageDir = '${Directory.current.path}/test/hive/verbatim';
+  const atSign = '@verbatim_user';
+
+  group('AtKeyValueStore.restore writes verbatim', () {
+    setUp(() async => await setUpTestKeyStore(atSign, storageDir: storageDir));
+    tearDown(() async => await tearDownTestPersistence(storageDir: storageDir));
+
+    // A fully-populated metadata with deliberately "old" audit fields,
+    // as a migrated record would carry.
+    AtMetaData sourceMetadata() => AtMetaData()
+      ..createdBy = '@someone_else'
+      ..updatedBy = '@someone_else'
+      ..createdAt = DateTime.utc(2020, 1, 2, 3, 4, 5, 678)
+      ..updatedAt = DateTime.utc(2021, 6, 7, 8, 9, 10, 111)
+      ..version = 99
+      ..ttl = 0
+      ..ttr = -1
+      ..isEncrypted = true
+      ..dataSignature = 'sig'
+      ..encoding = 'base64';
+
+    test('preserves version/createdAt/updatedAt exactly (no builder run)',
+        () async {
+      final ks = testKeyStoreFor(atSign);
+      const key = 'phone.wavi@verbatim_user';
+
+      final restored = AtData()
+        ..data = 'the-value'
+        ..metaData = sourceMetadata();
+      await ks.restore(key, restored);
+
+      final got = await ks.get(key);
+      expect(got!.data, 'the-value');
+      // The metadata oracle: == compares all 27 fields. A normal put()
+      // would have bumped version to 0/1 and set updatedAt to now.
+      expect(got.metaData, equals(restored.metaData));
+      expect(got.metaData!.version, 99);
+      expect(got.metaData!.createdAt, DateTime.utc(2020, 1, 2, 3, 4, 5, 678));
+      expect(got.metaData!.updatedAt, DateTime.utc(2021, 6, 7, 8, 9, 10, 111));
+      expect(got.metaData!.createdBy, '@someone_else');
+    });
+
+    test('does not append to the commit log', () async {
+      final ks = testKeyStoreFor(atSign);
+      // Seed one committed key so the log is non-empty.
+      await ks.create('seed.wavi@verbatim_user', AtData()..data = 'x');
+      final before = ks.commitLog!.lastCommittedSequenceNumber();
+
+      await ks.restore('phone.wavi@verbatim_user',
+          AtData()..data = 'v'..metaData = sourceMetadata());
+
+      expect(ks.commitLog!.lastCommittedSequenceNumber(), before,
+          reason: 'restore must not advance the commit id');
+      expect(ks.commitLog!.getLatestCommitEntry('phone.wavi@verbatim_user'),
+          isNull,
+          reason: 'restore must not create a commit entry');
+    });
+
+    test('is idempotent', () async {
+      final ks = testKeyStoreFor(atSign);
+      const key = 'phone.wavi@verbatim_user';
+      final atData = AtData()
+        ..data = 'v'
+        ..metaData = sourceMetadata();
+
+      await ks.restore(key, atData);
+      final first = await ks.get(key);
+      await ks.restore(key, atData);
+      final second = await ks.get(key);
+
+      expect(second!.data, first!.data);
+      expect(second.metaData, equals(first.metaData));
+    });
+  });
+
+  group('AtAccessLog.replay preserves the entry timestamp', () {
+    setUp(() async =>
+        await testAccessLogFor(atSign, accessLogPath: storageDir));
+    tearDown(() async => await tearDownTestPersistence(storageDir: storageDir));
+
+    test('replay keeps requestDateTime; insert would stamp now', () async {
+      final log = await testAccessLogFor(atSign);
+      final past = DateTime.utc(2019, 3, 4, 5, 6, 7, 8);
+      await log.replay(AccessLogEntry(atSign, past, 'lookup', 'phone@x'));
+
+      final last = await log.getLastAccessLogEntry();
+      expect(last.requestDateTime, past);
+      expect(last.verbName, 'lookup');
+      expect(last.fromAtSign, atSign);
+      expect(last.lookupKey, 'phone@x');
+    });
+  });
+}

--- a/packages/at_persistence_secondary_server/tool/dual_compare_ve.dart
+++ b/packages/at_persistence_secondary_server/tool/dual_compare_ve.dart
@@ -1,0 +1,53 @@
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_persistence_secondary_server/hive.dart';
+import 'package:at_persistence_secondary_server/sqlite.dart';
+import 'package:path/path.dart' as p;
+
+/// Compares one atSign's Hive vs SQLite DB sets as laid out by the functional
+/// virtualenv after a `persistenceBackend=dual` run: Hive under the legacy
+/// `hive/ commit_log/ access_log/ notification_log/` names, SQLite under
+/// `storage/sqlite/`. Prints IDENTICAL or the differences; exits 1 on any
+/// difference so a CI step can gate on it.
+///
+///   dart run tool/dual_compare_ve.dart `<secondary-dir>` `<atSign>`
+Future<void> main(List<String> args) async {
+  if (args.length != 2) {
+    print('usage: dual_compare_ve.dart <secondary-dir> <atSign>');
+    return;
+  }
+  final dir = args[0], atSign = args[1];
+
+  final hiveFactory = HiveAtPersistenceFactory();
+  final sqliteFactory = SqliteAtPersistenceFactory();
+  try {
+    final hive = await hiveFactory.initialize(
+        atSign,
+        HivePersistenceConfig.serverDefaults(
+          storagePath: p.join(dir, 'hive'),
+          commitLogPath: p.join(dir, 'commit_log'),
+          accessLogPath: p.join(dir, 'access_log'),
+          notificationStoragePath: p.join(dir, 'notification_log'),
+        ));
+    final sqlite = await sqliteFactory.initialize(
+        atSign,
+        SqlitePersistenceConfig.serverDefaults(
+            storagePath: p.join(dir, 'storage', 'sqlite')));
+
+    final hiveSnap = await PersistenceSnapshot.capture(hive);
+    final sqliteSnap = await PersistenceSnapshot.capture(sqlite);
+    final diffs = hiveSnap.differencesFrom(sqliteSnap);
+
+    if (diffs.isEmpty) {
+      print('IDENTICAL $atSign  hive=${hiveSnap.counts} sqlite=${sqliteSnap.counts}');
+    } else {
+      print('MISMATCH(${diffs.length}) $atSign  '
+          'hive=${hiveSnap.counts} sqlite=${sqliteSnap.counts}');
+      for (final d in diffs.take(8)) {
+        print('  $d');
+      }
+    }
+  } finally {
+    await hiveFactory.close();
+    await sqliteFactory.close();
+  }
+}

--- a/packages/at_secondary_server/bin/cleanup_stale_persistence.dart
+++ b/packages/at_secondary_server/bin/cleanup_stale_persistence.dart
@@ -1,0 +1,52 @@
+import 'dart:io';
+
+import 'package:at_secondary/src/server/persistence_backend.dart';
+import 'package:path/path.dart' as p;
+
+/// Reclaims a retained source-backend data tree after a persistence
+/// backend migration, once it is old enough to trust.
+///
+/// After `migrateIfNeeded` flips the marker it RETAINS the old-backend
+/// data (for rollback). This sweep deletes that data once the migration
+/// is older than the retention window. Intended to run as a cron entry
+/// on each atServer host.
+///
+/// Usage:
+///   dart bin/cleanup_stale_persistence.dart \
+///     --storage-root storage [--retention-days 7] [--dry-run]
+void main(List<String> args) {
+  var storageRoot = 'storage';
+  var retentionDays = 7;
+  var dryRun = false;
+
+  for (var i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case '--storage-root':
+        storageRoot = args[++i];
+      case '--retention-days':
+        retentionDays = int.parse(args[++i]);
+      case '--dry-run':
+        dryRun = true;
+      case '-h':
+      case '--help':
+        stdout.writeln('Usage: cleanup_stale_persistence.dart '
+            '--storage-root <dir> [--retention-days N] [--dry-run]');
+        return;
+    }
+  }
+
+  final markerPath = p.join(storageRoot, '.persistence_backend');
+  final deleted = PersistenceBackendManager.sweepStaleSource(
+    markerPath,
+    retention: Duration(days: retentionDays),
+    dryRun: dryRun,
+  );
+
+  if (deleted.isEmpty) {
+    stdout.writeln('Nothing to reclaim (no marker, no retained source, or '
+        'migration younger than $retentionDays days).');
+  } else {
+    stdout.writeln('${dryRun ? "Would delete" : "Deleted"} retained source '
+        'data:\n  ${deleted.join("\n  ")}');
+  }
+}

--- a/packages/at_secondary_server/config/config.yaml
+++ b/packages/at_secondary_server/config/config.yaml
@@ -35,6 +35,19 @@ security:
   # atServer
   clientCertificateRequired: true
 
+# Persistence backend selection.
+# - backend: 'hive' (default) keeps the historical Hive stores; 'sqlite'
+#   opens one atsign.db per atSign under <storageRoot>/sqlite.
+# - storageRoot: the common root under which each backend's data and the
+#   backend marker (.persistence_backend) live.
+# Changing 'backend' triggers a migrate-verify-flip at startup (aborting
+# startup on any failure, leaving the source data untouched). The old
+# backend's data is RETAINED after a successful migration; reclaim it with
+# bin/cleanup_stale_persistence.dart once you no longer need to roll back.
+persistence:
+  backend: 'hive'
+  storageRoot: 'storage'
+
 # The atProtocol storage configurations
 hive:
   # The storage path for secondary storage.

--- a/packages/at_secondary_server/lib/src/server/at_secondary_config.dart
+++ b/packages/at_secondary_server/lib/src/server/at_secondary_config.dart
@@ -33,6 +33,16 @@ class AtSecondaryConfig {
   static const String _notificationStoragePath = 'storage/notificationLog.v1';
   static const int _expiringRunFreqMins = 10;
 
+  // Persistence backend selection. 'hive' (default) keeps the historical
+  // Hive stores. 'sqlite' opens one atsign.db per atSign under
+  // <storageRoot>/sqlite. A mismatch between this and the on-disk backend
+  // marker triggers a migrate-verify-flip at startup (abort on failure).
+  static const String _persistenceBackend = 'hive';
+  // The common storage root under which both backends' data and the
+  // backend marker live (Hive under storage/hive etc., SQLite under
+  // storage/sqlite). Defaults to the parent of the Hive storagePath.
+  static const String _storageRoot = 'storage';
+
   //Commit Log
   static const int _commitLogCompactionFrequencyMins = 18;
   static const int _commitLogCompactionPercentage = 20;
@@ -354,6 +364,32 @@ class AtSecondaryConfig {
       return getConfigFromYaml(['hive', 'storagePath']);
     } on ElementNotFoundException {
       return _storagePath;
+    }
+  }
+
+  /// The active persistence backend: `'hive'` (default) or `'sqlite'`.
+  /// Override with env `persistenceBackend` or yaml
+  /// `persistence.backend`.
+  static String get persistenceBackend {
+    final result = _getStringEnvVar('persistenceBackend');
+    if (result != null) return result;
+    try {
+      return getConfigFromYaml(['persistence', 'backend']);
+    } on ElementNotFoundException {
+      return _persistenceBackend;
+    }
+  }
+
+  /// The common storage root under which each backend's data and the
+  /// backend marker live. Override with env `storageRoot` or yaml
+  /// `persistence.storageRoot`.
+  static String get storageRoot {
+    final result = _getStringEnvVar('storageRoot');
+    if (result != null) return result;
+    try {
+      return getConfigFromYaml(['persistence', 'storageRoot']);
+    } on ElementNotFoundException {
+      return _storageRoot;
     }
   }
 

--- a/packages/at_secondary_server/lib/src/server/at_secondary_impl.dart
+++ b/packages/at_secondary_server/lib/src/server/at_secondary_impl.dart
@@ -23,6 +23,7 @@ import 'package:at_secondary/src/notification/notify_connection_pool.dart';
 import 'package:at_secondary/src/notification/stats_notification_service.dart';
 import 'package:at_secondary/src/server/at_certificate_validation.dart';
 import 'package:at_secondary/src/server/at_secondary_config.dart';
+import 'package:at_secondary/src/server/persistence_backend.dart';
 import 'package:at_secondary/src/server/server_context.dart';
 import 'package:at_secondary/src/utils/logging_util.dart';
 import 'package:at_secondary/src/utils/secondary_util.dart';
@@ -843,14 +844,23 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
     AtNotification.defaultTtl =
         Duration(minutes: AtSecondaryConfig.notificationExpiryInMins);
 
-    final config = HivePersistenceConfig.serverDefaults(
-      storagePath: AtSecondaryConfig.storagePath,
-      commitLogPath: AtSecondaryConfig.commitLogPath,
-      accessLogPath: AtSecondaryConfig.accessLogPath,
-      notificationStoragePath: AtSecondaryConfig.notificationStoragePath,
-    );
-    final bundle = await persistenceFactory.initialize(
-        serverContext!.currentAtSign!, config);
+    final atSign = serverContext!.currentAtSign!;
+    final targetBackend = PersistenceBackendManager.configuredBackend;
+
+    // If the on-disk backend marker disagrees with the configured backend,
+    // migrate → verify → flip before opening the target. Any failure here
+    // throws out of start(), leaving the source data and marker untouched.
+    await PersistenceBackendManager.migrateIfNeeded(atSign, targetBackend);
+
+    // For 'hive' (default) keep using the injectable persistenceFactory
+    // field, so existing behaviour and test injection are unchanged; for
+    // 'sqlite' / 'dual' switch to the corresponding factory.
+    if (targetBackend != PersistenceBackendManager.hive) {
+      persistenceFactory = PersistenceBackendManager.factoryFor(targetBackend);
+    }
+    final config = PersistenceBackendManager.configFor(targetBackend);
+
+    final bundle = await persistenceFactory.initialize(atSign, config);
     _persistenceBundle = bundle;
 
     _assertServerCapabilities(bundle);

--- a/packages/at_secondary_server/lib/src/server/persistence_backend.dart
+++ b/packages/at_secondary_server/lib/src/server/persistence_backend.dart
@@ -1,0 +1,239 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_persistence_secondary_server/dual.dart';
+import 'package:at_persistence_secondary_server/hive.dart';
+import 'package:at_persistence_secondary_server/sqlite.dart';
+import 'package:at_secondary/src/server/at_secondary_config.dart';
+import 'package:at_utils/at_logger.dart';
+import 'package:path/path.dart' as p;
+
+/// Thrown when a backend migration (or its post-migration verify) fails.
+/// Propagating out of `start()` aborts server startup, leaving the source
+/// data and the marker untouched — a restart on the old config comes
+/// straight back up.
+class PersistenceMigrationException implements Exception {
+  final String message;
+  PersistenceMigrationException(this.message);
+  @override
+  String toString() => 'PersistenceMigrationException: $message';
+}
+
+/// The on-disk record of which backend currently holds an atServer's live
+/// data, written to a well-known path in the storage root so both the
+/// bootstrap (which backend to open) and an out-of-band cleanup sweep
+/// (whether a retained source is old enough to delete) can read it.
+class PersistenceBackendMarker {
+  final String activeBackend;
+  final String? previousBackend;
+  final List<String> previousPaths;
+  final DateTime? migratedAt;
+
+  PersistenceBackendMarker({
+    required this.activeBackend,
+    this.previousBackend,
+    this.previousPaths = const [],
+    this.migratedAt,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'activeBackend': activeBackend,
+        'previousBackend': previousBackend,
+        'previousPaths': previousPaths,
+        'migratedAt': migratedAt?.toUtc().toIso8601String(),
+      };
+
+  static PersistenceBackendMarker fromJson(Map<String, dynamic> json) =>
+      PersistenceBackendMarker(
+        activeBackend: json['activeBackend'] as String,
+        previousBackend: json['previousBackend'] as String?,
+        previousPaths:
+            (json['previousPaths'] as List?)?.cast<String>() ?? const [],
+        migratedAt: json['migratedAt'] == null
+            ? null
+            : DateTime.parse(json['migratedAt'] as String),
+      );
+
+  /// Reads the marker at [path], or `null` if it does not exist.
+  static PersistenceBackendMarker? read(String path) {
+    final file = File(path);
+    if (!file.existsSync()) return null;
+    return fromJson(jsonDecode(file.readAsStringSync()) as Map<String, dynamic>);
+  }
+
+  /// Writes the marker to [path] (creating parent dirs).
+  static void write(String path, PersistenceBackendMarker marker) {
+    final file = File(path);
+    file.parent.createSync(recursive: true);
+    file.writeAsStringSync(jsonEncode(marker.toJson()));
+  }
+}
+
+/// Selects the persistence backend from [AtSecondaryConfig] and, when the
+/// on-disk marker disagrees with the configured backend, performs a
+/// migrate → verify → flip-marker (retaining the source data) before the
+/// bootstrap opens the target. Abort-on-failure: any error propagates.
+class PersistenceBackendManager {
+  static const String hive = 'hive';
+  static const String sqlite = 'sqlite';
+
+  /// Validation harness backend: serves reads from Hive while mirroring every
+  /// write into SQLite. Run the functional pack against it, then compare the
+  /// two DB sets under <storageRoot> with bin/compare_persistence.dart. Not a
+  /// persistent backend — no marker, no migration.
+  static const String dual = 'dual';
+
+  static final _logger = AtSignLogger('PersistenceBackendManager');
+
+  static String get markerPath =>
+      p.join(AtSecondaryConfig.storageRoot, '.persistence_backend');
+
+  /// The configured target backend (normalised / validated).
+  static String get configuredBackend {
+    final b = AtSecondaryConfig.persistenceBackend.toLowerCase().trim();
+    if (b != hive && b != sqlite && b != dual) {
+      throw PersistenceMigrationException(
+          "Unknown persistenceBackend '$b' (expected 'hive', 'sqlite' or 'dual')");
+    }
+    return b;
+  }
+
+  static HivePersistenceConfig _hiveConfig() =>
+      HivePersistenceConfig.serverDefaults(
+        storagePath: AtSecondaryConfig.storagePath,
+        commitLogPath: AtSecondaryConfig.commitLogPath,
+        accessLogPath: AtSecondaryConfig.accessLogPath,
+        notificationStoragePath: AtSecondaryConfig.notificationStoragePath,
+      );
+
+  static SqlitePersistenceConfig _sqliteConfig() =>
+      SqlitePersistenceConfig.serverDefaults(
+          storagePath: p.join(AtSecondaryConfig.storageRoot, 'sqlite'));
+
+  static AtPersistenceConfig configFor(String backend) => switch (backend) {
+        sqlite => _sqliteConfig(),
+        dual => DualWritePersistenceConfig(
+            primary: _hiveConfig(), secondary: _sqliteConfig()),
+        _ => _hiveConfig(),
+      };
+
+  static AtPersistenceFactory factoryFor(String backend) => switch (backend) {
+        sqlite => SqliteAtPersistenceFactory(),
+        dual => DualWriteAtPersistenceFactory(
+            HiveAtPersistenceFactory(), SqliteAtPersistenceFactory()),
+        _ => HiveAtPersistenceFactory(),
+      };
+
+  static List<String> dataPathsFor(String backend) => backend == sqlite
+      ? [p.join(AtSecondaryConfig.storageRoot, 'sqlite')]
+      : [
+          AtSecondaryConfig.storagePath,
+          AtSecondaryConfig.commitLogPath,
+          AtSecondaryConfig.accessLogPath,
+          AtSecondaryConfig.notificationStoragePath,
+        ];
+
+  /// If the on-disk marker's active backend differs from [targetBackend],
+  /// migrates the atSign's data into the target backend, verifies a
+  /// byte-identical snapshot, and (only then) flips the marker while
+  /// retaining the source data. Absent marker ⇒ the legacy default `hive`.
+  static Future<void> migrateIfNeeded(
+      String atSign, String targetBackend) async {
+    // The dual-write harness is transient (it writes to both Hive and SQLite);
+    // it has no marker and never triggers a migration.
+    if (targetBackend == dual) return;
+    final marker = PersistenceBackendMarker.read(markerPath);
+    final currentBackend = marker?.activeBackend ?? hive;
+    if (currentBackend == targetBackend) return;
+
+    _logger.warning(
+        'Persistence backend change for $atSign: $currentBackend -> '
+        '$targetBackend. Migrating (abort-on-failure)...');
+
+    final sourceFactory = factoryFor(currentBackend);
+    final targetFactory = factoryFor(targetBackend);
+    try {
+      final source =
+          await sourceFactory.initialize(atSign, configFor(currentBackend));
+      final target =
+          await targetFactory.initialize(atSign, configFor(targetBackend));
+
+      // Clean slate so a retried migration (after a prior failure) does
+      // not stack onto partial target data.
+      await target.clear();
+
+      final report = await PersistenceMigrator.migrate(source, target);
+
+      final sourceSnapshot = await PersistenceSnapshot.capture(source);
+      final targetSnapshot = await PersistenceSnapshot.capture(target);
+      final diff = sourceSnapshot.describeDifferenceFrom(targetSnapshot);
+      if (diff != null) {
+        throw PersistenceMigrationException(
+            'post-migration verify failed for $atSign: $diff');
+      }
+      _logger.warning('Migration verified for $atSign: $report');
+    } finally {
+      await sourceFactory.close();
+      await targetFactory.close();
+    }
+
+    // Success — flip the marker, retaining the source data on disk for
+    // rollback / the cleanup sweep to reclaim later.
+    PersistenceBackendMarker.write(
+      markerPath,
+      PersistenceBackendMarker(
+        activeBackend: targetBackend,
+        previousBackend: currentBackend,
+        previousPaths: dataPathsFor(currentBackend),
+        migratedAt: DateTime.now(),
+      ),
+    );
+    _logger.warning(
+        'Persistence backend for $atSign is now $targetBackend '
+        '(previous $currentBackend data retained).');
+  }
+
+  /// Reclaims a retained source-backend data tree once a migration is old
+  /// enough to trust. Reads the marker at [markerPath]; if it records a
+  /// migration completed more than [retention] ago, deletes every path in
+  /// `previousPaths` and clears the `previous*` fields from the marker.
+  /// Returns the paths deleted (the paths that WOULD be deleted, on
+  /// [dryRun]). A no-op when there is no marker, no previous data, or the
+  /// migration is too recent.
+  static List<String> sweepStaleSource(
+    String markerPath, {
+    required Duration retention,
+    bool dryRun = false,
+  }) {
+    final marker = PersistenceBackendMarker.read(markerPath);
+    if (marker == null ||
+        marker.previousBackend == null ||
+        marker.previousPaths.isEmpty ||
+        marker.migratedAt == null) {
+      return const [];
+    }
+    final age = DateTime.now().difference(marker.migratedAt!);
+    if (age < retention) return const [];
+
+    final deleted = <String>[];
+    for (final path in marker.previousPaths) {
+      final dir = Directory(path);
+      final file = File(path);
+      if (dir.existsSync()) {
+        if (!dryRun) dir.deleteSync(recursive: true);
+        deleted.add(path);
+      } else if (file.existsSync()) {
+        if (!dryRun) file.deleteSync();
+        deleted.add(path);
+      }
+    }
+    if (!dryRun && deleted.isNotEmpty) {
+      PersistenceBackendMarker.write(
+        markerPath,
+        PersistenceBackendMarker(activeBackend: marker.activeBackend),
+      );
+    }
+    return deleted;
+  }
+}

--- a/packages/at_secondary_server/lib/src/server/persistence_backend.dart
+++ b/packages/at_secondary_server/lib/src/server/persistence_backend.dart
@@ -80,7 +80,7 @@ class PersistenceBackendManager {
 
   /// Validation harness backend: serves reads from Hive while mirroring every
   /// write into SQLite. Run the functional pack against it, then compare the
-  /// two DB sets under <storageRoot> with bin/compare_persistence.dart. Not a
+  /// two DB sets under `<storageRoot>` with bin/compare_persistence.dart. Not a
   /// persistent backend — no marker, no migration.
   static const String dual = 'dual';
 

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -8,6 +8,14 @@ publish_to: none
 environment:
   sdk: ">=3.0.0 <4.0.0"
 
+# Temporary bridge: at_secondary_server consumes new at_persistence_secondary_server
+# 5.2.0 API (SQLite backend, migrator) that is not yet published to pub.dev. Resolve
+# the sibling package by path so CI (plain `dart pub get`, no melos bootstrap) can
+# compile the secondary. Remove this once 5.2.0 is published and depend on it hosted.
+dependency_overrides:
+  at_persistence_secondary_server:
+    path: ../at_persistence_secondary_server
+
 dependencies:
   args: ^2.7.0
   uuid: ^4.5.3
@@ -24,7 +32,7 @@ dependencies:
   at_chops: ^3.3.0
   at_lookup: ^3.5.0
   at_server_spec: ^5.1.0
-  at_persistence_secondary_server: ^5.1.0
+  at_persistence_secondary_server: ^5.2.0
   intl: ^0.20.3
   json_annotation: ^4.12.0
   version: ^3.0.2

--- a/packages/at_secondary_server/test/persistence_migration_test.dart
+++ b/packages/at_secondary_server/test/persistence_migration_test.dart
@@ -1,0 +1,156 @@
+import 'dart:io';
+
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_persistence_secondary_server/sqlite.dart';
+import 'package:at_secondary/src/conf/config_util.dart';
+import 'package:at_secondary/src/server/at_secondary_config.dart';
+import 'package:at_secondary/src/server/persistence_backend.dart';
+import 'package:test/test.dart';
+import 'package:yaml/yaml.dart';
+
+void main() {
+  final tmp = '${Directory.current.path}/test/persistence_migration_tmp';
+
+  void useTempConfig() {
+    AtSecondaryConfig.configYamlMap = YamlMap.wrap({
+      'hive': {
+        'storagePath': '$tmp/hive',
+        'commitLogPath': '$tmp/commitLog',
+        'accessLogPath': '$tmp/accessLog',
+        'notificationStoragePath': '$tmp/notif',
+      },
+      'persistence': {'storageRoot': tmp},
+    });
+  }
+
+  setUp(useTempConfig);
+
+  tearDown(() {
+    AtSecondaryConfig.configYamlMap = ConfigUtil.getYaml();
+    final dir = Directory(tmp);
+    if (dir.existsSync()) dir.deleteSync(recursive: true);
+  });
+
+  test('config getters default to hive / storage', () {
+    AtSecondaryConfig.configYamlMap = YamlMap.wrap({});
+    expect(AtSecondaryConfig.persistenceBackend, 'hive');
+    expect(AtSecondaryConfig.storageRoot, 'storage');
+  });
+
+  test('marker round-trips through disk', () {
+    final path = '$tmp/.persistence_backend';
+    final now = DateTime.now();
+    PersistenceBackendMarker.write(
+        path,
+        PersistenceBackendMarker(
+            activeBackend: 'sqlite',
+            previousBackend: 'hive',
+            previousPaths: ['$tmp/hive', '$tmp/commitLog'],
+            migratedAt: now));
+    final read = PersistenceBackendMarker.read(path)!;
+    expect(read.activeBackend, 'sqlite');
+    expect(read.previousBackend, 'hive');
+    expect(read.previousPaths, ['$tmp/hive', '$tmp/commitLog']);
+    expect(read.migratedAt!.toUtc(), now.toUtc());
+  });
+
+  test('migrateIfNeeded hive -> sqlite migrates, verifies, flips marker, '
+      'retains source', () async {
+    const atSign = '@migrate_alice';
+
+    // Seed a Hive store via the configured hive config.
+    final hiveFactory = PersistenceBackendManager.factoryFor('hive');
+    final hiveBundle = await hiveFactory.initialize(
+        atSign, PersistenceBackendManager.configFor('hive'));
+    await hiveBundle.keyValueStore
+        .create('phone.wavi$atSign', AtData()..data = '12345');
+    await hiveBundle.keyValueStore
+        .create('email.wavi$atSign', AtData()..data = 'a@b.com');
+    await hiveFactory.close();
+
+    // No marker yet → current backend defaults to hive → migrate to sqlite.
+    await PersistenceBackendManager.migrateIfNeeded(atSign, 'sqlite');
+
+    // Marker flipped, source retained.
+    final marker =
+        PersistenceBackendMarker.read('$tmp/.persistence_backend')!;
+    expect(marker.activeBackend, 'sqlite');
+    expect(marker.previousBackend, 'hive');
+    expect(marker.previousPaths, isNotEmpty);
+    expect(marker.migratedAt, isNotNull);
+    expect(Directory('$tmp/hive').existsSync(), true, reason: 'source retained');
+
+    // The SQLite target has the data.
+    final sqliteFactory = SqliteAtPersistenceFactory();
+    final sqliteBundle = await sqliteFactory.initialize(
+        atSign, PersistenceBackendManager.configFor('sqlite'));
+    expect((await sqliteBundle.keyValueStore.get('phone.wavi$atSign'))!.data,
+        '12345');
+    expect((await sqliteBundle.keyValueStore.get('email.wavi$atSign'))!.data,
+        'a@b.com');
+    await sqliteFactory.close();
+
+    // Idempotent: with the marker now on sqlite, a second call is a no-op.
+    await PersistenceBackendManager.migrateIfNeeded(atSign, 'sqlite');
+  });
+
+  test('reverse migrateIfNeeded sqlite -> hive works', () async {
+    const atSign = '@migrate_bob';
+
+    // Start with data on sqlite + a marker saying sqlite is active.
+    final sqliteFactory = SqliteAtPersistenceFactory();
+    final sqliteBundle = await sqliteFactory.initialize(
+        atSign, PersistenceBackendManager.configFor('sqlite'));
+    await sqliteBundle.keyValueStore
+        .create('loc.wavi$atSign', AtData()..data = 'paris');
+    await sqliteFactory.close();
+    PersistenceBackendMarker.write('$tmp/.persistence_backend',
+        PersistenceBackendMarker(activeBackend: 'sqlite'));
+
+    await PersistenceBackendManager.migrateIfNeeded(atSign, 'hive');
+
+    final marker =
+        PersistenceBackendMarker.read('$tmp/.persistence_backend')!;
+    expect(marker.activeBackend, 'hive');
+    expect(marker.previousBackend, 'sqlite');
+
+    final hiveFactory = PersistenceBackendManager.factoryFor('hive');
+    final hiveBundle = await hiveFactory.initialize(
+        atSign, PersistenceBackendManager.configFor('hive'));
+    expect((await hiveBundle.keyValueStore.get('loc.wavi$atSign'))!.data,
+        'paris');
+    await hiveFactory.close();
+  });
+
+  test('sweepStaleSource deletes retained source once old enough', () {
+    // A marker recording a migration completed 10 days ago, with a
+    // retained (existing) source dir.
+    Directory('$tmp/oldhive').createSync(recursive: true);
+    File('$tmp/oldhive/box.hive').writeAsStringSync('stale');
+    PersistenceBackendMarker.write(
+        '$tmp/.persistence_backend',
+        PersistenceBackendMarker(
+          activeBackend: 'sqlite',
+          previousBackend: 'hive',
+          previousPaths: ['$tmp/oldhive'],
+          migratedAt: DateTime.now().subtract(Duration(days: 10)),
+        ));
+
+    // Too young → no-op.
+    expect(
+        PersistenceBackendManager.sweepStaleSource('$tmp/.persistence_backend',
+            retention: Duration(days: 30)),
+        isEmpty);
+    expect(Directory('$tmp/oldhive').existsSync(), true);
+
+    // Old enough → deleted, marker cleared of previous*.
+    final deleted = PersistenceBackendManager.sweepStaleSource(
+        '$tmp/.persistence_backend',
+        retention: Duration(days: 7));
+    expect(deleted, ['$tmp/oldhive']);
+    expect(Directory('$tmp/oldhive').existsSync(), false);
+    final after = PersistenceBackendMarker.read('$tmp/.persistence_backend')!;
+    expect(after.activeBackend, 'sqlite');
+    expect(after.previousBackend, isNull);
+  });
+}

--- a/tests/at_functional_test/runDualCompare.sh
+++ b/tests/at_functional_test/runDualCompare.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+#
+# Runs the functional pack against a secondary in DUAL persistence mode
+# (Hive primary + SQLite secondary, every write mirrored), then compares each
+# hosted atSign's Hive and SQLite DB sets for byte-identity.
+#
+#   ./runDualCompare.sh [--build]
+#
+# --build recompiles the root/secondary binaries first; without it, the
+# binaries already staged in ve/contents (e.g. from a prior runLocal.sh) are
+# reused. The VE image is always rebuilt so it picks up libsqlite3.
+#
+# Exit: 0 = pack passed AND every atSign's Hive == SQLite; non-zero otherwise.
+
+set -uo pipefail
+cd "$(dirname -- "$0")"; cd ../../; repoDir=$(pwd)
+CONT=at_server_func_cont
+PERSIST_PKG="${repoDir}/packages/at_persistence_secondary_server"
+
+if [[ "${1:-}" == "--build" ]]; then
+  echo "== compile root =="
+  docker run --rm -v "${repoDir}:/app" -w /app/packages/at_root_server \
+    dart:3.11.2 sh -c 'dart pub get && dart compile exe bin/main.dart -o root' || exit 1
+  echo "== compile secondary =="
+  docker run --rm -v "${repoDir}:/app" -w /app/packages/at_secondary_server \
+    dart:3.11.2 sh -c 'dart pub get && dart compile exe bin/main.dart -o secondary' || exit 1
+  cp packages/at_root_server/root tools/build_virtual_environment/ve/contents/atsign/root/
+  cp packages/at_secondary_server/secondary tools/build_virtual_environment/ve/contents/atsign/secondary/
+  chmod 755 tools/build_virtual_environment/ve/contents/atsign/root/root
+  chmod 755 tools/build_virtual_environment/ve/contents/atsign/secondary/secondary
+fi
+
+echo "== build VE image (with libsqlite3) =="
+( cd "${repoDir}/tools/build_virtual_environment/ve" && \
+  docker build -f ./Dockerfile -t at_virtual_env:local . ) || exit 1
+
+echo "== run container in DUAL mode =="
+docker stop $CONT 2>/dev/null
+docker run -d --rm --name $CONT \
+  -e testingMode="true" -e httpsEnabled="true" -e persistenceBackend="dual" \
+  -p 6379:6379 -p 25000-25040:25000-25040 -p 64:64 -p 443:443 \
+  at_virtual_env:local || exit 1
+
+echo "== readiness + keys =="
+cd "${repoDir}/tests/at_functional_test"
+dart run test/check_docker_readiness.dart || { docker stop $CONT; exit 1; }
+dart run test/check_root_server_readiness.dart || { docker stop $CONT; exit 1; }
+( cd "${repoDir}/tools/build_virtual_environment/install_PKAM_Keys" && \
+  dart pub get && dart bin/install_PKAM_Keys.dart ) || { docker stop $CONT; exit 1; }
+dart run test/check_test_env.dart || { docker stop $CONT; exit 1; }
+
+echo "== run functional pack (dual mode) =="
+dart run test --concurrency=1
+PACK_RC=$?
+echo "functional pack rc=$PACK_RC"
+
+echo "== discover per-atSign databases in $CONT and compare Hive vs SQLite =="
+# The VE lays Hive stores out as hive/ commit_log/ access_log/ notification_log/
+# (legacy names) and SQLite under storage/sqlite/. The checked-in tool
+# tool/dual_compare_ve.dart compares those exact paths; run it from inside the
+# persistence package so its package: imports resolve.
+( cd "$PERSIST_PKG" && dart pub get >/dev/null 2>&1 ) || true
+CMP_FAIL=0
+OUT=$(mktemp -d)
+docker exec $CONT sh -c "find / -name atsign.db 2>/dev/null" | tr -d '\r' | while IFS= read -r db; do
+  secdir=$(echo "$db" | sed 's|/storage/sqlite/.*||')   # /atsign/secondary/<name>
+  atSign=$(basename "$(dirname "$db")")                  # @name
+  dest="$OUT/$RANDOM"
+  docker cp "$CONT:$secdir/." "$dest" >/dev/null 2>&1
+  res=$(cd "$PERSIST_PKG" && dart run tool/dual_compare_ve.dart "$dest" "$atSign" 2>/dev/null | grep -vE "^(SHOUT|INFO|WARNING|FINE)")
+  echo "$res"
+  rm -rf "$dest"
+done | tee "$OUT/results.txt"
+IDENT=$(grep -c "^IDENTICAL" "$OUT/results.txt")
+TOTAL=$(grep -cE "^(IDENTICAL|MISMATCH)" "$OUT/results.txt")
+grep -q "^MISMATCH" "$OUT/results.txt" && CMP_FAIL=1
+if [[ $TOTAL -eq 0 ]]; then
+  echo "FAIL: no atsign.db found — dual mode did not write SQLite."
+  CMP_FAIL=1
+fi
+echo "atSigns: $TOTAL   IDENTICAL: $IDENT"
+rm -rf "$OUT"
+
+echo "== stop container =="
+docker stop $CONT >/dev/null
+
+echo "======================================================"
+echo "functional pack : $([[ $PACK_RC -eq 0 ]] && echo PASS || echo FAIL)"
+echo "DB-set identity : $([[ $CMP_FAIL -eq 0 ]] && echo IDENTICAL || echo MISMATCH)"
+echo "======================================================"
+[[ $PACK_RC -eq 0 && $CMP_FAIL -eq 0 ]] && exit 0 || exit 1

--- a/tools/build_secondary/Dockerfile
+++ b/tools/build_secondary/Dockerfile
@@ -34,16 +34,33 @@ RUN \
   cp config/config.yaml $HOMEDIR/config/ ; \
   cp cacert/cacert.pem /etc/cacert ; \
   cp pubspec.yaml $HOMEDIR/
+
+# Stage the architecture-appropriate libsqlite3 (+ its libz dependency) into
+# /runtime, alongside the Dart AOT runtime, so the scratch stage's static
+# `COPY --from=buildimage /runtime/ /` picks up the correct library for the
+# build architecture (a scratch-stage COPY cannot be arch-conditional).
+# `--dereference` resolves the SONAME symlink so a real file lands in the
+# scratch image (a copied symlink would dangle). Only dlopen'd at runtime when
+# persistence.backend=sqlite (the default hive image never loads it). NOTE:
+# confirm the full transitive .so set with a Docker build before the first
+# SQLite production deploy (this scratch image has no package manager).
+RUN \
+  case "$(dpkg --print-architecture)" in \
+    amd64) TRIPLET="x86_64-linux-gnu" ;; \
+    armhf) TRIPLET="arm-linux-gnueabihf" ;; \
+    arm64) TRIPLET="aarch64-linux-gnu" ;; \
+    riscv64) TRIPLET="riscv64-linux-gnu" ;; \
+    *) echo "Unsupported architecture: $(dpkg --print-architecture)" ; exit 5 ;; \
+  esac ; \
+  FILES="/usr/lib/$TRIPLET/libsqlite3.so.0 /usr/lib/$TRIPLET/libz.so.1" ; \
+  for f in $FILES ; do \
+    mkdir -p "/runtime$(dirname "$f")" ; \
+    cp --archive --link --dereference --no-target-directory "$f" "/runtime$f" ; \
+  done
+
 # Second stage of build FROM scratch
 FROM scratch
 COPY --from=buildimage /runtime/ /
-# libsqlite3 (+ libz) for the SQLite persistence backend's FFI. Only
-# dlopen'd when persistence.backend=sqlite; the default (hive) image never
-# loads it. NOTE: the exact transitive .so set must be confirmed with a
-# Docker build before the first SQLite production deploy (this scratch
-# image has no package manager to pull deps at runtime).
-COPY --from=buildimage /usr/lib/x86_64-linux-gnu/libsqlite3.so.0 /usr/lib/x86_64-linux-gnu/
-COPY --from=buildimage /usr/lib/x86_64-linux-gnu/libz.so.1 /usr/lib/x86_64-linux-gnu/
 COPY --from=buildimage /etc/passwd /etc/passwd
 COPY --from=buildimage /etc/group /etc/group
 COPY --from=buildimage /etc/cacert /etc/cacert

--- a/tools/build_secondary/Dockerfile
+++ b/tools/build_secondary/Dockerfile
@@ -12,6 +12,9 @@ COPY ./packages/at_persistence_spec/ ./at_persistence_spec
 COPY ./packages/at_persistence_secondary_server/ ./at_persistence_secondary_server
 COPY ./packages/at_secondary_server/ ./at_secondary_server
 RUN \
+  apt-get update ; \
+  apt-get install -y --no-install-recommends libsqlite3-0 ; \
+  rm -rf /var/lib/apt/lists/* ; \
   mkdir -p $HOMEDIR/storage ; \
   mkdir -p $HOMEDIR/config ; \
   mkdir -p /etc/cacert ; \
@@ -34,6 +37,13 @@ RUN \
 # Second stage of build FROM scratch
 FROM scratch
 COPY --from=buildimage /runtime/ /
+# libsqlite3 (+ libz) for the SQLite persistence backend's FFI. Only
+# dlopen'd when persistence.backend=sqlite; the default (hive) image never
+# loads it. NOTE: the exact transitive .so set must be confirmed with a
+# Docker build before the first SQLite production deploy (this scratch
+# image has no package manager to pull deps at runtime).
+COPY --from=buildimage /usr/lib/x86_64-linux-gnu/libsqlite3.so.0 /usr/lib/x86_64-linux-gnu/
+COPY --from=buildimage /usr/lib/x86_64-linux-gnu/libz.so.1 /usr/lib/x86_64-linux-gnu/
 COPY --from=buildimage /etc/passwd /etc/passwd
 COPY --from=buildimage /etc/group /etc/group
 COPY --from=buildimage /etc/cacert /etc/cacert

--- a/tools/build_virtual_environment/ve/Dockerfile
+++ b/tools/build_virtual_environment/ve/Dockerfile
@@ -1,6 +1,13 @@
 FROM atsigncompany/vebase:latest
 USER root
 
+# libsqlite3 for the SQLite persistence backend's FFI — needed when the
+# secondary runs with persistenceBackend=sqlite or =dual (e.g. the
+# dual-write DB-identity functional run). Harmless for the default hive mode.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libsqlite3-0 \
+    && rm -rf /var/lib/apt/lists/*
+
 # Secondary binary will be put in place by GitHub Actions
 # Context for this Dockerfile is its local directory:
 # tools/build_virtual_environment/ve


### PR DESCRIPTION
Fixes #2697 

**- What I did**

Add a SQLite persistence backend for the atServer alongside Hive, behind the existing factory/bundle/config abstraction, plus Hive↔SQLite migration and a dual-mode validation gate.

**- How I did it**

- New SQLite backend (`lib/sqlite.dart`): keystore, commit log (dense counters-based ids), notifications, access log — with full-fidelity snapshots, path queries, and true transactions. One `atsign.db` per atSign.
- Verbatim-restore primitives + `PersistenceMigrator` + `PersistenceSnapshot` comparator; config-driven backend selection with an abort-on-failure startup migrate-verify-flip.
- Dual-write mode (Hive primary, every write mirrored into SQLite) + a DB-set compare CLI, gated by a conversion-integrity round-trip and a new `functional_dual_verify` CI workflow.

Per-commit detail is in the commit messages.

**- How to verify it**

- `dart test --concurrency=1` in `at_persistence_secondary_server` (includes the 6-DB conversion-integrity gate).
- Functional pack in dual mode → every atSign's Hive and SQLite DB sets are identical (`functional_dual_verify.yaml`; 40/40 locally and in CI).

**- Description for the changelog**

Add a SQLite persistence backend for the atServer, with Hive↔SQLite migration and dual-mode DB-set validation.

---

## Scope & rollout notes

### This is a capability release — nothing flips by default

The default persistence backend stays **Hive**. `config.yaml` ships `persistence.backend: 'hive'` and `AtSecondaryConfig.persistenceBackend` defaults to `hive`, so merging and deploying this changes no server's behaviour or on-disk storage. It only *adds* the ability to select SQLite (or the transient `dual` validation harness) per server, via the `persistenceBackend` env var or the `persistence.backend` yaml key. No atServer runs on SQLite until it is explicitly, individually flipped.

### Client-side (at_client) migration is a separate, later effort

This PR is **server-side only** — it changes how the atServer persists data. The `at_client` SDK keeps its own on-device local storage (Hive today), and migrating that to SQLite is a distinct piece of work. The `at_client` migration code will live in a **later PR in the `at_client` repo**, if and when we decide to do that migration; it is deliberately out of scope here.

### Release sequencing (this PR carries a temporary bridge)

`at_secondary_server` consumes new `at_persistence_secondary_server` **5.2.0** API that isn't on pub.dev yet, and CI resolves sibling packages from pub.dev. So this PR includes a committed `dependency_overrides` path, isolated in its own commit so it reverts cleanly. Landing sequence:

1. **Merge** this PR.
2. **Publish** `at_persistence_secondary_server` 5.2.0 to pub.dev.
3. Open a small **follow-up PR** that removes the `dependency_overrides` block and depends on the hosted `^5.2.0`.
4. **Merge** the follow-up.
5. **Release** `at_secondary_server`.

### What happens when a container is restarted with the backend flipped to SQLite

Setting `persistenceBackend=sqlite` (env) or `persistence.backend: 'sqlite'` (yaml) and restarting triggers a one-time, in-process migration during startup — **before the server opens any store or accepts a connection**:

1. Startup reads a single marker file, `<storageRoot>/.persistence_backend`. On a Hive-only server it is absent, so the current backend is taken as `hive`; the configured target is `sqlite`; they differ, so a migration runs.
2. Both bundles are opened — Hive (source) and SQLite (target, under `<storageRoot>/sqlite`). The SQLite target is `clear()`ed first, so a retry after an earlier failed attempt starts from a clean tree rather than stacking onto partial data.
3. `PersistenceMigrator` copies all four stores **verbatim** — keystore, commit log (preserving commit ids), access log (preserving timestamps), and notifications — reading the source and never mutating it.
4. It then captures a backend-neutral snapshot of both stores and **verifies they are byte-identical**, while both are still open and *before* anything is committed.
5. **Only on a clean verify** does it write the marker (`activeBackend: sqlite`, `previousBackend: hive`, the retained Hive paths, and `migratedAt`). Bootstrap then opens SQLite, and the server comes up on SQLite.

The old Hive data is **retained on disk** — never deleted at startup. It is reclaimed only out-of-band by `bin/cleanup_stale_persistence.dart`, and only after a configurable retention window.

**Abort-on-failure.** If the migration or the verify fails, the exception propagates out of `start()` and the process exits without serving a single request. Because the marker is written only *after* a clean migration, and the migration only *reads* the Hive source (the `clear()` touches only the SQLite target), nothing is committed: a restart reverted to `hive` comes straight back up on the original, untouched data, and a restart still pointed at `sqlite` retries the whole migration from a clean target.

**Steady state & rollback.** Once a server is on SQLite, every subsequent restart sees the marker and config agree and skips migration entirely — it just opens SQLite. Flipping the config back to `hive` and restarting runs the reverse migration (SQLite→Hive) with the same clear → migrate → verify → flip, rebuilding Hive from the *current* SQLite so any writes made while on SQLite are preserved.

### Rollout: atSign by atSign on canaries — never a fleet flip

Each secondary hosts a **single atSign** with its own storage root and its own marker, so the backend is chosen per-server / per-atSign. The actual move to SQLite will be rolled out **one atSign at a time on canary servers** — flip, migrate, verify, observe — before the fleet is even considered. There is no fleet-wide switch; the default remains Hive, and each canary atSign is individually validated on SQLite before any broader rollout is contemplated.
