### PR TITLE
test(secondary): cross-enrollment isolation + CRAM bootstrap coverage for #2704

### DIFF
--- a/packages/at_secondary_server/lib/src/server/at_secondary_impl.dart
+++ b/packages/at_secondary_server/lib/src/server/at_secondary_impl.dart
@@ -839,6 +839,33 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
     throw Exception("AtSecondaryServer.getMetrics() is obsolete");
   }
 
+  /// Plants the CRAM (registrar activation) secret into [keyValueStore] for
+  /// first-time activation. Deliberately conservative: the secret is planted
+  /// only when it has NOT been explicitly deleted (marker absent), is NOT
+  /// already present, and a non-empty [sharedSecret] was supplied. This
+  /// prevents (a) clobbering a real secret with a null on a restart started
+  /// without `-s`, and (b) resurrecting a deleted secret. A null/empty secret
+  /// must never be stored — it would be CRAM-authenticatable (see
+  /// [CramVerbHandler]).
+  @visibleForTesting
+  Future<void> plantCramSecretIfRequired(
+      AtKeyValueStore<String, AtData, AtMetaData?> keyValueStore,
+      String? sharedSecret) async {
+    final cramSecretDeleted =
+        await keyValueStore.exists(AtConstants.atCramSecretDeleted);
+    final cramSecretExists =
+        await keyValueStore.exists(AtConstants.atCramSecret);
+    if (!cramSecretDeleted && !cramSecretExists) {
+      if (sharedSecret != null && sharedSecret.isNotEmpty) {
+        await keyValueStore.put(
+            AtConstants.atCramSecret, AtData()..data = sharedSecret);
+      } else {
+        logger.info('Not planting CRAM secret: no shared_secret supplied and'
+            ' none already present');
+      }
+    }
+  }
+
   /// Initializes [AtKeyValueStore], [AtCommitLog], [AtNotificationKeystore] and [AtAccessLog] instances.
   Future<void> _initializePersistentInstances() async {
     AtNotification.defaultTtl =
@@ -875,28 +902,9 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
 
     serverContext!.isKeyStoreInitialized = true;
 
-    // Ensure the CRAM secret is present in persistence for first-time
-    // activation, but never resurrect it once onboarding has moved to
-    // PKAM/APKAM. Only plant when:
-    //  - it has not been explicitly deleted (marker absent), AND
-    //  - it is not already present (don't clobber an existing secret with a
-    //    null on a restart that was started without -s), AND
-    //  - a non-empty shared_secret was actually supplied (a null/empty secret
-    //    would be CRAM-authenticatable, see CramVerbHandler).
-    final sharedSecret = serverContext!.sharedSecret;
-    final cramSecretDeleted =
-        await keyValueStore.exists(AtConstants.atCramSecretDeleted);
-    final cramSecretExists =
-        await keyValueStore.exists(AtConstants.atCramSecret);
-    if (!cramSecretDeleted && !cramSecretExists) {
-      if (sharedSecret != null && sharedSecret.isNotEmpty) {
-        await keyValueStore.put(
-            AtConstants.atCramSecret, AtData()..data = sharedSecret);
-      } else {
-        logger.info('Not planting CRAM secret: no shared_secret supplied and'
-            ' none already present');
-      }
-    }
+    // Plant the CRAM secret for first-time activation only — never resurrect
+    // or clobber it once onboarding has moved to PKAM/APKAM.
+    await plantCramSecretIfRequired(keyValueStore, serverContext!.sharedSecret);
     if (!await keyValueStore.exists(AtConstants.atSigningKeypairGenerated)) {
       var rsaKeypair = RSAKeypair.fromRandom();
       await keyValueStore.put('${AtConstants.atSigningPublicKey}$currentAtSign',

--- a/packages/at_secondary_server/test/cram_secret_bootstrap_test.dart
+++ b/packages/at_secondary_server/test/cram_secret_bootstrap_test.dart
@@ -1,0 +1,84 @@
+import 'package:at_commons/at_commons.dart';
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_secondary/src/server/at_secondary_impl.dart';
+import 'package:at_utils/at_logger.dart';
+import 'package:test/test.dart';
+
+import 'test_utils.dart';
+
+/// Covers [AtSecondaryServerImpl.plantCramSecretIfRequired] — the startup
+/// guard that decides whether to write `privatekey:at_secret`. This is the
+/// server-side half of the CRAM-resurrection fix (the CRAM verb handler's
+/// empty-secret rejection is the other half): the guard must plant on
+/// first-time activation only, and must never resurrect a deleted secret or
+/// overwrite an existing one with an empty value on a restart started without
+/// `-s`. Without these, the whole suite would still pass if the guard were
+/// reverted to the old unconditional planting.
+void main() {
+  AtSignLogger.root_level = 'WARNING';
+
+  group('CRAM secret bootstrap planting', () {
+    late AtSecondaryServerImpl server;
+
+    setUp(() async {
+      await verbTestsSetUp();
+      server = AtSecondaryServerImpl.getInstance();
+    });
+
+    tearDown(() async {
+      await verbTestsTearDown();
+    });
+
+    test('plants the secret on first activation (non-empty, no marker, absent)',
+        () async {
+      expect(await keyValueStore.exists(AtConstants.atCramSecret), isFalse);
+
+      await server.plantCramSecretIfRequired(
+          keyValueStore, 'super-secret-cram-value');
+
+      expect((await keyValueStore.get(AtConstants.atCramSecret))!.data,
+          'super-secret-cram-value');
+    });
+
+    test('does NOT plant an empty secret (the null/empty CRAM backdoor)',
+        () async {
+      await server.plantCramSecretIfRequired(keyValueStore, '');
+      expect(await keyValueStore.exists(AtConstants.atCramSecret), isFalse);
+    });
+
+    test('does NOT plant when no secret was supplied (restart without -s)',
+        () async {
+      await server.plantCramSecretIfRequired(keyValueStore, null);
+      expect(await keyValueStore.exists(AtConstants.atCramSecret), isFalse);
+    });
+
+    test('does NOT clobber an existing secret on a restart without -s',
+        () async {
+      await keyValueStore.put(
+          AtConstants.atCramSecret, AtData()..data = 'real-secret');
+
+      // Restart without -s -> sharedSecret is null: the existing secret stands.
+      await server.plantCramSecretIfRequired(keyValueStore, null);
+      expect((await keyValueStore.get(AtConstants.atCramSecret))!.data,
+          'real-secret');
+
+      // A restart WITH a different -s must not replace an existing secret either.
+      await server.plantCramSecretIfRequired(
+          keyValueStore, 'a-different-secret');
+      expect((await keyValueStore.get(AtConstants.atCramSecret))!.data,
+          'real-secret');
+    });
+
+    test('does NOT resurrect a deleted secret (deleted-marker suppresses plant)',
+        () async {
+      // Onboarding deleted the secret and left the tombstone marker behind.
+      await keyValueStore.put(
+          AtConstants.atCramSecretDeleted, AtData()..data = 'true');
+
+      await server.plantCramSecretIfRequired(
+          keyValueStore, 'attempted-resurrection');
+
+      expect(await keyValueStore.exists(AtConstants.atCramSecret), isFalse);
+    });
+  });
+}

--- a/packages/at_secondary_server/test/keys_verb_authorization_test.dart
+++ b/packages/at_secondary_server/test/keys_verb_authorization_test.dart
@@ -118,5 +118,55 @@ void main() {
       expect(inboundConnection.lastWrittenData, contains('my-own-public-key'),
           reason: 'legitimate self-owned key access must still work');
     });
+
+    test('cannot READ a keys-verb key tagged with another enrollmentId',
+        () async {
+      await setUpNarrowlyScopedApprovedEnrollment();
+
+      // A well-formed keys-verb value (a Map carrying an enrollmentId) that
+      // belongs to a DIFFERENT enrollment. This exercises the discriminating
+      // branch of the gate — `decoded is Map && decoded[enrollmentId] == enId`
+      // — which the other refuse tests never reach because they use non-JSON
+      // values (those only hit the jsonDecode-throws → refuse path). This is
+      // the canonical "A cannot read B's key" isolation case.
+      final foreignEnId = Uuid().v4();
+      const foreignKey = 'public:encryption_self.__public_keys.__global@alice';
+      final foreignValue = jsonEncode({
+        'value': 'another-enrollments-key-material',
+        'keyType': 'rsa2048',
+        AtConstants.enrollmentId: foreignEnId,
+      });
+      await keyValueStore.put(foreignKey, AtData()..data = foreignValue);
+
+      await expectLater(
+          keysVerbHandler.process(
+              'keys:get:keyName:$foreignKey', inboundConnection),
+          throwsA(isA<UnAuthorizedException>()),
+          reason: 'must not read a keys-verb key owned by another enrollment');
+      expect(inboundConnection.lastWrittenData ?? '',
+          isNot(contains('another-enrollments-key-material')));
+    });
+
+    test('cannot DELETE a keys-verb key tagged with another enrollmentId',
+        () async {
+      await setUpNarrowlyScopedApprovedEnrollment();
+
+      final foreignEnId = Uuid().v4();
+      const foreignKey = 'public:encryption_self.__public_keys.__global@alice';
+      await keyValueStore.put(
+          foreignKey,
+          AtData()
+            ..data = jsonEncode({
+              'value': 'do-not-delete',
+              AtConstants.enrollmentId: foreignEnId,
+            }));
+
+      await expectLater(
+          keysVerbHandler.process(
+              'keys:delete:keyName:$foreignKey', inboundConnection),
+          throwsA(isA<UnAuthorizedException>()),
+          reason: 'must not delete a keys-verb key owned by another enrollment');
+      expect(await keyValueStore.exists(foreignKey), isTrue);
+    });
   });
 }


### PR DESCRIPTION
**- What I did**

Two additional tests for #2704 (LGTM from me — this is follow-on coverage, targeted at your branch to merge in). They close the two coverage gaps a review of the PR surfaced; the shipped code is correct, these just guard it against future regressions.

- **Cross-enrollment isolation** (`keys_verb_authorization_test.dart`, +2 tests) — a well-formed keys-verb JSON value tagged with **another** enrollment's `enrollmentId` must be refused for both `get` and `delete`.
- **CRAM bootstrap planting guard** (`cram_secret_bootstrap_test.dart`, new) — the startup guard plants on first activation only, and never resurrects/clobbers/empties the secret.

**- How I did it**

- The isolation tests hit the *discriminating* branch of `_isAuthorizedForKey` — `decoded is Map && decoded[enrollmentId] == enId`. The existing refuse tests use non-JSON values, so they only reach the `jsonDecode`-throws path; a gate loosened to `return decoded is Map;` (i.e. dropping the enId equality — a real auth hole) passes the whole current suite. These catch that.
- The bootstrap guard was inline in `_initializePersistentInstances`, reachable only via a full `start()`, so it had no direct test — a revert to the old unconditional planting passes the suite. I extracted the block **verbatim** into `plantCramSecretIfRequired(...)` (`@visibleForTesting`, behaviour-identical) so it's unit-testable, and covered: plant-on-first-activation, don't-plant-empty, don't-plant-absent, don't-clobber-on-restart-without-`-s`, don't-resurrect-when-marker-present.

**Heads-up:** the second commit touches your production code (the extraction). It's a pure, behaviour-neutral move — happy to reshape or drop it if you'd rather structure the seam differently; the first commit is test-only and stands alone.

**- How to verify it**

Please review commit-by-commit — commit 1 is test-only; commit 2 is the extraction + its test. Locally: `dart analyze` clean, and `dart test test/keys_verb_authorization_test.dart test/cram_secret_bootstrap_test.dart test/cram_verb_test.dart test/keys_verb_test.dart --concurrency=1` all green.

**- Description for the changelog**

n/a — test-only (plus a behaviour-neutral `@visibleForTesting` extraction).
