### PR TITLE
release: docs, dart format and dependency chores ahead of c3.15.0 release

### DIFF
--- a/packages/at_persistence_secondary_server/bin/compare_persistence.dart
+++ b/packages/at_persistence_secondary_server/bin/compare_persistence.dart
@@ -40,8 +40,10 @@ Future<void> main(List<String> args) async {
     final aSnap = await PersistenceSnapshot.capture(aBundle);
     final bSnap = await PersistenceSnapshot.capture(bBundle);
 
-    stdout.writeln('A = ${opts.aBackend}@${opts.aRoot}  counts=${aSnap.counts}');
-    stdout.writeln('B = ${opts.bBackend}@${opts.bRoot}  counts=${bSnap.counts}');
+    stdout
+        .writeln('A = ${opts.aBackend}@${opts.aRoot}  counts=${aSnap.counts}');
+    stdout
+        .writeln('B = ${opts.bBackend}@${opts.bRoot}  counts=${bSnap.counts}');
 
     final diffs = aSnap.differencesFrom(bSnap);
     if (diffs.isEmpty) {

--- a/packages/at_persistence_secondary_server/lib/src/dual/dual_write_persistence.dart
+++ b/packages/at_persistence_secondary_server/lib/src/dual/dual_write_persistence.dart
@@ -148,7 +148,8 @@ class DualWriteBundle implements AtPersistenceBundle {
 
 /// Keystore wrapper: writes to primary, then mirrors the affected key's exact
 /// resulting state into secondary. Reads/capabilities delegate to primary.
-class _DualWriteKeyStore implements AtKeyValueStore<String, AtData, AtMetaData?> {
+class _DualWriteKeyStore
+    implements AtKeyValueStore<String, AtData, AtMetaData?> {
   final AtKeyValueStore<String, AtData, AtMetaData?> _primary;
   final AtKeyValueStore<String, AtData, AtMetaData?> _secondary;
 
@@ -366,7 +367,8 @@ class _DualWriteNotificationKeystore implements AtNotificationKeystore {
   Future<bool> deleteExpiredKeys() async {
     final expired = await (await _primary.getExpiredKeys()).toList();
     final result = await _primary.deleteExpiredKeys();
-    if (expired.isNotEmpty) await _secondary.removeMany(expired, skipCommit: true);
+    if (expired.isNotEmpty)
+      await _secondary.removeMany(expired, skipCommit: true);
     return result;
   }
 
@@ -454,8 +456,8 @@ class _DualWriteAccessLog implements AtAccessLog {
     // Build the entry once and replay the SAME entry to both logs. Using
     // primary.insert + getLastAccessLogEntry would race: a concurrent insert
     // could advance "last" between the two calls, mirroring the wrong entry.
-    final entry = AccessLogEntry(
-        fromAtSign, DateTime.now().toUtc(), verbName, lookupKey);
+    final entry =
+        AccessLogEntry(fromAtSign, DateTime.now().toUtc(), verbName, lookupKey);
     await _primary.replay(entry);
     await _secondary.replay(entry);
     return null;

--- a/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_at_commit_log.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_at_commit_log.dart
@@ -147,9 +147,8 @@ class SqliteAtCommitLog extends AtCommitLog {
   }
 
   int? _minMax(String fn) {
-    final v = _db.raw
-        .select('SELECT $fn(commit_id) v FROM commit_log;')
-        .first['v'];
+    final v =
+        _db.raw.select('SELECT $fn(commit_id) v FROM commit_log;').first['v'];
     return v as int?;
   }
 

--- a/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_at_keyvalue_store.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_at_keyvalue_store.dart
@@ -362,8 +362,8 @@ class SqliteAtKeyValueStore
         " ORDER BY json_extract(metadata, '\$.createdAt')",
       null => '',
     };
-    final rows = _db.raw
-        .select('SELECT atkey FROM at_data WHERE $where$order;', params);
+    final rows =
+        _db.raw.select('SELECT atkey FROM at_data WHERE $where$order;', params);
     // KeyPattern filter, then skip/limit (limit is post-filter, matching
     // the Hive semantics).
     var matched = rows
@@ -421,7 +421,8 @@ class SqliteAtKeyValueStore
   bool get supportsSnapshots => true;
 
   @override
-  Future<AtKeyValueStoreSnapshot<String, AtData, AtMetaData?>> snapshot() async {
+  Future<AtKeyValueStoreSnapshot<String, AtData, AtMetaData?>>
+      snapshot() async {
     return _SqliteSnapshot.open(_db.path);
   }
 
@@ -467,25 +468,23 @@ class SqliteAtKeyValueStore
 
   @override
   Future<KeyStoreStats> stats() async {
-    final row = _db.raw.select('SELECT '
-        'COUNT(*) total, '
-        'SUM(CASE WHEN expires_at IS NOT NULL THEN 1 ELSE 0 END) ttl, '
-        'SUM(CASE WHEN available_at IS NOT NULL THEN 1 ELSE 0 END) ttb, '
-        "MIN(json_extract(metadata, '\$.createdAt')) oldest, "
-        "MAX(json_extract(metadata, '\$.createdAt')) newest "
-        'FROM at_data;').first;
+    final row = _db.raw
+        .select('SELECT '
+            'COUNT(*) total, '
+            'SUM(CASE WHEN expires_at IS NOT NULL THEN 1 ELSE 0 END) ttl, '
+            'SUM(CASE WHEN available_at IS NOT NULL THEN 1 ELSE 0 END) ttb, '
+            "MIN(json_extract(metadata, '\$.createdAt')) oldest, "
+            "MAX(json_extract(metadata, '\$.createdAt')) newest "
+            'FROM at_data;')
+        .first;
     DateTime? parse(Object? v) =>
         v == null ? null : DateTime.tryParse(v as String);
     return KeyStoreStats(
       totalKeys: (row['total'] as int?) ?? 0,
       ttlKeys: (row['ttl'] as int?) ?? 0,
       ttbKeys: (row['ttb'] as int?) ?? 0,
-      sizeBytes: _db.raw
-              .select('PRAGMA page_count;')
-              .first
-              .values
-              .first as int? ??
-          0,
+      sizeBytes:
+          _db.raw.select('PRAGMA page_count;').first.values.first as int? ?? 0,
       oldestCreatedAt: parse(row['oldest']),
       newestCreatedAt: parse(row['newest']),
     );
@@ -507,8 +506,7 @@ class SqliteAtKeyValueStore
   // Internals
   // ---------------------------------------------------------------
 
-  String _normalize(String key) =>
-      key.trim().toLowerCase().replaceAll(' ', '');
+  String _normalize(String key) => key.trim().toLowerCase().replaceAll(' ', '');
 
   String _validateAndNormalize(String key) {
     final normalized = _normalize(key);
@@ -530,9 +528,9 @@ class SqliteAtKeyValueStore
 
   int _nowMillis() => DateTime.now().toUtc().millisecondsSinceEpoch;
 
-  bool _existsSync(String normalizedKey) => _db.raw
-      .select('SELECT 1 FROM at_data WHERE atkey = ? LIMIT 1;', [normalizedKey])
-      .isNotEmpty;
+  bool _existsSync(String normalizedKey) => _db.raw.select(
+      'SELECT 1 FROM at_data WHERE atkey = ? LIMIT 1;',
+      [normalizedKey]).isNotEmpty;
 
   AtData? _getSync(String normalizedKey) {
     final rows = _db.raw.select(

--- a/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_at_notification_keystore.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_at_notification_keystore.dart
@@ -8,8 +8,7 @@ import 'sqlite_notification_codec.dart';
 /// SQLite-backed [AtNotificationKeystore] (`notifications` table). A
 /// `KeyValueStore<String, AtNotification>` — no commit log, no metadata
 /// triplet — plus the notification-specific `init` / `iterate` surface.
-class SqliteAtNotificationKeystore
-    implements AtNotificationKeystore {
+class SqliteAtNotificationKeystore implements AtNotificationKeystore {
   final SqliteDatabase _db;
 
   final StreamController<KeyStoreChange> _changes =
@@ -65,8 +64,8 @@ class SqliteAtNotificationKeystore
 
   @override
   Future<AtNotification?> get(String key) async {
-    final rows =
-        _db.raw.select('SELECT payload FROM notifications WHERE id = ?;', [key]);
+    final rows = _db.raw
+        .select('SELECT payload FROM notifications WHERE id = ?;', [key]);
     if (rows.isEmpty) return null;
     return SqliteNotificationCodec.decode(rows.first['payload'] as String);
   }
@@ -85,9 +84,8 @@ class SqliteAtNotificationKeystore
   }
 
   @override
-  Future<bool> exists(String key) async => _db.raw
-      .select('SELECT 1 FROM notifications WHERE id = ? LIMIT 1;', [key])
-      .isNotEmpty;
+  Future<bool> exists(String key) async => _db.raw.select(
+      'SELECT 1 FROM notifications WHERE id = ? LIMIT 1;', [key]).isNotEmpty;
 
   @override
   Future<Map<String, AtNotification>> getMany(List<String> keys) async {
@@ -104,9 +102,8 @@ class SqliteAtNotificationKeystore
     var removed = 0;
     _db.runInTransaction(() {
       for (final k in keys) {
-        if (_db.raw
-            .select('SELECT 1 FROM notifications WHERE id = ? LIMIT 1;', [k])
-            .isEmpty) {
+        if (_db.raw.select(
+            'SELECT 1 FROM notifications WHERE id = ? LIMIT 1;', [k]).isEmpty) {
           continue;
         }
         _db.raw.execute('DELETE FROM notifications WHERE id = ?;', [k]);
@@ -193,9 +190,9 @@ class SqliteAtNotificationKeystore
 
   @override
   Future<KeyStoreStats> stats() async {
-    final total =
-        _db.raw.select('SELECT COUNT(*) c FROM notifications;').first['c']
-            as int;
+    final total = _db.raw
+        .select('SELECT COUNT(*) c FROM notifications;')
+        .first['c'] as int;
     return KeyStoreStats(
       totalKeys: total,
       ttlKeys: 0,

--- a/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_at_persistence_factory.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_at_persistence_factory.dart
@@ -41,8 +41,9 @@ class SqliteAtPersistenceFactory implements AtPersistenceFactory {
 
     final commitLog = config.enableCommitLog ? SqliteAtCommitLog(db) : null;
     final accessLog = config.enableAccessLog ? SqliteAtAccessLog(db) : null;
-    final notificationKeystore =
-        config.enableNotificationKeystore ? SqliteAtNotificationKeystore(db) : null;
+    final notificationKeystore = config.enableNotificationKeystore
+        ? SqliteAtNotificationKeystore(db)
+        : null;
 
     final keyValueStore = SqliteAtKeyValueStore(db, atSign)
       ..commitLog = commitLog;

--- a/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_database.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_database.dart
@@ -45,8 +45,7 @@ class SqliteDatabase {
     if (_libraryConfigured) return;
     _libraryConfigured = true;
     if (!Platform.isLinux) return;
-    sqlite_open.open
-        .overrideFor(sqlite_open.OperatingSystem.linux, () {
+    sqlite_open.open.overrideFor(sqlite_open.OperatingSystem.linux, () {
       try {
         return DynamicLibrary.open('libsqlite3.so.0');
       } on ArgumentError {
@@ -126,7 +125,8 @@ class SqliteDatabase {
       _db.execute('DELETE FROM commit_log;');
       _db.execute('DELETE FROM notifications;');
       _db.execute('DELETE FROM access_log;');
-      _db.execute("UPDATE counters SET value = 0 WHERE name = 'last_commit_id';");
+      _db.execute(
+          "UPDATE counters SET value = 0 WHERE name = 'last_commit_id';");
     });
   }
 

--- a/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_notification_codec.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_notification_codec.dart
@@ -48,7 +48,8 @@ class SqliteNotificationCodec {
       ..opType = _enum(OperationType.values, m['opType'])
       ..messageType = _enum(MessageType.values, m['messageType'])
       ..priority = _enum(NotificationPriority.values, m['priority'])
-      ..notificationStatus = _enum(NotificationStatus.values, m['notificationStatus'])
+      ..notificationStatus =
+          _enum(NotificationStatus.values, m['notificationStatus'])
       ..retryCount = (m['retryCount'] as int?) ?? 1
       ..strategy = m['strategy'] as String?
       ..depth = m['depth'] as int?

--- a/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_persistence_config.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_persistence_config.dart
@@ -50,8 +50,7 @@ class SqlitePersistenceConfig implements AtPersistenceConfig {
             backendMarkerPath ?? p.join(storagePath, '.persistence_backend');
 
   /// The `.db` file path for [atSign]: `<storagePath>/<atSign>/atsign.db`.
-  String dbPathFor(String atSign) =>
-      p.join(storagePath, atSign, 'atsign.db');
+  String dbPathFor(String atSign) => p.join(storagePath, atSign, 'atsign.db');
 
   /// atSecondary server config: all optional capabilities on.
   factory SqlitePersistenceConfig.serverDefaults({

--- a/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_query_translator.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_query_translator.dart
@@ -56,10 +56,7 @@ class SqliteQueryTranslator {
         }
         final expected = p.expected;
         final bound = expected is bool ? (expected ? 1 : 0) : expected;
-        return (
-          sql: "json_extract($column, ?) = ?",
-          params: [path, bound]
-        );
+        return (sql: "json_extract($column, ?) = ?", params: [path, bound]);
       case And a:
         if (a.children.isEmpty) return (sql: '1=1', params: []);
         return _combine(a.children, 'AND', column);

--- a/packages/at_persistence_secondary_server/lib/src/migration/persistence_snapshot.dart
+++ b/packages/at_persistence_secondary_server/lib/src/migration/persistence_snapshot.dart
@@ -123,8 +123,7 @@ class PersistenceSnapshot {
     return diffs;
   }
 
-  bool matches(PersistenceSnapshot other) =>
-      differencesFrom(other).isEmpty;
+  bool matches(PersistenceSnapshot other) => differencesFrom(other).isEmpty;
 
   /// Per-store row counts, for the compare CLI's summary line.
   Map<String, int> get counts => {
@@ -162,7 +161,8 @@ class PersistenceSnapshot {
       if (!b.containsKey(key)) {
         out.add('$label: key only in A: $key');
       } else if (a[key] != b[key]) {
-        out.add('$label: value differs for $key\n    A=${a[key]}\n    B=${b[key]}');
+        out.add(
+            '$label: value differs for $key\n    A=${a[key]}\n    B=${b[key]}');
       }
     }
     for (final key in b.keys) {

--- a/packages/at_persistence_secondary_server/test/conversion_integrity_test.dart
+++ b/packages/at_persistence_secondary_server/test/conversion_integrity_test.dart
@@ -37,7 +37,8 @@ void main() {
         notificationStoragePath: '$root/hive/$name',
       ));
 
-  Future<AtPersistenceBundle> sqliteBundle(String name) =>
+  Future<AtPersistenceBundle> sqliteBundle(
+          String name) =>
       sqliteFactory.initialize(
           '$atSign-$name-key',
           SqlitePersistenceConfig.serverDefaults(
@@ -48,7 +49,13 @@ void main() {
     ..metaData = m;
 
   // ms-precision so Hive's ms-truncation and SQLite's JSON string form agree.
-  DateTime t(int y, [int mo = 1, int d = 1, int h = 0, int mi = 0, int s = 0, int ms = 0]) =>
+  DateTime t(int y,
+          [int mo = 1,
+          int d = 1,
+          int h = 0,
+          int mi = 0,
+          int s = 0,
+          int ms = 0]) =>
       DateTime.utc(y, mo, d, h, mi, s, ms);
 
   /// Seeds a bundle with a fixture exercising every field/edge the round
@@ -59,24 +66,28 @@ void main() {
 
     // 1. A fully-populated metadata record (via verbatim restore so the
     //    audit fields are fixed and comparable).
-    await ks.restore('public:publickey$owner', atData('RSA_PUB', AtMetaData()
-      ..createdBy = owner
-      ..updatedBy = owner
-      ..createdAt = t(2021, 1, 2, 3, 4, 5, 678)
-      ..updatedAt = t(2021, 1, 2, 3, 4, 5, 678)
-      ..version = 0
-      ..ttr = -1
-      ..isBinary = false
-      ..isEncrypted = false
-      ..dataSignature = 'sig-data'
-      ..sharedKeyEnc = 'shared-enc'
-      ..pubKeyCS = 'cs123'
-      ..encoding = 'base64'
-      ..encKeyName = 'ek'
-      ..encAlgo = 'AES/GCM'
-      ..ivNonce = 'iv123'
-      ..skeEncKeyName = 'ske'
-      ..skeEncAlgo = 'RSA'));
+    await ks.restore(
+        'public:publickey$owner',
+        atData(
+            'RSA_PUB',
+            AtMetaData()
+              ..createdBy = owner
+              ..updatedBy = owner
+              ..createdAt = t(2021, 1, 2, 3, 4, 5, 678)
+              ..updatedAt = t(2021, 1, 2, 3, 4, 5, 678)
+              ..version = 0
+              ..ttr = -1
+              ..isBinary = false
+              ..isEncrypted = false
+              ..dataSignature = 'sig-data'
+              ..sharedKeyEnc = 'shared-enc'
+              ..pubKeyCS = 'cs123'
+              ..encoding = 'base64'
+              ..encKeyName = 'ek'
+              ..encAlgo = 'AES/GCM'
+              ..ivNonce = 'iv123'
+              ..skeEncKeyName = 'ske'
+              ..skeEncAlgo = 'RSA'));
 
     // 2. A normal write (goes through the builder → commit entry).
     await ks.create('phone.wavi$owner', atData('+1234', AtMetaData()));
@@ -89,26 +100,35 @@ void main() {
     //    stored data — the builder stamps it — so the fixture sets it too;
     //    AtMetaData.fromJson coerces a null version to 0, which would
     //    otherwise diverge from Hive's binary adapter that preserves null.)
-    await ks.restore('temp.wavi$owner', atData('gone', AtMetaData()
-      ..createdAt = t(2020)
-      ..updatedAt = t(2020)
-      ..version = 3
-      ..ttl = 1000
-      ..expiresAt = t(2020, 1, 1, 0, 0, 1)));
+    await ks.restore(
+        'temp.wavi$owner',
+        atData(
+            'gone',
+            AtMetaData()
+              ..createdAt = t(2020)
+              ..updatedAt = t(2020)
+              ..version = 3
+              ..ttl = 1000
+              ..expiresAt = t(2020, 1, 1, 0, 0, 1)));
 
     // 5. A TTB key not yet born.
-    await ks.restore('future.wavi$owner', atData('later', AtMetaData()
-      ..createdAt = t(2021)
-      ..updatedAt = t(2021)
-      ..version = 0
-      ..ttb = 999999999
-      ..availableAt = t(2099)));
+    await ks.restore(
+        'future.wavi$owner',
+        atData(
+            'later',
+            AtMetaData()
+              ..createdAt = t(2021)
+              ..updatedAt = t(2021)
+              ..version = 0
+              ..ttb = 999999999
+              ..availableAt = t(2099)));
 
     // 6. An elided key (no commit entry).
     await ks.create('private:secret.wavi$owner', atData('hush', AtMetaData()));
 
     // 7. A public:__ (double underscore) key — IS synced.
-    await ks.create('public:__internal.wavi$owner', atData('vis', AtMetaData()));
+    await ks.create(
+        'public:__internal.wavi$owner', atData('vis', AtMetaData()));
 
     // 8. A unicode atKey.
     await ks.create('emoji.wavi$owner', atData('🎉', AtMetaData()));
@@ -118,10 +138,10 @@ void main() {
     await ks.remove('goodbye.wavi$owner');
 
     // Access log.
-    await b.accessLog!.replay(
-        AccessLogEntry(owner, t(2022, 5, 5, 1, 2, 3), 'pkam', null));
     await b.accessLog!
-        .replay(AccessLogEntry('@bob', t(2022, 5, 5, 1, 2, 4), 'lookup', 'phone.wavi$owner'));
+        .replay(AccessLogEntry(owner, t(2022, 5, 5, 1, 2, 3), 'pkam', null));
+    await b.accessLog!.replay(AccessLogEntry(
+        '@bob', t(2022, 5, 5, 1, 2, 4), 'lookup', 'phone.wavi$owner'));
     await b.accessLog!
         .replay(AccessLogEntry('@bob', t(2022, 5, 5, 1, 2, 5), 'pol', null));
 

--- a/packages/at_persistence_secondary_server/test/dual_write_test.dart
+++ b/packages/at_persistence_secondary_server/test/dual_write_test.dart
@@ -51,7 +51,8 @@ void main() {
     // mirror must copy the primary's stamps, not let sqlite stamp its own).
     await ks.create('phone.wavi$atSign', d('111'));
     await ks.put('phone.wavi$atSign', d('222')); // update → version bump
-    await ks.create('email.wavi$atSign', d('a@b', AtMetaData()..isEncrypted = true));
+    await ks.create(
+        'email.wavi$atSign', d('a@b', AtMetaData()..isEncrypted = true));
     await ks.putMeta('email.wavi$atSign', AtMetaData()..ttr = 3600);
 
     // Shared + elided + public:__ keys.
@@ -64,12 +65,16 @@ void main() {
     await ks.remove('bye.wavi$atSign');
 
     // Expired TTL key swept via deleteExpiredKeys.
-    await ks.restore('exp.wavi$atSign', d('gone', AtMetaData()
-      ..createdAt = DateTime.utc(2020)
-      ..updatedAt = DateTime.utc(2020)
-      ..version = 0
-      ..ttl = 1
-      ..expiresAt = DateTime.utc(2020, 1, 1, 0, 0, 1)));
+    await ks.restore(
+        'exp.wavi$atSign',
+        d(
+            'gone',
+            AtMetaData()
+              ..createdAt = DateTime.utc(2020)
+              ..updatedAt = DateTime.utc(2020)
+              ..version = 0
+              ..ttl = 1
+              ..expiresAt = DateTime.utc(2020, 1, 1, 0, 0, 1)));
     await ks.deleteExpiredKeys();
 
     // Notifications — including one whose embedded metadata has null
@@ -90,7 +95,8 @@ void main() {
     await bundle.notificationKeystore!.put(n.id!, n);
 
     // Access log.
-    await bundle.accessLog!.insert('@bob', 'lookup', lookupKey: 'phone.wavi$atSign');
+    await bundle.accessLog!
+        .insert('@bob', 'lookup', lookupKey: 'phone.wavi$atSign');
     await bundle.accessLog!.insert(atSign, 'pkam');
 
     // The two underlying DB sets must be byte-identical.

--- a/packages/at_persistence_secondary_server/test/persistence_snapshot_test.dart
+++ b/packages/at_persistence_secondary_server/test/persistence_snapshot_test.dart
@@ -43,13 +43,14 @@ void main() {
   });
 
   Future<List<AtPersistenceBundle>> two() async => [
-        await fa.initialize(
-            '@a', SqlitePersistenceConfig.serverDefaults(storagePath: '$root/a')),
-        await fb.initialize(
-            '@a', SqlitePersistenceConfig.serverDefaults(storagePath: '$root/b')),
+        await fa.initialize('@a',
+            SqlitePersistenceConfig.serverDefaults(storagePath: '$root/a')),
+        await fb.initialize('@a',
+            SqlitePersistenceConfig.serverDefaults(storagePath: '$root/b')),
       ];
 
-  Future<List<String>> diffs(AtPersistenceBundle a, AtPersistenceBundle b) async =>
+  Future<List<String>> diffs(
+          AtPersistenceBundle a, AtPersistenceBundle b) async =>
       (await PersistenceSnapshot.capture(a))
           .differencesFrom(await PersistenceSnapshot.capture(b));
 

--- a/packages/at_persistence_secondary_server/test/sqlite/sqlite_keystore_test.dart
+++ b/packages/at_persistence_secondary_server/test/sqlite/sqlite_keystore_test.dart
@@ -69,8 +69,8 @@ void main() {
     test('getMany returns only present keys', () async {
       await ks.create('a.wavi@alice', data('1'));
       await ks.create('b.wavi@alice', data('2'));
-      final many = await ks.getMany(
-          ['a.wavi@alice', 'b.wavi@alice', 'missing.wavi@alice']);
+      final many = await ks
+          .getMany(['a.wavi@alice', 'b.wavi@alice', 'missing.wavi@alice']);
       expect(many.keys.toSet(), {'a.wavi@alice', 'b.wavi@alice'});
     });
 
@@ -80,7 +80,8 @@ void main() {
       await ks.create('c.wavi@alice', data('3'));
       await ks.remove('a.wavi@alice');
       expect(await ks.exists('a.wavi@alice'), false);
-      final n = await ks.removeMany(['b.wavi@alice', 'c.wavi@alice', 'x@alice']);
+      final n =
+          await ks.removeMany(['b.wavi@alice', 'c.wavi@alice', 'x@alice']);
       expect(n, 2);
     });
   });
@@ -184,8 +185,8 @@ void main() {
     test('scanKeys filters by KeyPattern', () async {
       await ks.create('phone.wavi@alice', data('1'));
       await ks.create('email.buzz@alice', data('2'));
-      final wavi = await (await ks.scanKeys(KeyPattern(namespace: 'wavi')))
-          .toList();
+      final wavi =
+          await (await ks.scanKeys(KeyPattern(namespace: 'wavi'))).toList();
       expect(wavi, ['phone.wavi@alice']);
     });
 
@@ -215,13 +216,11 @@ void main() {
 
   group('transaction', () {
     test('all-or-nothing: a throw rolls back every buffered write', () async {
-      await expectLater(
-          ks.transaction((txn) async {
-            await txn.put('a.wavi@alice', data('1'), null);
-            await txn.put('b.wavi@alice', data('2'), null);
-            throw StateError('boom');
-          }),
-          throwsA(isA<StateError>()));
+      await expectLater(ks.transaction((txn) async {
+        await txn.put('a.wavi@alice', data('1'), null);
+        await txn.put('b.wavi@alice', data('2'), null);
+        throw StateError('boom');
+      }), throwsA(isA<StateError>()));
       expect(await ks.exists('a.wavi@alice'), false);
       expect(await ks.exists('b.wavi@alice'), false);
     });

--- a/packages/at_persistence_secondary_server/test/sqlite/sqlite_schema_test.dart
+++ b/packages/at_persistence_secondary_server/test/sqlite/sqlite_schema_test.dart
@@ -48,27 +48,30 @@ void main() {
           .toList();
       expect(
           tables,
-          containsAll(
-              ['at_data', 'commit_log', 'counters', 'notifications', 'access_log']));
+          containsAll([
+            'at_data',
+            'commit_log',
+            'counters',
+            'notifications',
+            'access_log'
+          ]));
 
       final ver = db.raw.select('PRAGMA user_version;').first.values.first;
       expect(ver, SqliteSchema.contractVersion);
 
-      final counter = db.raw.select(
-          "SELECT value FROM counters WHERE name = 'last_commit_id';");
+      final counter = db.raw
+          .select("SELECT value FROM counters WHERE name = 'last_commit_id';");
       expect(counter.first['value'], 0);
 
-      final journal =
-          db.raw.select('PRAGMA journal_mode;').first.values.first;
+      final journal = db.raw.select('PRAGMA journal_mode;').first.values.first;
       expect((journal as String).toLowerCase(), 'wal');
 
       db.close();
     });
 
     test('re-opening an existing db is idempotent (no data loss)', () {
-      final path =
-          SqlitePersistenceConfig.serverDefaults(storagePath: root)
-              .dbPathFor('@bob');
+      final path = SqlitePersistenceConfig.serverDefaults(storagePath: root)
+          .dbPathFor('@bob');
       var db = SqliteDatabase.open('@bob', path);
       db.raw.execute(
           "INSERT INTO at_data (atkey, value, metadata) VALUES ('k@bob','v','{}');");
@@ -82,9 +85,8 @@ void main() {
     });
 
     test('runInTransaction rolls back on throw', () {
-      final path =
-          SqlitePersistenceConfig.serverDefaults(storagePath: root)
-              .dbPathFor('@carol');
+      final path = SqlitePersistenceConfig.serverDefaults(storagePath: root)
+          .dbPathFor('@carol');
       final db = SqliteDatabase.open('@carol', path);
 
       expect(
@@ -101,9 +103,8 @@ void main() {
 
     test('nested runInTransaction commits once; inner throw rolls back all',
         () {
-      final path =
-          SqlitePersistenceConfig.serverDefaults(storagePath: root)
-              .dbPathFor('@dave');
+      final path = SqlitePersistenceConfig.serverDefaults(storagePath: root)
+          .dbPathFor('@dave');
       final db = SqliteDatabase.open('@dave', path);
 
       // Happy path: nested join commits the whole thing.
@@ -132,9 +133,8 @@ void main() {
     });
 
     test('clear drops rows and resets the counter, keeping the db open', () {
-      final path =
-          SqlitePersistenceConfig.serverDefaults(storagePath: root)
-              .dbPathFor('@erin');
+      final path = SqlitePersistenceConfig.serverDefaults(storagePath: root)
+          .dbPathFor('@erin');
       final db = SqliteDatabase.open('@erin', path);
       db.raw.execute(
           "INSERT INTO at_data (atkey, value, metadata) VALUES ('k@erin','v','{}');");
@@ -153,9 +153,8 @@ void main() {
     });
 
     test('refuses to open a forward-versioned database', () {
-      final path =
-          SqlitePersistenceConfig.serverDefaults(storagePath: root)
-              .dbPathFor('@frank');
+      final path = SqlitePersistenceConfig.serverDefaults(storagePath: root)
+          .dbPathFor('@frank');
       // Create the db normally (dir + file + schema at v1), then stamp it
       // with a newer contract version to simulate a forward-versioned file.
       SqliteDatabase.open('@frank', path).close();

--- a/packages/at_persistence_secondary_server/test/verbatim_restore_test.dart
+++ b/packages/at_persistence_secondary_server/test/verbatim_restore_test.dart
@@ -58,8 +58,11 @@ void main() {
       await ks.create('seed.wavi@verbatim_user', AtData()..data = 'x');
       final before = ks.commitLog!.lastCommittedSequenceNumber();
 
-      await ks.restore('phone.wavi@verbatim_user',
-          AtData()..data = 'v'..metaData = sourceMetadata());
+      await ks.restore(
+          'phone.wavi@verbatim_user',
+          AtData()
+            ..data = 'v'
+            ..metaData = sourceMetadata());
 
       expect(ks.commitLog!.lastCommittedSequenceNumber(), before,
           reason: 'restore must not advance the commit id');
@@ -86,8 +89,8 @@ void main() {
   });
 
   group('AtAccessLog.replay preserves the entry timestamp', () {
-    setUp(() async =>
-        await testAccessLogFor(atSign, accessLogPath: storageDir));
+    setUp(
+        () async => await testAccessLogFor(atSign, accessLogPath: storageDir));
     tearDown(() async => await tearDownTestPersistence(storageDir: storageDir));
 
     test('replay keeps requestDateTime; insert would stamp now', () async {

--- a/packages/at_persistence_secondary_server/tool/dual_compare_ve.dart
+++ b/packages/at_persistence_secondary_server/tool/dual_compare_ve.dart
@@ -38,7 +38,8 @@ Future<void> main(List<String> args) async {
     final diffs = hiveSnap.differencesFrom(sqliteSnap);
 
     if (diffs.isEmpty) {
-      print('IDENTICAL $atSign  hive=${hiveSnap.counts} sqlite=${sqliteSnap.counts}');
+      print(
+          'IDENTICAL $atSign  hive=${hiveSnap.counts} sqlite=${sqliteSnap.counts}');
     } else {
       print('MISMATCH(${diffs.length}) $atSign  '
           'hive=${hiveSnap.counts} sqlite=${sqliteSnap.counts}');

--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,5 +1,21 @@
 # 3.15.0
 
+- feat: cross-server `to:@<atSign>` first-verb. On an outbound peer connection
+  the atServer can name the target tenant with `to:` as the first verb — giving
+  architectural flexibility for endpoints reached through proxies / gateways and
+  for multi-tenant peers that resolve a connection's tenant from its first verb.
+  Inbound understanding of `to:@x` is unconditional (unauthenticated, serving
+  only data already publicly readable via `lookup`); outbound emission is gated
+  by `toVerbOutboundEnabled` (default false), falling back to the legacy
+  `lookup:all:publickey` (reconnecting first) when a peer rejects or closes on
+  `to:`, so it is safe to enable against legacy and pre-c3.0.35 peers.
+- feat: optional SQLite persistence backend, selected by `persistence.backend`
+  (`hive` default, or `sqlite`). SQLite opens one `atsign.db` per atSign under
+  `<storageRoot>/sqlite`. Changing the backend triggers a migrate-verify-flip at
+  startup (abort-on-failure, with the source data retained for rollback and
+  reclaimed later by `bin/cleanup_stale_persistence.dart`); a `dual` validation
+  mode mirrors every write into both stores for comparison. The default `hive`
+  image is unchanged and never loads libsqlite3.
 - feat: `enroll:listns:<namespace>` verb for the WP-SS secret-sharing
   substrate (at_commons 5.12.0). Returns all approved enrollments that hold
   read-or-better access to the requested namespace, including their opaque

--- a/packages/at_secondary_server/config/config.yaml
+++ b/packages/at_secondary_server/config/config.yaml
@@ -38,8 +38,24 @@ security:
 # Persistence backend selection.
 # - backend: 'hive' (default) keeps the historical Hive stores; 'sqlite'
 #   opens one atsign.db per atSign under <storageRoot>/sqlite.
-# - storageRoot: the common root under which each backend's data and the
-#   backend marker (.persistence_backend) live.
+# - storageRoot: the common root for the backend marker (.persistence_backend)
+#   and, for the 'sqlite'/'dual' backends, the SQLite data (<storageRoot>/sqlite).
+#   IMPORTANT: with the default 'hive' backend, storageRoot ONLY locates the
+#   marker file — the Hive data paths come from the 'hive:' section below, NOT
+#   from here. The two are independent: changing storageRoot does not move Hive
+#   data, and on a legacy Hive-only install the marker file is never even
+#   written (it is created only when 'backend' changes). storageRoot becomes the
+#   actual data root only under the 'sqlite'/'dual' backends.
+#
+# Production note: these are RELATIVE paths. The secondary container runs with
+# working directory /atsign (tools/build_secondary/Dockerfile: WORKDIR /atsign),
+# so 'storage' resolves to /atsign/storage — the mount point of the persistent
+# volume that holds atServer state across container restarts. The volume is
+# supplied by the deploy layer (docker `-v` / k8s PVC); the image only
+# pre-creates the /atsign/storage directory. Keep every storage path (this one
+# and the 'hive:' paths) under the same root so all state lands on that one
+# mounted volume.
+#
 # Changing 'backend' triggers a migrate-verify-flip at startup (aborting
 # startup on any failure, leaving the source data untouched). The old
 # backend's data is RETAINED after a successful migration; reclaim it with
@@ -62,7 +78,13 @@ persistence:
 protocol:
   toVerbOutboundEnabled: false
 
-# The atProtocol storage configurations
+# Hive storage paths — used when persistence.backend is 'hive' (the default).
+# These are INDEPENDENT of persistence.storageRoot above: the backend marker
+# lives at <storageRoot>/.persistence_backend, but the Hive data itself lives at
+# exactly the paths below. They default under the same 'storage/' root that is
+# mounted into the container in production (see the 'persistence:' section
+# above), so all atServer state lands on the one persistent volume — keep them
+# consistent with storageRoot if you relocate it.
 hive:
   # The storage path for secondary storage.
   storagePath: 'storage/hive'

--- a/packages/at_secondary_server/lib/src/server/at_secondary_config.dart
+++ b/packages/at_secondary_server/lib/src/server/at_secondary_config.dart
@@ -47,9 +47,14 @@ class AtSecondaryConfig {
   // <storageRoot>/sqlite. A mismatch between this and the on-disk backend
   // marker triggers a migrate-verify-flip at startup (abort on failure).
   static const String _persistenceBackend = 'hive';
-  // The common storage root under which both backends' data and the
-  // backend marker live (Hive under storage/hive etc., SQLite under
-  // storage/sqlite). Defaults to the parent of the Hive storagePath.
+  // The common storage root for the backend marker (.persistence_backend) and,
+  // for the 'sqlite'/'dual' backends, the SQLite data (<storageRoot>/sqlite).
+  // INDEPENDENT of the Hive path constants above (_storagePath / _commitLogPath
+  // / ...): with the default 'hive' backend this only locates the marker file —
+  // the Hive stores live at those paths, NOT under here. A relative path, so in
+  // the secondary container (WORKDIR /atsign) it resolves to /atsign/storage,
+  // the mounted persistent volume. Kept equal to the Hive paths' parent by
+  // convention so all state lands on that one volume.
   static const String _storageRoot = 'storage';
 
   //Commit Log
@@ -407,9 +412,13 @@ class AtSecondaryConfig {
     }
   }
 
-  /// The common storage root under which each backend's data and the
-  /// backend marker live. Override with env `storageRoot` or yaml
-  /// `persistence.storageRoot`.
+  /// The common storage root for the backend marker and (for the
+  /// `'sqlite'`/`'dual'` backends) the SQLite data. INDEPENDENT of the Hive
+  /// paths — with the default `'hive'` backend this only locates the marker
+  /// file; the Hive stores live at [storagePath] / [commitLogPath] / etc.,
+  /// not under here. Relative to the container working dir in production
+  /// (`/atsign` → `/atsign/storage`, the mounted volume). Override with env
+  /// `storageRoot` or yaml `persistence.storageRoot`.
   static String get storageRoot {
     final result = _getStringEnvVar('storageRoot');
     if (result != null) return result;

--- a/packages/at_secondary_server/lib/src/server/persistence_backend.dart
+++ b/packages/at_secondary_server/lib/src/server/persistence_backend.dart
@@ -86,6 +86,14 @@ class PersistenceBackendManager {
 
   static final _logger = AtSignLogger('PersistenceBackendManager');
 
+  /// The backend marker file: `<storageRoot>/.persistence_backend`. In
+  /// production `storageRoot` is relative and resolves to `/atsign/storage`
+  /// (the secondary container's WORKDIR is `/atsign`, and that path is the
+  /// mounted persistent volume — see config.yaml's `persistence:` notes).
+  /// NOTE: with the default `hive` backend the marker is only ever READ, never
+  /// written — [migrateIfNeeded] writes it solely on a backend switch — so a
+  /// legacy Hive-only install has no marker file at all, and `read` returning
+  /// null there is the normal case (treated as `hive`).
   static String get markerPath =>
       p.join(AtSecondaryConfig.storageRoot, '.persistence_backend');
 
@@ -99,6 +107,10 @@ class PersistenceBackendManager {
     return b;
   }
 
+  // Hive data paths come from the dedicated storagePath / commitLogPath /
+  // accessLogPath / notificationStoragePath config (the `hive:` yaml block),
+  // NOT from storageRoot — the two are independent. storageRoot governs only
+  // the marker ([markerPath]) and the SQLite root (_sqliteConfig below).
   static HivePersistenceConfig _hiveConfig() =>
       HivePersistenceConfig.serverDefaults(
         storagePath: AtSecondaryConfig.storagePath,
@@ -107,6 +119,8 @@ class PersistenceBackendManager {
         notificationStoragePath: AtSecondaryConfig.notificationStoragePath,
       );
 
+  // SQLite keeps one atsign.db per atSign under <storageRoot>/sqlite — here
+  // storageRoot IS the data root (unlike the Hive case above).
   static SqlitePersistenceConfig _sqliteConfig() =>
       SqlitePersistenceConfig.serverDefaults(
           storagePath: p.join(AtSecondaryConfig.storageRoot, 'sqlite'));

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -8,14 +8,6 @@ publish_to: none
 environment:
   sdk: ">=3.0.0 <4.0.0"
 
-# Temporary bridge: at_secondary_server consumes new at_persistence_secondary_server
-# 5.2.0 API (SQLite backend, migrator) that is not yet published to pub.dev. Resolve
-# the sibling package by path so CI (plain `dart pub get`, no melos bootstrap) can
-# compile the secondary. Remove this once 5.2.0 is published and depend on it hosted.
-dependency_overrides:
-  at_persistence_secondary_server:
-    path: ../at_persistence_secondary_server
-
 dependencies:
   args: ^2.7.0
   uuid: ^4.5.3


### PR DESCRIPTION
**- What I did**

- `config.yaml` `persistence:` — spell out that under the default `hive` backend `storageRoot` only locates the marker (Hive data lives in the `hive:` block), and that `storage` mounts to `/atsign/storage` in production.
- `config.yaml` `hive:` — note its independence from `persistence.storageRoot` (and fix a stray "atProtocol").
- `AtSecondaryConfig` / `PersistenceBackendManager` — same clarifications in the const, getter dartdoc, and `markerPath` / config builders.
- `CHANGELOG` — add the 3.15.0 cross-server `to:` verb and the optional SQLite backend (both already shipped, previously unlisted).
- chore: `dart format` the `at_persistence_secondary_server` SQLite/dual/migration sources + tests (whitespace only, separate commit).
- chore(deps): drop the temporary `at_persistence_secondary_server` path override now 5.2.0 is published — it resolves hosted via `^5.2.0` (separate commit).

**- How I did it**

See commits and file diffs.

**- How to verify it**

Please eyeball the changes. (No product code changed; `dart analyze` clean, `config.yaml` values unchanged.)

**- Description for the changelog**

Docs/comments only; the CHANGELOG additions cover the already-merged 3.15.0 `to:` verb and SQLite backend.
