### PR TITLE
perf: push sync's skipDeletesUntil into the commit-log query

### DIFF
--- a/packages/at_persistence_secondary_server/CHANGELOG.md
+++ b/packages/at_persistence_secondary_server/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## 5.2.1
 
+- feat: `AtCommitLog.iterate` accepts `skipDeletesUntil`/`latestCommitId`,
+  pushing sync's delete-skip into the query. Previously sync fetched every
+  commit entry from `fromCommitId` and discarded below-watermark DELETE entries
+  in a Dart filter; now the backend excludes them at the source — SQLite in the
+  SQL `WHERE`, so those rows are never read or deserialised — while always
+  yielding the single latest entry so the client can still advance its
+  watermark. Legacy callers (no `skipDeletesUntil`) are unaffected.
+
 - fix: `PersistenceMigrator` now drops ORPHANED commit entries rather than
   copying them into the target — a non-delete commit entry whose key is absent
   from the keystore. Hive accumulates these (its commit log's box and in-memory

--- a/packages/at_persistence_secondary_server/lib/src/impl/hive/hive_at_commit_log.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/hive/hive_at_commit_log.dart
@@ -77,8 +77,14 @@ class HiveAtCommitLog extends AtCommitLog {
   Stream<CommitEntry> iterate({
     int? fromCommitId,
     bool Function(CommitEntry)? where,
+    int? skipDeletesUntil,
+    int? latestCommitId,
   }) {
-    return _commitLogKeyStore.iterate(fromCommitId: fromCommitId, where: where);
+    return _commitLogKeyStore.iterate(
+        fromCommitId: fromCommitId,
+        where: where,
+        skipDeletesUntil: skipDeletesUntil,
+        latestCommitId: latestCommitId);
   }
 
   /// Returns the latest committed sequence number

--- a/packages/at_persistence_secondary_server/lib/src/impl/hive/hive_commit_log_keystore.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/hive/hive_commit_log_keystore.dart
@@ -192,16 +192,28 @@ class HiveCommitLogKeyStore with HiveBase<CommitEntry?> {
   /// Lazy stream over every commit entry with `commitId >= [fromCommitId]`
   /// (or all entries if [fromCommitId] is null), in commit-id order.
   /// If [where] is provided, only entries for which `where(entry)` returns
-  /// true are yielded. The box's one-entry-per-atKey invariant
-  /// (enforced inline by [add] and by the startup dedup migration)
+  /// true are yielded. [skipDeletesUntil]/[latestCommitId] apply sync's
+  /// delete-skip (see [AtCommitLog.iterate]). The box's one-entry-per-atKey
+  /// invariant (enforced inline by [add] and by the startup dedup migration)
   /// means this yields one entry per atKey naturally.
   Stream<CommitEntry> iterate({
     int? fromCommitId,
     bool Function(CommitEntry)? where,
+    int? skipDeletesUntil,
+    int? latestCommitId,
   }) async* {
     for (final key in getBox().keys) {
       if (fromCommitId != null && (key as int) < fromCommitId) continue;
       final entry = await getValue(key) as CommitEntry;
+      // Sync's delete-skip: drop below-watermark DELETE entries, keeping
+      // only the latest so the client can still advance its watermark.
+      if (skipDeletesUntil != null &&
+          entry.operation == CommitOp.DELETE &&
+          entry.commitId != null &&
+          entry.commitId! <= skipDeletesUntil &&
+          entry.commitId != latestCommitId) {
+        continue;
+      }
       if (where != null && !where(entry)) continue;
       yield entry;
     }

--- a/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_at_commit_log.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_at_commit_log.dart
@@ -97,15 +97,31 @@ class SqliteAtCommitLog extends AtCommitLog {
   Stream<CommitEntry> iterate({
     int? fromCommitId,
     bool Function(CommitEntry)? where,
+    int? skipDeletesUntil,
+    int? latestCommitId,
   }) async* {
-    final rows = fromCommitId == null
-        ? _db.raw.select(
-            'SELECT atkey, commit_id, operation, op_time FROM commit_log '
-            'ORDER BY commit_id;')
-        : _db.raw.select(
-            'SELECT atkey, commit_id, operation, op_time FROM commit_log '
-            'WHERE commit_id >= ? ORDER BY commit_id;',
-            [fromCommitId]);
+    final conditions = <String>[];
+    final params = <Object?>[];
+    if (fromCommitId != null) {
+      conditions.add('commit_id >= ?');
+      params.add(fromCommitId);
+    }
+    if (skipDeletesUntil != null) {
+      // Push sync's delete-skip into the query so below-watermark DELETE
+      // rows are filtered by SQLite and never read into Dart. Keep the
+      // single latest entry so the client can still advance its watermark.
+      // ('-' is the DELETE operation symbol; see _opFromSymbol.)
+      conditions.add("NOT (operation = '-' AND commit_id IS NOT NULL "
+          'AND commit_id <= ? AND commit_id <> ?)');
+      params.add(skipDeletesUntil);
+      params.add(latestCommitId ?? -1);
+    }
+    final whereSql =
+        conditions.isEmpty ? '' : 'WHERE ${conditions.join(' AND ')} ';
+    final rows = _db.raw.select(
+        'SELECT atkey, commit_id, operation, op_time FROM commit_log '
+        '${whereSql}ORDER BY commit_id;',
+        params);
     for (final row in rows) {
       final entry = _entryFromRow(row);
       if (where == null || where(entry)) yield entry;

--- a/packages/at_persistence_secondary_server/lib/src/spec/commitlog/at_commit_log.dart
+++ b/packages/at_persistence_secondary_server/lib/src/spec/commitlog/at_commit_log.dart
@@ -29,12 +29,23 @@ abstract class AtCommitLog implements Compactable {
   /// the rest are silently skipped. Used by sync, by migration,
   /// and by anything that needs full-log traversal.
   ///
+  /// [skipDeletesUntil] pushes sync's "skip deletes" policy into the
+  /// query so DELETE entries the client does not need are never
+  /// materialised: when set, a DELETE entry whose `commitId <=
+  /// skipDeletesUntil` is not yielded — EXCEPT the entry whose
+  /// `commitId == [latestCommitId]`, which is always yielded so the
+  /// client can still advance its watermark. Applied before [where].
+  /// Backends that can (SQLite) filter these rows in the query itself
+  /// rather than reading and discarding them.
+  ///
   /// After 3.5a's dedup invariant, the box has at most one entry
   /// per atKey, so a full-log walk yields one entry per atKey
   /// in commit-id order.
   Stream<CommitEntry> iterate({
     int? fromCommitId,
     bool Function(CommitEntry)? where,
+    int? skipDeletesUntil,
+    int? latestCommitId,
   });
 
   /// Latest assigned `commitId`, or `null` if the log is empty.

--- a/packages/at_persistence_secondary_server/test/commit_log_skip_deletes_test.dart
+++ b/packages/at_persistence_secondary_server/test/commit_log_skip_deletes_test.dart
@@ -1,0 +1,122 @@
+import 'dart:io';
+
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_persistence_secondary_server/hive.dart';
+import 'package:at_persistence_secondary_server/sqlite.dart';
+import 'package:test/test.dart';
+
+/// Query-level `skipDeletesUntil` for sync.
+///
+/// [AtCommitLog.iterate] filters below-watermark DELETE entries itself — in
+/// SQLite, in the query, so those rows are never materialised — while always
+/// yielding the single latest entry so the client can advance its watermark.
+/// Runs identically against both backends.
+void main() {
+  for (final backend in ['hive', 'sqlite']) {
+    group('$backend commit log iterate(skipDeletesUntil:)', () {
+      late Directory tempDir;
+      late AtPersistenceFactory factory;
+      late AtCommitLog commitLog;
+
+      // Commit ids of the entries seeded in setUp.
+      late int idU1, idD1, idD2;
+
+      setUp(() async {
+        tempDir = await Directory.systemTemp.createTemp('skip_deletes_');
+        final AtPersistenceBundle bundle;
+        if (backend == 'hive') {
+          factory = HiveAtPersistenceFactory();
+          bundle = await factory.initialize(
+            '@alice',
+            HivePersistenceConfig.serverDefaults(
+              storagePath: '${tempDir.path}/hive',
+              commitLogPath: '${tempDir.path}/commitLog',
+              accessLogPath: '${tempDir.path}/accessLog',
+              notificationStoragePath: '${tempDir.path}/notification',
+            ),
+          );
+        } else {
+          factory = SqliteAtPersistenceFactory();
+          bundle = await factory.initialize(
+            '@alice',
+            SqlitePersistenceConfig.serverDefaults(
+                storagePath: '${tempDir.path}/sqlite'),
+          );
+        }
+        commitLog = bundle.keyValueStore.commitLog!;
+
+        // Seed: two UPDATE-only keys and two keys ending in DELETE, at
+        // increasing commit ids. The one-entry-per-atKey dedup invariant keeps
+        // the DELETE entry for the deleted keys (the interim UPDATE is dropped).
+        idU1 = (await commitLog.commit('public:u1@alice', CommitOp.UPDATE))!;
+        await commitLog.commit('public:d1@alice', CommitOp.UPDATE);
+        idD1 = (await commitLog.commit('public:d1@alice', CommitOp.DELETE))!;
+        await commitLog.commit('public:u2@alice', CommitOp.UPDATE);
+        await commitLog.commit('public:d2@alice', CommitOp.UPDATE);
+        idD2 = (await commitLog.commit('public:d2@alice', CommitOp.DELETE))!;
+      });
+
+      tearDown(() async {
+        await factory.close();
+        if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+      });
+
+      Future<List<String?>> keysFrom(Stream<CommitEntry> s) async =>
+          (await s.toList()).map((e) => e.atKey).toList();
+
+      test('skips a below-watermark DELETE, keeps UPDATEs and later DELETEs',
+          () async {
+        final keys = await keysFrom(commitLog.iterate(
+            fromCommitId: idU1, skipDeletesUntil: idD1, latestCommitId: idD2));
+        expect(keys, isNot(contains('public:d1@alice')),
+            reason: 'below-watermark DELETE must be filtered by the query');
+        expect(
+            keys,
+            containsAll(<String>[
+              'public:u1@alice', // UPDATE below watermark - kept
+              'public:u2@alice', // UPDATE - kept
+              'public:d2@alice', // DELETE above watermark - kept
+            ]));
+      });
+
+      test('always keeps the latest entry even if it is a below-watermark '
+          'DELETE', () async {
+        // Threshold at the latest delete: d1 is dropped, but d2 (== latest) is
+        // retained so the client can still advance its commit id.
+        final keys = await keysFrom(commitLog.iterate(
+            fromCommitId: idU1, skipDeletesUntil: idD2, latestCommitId: idD2));
+        expect(keys, isNot(contains('public:d1@alice')));
+        expect(keys, contains('public:d2@alice'),
+            reason: 'the latest commit entry is always yielded');
+      });
+
+      test('with latestCommitId omitted (null), no below-watermark DELETE '
+          'survives — not even the latest', () async {
+        // Mirror of the previous test with latestCommitId left null: there is
+        // then no keep-latest exemption, so d2 is dropped too. This pins the
+        // SQLite `?? -1` fallback and the Hive null-compare to the same
+        // "exempt nothing" behaviour across both backends.
+        final keys = await keysFrom(
+            commitLog.iterate(fromCommitId: idU1, skipDeletesUntil: idD2));
+        expect(keys, isNot(contains('public:d1@alice')));
+        expect(keys, isNot(contains('public:d2@alice')),
+            reason: 'without latestCommitId there is no keep-latest exemption');
+        expect(
+            keys, containsAll(<String>['public:u1@alice', 'public:u2@alice']));
+      });
+
+      test('without skipDeletesUntil, every entry (incl. deletes) is yielded',
+          () async {
+        final keys = await keysFrom(commitLog.iterate(fromCommitId: idU1));
+        expect(
+            keys,
+            containsAll(<String>[
+              'public:u1@alice',
+              'public:d1@alice',
+              'public:u2@alice',
+              'public:d2@alice',
+            ]));
+      });
+    });
+  }
+}

--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # 3.15.1
 - feat: augmented pol challenge
+- perf: sync now pushes `skipDeletesUntil` into the commit-log query rather than
+  filtering deletes out of the results. `SyncProgressiveVerbHandler` passed
+  `skipDeletesUntil` to a Dart `where` predicate over a full `iterate()` walk, so
+  below-watermark DELETE entries were still read from the store (for SQLite,
+  every such row materialised) before being dropped. They are now excluded by
+  the query itself, materially cutting sync work on atSigns with many deletes.
 
 # 3.15.0
 

--- a/packages/at_secondary_server/lib/src/verb/handler/sync_progressive_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/sync_progressive_verb_handler.dart
@@ -78,16 +78,9 @@ class SyncProgressiveVerbHandler extends AbstractVerbHandler {
         return false;
       }
 
-      // skipDeletesUntil: skip DELETE entries below the threshold,
-      // unless this is the latest commit entry overall (then it stays
-      // so the client can advance its watermark).
-      if (skipDeletesUntil != null &&
-          entry.operation == CommitOp.DELETE &&
-          entry.commitId != null &&
-          entry.commitId! <= skipDeletesUntil &&
-          entry.commitId != latestCommitId) {
-        return false;
-      }
+      // skipDeletesUntil is handled at the query level (see the iterate()
+      // call below), so below-watermark DELETE entries never reach this
+      // filter and are never read from the store.
 
       // Regex / always-include-in-sync filter.
       if (regex != null &&
@@ -116,7 +109,12 @@ class SyncProgressiveVerbHandler extends AbstractVerbHandler {
       capacity,
       syncLimit,
       syncResponse,
-      commitLog.iterate(fromCommitId: fromCommitId, where: whereFilter),
+      commitLog.iterate(
+        fromCommitId: fromCommitId,
+        where: whereFilter,
+        skipDeletesUntil: skipDeletesUntil,
+        latestCommitId: latestCommitId,
+      ),
     );
 
     response.data = jsonEncode(syncResponse);

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   at_chops: ^3.3.0
   at_lookup: ^3.5.0
   at_server_spec: ^5.1.0
-  at_persistence_secondary_server: ^5.2.0
+  at_persistence_secondary_server: ^5.2.1
   intl: ^0.20.3
   json_annotation: ^4.12.0
   version: ^3.0.2


### PR DESCRIPTION
**- What I did**
- Sync's `skipDeletesUntil` delete-skip now runs in the commit-log query instead of a caller-side filter, so below-watermark DELETE entries are never read from the store (SQLite excludes them in the SQL `WHERE`; Hive skips them in the walk).
- `AtCommitLog.iterate` gains optional `skipDeletesUntil`/`latestCommitId` params; `SyncProgressiveVerbHandler` passes them. The single latest entry is always kept so the client can still advance its watermark; legacy callers are unaffected.
- Restores the query-level pushdown the 4.3.x commit log had before the 5.x `iterate(where:)` refactor reduced it to an in-memory filter.

**- How I did it**
See commits & diffs.

**- How to verify it**
Tests pass — new both-backends `commit_log_skip_deletes_test.dart`, plus the existing sync skip-deletes suite in `sync_unit_test.dart`.

**- Description for the changelog**
perf: sync pushes `skipDeletesUntil` into the commit-log query rather than filtering deletes out of the results, cutting sync work on atSigns with many delete entries.
