### PR TITLE
fix(secondary): enforce authorization in keys verb + harden CRAM secret handling

### DIFF
--- a/packages/at_secondary_server/lib/src/server/at_secondary_impl.dart
+++ b/packages/at_secondary_server/lib/src/server/at_secondary_impl.dart
@@ -839,6 +839,33 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
     throw Exception("AtSecondaryServer.getMetrics() is obsolete");
   }
 
+  /// Plants the CRAM (registrar activation) secret into [keyValueStore] for
+  /// first-time activation. Deliberately conservative: the secret is planted
+  /// only when it has NOT been explicitly deleted (marker absent), is NOT
+  /// already present, and a non-empty [sharedSecret] was supplied. This
+  /// prevents (a) clobbering a real secret with a null on a restart started
+  /// without `-s`, and (b) resurrecting a deleted secret. A null/empty secret
+  /// must never be stored — it would be CRAM-authenticatable (see
+  /// [CramVerbHandler]).
+  @visibleForTesting
+  Future<void> plantCramSecretIfRequired(
+      AtKeyValueStore<String, AtData, AtMetaData?> keyValueStore,
+      String? sharedSecret) async {
+    final cramSecretDeleted =
+        await keyValueStore.exists(AtConstants.atCramSecretDeleted);
+    final cramSecretExists =
+        await keyValueStore.exists(AtConstants.atCramSecret);
+    if (!cramSecretDeleted && !cramSecretExists) {
+      if (sharedSecret != null && sharedSecret.isNotEmpty) {
+        await keyValueStore.put(
+            AtConstants.atCramSecret, AtData()..data = sharedSecret);
+      } else {
+        logger.info('Not planting CRAM secret: no shared_secret supplied and'
+            ' none already present');
+      }
+    }
+  }
+
   /// Initializes [AtKeyValueStore], [AtCommitLog], [AtNotificationKeystore] and [AtAccessLog] instances.
   Future<void> _initializePersistentInstances() async {
     AtNotification.defaultTtl =
@@ -875,28 +902,9 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
 
     serverContext!.isKeyStoreInitialized = true;
 
-    // Ensure the CRAM secret is present in persistence for first-time
-    // activation, but never resurrect it once onboarding has moved to
-    // PKAM/APKAM. Only plant when:
-    //  - it has not been explicitly deleted (marker absent), AND
-    //  - it is not already present (don't clobber an existing secret with a
-    //    null on a restart that was started without -s), AND
-    //  - a non-empty shared_secret was actually supplied (a null/empty secret
-    //    would be CRAM-authenticatable, see CramVerbHandler).
-    final sharedSecret = serverContext!.sharedSecret;
-    final cramSecretDeleted =
-        await keyValueStore.exists(AtConstants.atCramSecretDeleted);
-    final cramSecretExists =
-        await keyValueStore.exists(AtConstants.atCramSecret);
-    if (!cramSecretDeleted && !cramSecretExists) {
-      if (sharedSecret != null && sharedSecret.isNotEmpty) {
-        await keyValueStore.put(
-            AtConstants.atCramSecret, AtData()..data = sharedSecret);
-      } else {
-        logger.info('Not planting CRAM secret: no shared_secret supplied and'
-            ' none already present');
-      }
-    }
+    // Plant the CRAM secret for first-time activation only — never resurrect
+    // or clobber it once onboarding has moved to PKAM/APKAM.
+    await plantCramSecretIfRequired(keyValueStore, serverContext!.sharedSecret);
     if (!await keyValueStore.exists(AtConstants.atSigningKeypairGenerated)) {
       var rsaKeypair = RSAKeypair.fromRandom();
       await keyValueStore.put('${AtConstants.atSigningPublicKey}$currentAtSign',

--- a/packages/at_secondary_server/lib/src/server/at_secondary_impl.dart
+++ b/packages/at_secondary_server/lib/src/server/at_secondary_impl.dart
@@ -875,12 +875,27 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
 
     serverContext!.isKeyStoreInitialized = true;
 
-    var atData = AtData();
-    atData.data = serverContext!.sharedSecret;
-
-    // Ensure essential data is present in persistence
-    if (!await keyValueStore.exists(AtConstants.atCramSecretDeleted)) {
-      await keyValueStore.put(AtConstants.atCramSecret, atData);
+    // Ensure the CRAM secret is present in persistence for first-time
+    // activation, but never resurrect it once onboarding has moved to
+    // PKAM/APKAM. Only plant when:
+    //  - it has not been explicitly deleted (marker absent), AND
+    //  - it is not already present (don't clobber an existing secret with a
+    //    null on a restart that was started without -s), AND
+    //  - a non-empty shared_secret was actually supplied (a null/empty secret
+    //    would be CRAM-authenticatable, see CramVerbHandler).
+    final sharedSecret = serverContext!.sharedSecret;
+    final cramSecretDeleted =
+        await keyValueStore.exists(AtConstants.atCramSecretDeleted);
+    final cramSecretExists =
+        await keyValueStore.exists(AtConstants.atCramSecret);
+    if (!cramSecretDeleted && !cramSecretExists) {
+      if (sharedSecret != null && sharedSecret.isNotEmpty) {
+        await keyValueStore.put(
+            AtConstants.atCramSecret, AtData()..data = sharedSecret);
+      } else {
+        logger.info('Not planting CRAM secret: no shared_secret supplied and'
+            ' none already present');
+      }
     }
     if (!await keyValueStore.exists(AtConstants.atSigningKeypairGenerated)) {
       var rsaKeypair = RSAKeypair.fromRandom();

--- a/packages/at_secondary_server/lib/src/verb/handler/cram_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/cram_verb_handler.dart
@@ -40,9 +40,14 @@ class CramVerbHandler extends AbstractVerbHandler {
     var atSign = AtSecondaryServerImpl.getInstance().currentAtSign;
     AtData? internalSecret = await keyStore.get('privatekey:at_secret');
 
-    // If there is no secret in keystore then return error
-    if (internalSecret == null) {
-      logger.severe('privatekey:at_secret is null');
+    // If there is no secret in keystore - or it is null/empty - then return
+    // error. An empty/null secret must never authenticate: the expected digest
+    // would be computed over a known constant (e.g. the literal 'null'), which
+    // any caller could reproduce from the public session id and proof.
+    if (internalSecret == null ||
+        internalSecret.data == null ||
+        internalSecret.data!.isEmpty) {
+      logger.severe('privatekey:at_secret is null or empty');
       throw UnAuthenticatedException('Authentication Failed');
     }
 

--- a/packages/at_secondary_server/lib/src/verb/handler/keys_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/keys_verb_handler.dart
@@ -79,7 +79,7 @@ class KeysVerbHandler extends AbstractVerbHandler {
             response, enrollIdFromMetadata);
         break;
       case 'delete':
-        await _handleDeleteOperation(verbParams, response);
+        await _handleDeleteOperation(verbParams, response, enrollIdFromMetadata);
         break;
     }
   }
@@ -110,14 +110,20 @@ class KeysVerbHandler extends AbstractVerbHandler {
   ) async {
     final keyNameFromParams = verbParams[AtConstants.keyName];
     if (keyNameFromParams != null && keyNameFromParams.isNotEmpty) {
+      final AtData value;
       try {
-        final value = (await keyStore.get(keyNameFromParams))!;
-        response.data = value.data;
-        return;
+        value = (await keyStore.get(keyNameFromParams))!;
       } on KeyNotFoundException {
         throw KeyNotFoundException(
             'key $keyNameFromParams not found in keystore');
       }
+      if (!_isAuthorizedForKey(keyNameFromParams, value, enrollIdFromMetadata)) {
+        throw UnAuthorizedException(
+            'Enrollment $enrollIdFromMetadata is not authorized to access key'
+            ' $keyNameFromParams');
+      }
+      response.data = value.data;
+      return;
     }
     final filteredKeys = await _getFilteredKeys(
         keyVisibility, hasManageAccess, enrollIdFromMetadata);
@@ -168,10 +174,50 @@ class KeysVerbHandler extends AbstractVerbHandler {
   Future<void> _handleDeleteOperation(
     HashMap<String, String?> verbParams,
     Response response,
+    String enrollIdFromMetadata,
   ) async {
     final keyNameFromParams = verbParams[AtConstants.keyName]!;
+    AtData? value;
+    try {
+      value = await keyStore.get(keyNameFromParams);
+    } on KeyNotFoundException {
+      value = null;
+    }
+    if (value == null) {
+      throw KeyNotFoundException('key $keyNameFromParams not found in keystore');
+    }
+    if (!_isAuthorizedForKey(keyNameFromParams, value, enrollIdFromMetadata)) {
+      throw UnAuthorizedException(
+          'Enrollment $enrollIdFromMetadata is not authorized to delete key'
+          ' $keyNameFromParams');
+    }
     response.data =
         (await keyStore.remove(keyNameFromParams, skipCommit: true)).toString();
+  }
+
+  /// Authorization gate for the by-name `get`/`delete` branches.
+  ///
+  /// Mirrors the filtered-list branch ([_addKeyIfEnrollmentIdMatches]): a
+  /// caller may only touch keys tagged with its own [enId], plus its own
+  /// default-encryption-private-key and self-encryption-key. Any other key —
+  /// including keys belonging to another enrollment and reserved server
+  /// secrets such as `privatekey:at_secret` (which are not keys-verb-managed
+  /// JSON values) — is refused.
+  bool _isAuthorizedForKey(String keyName, AtData value, String enId) {
+    if (keyName == enMgr.keyForPEK(enId) || keyName == enMgr.keyForSEK(enId)) {
+      return true;
+    }
+    final data = value.data;
+    if (data == null) {
+      return false;
+    }
+    try {
+      final decoded = jsonDecode(data);
+      return decoded is Map && decoded[AtConstants.enrollmentId] == enId;
+    } catch (_) {
+      // Not a keys-verb-managed value (e.g. a raw server secret) -> refuse.
+      return false;
+    }
   }
 
   /// List only keys from current enrollment. Do not list keys from another enrollment.

--- a/packages/at_secondary_server/lib/src/verb/handler/keys_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/keys_verb_handler.dart
@@ -79,7 +79,8 @@ class KeysVerbHandler extends AbstractVerbHandler {
             response, enrollIdFromMetadata);
         break;
       case 'delete':
-        await _handleDeleteOperation(verbParams, response, enrollIdFromMetadata);
+        await _handleDeleteOperation(
+            verbParams, response, enrollIdFromMetadata);
         break;
     }
   }
@@ -117,7 +118,8 @@ class KeysVerbHandler extends AbstractVerbHandler {
         throw KeyNotFoundException(
             'key $keyNameFromParams not found in keystore');
       }
-      if (!_isAuthorizedForKey(keyNameFromParams, value, enrollIdFromMetadata)) {
+      if (!_isAuthorizedForKey(
+          keyNameFromParams, value, enrollIdFromMetadata)) {
         throw UnAuthorizedException(
             'Enrollment $enrollIdFromMetadata is not authorized to access key'
             ' $keyNameFromParams');
@@ -184,7 +186,8 @@ class KeysVerbHandler extends AbstractVerbHandler {
       value = null;
     }
     if (value == null) {
-      throw KeyNotFoundException('key $keyNameFromParams not found in keystore');
+      throw KeyNotFoundException(
+          'key $keyNameFromParams not found in keystore');
     }
     if (!_isAuthorizedForKey(keyNameFromParams, value, enrollIdFromMetadata)) {
       throw UnAuthorizedException(

--- a/packages/at_secondary_server/test/cram_secret_bootstrap_test.dart
+++ b/packages/at_secondary_server/test/cram_secret_bootstrap_test.dart
@@ -1,0 +1,84 @@
+import 'package:at_commons/at_commons.dart';
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_secondary/src/server/at_secondary_impl.dart';
+import 'package:at_utils/at_logger.dart';
+import 'package:test/test.dart';
+
+import 'test_utils.dart';
+
+/// Covers [AtSecondaryServerImpl.plantCramSecretIfRequired] — the startup
+/// guard that decides whether to write `privatekey:at_secret`. This is the
+/// server-side half of the CRAM-resurrection fix (the CRAM verb handler's
+/// empty-secret rejection is the other half): the guard must plant on
+/// first-time activation only, and must never resurrect a deleted secret or
+/// overwrite an existing one with an empty value on a restart started without
+/// `-s`. Without these, the whole suite would still pass if the guard were
+/// reverted to the old unconditional planting.
+void main() {
+  AtSignLogger.root_level = 'WARNING';
+
+  group('CRAM secret bootstrap planting', () {
+    late AtSecondaryServerImpl server;
+
+    setUp(() async {
+      await verbTestsSetUp();
+      server = AtSecondaryServerImpl.getInstance();
+    });
+
+    tearDown(() async {
+      await verbTestsTearDown();
+    });
+
+    test('plants the secret on first activation (non-empty, no marker, absent)',
+        () async {
+      expect(await keyValueStore.exists(AtConstants.atCramSecret), isFalse);
+
+      await server.plantCramSecretIfRequired(
+          keyValueStore, 'super-secret-cram-value');
+
+      expect((await keyValueStore.get(AtConstants.atCramSecret))!.data,
+          'super-secret-cram-value');
+    });
+
+    test('does NOT plant an empty secret (the null/empty CRAM backdoor)',
+        () async {
+      await server.plantCramSecretIfRequired(keyValueStore, '');
+      expect(await keyValueStore.exists(AtConstants.atCramSecret), isFalse);
+    });
+
+    test('does NOT plant when no secret was supplied (restart without -s)',
+        () async {
+      await server.plantCramSecretIfRequired(keyValueStore, null);
+      expect(await keyValueStore.exists(AtConstants.atCramSecret), isFalse);
+    });
+
+    test('does NOT clobber an existing secret on a restart without -s',
+        () async {
+      await keyValueStore.put(
+          AtConstants.atCramSecret, AtData()..data = 'real-secret');
+
+      // Restart without -s -> sharedSecret is null: the existing secret stands.
+      await server.plantCramSecretIfRequired(keyValueStore, null);
+      expect((await keyValueStore.get(AtConstants.atCramSecret))!.data,
+          'real-secret');
+
+      // A restart WITH a different -s must not replace an existing secret either.
+      await server.plantCramSecretIfRequired(
+          keyValueStore, 'a-different-secret');
+      expect((await keyValueStore.get(AtConstants.atCramSecret))!.data,
+          'real-secret');
+    });
+
+    test('does NOT resurrect a deleted secret (deleted-marker suppresses plant)',
+        () async {
+      // Onboarding deleted the secret and left the tombstone marker behind.
+      await keyValueStore.put(
+          AtConstants.atCramSecretDeleted, AtData()..data = 'true');
+
+      await server.plantCramSecretIfRequired(
+          keyValueStore, 'attempted-resurrection');
+
+      expect(await keyValueStore.exists(AtConstants.atCramSecret), isFalse);
+    });
+  });
+}

--- a/packages/at_secondary_server/test/cram_verb_test.dart
+++ b/packages/at_secondary_server/test/cram_verb_test.dart
@@ -129,6 +129,39 @@ void main() {
       expect(connectionMetadata.isAuthenticated, false);
     });
 
+    test(
+        'test cram verb handler rejects an empty secret (null-replant backdoor)',
+        () async {
+      // Simulate a secondary where privatekey:at_secret was re-planted with an
+      // empty/null value (e.g. restart without -s after the deleted-marker was
+      // removed). The digest is then computable from public session data, so
+      // the server must refuse to authenticate.
+      await keyValueStore.put('privatekey:at_secret', AtData()..data = '');
+      var fromVerbHandler = FromVerbHandler(keyValueStore,
+          commitLog: atCommitLog, accessLog: atAccessLog);
+      AtSecondaryServerImpl.getInstance().currentAtSign =
+          '@test_user_1'.toAtsign();
+      var inBoundSessionId = '_6665436c-29ff-481b-8dc6-129e89199718';
+      var atConnection = InboundConnectionImpl(mockSocket, inBoundSessionId);
+      var fromVerbParams = HashMap<String, String>();
+      fromVerbParams.putIfAbsent('atSign', () => 'test_user_1');
+      var response = Response();
+      await fromVerbHandler.processVerb(response, fromVerbParams, atConnection);
+      var fromResponse = response.data!.replaceFirst(RegExp('^data:'), '');
+      // The digest an attacker would compute against an empty secret.
+      var cramVerbParams = HashMap<String, String>();
+      var digest = sha512.convert(utf8.encode(fromResponse));
+      cramVerbParams.putIfAbsent('digest', () => digest.toString());
+      var verbHandler = CramVerbHandler(keyValueStore, accessLog: atAccessLog);
+      var connectionMetadata =
+          atConnection.metaData as InboundConnectionMetadata;
+      expect(
+          () async => await verbHandler.processVerb(
+              Response(), cramVerbParams, atConnection),
+          throwsA(predicate((dynamic e) => e is UnAuthenticatedException)));
+      expect(connectionMetadata.isAuthenticated, false);
+    });
+
     test('test cram verb handler processVerb no secret in keystore', () async {
       var fromVerbHandler = FromVerbHandler(keyValueStore,
           commitLog: atCommitLog, accessLog: atAccessLog);

--- a/packages/at_secondary_server/test/delete_verb_test.dart
+++ b/packages/at_secondary_server/test/delete_verb_test.dart
@@ -149,6 +149,21 @@ void main() {
               predicate((exception) => exception is UnAuthorizedException)));
     });
 
+    // The cram-secret-deleted marker keeps CRAM permanently disabled after
+    // onboarding. The delete verb's atKey regex only special-cases the literal
+    // 'privatekey:at_secret'; the marker contains a colon and is not that
+    // literal, so it cannot be parsed - and therefore cannot be deleted via the
+    // delete verb to resurrect CRAM. (The keys verb path is closed separately
+    // by KeysVerbHandler authorization.)
+    test('verify the cram-secret-deleted marker cannot be deleted', () {
+      inboundConnection.metadata.isAuthenticated = true;
+      var command = 'delete:${AtConstants.atCramSecretDeleted}';
+      expect(
+          () => handler.processInternal(command, inboundConnection),
+          throwsA(
+              predicate((exception) => exception is InvalidSyntaxException)));
+    });
+
     // the following test throws a syntax exception since delete verb handler
     // expects a key to contain its atsign; but at_pkam_publickey does not
     test('verify deletion of pkam public key throws exception', () {

--- a/packages/at_secondary_server/test/keys_verb_authorization_test.dart
+++ b/packages/at_secondary_server/test/keys_verb_authorization_test.dart
@@ -9,14 +9,15 @@ import 'package:uuid/uuid.dart';
 
 import 'test_utils.dart';
 
-/// PoC: demonstrates that the `keys:get`/`keys:delete` by-name branches perform
-/// NO per-namespace / per-enrollment authorization. An enrollment scoped only to
-/// the `wavi` namespace (no `__manage`) can read the raw CRAM secret and keys in
-/// namespaces it was never granted, and delete arbitrary keys.
+/// Verifies that the `keys:get`/`keys:delete` by-name branches enforce
+/// per-enrollment authorization: an enrollment scoped only to the `wavi`
+/// namespace (no `__manage`) must NOT be able to read the raw CRAM secret or
+/// keys in namespaces it was never granted, nor delete arbitrary keys — while
+/// still being able to access keys tagged with its own enrollmentId.
 void main() {
   AtSignLogger.root_level = 'WARNING';
 
-  group('keys verb authorization PoC', () {
+  group('keys verb authorization', () {
     late KeysVerbHandler keysVerbHandler;
 
     setUpAll(() async {
@@ -64,7 +65,8 @@ void main() {
               'keys:get:keyName:privatekey:at_secret', inboundConnection),
           throwsA(isA<UnAuthorizedException>()),
           reason: 'wavi-scoped enrollment must not read the raw CRAM secret');
-      expect(inboundConnection.lastWrittenData ?? '', isNot(contains(cramSecret)));
+      expect(
+          inboundConnection.lastWrittenData ?? '', isNot(contains(cramSecret)));
     });
 
     test('wavi-scoped app cannot read a foreign-namespace key', () async {
@@ -79,8 +81,8 @@ void main() {
               'keys:get:keyName:$foreignKey', inboundConnection),
           throwsA(isA<UnAuthorizedException>()),
           reason: 'must not read a key outside the granted wavi namespace');
-      expect(
-          inboundConnection.lastWrittenData ?? '', isNot(contains(foreignValue)));
+      expect(inboundConnection.lastWrittenData ?? '',
+          isNot(contains(foreignValue)));
     });
 
     test('wavi-scoped app cannot delete an arbitrary key', () async {
@@ -97,8 +99,7 @@ void main() {
       expect(await keyValueStore.exists(victimKey), isTrue);
     });
 
-    test('POSITIVE: wavi-scoped app CAN read its own enrollment-tagged key',
-        () async {
+    test('wavi-scoped app CAN read its own enrollment-tagged key', () async {
       await setUpNarrowlyScopedApprovedEnrollment();
       final enId = inboundConnection.metadata.enrollmentId!;
 

--- a/packages/at_secondary_server/test/keys_verb_authorization_test.dart
+++ b/packages/at_secondary_server/test/keys_verb_authorization_test.dart
@@ -118,5 +118,55 @@ void main() {
       expect(inboundConnection.lastWrittenData, contains('my-own-public-key'),
           reason: 'legitimate self-owned key access must still work');
     });
+
+    test('cannot READ a keys-verb key tagged with another enrollmentId',
+        () async {
+      await setUpNarrowlyScopedApprovedEnrollment();
+
+      // A well-formed keys-verb value (a Map carrying an enrollmentId) that
+      // belongs to a DIFFERENT enrollment. This exercises the discriminating
+      // branch of the gate — `decoded is Map && decoded[enrollmentId] == enId`
+      // — which the other refuse tests never reach because they use non-JSON
+      // values (those only hit the jsonDecode-throws → refuse path). This is
+      // the canonical "A cannot read B's key" isolation case.
+      final foreignEnId = Uuid().v4();
+      const foreignKey = 'public:encryption_self.__public_keys.__global@alice';
+      final foreignValue = jsonEncode({
+        'value': 'another-enrollments-key-material',
+        'keyType': 'rsa2048',
+        AtConstants.enrollmentId: foreignEnId,
+      });
+      await keyValueStore.put(foreignKey, AtData()..data = foreignValue);
+
+      await expectLater(
+          keysVerbHandler.process(
+              'keys:get:keyName:$foreignKey', inboundConnection),
+          throwsA(isA<UnAuthorizedException>()),
+          reason: 'must not read a keys-verb key owned by another enrollment');
+      expect(inboundConnection.lastWrittenData ?? '',
+          isNot(contains('another-enrollments-key-material')));
+    });
+
+    test('cannot DELETE a keys-verb key tagged with another enrollmentId',
+        () async {
+      await setUpNarrowlyScopedApprovedEnrollment();
+
+      final foreignEnId = Uuid().v4();
+      const foreignKey = 'public:encryption_self.__public_keys.__global@alice';
+      await keyValueStore.put(
+          foreignKey,
+          AtData()
+            ..data = jsonEncode({
+              'value': 'do-not-delete',
+              AtConstants.enrollmentId: foreignEnId,
+            }));
+
+      await expectLater(
+          keysVerbHandler.process(
+              'keys:delete:keyName:$foreignKey', inboundConnection),
+          throwsA(isA<UnAuthorizedException>()),
+          reason: 'must not delete a keys-verb key owned by another enrollment');
+      expect(await keyValueStore.exists(foreignKey), isTrue);
+    });
   });
 }

--- a/packages/at_secondary_server/test/keys_verb_authz_poc_test.dart
+++ b/packages/at_secondary_server/test/keys_verb_authz_poc_test.dart
@@ -1,0 +1,121 @@
+import 'dart:convert';
+
+import 'package:at_commons/at_commons.dart';
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_secondary/src/verb/handler/keys_verb_handler.dart';
+import 'package:at_utils/at_logger.dart';
+import 'package:test/test.dart';
+import 'package:uuid/uuid.dart';
+
+import 'test_utils.dart';
+
+/// PoC: demonstrates that the `keys:get`/`keys:delete` by-name branches perform
+/// NO per-namespace / per-enrollment authorization. An enrollment scoped only to
+/// the `wavi` namespace (no `__manage`) can read the raw CRAM secret and keys in
+/// namespaces it was never granted, and delete arbitrary keys.
+void main() {
+  AtSignLogger.root_level = 'WARNING';
+
+  group('keys verb authorization PoC', () {
+    late KeysVerbHandler keysVerbHandler;
+
+    setUpAll(() async {
+      await verbTestsSetUpAll();
+    });
+
+    setUp(() async {
+      await verbTestsSetUp();
+      keysVerbHandler = KeysVerbHandler(keyValueStore, enMgr, alice);
+    });
+
+    tearDown(() async {
+      await verbTestsTearDown();
+    });
+
+    /// Registers an approved enrollment scoped ONLY to the `wavi` namespace
+    /// (no `__manage`) and binds it to the connection.
+    Future<void> setUpNarrowlyScopedApprovedEnrollment() async {
+      inboundConnection.metadata.isAuthenticated = true;
+      final enrollId = Uuid().v4();
+      inboundConnection.metadata.enrollmentId = enrollId;
+      final enrollJson = {
+        'sessionId': '123',
+        'appName': 'wavi',
+        'deviceName': 'pixel',
+        'namespaces': {'wavi': 'rw'}, // narrow scope, NO __manage, NO '*'
+        'apkamPublicKey': 'testPublicKeyValue',
+        'requestType': 'newEnrollment',
+        'approval': {'state': 'approved'}
+      };
+      await keyValueStore.put('$enrollId.new.enrollments.__manage$alice',
+          AtData()..data = jsonEncode(enrollJson));
+    }
+
+    test('wavi-scoped app cannot read the CRAM secret', () async {
+      await setUpNarrowlyScopedApprovedEnrollment();
+
+      // The CRAM secret as planted at onboarding.
+      const cramSecret = 'super-secret-cram-value';
+      await keyValueStore.put(
+          'privatekey:at_secret', AtData()..data = cramSecret);
+
+      await expectLater(
+          keysVerbHandler.process(
+              'keys:get:keyName:privatekey:at_secret', inboundConnection),
+          throwsA(isA<UnAuthorizedException>()),
+          reason: 'wavi-scoped enrollment must not read the raw CRAM secret');
+      expect(inboundConnection.lastWrittenData ?? '', isNot(contains(cramSecret)));
+    });
+
+    test('wavi-scoped app cannot read a foreign-namespace key', () async {
+      await setUpNarrowlyScopedApprovedEnrollment();
+
+      const foreignKey = '@alice:secret.buzz@alice';
+      const foreignValue = 'buzz-namespace-private-data';
+      await keyValueStore.put(foreignKey, AtData()..data = foreignValue);
+
+      await expectLater(
+          keysVerbHandler.process(
+              'keys:get:keyName:$foreignKey', inboundConnection),
+          throwsA(isA<UnAuthorizedException>()),
+          reason: 'must not read a key outside the granted wavi namespace');
+      expect(
+          inboundConnection.lastWrittenData ?? '', isNot(contains(foreignValue)));
+    });
+
+    test('wavi-scoped app cannot delete an arbitrary key', () async {
+      await setUpNarrowlyScopedApprovedEnrollment();
+
+      const victimKey = '@alice:important.buzz@alice';
+      await keyValueStore.put(victimKey, AtData()..data = 'do-not-delete');
+
+      await expectLater(
+          keysVerbHandler.process(
+              'keys:delete:keyName:$victimKey', inboundConnection),
+          throwsA(isA<UnAuthorizedException>()),
+          reason: 'must not delete a key outside the granted namespace');
+      expect(await keyValueStore.exists(victimKey), isTrue);
+    });
+
+    test('POSITIVE: wavi-scoped app CAN read its own enrollment-tagged key',
+        () async {
+      await setUpNarrowlyScopedApprovedEnrollment();
+      final enId = inboundConnection.metadata.enrollmentId!;
+
+      // A key legitimately created via keys:put carries the caller's enrollmentId.
+      const ownKey = 'public:encryption_self.__public_keys.__global@alice';
+      final ownValue = jsonEncode({
+        'value': 'my-own-public-key',
+        'keyType': 'rsa2048',
+        AtConstants.enrollmentId: enId,
+      });
+      await keyValueStore.put(ownKey, AtData()..data = ownValue);
+
+      await keysVerbHandler.process(
+          'keys:get:keyName:$ownKey', inboundConnection);
+
+      expect(inboundConnection.lastWrittenData, contains('my-own-public-key'),
+          reason: 'legitimate self-owned key access must still work');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Fixes a **authorization gap in the `keys` verb** plus the CRAM-secret handling . Found during a security review of the secondary server.

## The problem

The `keys:get` / `keys:delete` **by-name** branches performed **no authorization**. `hasManageAccess` was computed but only consulted in the list branch; the by-name branches called `keyStore.get` / `keyStore.remove` on any exact key name supplied (the `keyName` param is `\S+`, so it can contain `:`).

Impact — any **approved enrollment**, even one scoped to a single namespace with no `__manage`, could:
- Read or delete **any** key on the secondary, including other enrollments' keys and arbitrary namespace data outside its grant.
- Read the raw CRAM secret (`privatekey:at_secret`) → CRAM-authenticate → a CRAM-authed `enroll:request` is auto-approved with `__manage:rw` + `*:rw` = full account takeover.

CRAM resurrection variant: even where onboarding had deleted the CRAM secret, the same bug could delete the `privatekey:at_secret_deleted` marker; on the next restart bootstrap re-plants the secret from the `-s` arg — and since long-running servers restart without `-s`, it re-planted an **empty** secret. The CRAM handler only checked the record existed, not that it had a value, so the auth digest was computed over the literal string `null`, which any caller can reproduce from the public session id.

## The fix

- **`keys` verb** (`keys_verb_handler.dart`): by-name `get`/`delete` now enforce the same rule the list branch already applied — a caller may only touch keys tagged with its **own `enrollmentId`** (plus its own PEK/SEK). Everything else, including raw non-enrollment keys, is refused with `UnAuthorizedException`.
- **Bootstrap** (`at_secondary_impl.dart`): only plants the CRAM secret when it is not already present **and** a non-empty `shared_secret` was supplied — so a restart can neither clobber nor resurrect it.
- **CRAM handler** (`cram_verb_handler.dart`): rejects a null/empty secret, closing the empty-secret digest path.

No behaviour change for legitimate flows: keys created via `keys:put` always carry the caller's `enrollmentId`, so they remain accessible.

## Tests

- `keys_verb_authorization_test.dart` (new): a wavi-scoped enrollment is denied reading the CRAM secret, reading a foreign-namespace key, and deleting an arbitrary key — and is still allowed to read its own enrollment-tagged key.
- `cram_verb_test.dart`: new case proving an empty CRAM secret is rejected (the null-replant backdoor).
- `delete_verb_test.dart`: confirms the `privatekey:at_secret_deleted` marker cannot be deleted via the delete verb.

All `at_secondary_server` tests pass (822), `dart format` clean (80-col), `dart analyze` clean.

## Scope

Changes are confined to `packages/at_secondary_server`. No keyless RCE or atClient impersonation was found — core auth (PKAM/CRAM/pol) is sound; this closes a privilege-escalation path available to an already-enrolled app.
