### PR TITLE
test(functional): enroll:listns roster + enrollment metadata

### DIFF
--- a/tests/at_functional_test/lib/conf/config_util.dart
+++ b/tests/at_functional_test/lib/conf/config_util.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:at_utils/at_utils.dart';
 import 'package:yaml/yaml.dart';
 
@@ -5,7 +7,32 @@ class ConfigUtil {
   static final ApplicationConfiguration appConfig =
       ApplicationConfiguration('config/config.yaml');
 
+  /// The functional-test config from `config/config.yaml`.
+  ///
+  /// When the `VIRTUALENV_BASE_PORT` environment variable is set, the first
+  /// atSign's port is overlaid with the value the ve entrypoint assigns to the
+  /// first atServer (`BASE + 1`), so tests run against a virtualenv launched on
+  /// a shifted port range without editing the config file. Unset => the config
+  /// file's ports are used unchanged.
   static YamlMap? getYaml() {
-    return appConfig.getYaml();
+    final yaml = appConfig.getYaml();
+    final basePort =
+        int.tryParse(Platform.environment['VIRTUALENV_BASE_PORT'] ?? '');
+    if (yaml == null || basePort == null) {
+      return yaml;
+    }
+    final overlaid = _deepCopy(yaml) as Map;
+    (overlaid['firstAtSignServer'] as Map)['firstAtSignPort'] = basePort + 1;
+    return YamlMap.wrap(overlaid);
+  }
+
+  static dynamic _deepCopy(dynamic node) {
+    if (node is Map) {
+      return {for (final e in node.entries) e.key: _deepCopy(e.value)};
+    }
+    if (node is List) {
+      return [for (final e in node) _deepCopy(e)];
+    }
+    return node;
   }
 }

--- a/tests/at_functional_test/runLocal.sh
+++ b/tests/at_functional_test/runLocal.sh
@@ -5,6 +5,28 @@ cd "$(dirname -- "$0")"
 cd ../../
 repoDir=$(pwd)
 
+# Optional VE base port. Set VIRTUALENV_BASE_PORT (env) or pass it as the first
+# argument to run the virtualenv on a shifted port range, so it doesn't clash
+# with another VE already running on the default ports. The ve entrypoint binds
+# atDirectory to BASE, atServers to BASE+1.., Redis to BASE+99
+# (tools/build_virtual_environment/ve/contents/atsign/entrypoint.sh). The Dart
+# harness reads VIRTUALENV_BASE_PORT too (config_util, the readiness checks), so
+# tests target the shifted ports without editing config.yaml. Unset => original
+# ports (atDirectory 64, atServers 25000.., Redis 6379).
+VIRTUALENV_BASE_PORT="${1:-${VIRTUALENV_BASE_PORT:-}}"
+if [[ -n "$VIRTUALENV_BASE_PORT" ]]; then
+  export VIRTUALENV_BASE_PORT
+  export rootServerPort="$VIRTUALENV_BASE_PORT" # install_PKAM_Keys reads this
+  veEnvArgs="-e VIRTUALENV_BASE_PORT=${VIRTUALENV_BASE_PORT}"
+  vePortArgs="-p ${VIRTUALENV_BASE_PORT}-$((VIRTUALENV_BASE_PORT + 99)):${VIRTUALENV_BASE_PORT}-$((VIRTUALENV_BASE_PORT + 99))"
+  veCmd="bash /atsign/entrypoint.sh"
+  echo "Using VE base port ${VIRTUALENV_BASE_PORT} (atServers ${VIRTUALENV_BASE_PORT}+1.., Redis +99)"
+else
+  veEnvArgs=""
+  vePortArgs="-p 6379:6379 -p 25000-25040:25000-25040 -p 64:64 -p 443:443"
+  veCmd=""
+fi
+
 echo "Generate atDirectory binary (root) [in dart:3.11.2 Linux container]"
 # Compile the binaries inside a Linux Dart container so they run inside the
 # Linux at_virtual_env container we build below. Compiling on the host
@@ -45,8 +67,8 @@ docker stop at_server_func_cont
 echo "Run docker container"
 docker run -d --rm --name at_server_func_cont \
   -e testingMode="true" -e httpsEnabled="true" \
-  -p 6379:6379 -p 25000-25040:25000-25040 -p 64:64 -p 443:443 \
-  at_virtual_env:local || exit 1
+  $veEnvArgs $vePortArgs \
+  at_virtual_env:local $veCmd || exit 1
 
 echo "Check docker readiness to load PKAM keys"
 cd ${repoDir}/tests/at_functional_test

--- a/tests/at_functional_test/test/check_docker_readiness.dart
+++ b/tests/at_functional_test/test/check_docker_readiness.dart
@@ -5,7 +5,14 @@ import 'package:test/test.dart';
 
 void main() {
   var atsign = '@sitaram🛠';
-  var atsignPort = 25017;
+  // Match the port the ve entrypoint assigns to @sitaram🛠 when the VE runs on a
+  // shifted base port (VIRTUALENV_BASE_PORT); default 25017 otherwise.
+  const defaultAtsignPort = 25017;
+  final basePort =
+      int.tryParse(Platform.environment['VIRTUALENV_BASE_PORT'] ?? '');
+  final atsignPort = basePort != null
+      ? defaultAtsignPort + (basePort + 1 - 25000)
+      : defaultAtsignPort;
   var rootServer = 'vip.ve.atsign.zone';
   String response = '';
 

--- a/tests/at_functional_test/test/check_root_server_readiness.dart
+++ b/tests/at_functional_test/test/check_root_server_readiness.dart
@@ -10,7 +10,10 @@ Queue rootServerResponseQueue = Queue();
 
 void main() {
   var atSign = 'sitaram🛠';
-  var rootServerPort = 64;
+  // Root/atDirectory binds to VIRTUALENV_BASE_PORT when the VE runs on a shifted
+  // base port; default 64 otherwise.
+  final rootServerPort =
+      int.tryParse(Platform.environment['VIRTUALENV_BASE_PORT'] ?? '') ?? 64;
   var rootServer = 'vip.ve.atsign.zone';
 
   late SecureSocket secureSocket;

--- a/tests/at_functional_test/test/check_test_env.dart
+++ b/tests/at_functional_test/test/check_test_env.dart
@@ -7,7 +7,14 @@ void main() {
   SecureSocket secureSocket;
   var rootServer = 'vip.ve.atsign.zone';
   var atsign = '@sitaram🛠';
-  var atsignPort = 25017;
+  // Match the port the ve entrypoint assigns to @sitaram🛠 when the VE runs on a
+  // shifted base port (VIRTUALENV_BASE_PORT); default 25017 otherwise.
+  const defaultAtsignPort = 25017;
+  final basePort =
+      int.tryParse(Platform.environment['VIRTUALENV_BASE_PORT'] ?? '');
+  final atsignPort = basePort != null
+      ? defaultAtsignPort + (basePort + 1 - 25000)
+      : defaultAtsignPort;
   int maxRetryCount = 10;
   int retryCount = 1;
 

--- a/tests/at_functional_test/test/enroll_listns_test.dart
+++ b/tests/at_functional_test/test/enroll_listns_test.dart
@@ -1,0 +1,159 @@
+import 'dart:convert';
+
+import 'package:at_demo_data/at_demo_data.dart' as at_demos;
+import 'package:at_functional_test/conf/config_util.dart';
+import 'package:at_functional_test/connection/outbound_connection_wrapper.dart';
+import 'package:at_functional_test/utils/encryption_util.dart';
+import 'package:test/test.dart';
+import 'package:uuid/uuid.dart';
+
+/// Functional tests for the `enroll:listns:<namespace>` discovery verb and the
+/// `metadata` / `signingAlgo` fields that now ride an `enroll:request`.
+///
+/// `enroll:listns` returns every approved enrollment that holds read-or-better
+/// access to the requested namespace, as a flat list of
+/// `{enrollmentId, access, apkamPubKey, metadata}`. The caller must be
+/// APKAM-authenticated with an approved enrollment that itself holds >=r on the
+/// namespace, otherwise the server refuses with UnAuthorized.
+void main() {
+  final firstAtSign =
+      ConfigUtil.getYaml()!['firstAtSignServer']['firstAtSignName'];
+  final firstAtSignHost =
+      ConfigUtil.getYaml()!['firstAtSignServer']['firstAtSignUrl'];
+  final firstAtSignPort =
+      ConfigUtil.getYaml()!['firstAtSignServer']['firstAtSignPort'];
+
+  // Encrypted-key bundle the enroll flow needs: the two default keys wrapped for
+  // enroll:approve, and the APKAM symmetric key for a second (OTP) enrollment.
+  final apkamEncryptedKeysMap = <String, String>{
+    'encryptedDefaultEncPrivateKey': EncryptionUtil.encryptValue(
+        at_demos.encryptionPrivateKeyMap[firstAtSign]!,
+        at_demos.apkamSymmetricKeyMap[firstAtSign]!),
+    'encryptedSelfEncKey': EncryptionUtil.encryptValue(
+        at_demos.aesKeyMap[firstAtSign]!,
+        at_demos.apkamSymmetricKeyMap[firstAtSign]!),
+    'encryptedAPKAMSymmetricKey': EncryptionUtil.encryptKey(
+        at_demos.apkamSymmetricKeyMap[firstAtSign]!,
+        at_demos.encryptionPublicKeyMap[firstAtSign]!),
+  };
+
+  final firstAtSignConnection = OutboundConnectionFactory();
+
+  setUp(() async {
+    await firstAtSignConnection.initiateConnectionWithListener(
+        firstAtSign, firstAtSignHost, firstAtSignPort);
+  });
+
+  tearDown(() async {
+    await firstAtSignConnection.close();
+  });
+
+  group('enroll:listns discovery + request metadata', () {
+    test(
+        'listns returns an approved enrollment carrying its apkamPubKey and '
+        'metadata', () async {
+      await firstAtSignConnection.authenticateConnection(
+          authType: AuthType.cram);
+
+      // A namespace unique to this run so the assertions are unambiguous.
+      final namespace = 'listns${Uuid().v4().hashCode}';
+      final apkamPublicKey = at_demos.pkamPublicKeyMap[firstAtSign]!;
+      final keyPackage = {
+        'v': 1,
+        'keys': [
+          {'kid': 'k', 'use': 'enc', 'alg': 'x-wing', 'pub': 'p'}
+        ]
+      };
+
+      // enroll:request on a CRAM connection is auto-approved. metadata and
+      // signingAlgo ride the request and are persisted on the record.
+      final enrollRequest = 'enroll:request:${jsonEncode({
+            'appName': 'listns-app',
+            'deviceName': 'device-${Uuid().v4().hashCode}',
+            'namespaces': {namespace: 'rw'},
+            'apkamPublicKey': apkamPublicKey,
+            'signingAlgo': 'mldsa65',
+            'metadata': {'keyPackage': keyPackage},
+          })}\n';
+      final enrollJson = jsonDecode(
+          (await firstAtSignConnection.sendRequestToServer(enrollRequest))
+              .replaceFirst('data:', ''));
+      final enrollmentId = enrollJson['enrollmentId'];
+      expect(enrollmentId, isNotEmpty);
+      expect(enrollJson['status'], 'approved');
+
+      // APKAM-authenticate as the new enrollment, then query the roster.
+      await firstAtSignConnection.authenticateConnection(
+          authType: AuthType.pkam, enrollmentId: enrollmentId);
+
+      final roster = jsonDecode(
+          (await firstAtSignConnection
+                  .sendRequestToServer('enroll:listns:$namespace\n'))
+              .replaceFirst('data:', '')) as List;
+
+      final mine = roster.firstWhere((m) => m['enrollmentId'] == enrollmentId,
+          orElse: () => null);
+      expect(mine, isNotNull,
+          reason: 'the enrollment should appear in the listns roster for the '
+              'namespace it was granted');
+      expect(mine['access'], 'rw');
+      expect(mine['apkamPubKey'], apkamPublicKey);
+      expect(mine['metadata'], {'keyPackage': keyPackage});
+    });
+
+    test(
+        'listns refuses a caller whose enrollment lacks access to the '
+        'namespace', () async {
+      await firstAtSignConnection.authenticateConnection(
+          authType: AuthType.cram);
+
+      final grantedNamespace = 'buzz${Uuid().v4().hashCode}';
+      final otherNamespace = 'wavi${Uuid().v4().hashCode}';
+
+      // Second enrollment via OTP, scoped to grantedNamespace only.
+      final otp = (await firstAtSignConnection.sendRequestToServer('otp:get'))
+          .replaceAll('data:', '')
+          .trim();
+      final secondConnection = await OutboundConnectionFactory()
+          .initiateConnectionWithListener(
+              firstAtSign, firstAtSignHost, firstAtSignPort);
+      final secondEnrollRequest = 'enroll:request:${jsonEncode({
+            'appName': 'buzz',
+            'deviceName': 'device-${Uuid().v4().hashCode}',
+            'namespaces': {grantedNamespace: 'rw'},
+            'otp': otp,
+            'apkamPublicKey': at_demos.pkamPublicKeyMap[firstAtSign],
+            'encryptedAPKAMSymmetricKey':
+                apkamEncryptedKeysMap['encryptedAPKAMSymmetricKey'],
+          })}\n';
+      final pendingJson = jsonDecode(
+          (await secondConnection.sendRequestToServer(secondEnrollRequest))
+              .replaceFirst('data:', ''));
+      expect(pendingJson['status'], 'pending');
+      final secondEnrollId = pendingJson['enrollmentId'];
+
+      // Approve it from the CRAM (owner) connection.
+      final approveJson = jsonDecode((await firstAtSignConnection
+              .sendRequestToServer('enroll:approve:${jsonEncode({
+                    'enrollmentId': secondEnrollId,
+                    'encryptedDefaultEncryptionPrivateKey':
+                        apkamEncryptedKeysMap['encryptedDefaultEncPrivateKey'],
+                    'encryptedDefaultSelfEncryptionKey':
+                        apkamEncryptedKeysMap['encryptedSelfEncKey'],
+                  })}'))
+          .replaceFirst('data:', ''));
+      expect(approveJson['status'], 'approved');
+
+      // APKAM-authenticate as the second enrollment and query a namespace it
+      // was NOT granted -> the server refuses.
+      await secondConnection.authenticateConnection(
+          authType: AuthType.apkam, enrollmentId: secondEnrollId);
+      final refusal = await secondConnection
+          .sendRequestToServer('enroll:listns:$otherNamespace\n');
+      expect(refusal, startsWith('error:'),
+          reason: 'a caller without >=r on the namespace must be refused');
+
+      await secondConnection.close();
+    });
+  });
+}

--- a/tests/at_functional_test/test/http_test.dart
+++ b/tests/at_functional_test/test/http_test.dart
@@ -18,12 +18,16 @@ void main() {
 
   AtSignLogger.root_level = 'shout';
   final root = 'vip.ve.atsign.zone';
+  // atDirectory binds to VIRTUALENV_BASE_PORT when the VE runs on a shifted base
+  // port; default 64 otherwise.
+  final rootPort =
+      int.tryParse(Platform.environment['VIRTUALENV_BASE_PORT'] ?? '') ?? 64;
 
   group('basic atDirectory tests', () {
     test('lookup existing atSign via 64', () async {
       List<Future> futures = [];
       for (final atSign in atSigns) {
-        final saf = CacheableSecondaryAddressFinder(root, 64);
+        final saf = CacheableSecondaryAddressFinder(root, rootPort);
         futures.add(saf.findSecondary(atSign));
       }
       final responses = await Future.wait(futures);
@@ -33,7 +37,7 @@ void main() {
     test('lookup non-existent atSign avia 64', () async {
       List<Future> futures = [];
       for (final atSign in atSigns.map((e) => '${e}_nope')) {
-        final saf = CacheableSecondaryAddressFinder(root, 64);
+        final saf = CacheableSecondaryAddressFinder(root, rootPort);
         futures.add(expectLater(saf.findSecondary(atSign),
             throwsA(isA<SecondaryNotFoundException>())));
       }
@@ -71,7 +75,7 @@ void main() {
   group('atDirectory redirect tests', () {
     Future<bool> getAndCompareServerSigningKeyData(String atSign) async {
       final String command = 'lookup:signing_publickey$atSign';
-      final atLookup = AtLookupImpl(atSign, root, 64);
+      final atLookup = AtLookupImpl(atSign, root, rootPort);
       String pskFromAtLookup;
       try {
         pskFromAtLookup = (await atLookup.executeCommand('$command\n'))!;
@@ -93,7 +97,7 @@ void main() {
 
     Future<bool> getAndCompareServerSigningKeyMetadata(String atSign) async {
       final String command = 'lookup:meta:signing_publickey$atSign';
-      final atLookup = AtLookupImpl(atSign, root, 64);
+      final atLookup = AtLookupImpl(atSign, root, rootPort);
       String atMetaDataFromAtLookup = '';
       try {
         atMetaDataFromAtLookup = (await atLookup.executeCommand('$command\n'))!;

--- a/tests/at_functional_test/test/http_test.dart
+++ b/tests/at_functional_test/test/http_test.dart
@@ -18,10 +18,13 @@ void main() {
 
   AtSignLogger.root_level = 'shout';
   final root = 'vip.ve.atsign.zone';
-  // atDirectory binds to VIRTUALENV_BASE_PORT when the VE runs on a shifted base
-  // port; default 64 otherwise.
-  final rootPort =
-      int.tryParse(Platform.environment['VIRTUALENV_BASE_PORT'] ?? '') ?? 64;
+  // When the VE runs on a shifted base port (VIRTUALENV_BASE_PORT), the
+  // atDirectory binds to BASE and serves HTTPS on BASE + 98 (see the ve
+  // entrypoint); otherwise the defaults 64 / 443.
+  final basePort =
+      int.tryParse(Platform.environment['VIRTUALENV_BASE_PORT'] ?? '');
+  final rootPort = basePort ?? 64;
+  final httpsPort = basePort != null ? basePort + 98 : 443;
 
   group('basic atDirectory tests', () {
     test('lookup existing atSign via 64', () async {
@@ -48,7 +51,7 @@ void main() {
     test('lookup existing atSign via https', () async {
       List<Future> futures = [];
       for (final atSign in atSigns) {
-        final Uri url = Uri.https(root, atSign);
+        final Uri url = Uri.https('$root:$httpsPort', atSign);
         futures.add(expectLater(
           http.get(url).then((response) => response.statusCode),
           completion(HttpStatus.ok),
@@ -61,7 +64,7 @@ void main() {
     test('lookup non-existent atSign via https', () async {
       List<Future> futures = [];
       for (final atSign in atSigns.map((e) => '${e}_nope')) {
-        final Uri url = Uri.https(root, atSign);
+        final Uri url = Uri.https('$root:$httpsPort', atSign);
         futures.add(expectLater(
           http.get(url).then((response) => response.statusCode),
           completion(HttpStatus.notFound),
@@ -87,7 +90,7 @@ void main() {
       }
 
       final (statusCode, pskFromHttpRedirect) = await dartIoHttpClientGet(
-          Uri.https(root, '/$atSign/signing_publickey'));
+          Uri.https('$root:$httpsPort', '/$atSign/signing_publickey'));
 
       expect(statusCode, HttpStatus.ok);
       expect(pskFromHttpRedirect, pskFromAtLookup);
@@ -112,7 +115,7 @@ void main() {
       }
 
       final (statusCode, atMetaDataFromHttpGet) = await dartIoHttpClientGet(
-          Uri.https(root, '/$atSign/signing_publickey', {'at_rt': 'meta'}));
+          Uri.https('$root:$httpsPort', '/$atSign/signing_publickey', {'at_rt': 'meta'}));
 
       expect(statusCode, HttpStatus.ok);
       expect(atMetaDataFromHttpGet, atMetaDataFromAtLookup);

--- a/tools/build_virtual_environment/ve/contents/atsign/entrypoint.sh
+++ b/tools/build_virtual_environment/ve/contents/atsign/entrypoint.sh
@@ -10,6 +10,7 @@
 # into the [BASE, BASE+99] range:
 #   atDirectory  -> BASE
 #   atServers    -> BASE+1 .. BASE+80
+#   HTTPS        -> BASE+98
 #   Redis        -> BASE+99
 # This makes it possible to run several VE containers side-by-side on
 # one host without port collisions.
@@ -24,6 +25,7 @@ fi
 BASE=${VIRTUALENV_BASE_PORT}
 ROOT_PORT=${BASE}
 REDIS_PORT=$((BASE + 99))
+HTTPS_PORT=$((BASE + 98))
 SECONDARY_BASE=$((BASE + 1))
 SHIFT=$((SECONDARY_BASE - 25000))
 
@@ -32,6 +34,8 @@ sed -i "s/^port .*/port ${REDIS_PORT}/" /etc/redis/redis.conf
 
 # root_server: redis client port (the -p arg) and bind port (env var)
 export rootServerPort="${ROOT_PORT}"
+# root_server: HTTPS bind port (env var read by AtRootConfig.httpsPort)
+export httpsPort="${HTTPS_PORT}"
 sed -i "s/-p 6379/-p ${REDIS_PORT}/" /etc/supervisor/conf.d/30_root.conf
 
 # Secondary atServer supervisord program blocks: rewrite the -p N arg


### PR DESCRIPTION
**- What I did**

Add functional (over-the-wire) tests for the `enroll:listns` discovery verb and the enrollment `metadata` / `signingAlgo` fields introduced in this PR, and separately make the functional harness able to run the virtualenv on a shifted base port (including the https port, which was the one port the shift had been missing).

These are three independent concerns, one per commit.

**- How I did it**

**Commit 1 — `test(functional): enroll:listns roster + enrollment metadata`** (`tests/at_functional_test/test/enroll_listns_test.dart`), two tests:
- **Roster + metadata:** CRAM-authenticate, `enroll:request` (auto-approved) carrying `metadata` (a `keyPackage`) and `signingAlgo`, APKAM-authenticate as the new enrollment, then `enroll:listns:<namespace>` and assert the roster entry has the right `access`, `apkamPubKey`, and `metadata`.
- **Authorization:** create a second, OTP-based enrollment scoped to one namespace, approve it, APKAM-authenticate, then `enroll:listns` on a namespace it was not granted and assert the server refuses.

`signingAlgo` is sent on the request (so the record bears it) but isn't surfaced in any wire response yet, so it isn't asserted here; its persistence is covered by the unit tests.

**Commit 2 — `test(functional): make runLocal + harness accept a VE base port`.** `runLocal.sh` takes a base port (first arg, or `VIRTUALENV_BASE_PORT` env); `ConfigUtil`, the three readiness scripts, and `http_test` read that same env var, falling back to the existing hardcoded defaults. Unset keeps the original ports, so the default path is unchanged. This exists because the functional suite otherwise clashes with another virtualenv already running on the default ports.

**Commit 3 — `test(functional): shift the VE https port with the base port`.** The atDirectory's https port was the one port the base-port shift didn't move (it stayed on 443). The ve entrypoint now exports `httpsPort` as `BASE+98` (the root already reads that env var; 443 when unset), between the atServers (`BASE+1..+80`) and Redis (`BASE+99`); `http_test` derives the https port from the base too.

**- How to verify it**

**Please review this one commit by commit rather than all files together** — the three commits are separable concerns, and the file list only makes sense split that way. Commit 1 is the feature coverage; commits 2 and 3 are harness changes that touch no product code.

- **Commit 1:** with a virtualenv running, `dart run test test/enroll_listns_test.dart --concurrency=1` — both tests pass.
- **Commit 2:** `./runLocal.sh 15500` brings the virtualenv up on the shifted range (atDirectory 15500, atServers 15501.., Redis 15599), loads PKAM keys, passes the readiness checks, and runs the pack against `BASE+1`. `./runLocal.sh` with no argument behaves exactly as before.
- **Commit 3:** `./runLocal.sh 15500` runs `http_test` against https on `BASE+98` (15598) and the atDirectory on 15500; `./runLocal.sh` with no argument runs it against 443 / 64. I ran both — `http_test` is green either way.

I verified all of this locally; the `functional_tests` CI job runs only for PRs to `trunk`, so it won't run on this PR.

**- Description for the changelog**

n/a — test-only.
