### PR TITLE
fix(sync): skip commit entries whose key is absent from the keystore

### DIFF
--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,5 +1,13 @@
 # 3.15.0
 
+- fix: a sync request no longer fails outright when a commit entry outlives its
+  key. `SyncProgressiveVerbHandler` fetched each non-delete entry's value from
+  the keystore with no guard, so one commit entry whose key is absent — an
+  expired key whose commit entry was not purged — failed the WHOLE sync request
+  with `AT0015 key not found`, leaving the client unable to sync at all. Such
+  entries are now skipped and logged. Note the pre-existing `atData == null`
+  guard below it is dead code against both real backends, which throw
+  `KeyNotFoundException` rather than returning null.
 - fix: `EnrollmentManager.movePerEnrollmentData` now scopes its key moves to the
   transitioning enrollment. It previously ignored its `enId` argument and moved
   EVERY enrollment's per-enrollment reserved-namespace (`<enId>.[ard].__e`) keys,

--- a/packages/at_secondary_server/lib/src/verb/handler/sync_progressive_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/sync_progressive_verb_handler.dart
@@ -158,7 +158,17 @@ class SyncProgressiveVerbHandler extends AbstractVerbHandler {
         ..operation = entry.operation!;
 
       if (entry.operation != CommitOp.DELETE) {
-        final atData = await keyStore.get(entry.atKey!);
+        final AtData? atData;
+        try {
+          atData = await keyStore.get(entry.atKey!);
+        } on KeyNotFoundException {
+          // The commit entry outlived the key: an expired key whose commit
+          // entry was not purged, or a concurrent delete between filter-time
+          // and fetch-time. Skip the entry rather than failing the whole
+          // sync request for the client.
+          logger.info('${entry.atKey} not found in keystore; skipping entry');
+          continue;
+        }
         if (atData == null) {
           logger.info('atData is null for ${entry.atKey}');
           continue;

--- a/packages/at_secondary_server/test/sync_unit_test.dart
+++ b/packages/at_secondary_server/test/sync_unit_test.dart
@@ -609,6 +609,37 @@ void main() async {
         expect(syncResponse[3]['commitId'], 3);
         expect(syncResponse[3]['operation'], '+');
       });
+      test(
+          'A test to verify a commit entry whose key is absent from the keystore is skipped, not fatal',
+          () async {
+        // Reproduces the AT0015 sync failure: a commit entry outlives its
+        // key (e.g. an expired key whose commit entry was not purged).
+        // keyStore.get throws KeyNotFoundException rather than returning
+        // null, so an unguarded fetch failed the entire sync request.
+        AtCommitLog atCommitLog = (keyValueStore.commitLog) as HiveAtCommitLog;
+        await atCommitLog.commit(
+            'cached:$alice:orphaned.wavi$alice', CommitOp.UPDATE);
+
+        var syncProgressiveVerbHandler =
+            SyncProgressiveVerbHandler(keyValueStore, commitLog: atCommitLog);
+        var response = Response();
+        var atConnection = InboundConnectionImpl(
+            mockSocket, '_6665436c-29ff-481b-8dc6-129e89199718');
+        atConnection.metaData.isAuthenticated = true;
+        var syncVerbParams = HashMap<String, String>();
+        syncVerbParams.putIfAbsent(AtConstants.fromCommitSequence, () => '-1');
+
+        await syncProgressiveVerbHandler.processVerb(
+            response, syncVerbParams, atConnection);
+
+        List syncResponse = jsonDecode(response.data!);
+        // The four keys from setUp sync; the orphaned entry is skipped.
+        expect(syncResponse.length, 4);
+        expect(
+            syncResponse
+                .any((e) => e['atKey'] == 'cached:$alice:orphaned.wavi$alice'),
+            false);
+      });
       tearDown(() async => await verbTestsTearDown());
     });
     group('A group of test to validate the commit entry data', () {


### PR DESCRIPTION
**- What I did**

- A single commit entry whose key is missing from the keystore no longer fails the entire sync request with `AT0015`.
  - `SyncProgressiveVerbHandler.prepareResponse` fetched each non-delete entry's value with an unguarded `keyStore.get`; both real backends throw `KeyNotFoundException` rather than returning null, so the pre-existing `atData == null` guard was dead code and the exception propagated out of `processVerb`.
  - One orphaned entry therefore left the client unable to sync at all.
- Added a regression test that reproduces the production failure and is red without the fix.
- CHANGELOG entry under the in-progress 3.15.0.

The orphan itself is a Hive-backend defect (commit-log box and its in-memory cache can disagree; the TTL-expiry purge is cache-driven so it can miss the box row). The SQLite backend purges by atKey directly against storage and cannot produce one. This PR is the consumer-side guard, not that fix — sync should tolerate an orphan from any cause rather than fail closed.

**- How I did it**

See commit & diffs

**- How to verify it**

Tests pass