### PR TITLE
fix: `securityTrustedCertificateLocation="certs/cacert.pem"`

### DIFF
--- a/tools/run_locally/scripts/macos/at_server
+++ b/tools/run_locally/scripts/macos/at_server
@@ -68,6 +68,8 @@ export logLevel="WARNING"
 
 export testingMode="true"
 
+export securityTrustedCertificateLocation="certs/cacert.pem"
+
 # Set up on the local root server
 redis-cli << EOF
 auth foobared


### PR DESCRIPTION
**- What I did**
- at_secondary_server needs a trusted CA cert to verify other atServers' certs during mTLS.

The default path is /etc/cacert/cacert.pem, which doesn't exist. The dev CA that matches the self-signed certs the script already symlinks was sitting right there at certs/cacert.pem (via the existing symlink); the script just wasn't telling the server about it.

**- How I did it**

- Claude

**- How to verify it**

Runs as expected

```
run_locally/scripts/macos on  jt/at_secondary_server-fix [$] took 3s
❯ ./at_server -a @charlie -p 65000 -s charlie-secret
Running at_server in working directory /Users/jeremytubongbanua/GitHub/atsign/at_server/trunk/tools/run_locally/runtime/atServers
OK
OK
Linking secondary certs
SHOUT|2026-07-23 18:19:39.134634|AtSecondaryServer|executableArguments: [--resolved_executable_name=/opt/homebrew/Caskroom/flutter/3.13.4/flutter/bin/cache/dart-sdk/bin/dart, --executable_name=/opt/homebrew/Caskroom/flutter/3.13.4/flutter/bin/cache/dart-sdk/bin/dart, --use_compactor, --dontneed_on_sweep, --old_gen_growth_time_ratio=50, --old_gen_growth_space_ratio=10, --new_gen_semi_max_size=8]
SHOUT|2026-07-23 18:19:39.142626|AtSecondaryServer|DART_VM_OPTIONS: null
INFO|2026-07-23 18:19:39.148397|DefaultOutboundConnectionFactory|Will not present client cert to other atServers
SHOUT|2026-07-23 18:19:39.160171|AtSecondaryServer|start(): currentAtSign : @charlie
INFO|2026-07-23 18:19:39.429071|DefaultOutboundConnectionFactory|Using MTLS cert when making outbound client connections
SHOUT|2026-07-23 18:19:39.459178|AtSecondaryServer|Secondary server started on version : 3.15.1 on root server : vip.ve.atsign.zone
SHOUT|2026-07-23 18:19:39.459263|AtSecondaryServer|Secure Socket open for @charlie !
```

**- Description for the changelog**
fix: `securityTrustedCertificateLocation="certs/cacert.pem"`
