### PR TITLE
fix(migration): drop orphaned commit entries instead of migrating them

### DIFF
--- a/packages/at_persistence_secondary_server/CHANGELOG.md
+++ b/packages/at_persistence_secondary_server/CHANGELOG.md
@@ -1,7 +1,23 @@
 ## 5.2.1
 
+- fix: `PersistenceMigrator` now drops ORPHANED commit entries rather than
+  copying them into the target — a non-delete commit entry whose key is absent
+  from the keystore. Hive accumulates these (its commit log's box and in-memory
+  cache can disagree, and the TTL-expiry purge is cache-driven, so it can miss
+  the box row); SQLite purges by atKey directly against storage and cannot
+  produce one. Migrating them forward would make them permanent residents of a
+  backend that can never generate one, and `PersistenceSnapshot` filters them
+  from both sides so the post-migration verify cannot see them. Migration is
+  where both stores are already walked, so reconciling costs nothing.
+  DELETE tombstones always survive — they legitimately have no keystore row,
+  and dropping them would break delete propagation to clients. Keys that are
+  expired but still present are NOT orphans and migrate verbatim. The dropped
+  count is reported as `MigrationReport.orphanedCommitEntries` (a new required
+  field on that class) and logged per entry.
+- fix: corrected the 5.2.0 entry below, which described a commit-log orphan as
+  "sync-benign". It was not — an orphan failed the whole sync request with
+  `AT0015` until the fix in at_secondary_server 3.15.0.
 - fix: resolve sqlite migration deadlocks and OOMs by enforcing TRUNCATE mode and disabling true MVCC snapshots
-- fix: fix path overlap bug in `sweepStaleSource`
 
 ## 5.2.0
 
@@ -31,7 +47,11 @@
   After a TTL-expiry `skipCommit` sweep, Hive can leave a stale commit entry in
   its box (its cache-based `getLatestCommitEntry` purge misses the box entry —
   a cache/box inconsistency); a faithful SQLite mirror carries no such entry.
-  Such an entry is sync-benign, so it is excluded from both snapshots. DELETE
+  Such an entry is excluded from both snapshots. (Corrected in 5.2.1: this
+  entry originally described the orphan as "sync-benign". It was not — until
+  the fix in at_secondary_server 3.15.0 an orphan failed the entire sync
+  request with `AT0015`. It is benign to the SNAPSHOT COMPARISON, which is
+  what this change is about.) DELETE
   entries and live unexpired-key entries are always compared, so real mirror
   data loss still fails. Makes the dual-write Hive-vs-SQLite DB-set comparison
   deterministic under a real functional workload, so it can gate CI.

--- a/packages/at_persistence_secondary_server/lib/src/migration/persistence_migrator.dart
+++ b/packages/at_persistence_secondary_server/lib/src/migration/persistence_migrator.dart
@@ -1,4 +1,5 @@
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_utils/at_utils.dart';
 
 /// Per-store counts produced by a [PersistenceMigrator.migrate] run.
 class MigrationReport {
@@ -7,17 +8,24 @@ class MigrationReport {
   final int accessEntries;
   final int notifications;
 
+  /// Non-delete commit entries dropped because their key is absent from the
+  /// source keystore. See [PersistenceMigrator] for why these exist and why
+  /// migration is where they get cleaned up.
+  final int orphanedCommitEntries;
+
   MigrationReport({
     required this.keys,
     required this.commitEntries,
     required this.accessEntries,
     required this.notifications,
+    required this.orphanedCommitEntries,
   });
 
   @override
   String toString() =>
       'MigrationReport{keys: $keys, commitEntries: $commitEntries, '
-      'accessEntries: $accessEntries, notifications: $notifications}';
+      'accessEntries: $accessEntries, notifications: $notifications, '
+      'orphanedCommitEntries: $orphanedCommitEntries}';
 }
 
 /// Copies every store from one [AtPersistenceBundle] to another, backend-
@@ -31,11 +39,29 @@ class MigrationReport {
 /// The result is byte-identical to the source under
 /// [PersistenceSnapshot]. The target should be freshly initialised (empty)
 /// — the migrator does not clear it first.
+///
+/// One exception to "verbatim": ORPHANED commit entries are dropped. A
+/// non-delete commit entry whose key is absent from the keystore cannot be
+/// synced — the atServer fetches each entry's value by atKey, finds nothing,
+/// and skips it. The Hive backend produces these: its commit log's box and
+/// its in-memory cache can disagree, and the TTL-expiry purge is driven by
+/// the cache, so it can miss the box row. The SQLite backend purges by atKey
+/// directly against storage and cannot produce one.
+///
+/// Migration is the right place to clean them up: both stores are already
+/// being walked, so it costs nothing, and copying them forward would make
+/// them permanent residents of a backend that can never generate one.
 class PersistenceMigrator {
+  static final _logger = AtSignLogger('PersistenceMigrator');
+
   static Future<MigrationReport> migrate(
       AtPersistenceBundle source, AtPersistenceBundle target) async {
     // 1. Keystore — every key, including expired / not-yet-born.
     var keys = 0;
+    // Lower-cased keys actually restored into the target. Pass 2 keeps a
+    // commit entry only if its key made it here, so the target can never
+    // hold a commit entry referencing a key it does not have.
+    final restoredKeys = <String>{};
     final keyList = await (await source.keyValueStore
             .scanKeys(KeyPattern(), includeExpired: true))
         .toList();
@@ -43,18 +69,38 @@ class PersistenceMigrator {
       final data = await source.keyValueStore.get(k);
       if (data == null) continue;
       await target.keyValueStore.restore(k, data);
+      restoredKeys.add(k.toLowerCase());
       keys++;
     }
 
-    // 2. Commit log — preserve commit ids and sync identity.
+    // 2. Commit log — preserve commit ids and sync identity, minus orphans.
     var commitEntries = 0;
+    var orphanedCommitEntries = 0;
     final srcCommitLog = source.keyValueStore.commitLog;
     final tgtCommitLog = target.keyValueStore.commitLog;
     if (srcCommitLog != null && tgtCommitLog != null) {
       await for (final entry in srcCommitLog.iterate()) {
+        final atKey = entry.atKey;
+        // A DELETE entry legitimately has no keystore row — it IS the
+        // tombstone telling clients the key went away. Dropping those would
+        // break delete propagation, so they always survive. An entry with a
+        // null atKey is left alone too: it cannot be matched either way, and
+        // malformed-entry repair is the backend's job, not the migrator's.
+        if (entry.operation != CommitOp.DELETE &&
+            atKey != null &&
+            !restoredKeys.contains(atKey.toLowerCase())) {
+          _logger.info('Dropping orphaned commit entry: commitId'
+              '=${entry.commitId} $atKey (key absent from keystore)');
+          orphanedCommitEntries++;
+          continue;
+        }
         await tgtCommitLog.replay(entry);
         commitEntries++;
       }
+    }
+    if (orphanedCommitEntries > 0) {
+      _logger.warning('Dropped $orphanedCommitEntries orphaned commit '
+          'entries during migration (keys absent from keystore)');
     }
 
     // 3. Access log — preserve timestamps and order.
@@ -86,6 +132,7 @@ class PersistenceMigrator {
       commitEntries: commitEntries,
       accessEntries: accessEntries,
       notifications: notifications,
+      orphanedCommitEntries: orphanedCommitEntries,
     );
   }
 }

--- a/packages/at_persistence_secondary_server/test/persistence_migrator_orphan_test.dart
+++ b/packages/at_persistence_secondary_server/test/persistence_migrator_orphan_test.dart
@@ -1,0 +1,123 @@
+import 'dart:io';
+
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_persistence_secondary_server/hive.dart';
+import 'package:at_persistence_secondary_server/sqlite.dart';
+import 'package:test/test.dart';
+
+/// The migrator drops ORPHANED commit entries — non-delete entries whose key
+/// is absent from the keystore. The Hive backend accumulates these (its
+/// commit-log box and in-memory cache can disagree, and the TTL-expiry purge
+/// is cache-driven, so it can miss the box row); SQLite cannot generate one.
+/// Copying them forward would make them permanent residents of a backend that
+/// can never produce them, so migration is where they get cleaned up.
+///
+/// The load-bearing negative case is the DELETE tombstone: it legitimately has
+/// no keystore row, and dropping it would silently break delete propagation to
+/// clients.
+void main() {
+  const atSign = '@alice';
+  final root = '${Directory.current.path}/test/migrator_orphan_tmp';
+
+  final hiveFactory = HiveAtPersistenceFactory();
+  final sqliteFactory = SqliteAtPersistenceFactory();
+
+  tearDown(() async {
+    await hiveFactory.close();
+    await sqliteFactory.close();
+    final dir = Directory(root);
+    if (dir.existsSync()) dir.deleteSync(recursive: true);
+  });
+
+  Future<AtPersistenceBundle> hiveBundle(String name) => hiveFactory.initialize(
+      '$atSign-$name-key',
+      HivePersistenceConfig.serverDefaults(
+        storagePath: '$root/hive/$name',
+        commitLogPath: '$root/hive/$name',
+        accessLogPath: '$root/hive/$name',
+        notificationStoragePath: '$root/hive/$name',
+      ));
+
+  Future<AtPersistenceBundle> sqliteBundle(String name) =>
+      sqliteFactory.initialize('$atSign-$name-key',
+          SqlitePersistenceConfig.serverDefaults(storagePath: '$root/sqlite/$name'));
+
+  /// Plants a commit entry directly, bypassing the keystore — the shape an
+  /// orphan has on disk.
+  Future<void> plant(
+      AtPersistenceBundle b, String atKey, CommitOp op, int commitId) async {
+    await b.keyValueStore.commitLog!.replay(
+        CommitEntry(atKey, op, DateTime.now().toUtc())..commitId = commitId);
+  }
+
+  Future<List<CommitEntry>> entriesOf(AtPersistenceBundle b) =>
+      b.keyValueStore.commitLog!.iterate().toList();
+
+  test('orphaned non-delete commit entry is dropped; live key survives',
+      () async {
+    final src = await hiveBundle('src1');
+    final tgt = await sqliteBundle('tgt1');
+
+    await src.keyValueStore.put('phone.wavi$atSign', AtData()..data = '123');
+    await plant(
+        src,
+        'cached:@garycasey:request.1698407612096620.auth_checks.__rpcs.sshnp$atSign',
+        CommitOp.UPDATE,
+        500);
+
+    final report = await PersistenceMigrator.migrate(src, tgt);
+
+    expect(report.orphanedCommitEntries, 1);
+    final keys = (await entriesOf(tgt)).map((e) => e.atKey).toList();
+    expect(keys, contains('phone.wavi$atSign'));
+    expect(keys.any((k) => k!.startsWith('cached:@garycasey:')), false,
+        reason: 'orphan must not be carried into the target');
+  });
+
+  test('DELETE tombstone with no keystore row SURVIVES', () async {
+    final src = await hiveBundle('src2');
+    final tgt = await sqliteBundle('tgt2');
+
+    // A legitimately deleted key: tombstone present, no keystore row.
+    await plant(src, 'deleted.wavi$atSign', CommitOp.DELETE, 501);
+
+    final report = await PersistenceMigrator.migrate(src, tgt);
+
+    expect(report.orphanedCommitEntries, 0,
+        reason: 'a DELETE tombstone is not an orphan');
+    final entries = await entriesOf(tgt);
+    expect(entries.map((e) => e.atKey), contains('deleted.wavi$atSign'));
+    expect(entries.single.operation, CommitOp.DELETE);
+  });
+
+  test('expired-but-present key keeps its commit entry', () async {
+    final src = await hiveBundle('src3');
+    final tgt = await sqliteBundle('tgt3');
+
+    // Expired, but the expiry sweep has not run — the keystore row is still
+    // there, so the entry is NOT an orphan and must be migrated verbatim.
+    await src.keyValueStore.put('temp.wavi$atSign',
+        AtData()..data = 'x'..metaData = (AtMetaData()..ttl = 1));
+    await Future.delayed(Duration(milliseconds: 5));
+
+    final report = await PersistenceMigrator.migrate(src, tgt);
+
+    expect(report.orphanedCommitEntries, 0);
+    expect((await entriesOf(tgt)).map((e) => e.atKey),
+        contains('temp.wavi$atSign'));
+  });
+
+  test('a clean store migrates with no orphans reported', () async {
+    final src = await hiveBundle('src4');
+    final tgt = await sqliteBundle('tgt4');
+
+    await src.keyValueStore.put('a.wavi$atSign', AtData()..data = '1');
+    await src.keyValueStore.put('b.wavi$atSign', AtData()..data = '2');
+    await src.keyValueStore.remove('b.wavi$atSign');
+
+    final report = await PersistenceMigrator.migrate(src, tgt);
+
+    expect(report.orphanedCommitEntries, 0);
+    expect(report.commitEntries, (await entriesOf(src)).length);
+  });
+}


### PR DESCRIPTION
**- What I did**

- `PersistenceMigrator` no longer copies ORPHANED commit entries into the target — a non-delete commit entry whose key is absent from the keystore.
  - Hive accumulates these (commit-log box and in-memory cache can disagree; the TTL-expiry purge is cache-driven so it can miss the box row). SQLite purges by atKey directly against storage and cannot produce one.
  - Migrating them forward would make them permanent residents of a backend that can never generate one. `PersistenceSnapshot` filters them from both sides, so the post-migration verify is structurally blind to them.
  - Migration already walks both stores, so the live-key set is free.
- Deliberately NOT treated as orphans: DELETE tombstones (they legitimately have no keystore row — dropping them would break delete propagation), keys that are expired but still present, and entries with a null atKey.
- `MigrationReport` gains a required `orphanedCommitEntries` field; drops are logged per entry plus a total.
- Corrected the 5.2.0 CHANGELOG entry that called such an orphan "sync-benign" — it wasn't, it failed the whole sync request with `AT0015` until #2715.
- Dropped the stray 5.2.1 CHANGELOG line for the `sweepStaleSource` fix; that code lives in `at_secondary_server` and is already recorded under its 3.15.0 heading.

Related: #2715 is the consumer-side guard in the sync verb handler. This PR removes the orphans themselves at migration time.

Note for review: `PersistenceSnapshot`'s public fields were already replaced in 5.2.1 (a breaking change to an exported class under a patch bump), and the new required `MigrationReport` field compounds that. The version floor may want revisiting before this ships — not changed here.

**- How I did it**

See commit & diffs

**- How to verify it**

Tests pass — new `persistence_migrator_orphan_test.dart` (4 cases, including the load-bearing "DELETE tombstone survives" negative test); full package suite 292/292 green including the `conversion_integrity` round-trip gate and `dual_write`.