### PR TITLE
refactor(enroll): typed EnrollParams metadata/signingAlgo + prep atServer 3.15.0

### DIFF
--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 3.14.0
+# 3.15.0
 
 - feat: `enroll:listns:<namespace>` verb for the WP-SS secret-sharing
   substrate (at_commons 5.12.0). Returns all approved enrollments that hold
@@ -10,6 +10,9 @@
 - feat: `metadata` field on enrollment records — an opaque JSON map stored
   verbatim from `enroll:request`'s `EnrollParams.metadata`; surfaced in
   `enroll:fetch`, `enroll:list`, and `enroll:listns` responses.
+
+# 3.14.0
+
 - feat: `appMetadata` support on `update`, `update:meta` and `notify`
   (at_commons 5.11.0). The base64(JSON)
   `:appMetadata:` fragment is parsed into

--- a/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
@@ -67,11 +67,6 @@ class EnrollVerbHandler extends AbstractVerbHandler {
           'Cannot $operation enrollment without authentication');
     }
     EnrollParams? enrollVerbParams;
-    // The raw decoded enrollParams JSON map. Used to read fields the pinned
-    // at_commons EnrollParams model does not yet type (`metadata`,
-    // `signingAlgo`) — these ride the opaque JSON tail on enroll:request and
-    // are persisted verbatim onto the enrollment record.
-    Map<String, dynamic>? rawEnrollParams;
 
     // Ensure that enrollParams are present for all enroll operation.
     // 'list' and 'listns' carry no enrollParams JSON body.
@@ -82,9 +77,9 @@ class EnrollVerbHandler extends AbstractVerbHandler {
         throw IllegalArgumentException('Enroll parameters not provided');
       }
     } else {
-      rawEnrollParams =
-          jsonDecode(verbParams[AtConstants.enrollParams]!) as Map<String, dynamic>;
-      enrollVerbParams = EnrollParams.fromJson(rawEnrollParams);
+      enrollVerbParams = EnrollParams.fromJson(
+          jsonDecode(verbParams[AtConstants.enrollParams]!)
+              as Map<String, dynamic>);
     }
 
     _validateParams(enrollVerbParams, operation!, atConnection);
@@ -94,7 +89,6 @@ class EnrollVerbHandler extends AbstractVerbHandler {
         await _handleEnrollmentRequest(
           enMgr,
           enrollVerbParams!,
-          rawEnrollParams,
           currentAtSign,
           responseJson,
           atConnection,
@@ -221,7 +215,6 @@ class EnrollVerbHandler extends AbstractVerbHandler {
   Future<void> _handleEnrollmentRequest(
       EnrollmentManager enMgr,
       EnrollParams enrollParams,
-      Map<String, dynamic>? rawEnrollParams,
       currentAtSign,
       Map<dynamic, dynamic> responseJson,
       InboundConnection atConnection) async {
@@ -273,17 +266,14 @@ class EnrollVerbHandler extends AbstractVerbHandler {
     enrollmentValue.requestType = EnrollRequestType.newEnrollment;
 
     // The X-Wing key package (at `metadata.keyPackage`) and the APKAM
-    // `signingAlgo` ride the opaque enrollParams JSON tail on enroll:request and
-    // are persisted verbatim onto the enrollment record — there is no separate
-    // enroll:metadata write. Read from the raw JSON: the pinned at_commons
-    // EnrollParams model does not yet type these fields.
-    final rawMetadata = rawEnrollParams?['metadata'];
-    if (rawMetadata is Map<String, dynamic>) {
-      enrollmentValue.metadata = rawMetadata;
+    // `signingAlgo` ride EnrollParams on enroll:request and are persisted
+    // verbatim onto the enrollment record — there is no separate
+    // enroll:metadata write.
+    if (enrollParams.metadata != null) {
+      enrollmentValue.metadata = enrollParams.metadata;
     }
-    final rawSigningAlgo = rawEnrollParams?['signingAlgo'];
-    if (rawSigningAlgo is String) {
-      enrollmentValue.signingAlgo = rawSigningAlgo;
+    if (enrollParams.signingAlgo != null) {
+      enrollmentValue.signingAlgo = enrollParams.signingAlgo;
     }
 
     if (enrollParams.apkamKeysExpiryDuration != null) {

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_secondary
 description: Implementation of secondary server.
-version: 3.14.0
+version: 3.15.0
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://www.example.com
 publish_to: none

--- a/packages/at_server_spec/CHANGELOG.md
+++ b/packages/at_server_spec/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.2.0
+- chore: dependency bump — `at_commons` to `^5.12.0`
+
 ## 5.1.0
 - feat: introduce enum AtVerb for better preparsing of verbs
 

--- a/packages/at_server_spec/pubspec.yaml
+++ b/packages/at_server_spec/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_server_spec
 description: A Dart library containing abstract classes that defines what implementations of the root and secondary servers are responsible for.
-version: 5.1.0
+version: 5.2.0
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://docs.atsign.com
 documentation: https://docs.atsign.com/atplatform/secondaryserver


### PR DESCRIPTION
**- What I did**

Drop the temporary `rawEnrollParams` raw-JSON workaround in `EnrollVerbHandler` (now that `at_commons 5.12.0` types `EnrollParams.metadata`/`signingAlgo`), and make trunk immediately releasable as **atServer 3.15.0** once this and #2685 land.

**- How I did it**

- `enroll:request` now reads `enrollParams.metadata` / `enrollParams.signingAlgo` from the typed model and persists them onto the record; removed the `rawEnrollParams` local, the `_handleEnrollmentRequest` parameter, and the raw `['metadata']`/`['signingAlgo']` reads. Behaviour-preserving — under the pinned `^5.12.0`, `EnrollParams.fromJson` already parses/validates both fields, so the old `is Map`/`is String` guards were unreachable.
- Bumped `at_secondary_server` to `3.15.0` and moved the unreleased `enroll:listns` + enrollment-`metadata` CHANGELOG entries under a new `# 3.15.0` heading (they had been sitting under the already-released `# 3.14.0`).
- Bumped `at_server_spec` to `5.2.0` — a dependency bump only (`at_commons ^5.12.0`).

**- How to verify it**

- `dart analyze --fatal-warnings` on `at_secondary_server` — clean.
- `dart test --concurrency=1 test/enroll_verb_test.dart` — 82/82 pass, including *"metadata + signingAlgo on enroll:request are persisted on the record"* and the `enroll:listns` / `_apsk` tests.

**- Description for the changelog**

Covered by the `3.15.0` entries added to `at_secondary_server`'s CHANGELOG.
