### PR TITLE
fix(at_secondary_server): namespace-less key authorization hygiene

### DIFF
--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,4 +1,5 @@
 # 3.15.1
+- fix: deny, not throw, on an unparseable atKey in authz
 - feat: augmented pol challenge
 - perf: sync now pushes `skipDeletesUntil` into the commit-log query rather than
   filtering deletes out of the results. `SyncProgressiveVerbHandler` passed

--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -2,6 +2,7 @@
 - fix: deny, not throw, on an unparseable atKey in authz
 - fix: defensive code to properly handle a namespace named 'null'
 - fix: scope namespace-less keys to the legacy shared_key forms
+- fix: restrict config:block to root enrollments
 - feat: augmented pol challenge
 - perf: sync now pushes `skipDeletesUntil` into the commit-log query rather than
   filtering deletes out of the results. `SyncProgressiveVerbHandler` passed

--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 3.15.1
 - fix: deny, not throw, on an unparseable atKey in authz
+- fix: defensive code to properly handle a namespace named 'null'
 - feat: augmented pol challenge
 - perf: sync now pushes `skipDeletesUntil` into the commit-log query rather than
   filtering deletes out of the results. `SyncProgressiveVerbHandler` passed

--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 3.15.1
 - fix: deny, not throw, on an unparseable atKey in authz
 - fix: defensive code to properly handle a namespace named 'null'
+- fix: scope namespace-less keys to the legacy shared_key forms
 - feat: augmented pol challenge
 - perf: sync now pushes `skipDeletesUntil` into the commit-log query rather than
   filtering deletes out of the results. `SyncProgressiveVerbHandler` passed

--- a/packages/at_secondary_server/lib/src/utils/regex_util.dart
+++ b/packages/at_secondary_server/lib/src/utils/regex_util.dart
@@ -53,7 +53,9 @@ bool isNamespaceAuthorised(
   late AtKey atKey;
   try {
     atKey = AtKey.fromString(atKeyAsString);
-  } on InvalidSyntaxException catch (_) {
+  } catch (_) {
+    // AtKey.fromString raises Errors as well as Exceptions on some key shapes;
+    // an unparseable key is treated as unauthorised.
     logger.warning(
         'isNamespaceAuthorised found an invalid key "$atKeyAsString" in the commit log. Returning false');
     return false;

--- a/packages/at_secondary_server/lib/src/verb/handler/abstract_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/abstract_verb_handler.dart
@@ -213,9 +213,9 @@ abstract class AbstractVerbHandler implements VerbHandler {
       String enrolledNamespaceAccess = '',
       String operation = ''}) async {
     final enrollmentId = inboundConnectionMetadata.enrollmentId;
-    // If legacy PKAM (full permissions) or is a reserved key (to which all
-    // authenticated connections have access) then return true
-    if (enrollmentId == null || _isReservedKey(atKey)) {
+    // A connection with no enrollment id has full permissions. Namespace-less
+    // keys are decided in isAuthorizedSync, against the resolved enrollment.
+    if (enrollmentId == null) {
       return true;
     }
     final enroll = await resolveEnrollment(enrollmentId);
@@ -251,12 +251,12 @@ abstract class AbstractVerbHandler implements VerbHandler {
   /// context (e.g. sync's commit-log walk) — resolve once via
   /// [_resolveEnrollment], then call this for each candidate atKey.
   ///
-  /// Three input states:
+  /// Input states:
   ///   - [enrollmentId] is null → legacy PKAM, full access → true
-  ///   - [atKey] is a reserved key → all authenticated connections
-  ///     have access → true (does not require a resolved enrollment)
   ///   - [enrollDataStoreValue] is null → enrollment record unresolvable
   ///     ([KeyNotFoundException] from [_resolveEnrollment]) → false
+  ///   - [atKey] is a root key (no grantable namespace) → decided by
+  ///     [_decideRootKey], which may defer to the namespace check
   ///   - otherwise → namespace-access decision based on the enrollment
   bool isAuthorizedSync(
       EnrollDataStoreValue? enrollDataStoreValue, String? enrollmentId,
@@ -264,7 +264,7 @@ abstract class AbstractVerbHandler implements VerbHandler {
       String? namespace,
       String enrolledNamespaceAccess = '',
       String operation = ''}) {
-    if (enrollmentId == null || _isReservedKey(atKey)) {
+    if (enrollmentId == null) {
       return true;
     }
     if (enrollDataStoreValue == null) {
@@ -286,6 +286,13 @@ abstract class AbstractVerbHandler implements VerbHandler {
     if (atKey != null &&
         isForeignPerEnrollmentReservedKey(atKey, enrollmentId)) {
       return false;
+    }
+
+    // Namespace-less keys carry no namespace an enrollment can hold. A null
+    // verdict defers the decision to the namespace check below.
+    final bool? rootKeyVerdict = _decideRootKey(atKey, enrollDataStoreValue);
+    if (rootKeyVerdict != null) {
+      return rootKeyVerdict;
     }
 
     // If namespace is null or empty, fetch namespace from AtKey.
@@ -501,10 +508,116 @@ abstract class AbstractVerbHandler implements VerbHandler {
         access == 'rw';
   }
 
-  bool _isReservedKey(String? atKey) {
-    return atKey == null
-        ? false
-        : AtKey.getKeyType(atKey) == KeyType.reservedKey;
+  /// An atSign body, without the leading '@'. Reuses at_commons' own charset
+  /// (word characters, '-', '_' and emoji; 1..55) rather than a hand-rolled
+  /// `[\w\-_]{1,55}`, so emoji atSigns stay in lockstep with AtKey parsing.
+  /// Contains no named groups, so it is safe to interpolate more than once.
+  static const String _atSignBody = Regexes.ownershipFragmentWithoutAtPrefix;
+
+  /// Namespace-less keys that any approved enrollment may read and write: the
+  /// two encryption shared-key forms a client writes the first time it shares
+  /// with another atSign.
+  ///
+  /// Anchored at both ends, so it matches the whole key rather than a
+  /// substring of it.
+  ///
+  /// Neither atSign is compared against this server's own: the receiving side
+  /// reads `@<me>:shared_key@<them>`, which LookupVerbHandler synthesises for
+  /// an inbound `lookup:shared_key@<them>`.
+  static final RegExp _rootSharedKeyRegex = RegExp(
+      '^(?:@$_atSignBody:shared_key|shared_key\\.$_atSignBody)@$_atSignBody\$',
+      caseSensitive: false);
+
+  /// Namespace-less keys holding the atSign's own key material. Readable by
+  /// any approved enrollment; writable only by a root enrollment
+  /// ([isRootEnrollment]).
+  ///
+  /// Reads stay open because sync force-includes these keys
+  /// (`alwaysIncludeInSync` in utils/regex_util.dart admits any namespace-less
+  /// `public:` key) and then ANDs the result with this check.
+  static final RegExp _ownKeyMaterialRegex = RegExp(
+      '^(?:public:(?:publickey|signing_publickey)@$_atSignBody'
+      '|@$_atSignBody:signing_privatekey@$_atSignBody)\$',
+      caseSensitive: false);
+
+  /// Cached copies of another atSign's public key material. Readable by any
+  /// approved enrollment; writes are decided by the namespace check rather
+  /// than by a root enrollment, since the data is public at its origin and the
+  /// cached copy is local. DeleteVerbHandler treats cached keys the same way
+  /// in exempting them from `protectedKeys`.
+  static final RegExp _cachedKeyMaterialRegex = RegExp(
+      '^cached:public:(?:publickey|signing_publickey)@$_atSignBody\$',
+      caseSensitive: false);
+
+  /// Namespace-less keys writable only by a root enrollment. Reads are decided
+  /// by the namespace check, so sync membership is unaffected.
+  ///
+  /// The whole `privatekey:` prefix is covered. Its members hold the server's
+  /// own credentials and internal state, and are written by the server rather
+  /// than by an enrollment.
+  static final RegExp _rootOnlyWritableKeyRegex = RegExp(
+      '^(?:privatekey:[^\\s]+'
+      '|private:blocklist@$_atSignBody'
+      '|configkey)\$',
+      caseSensitive: false);
+
+  /// A "root" enrollment: read-write on every namespace AND on `__manage`.
+  /// This is what the first (CRAM-path) enrollment is auto-granted, and what a
+  /// later enrollment must be given explicitly to hold full privileges.
+  /// Holding '*' alone does not qualify.
+  static bool isRootEnrollment(EnrollDataStoreValue enrollDataStoreValue) {
+    return enrollDataStoreValue.namespaces[EnrollmentConstants.allNamespaces] ==
+            'rw' &&
+        enrollDataStoreValue
+                .namespaces[EnrollmentConstants.enrollManageNamespace] ==
+            'rw';
+  }
+
+  /// Whether the verb being handled mutates a key.
+  ///
+  /// Not derived from [_isWriteAllowed]: Config, Monitor and SyncFrom appear in
+  /// both that list and [_isReadAllowed], which would classify sync as a write.
+  ///
+  /// [UpdateMeta] is listed explicitly because it `extends Verb` rather than
+  /// Update, so `getVerb() is Update` does not match it.
+  bool isMutatingVerb() {
+    final Verb verb = getVerb();
+    return verb is Update ||
+        verb is UpdateMeta ||
+        verb is Delete ||
+        verb is Notify ||
+        verb is NotifyAll ||
+        verb is NotifyRemove;
+  }
+
+  /// Decides a namespace-less key for an enrollment, or returns null to let
+  /// the namespace check decide.
+  bool? _decideRootKey(
+      String? atKey, EnrollDataStoreValue enrollDataStoreValue) {
+    if (atKey == null) {
+      return null;
+    }
+    // Matched against the form the keystore writes: HiveKeyStoreHelper
+    // .prepareKey normalises with `trim().toLowerCase().replaceAll(' ', '')`.
+    final String key = atKey.trim().toLowerCase().replaceAll(' ', '');
+
+    if (_rootSharedKeyRegex.hasMatch(key)) {
+      return true;
+    }
+    // Cached copies of another atSign's public keys: readable by any
+    // enrollment; writes are decided by the namespace check.
+    if (_cachedKeyMaterialRegex.hasMatch(key)) {
+      return isMutatingVerb() ? null : true;
+    }
+    final bool isOwnKeyMaterial = _ownKeyMaterialRegex.hasMatch(key);
+    if (isOwnKeyMaterial || _rootOnlyWritableKeyRegex.hasMatch(key)) {
+      if (isMutatingVerb()) {
+        return isRootEnrollment(enrollDataStoreValue);
+      }
+      // Own key material stays readable; the rest is decided below.
+      return isOwnKeyMaterial ? true : null;
+    }
+    return null;
   }
 
   /// This function checks the validity of a provided OTP.

--- a/packages/at_secondary_server/lib/src/verb/handler/abstract_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/abstract_verb_handler.dart
@@ -573,6 +573,26 @@ abstract class AbstractVerbHandler implements VerbHandler {
             'rw';
   }
 
+  /// Whether this connection may perform atSign-level privileged operations
+  /// (as opposed to key-level ones, which [isAuthorized] decides).
+  ///
+  /// True for a connection with no enrollment id, or for an approved root
+  /// enrollment. An enrollment's namespace map is what the requesting client
+  /// asked for, so approval state is part of the check.
+  Future<bool> isRootPrivilegedConnection(
+      InboundConnectionMetadata inboundConnectionMetadata) async {
+    final enrollmentId = inboundConnectionMetadata.enrollmentId;
+    if (enrollmentId == null) {
+      return true;
+    }
+    final EnrollDataStoreValue? enroll = await resolveEnrollment(enrollmentId);
+    if (enroll == null ||
+        enroll.approval?.state != EnrollmentStatus.approved.name) {
+      return false;
+    }
+    return isRootEnrollment(enroll);
+  }
+
   /// Whether the verb being handled mutates a key.
   ///
   /// Not derived from [_isWriteAllowed]: Config, Monitor and SyncFrom appear in

--- a/packages/at_secondary_server/lib/src/verb/handler/abstract_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/abstract_verb_handler.dart
@@ -298,7 +298,10 @@ abstract class AbstractVerbHandler implements VerbHandler {
       try {
         AtKey atKeyObj = AtKey.fromString(atKey);
         namespace = atKeyObj.namespace;
-        keyWithNamespace = '${atKeyObj.key}.$namespace';
+        // Built only when the key carries a namespace.
+        if (namespace != null && namespace.isNotEmpty) {
+          keyWithNamespace = '${atKeyObj.key}.$namespace';
+        }
       } catch (_) {
         namespace = null;
       }
@@ -392,10 +395,14 @@ abstract class AbstractVerbHandler implements VerbHandler {
       String? keyWithNamespace) {
     String authorisedNamespace = '';
     String? access;
-    for (String enrolledNamespace in enrollDataStoreValue.namespaces.keys) {
-      if ('.$namespace'.endsWith('.$enrolledNamespace')) {
-        authorisedNamespace = enrolledNamespace;
-        break;
+    // Only a key that carries a namespace is matched against the enrolled
+    // namespaces.
+    if (namespace != null && namespace.isNotEmpty) {
+      for (String enrolledNamespace in enrollDataStoreValue.namespaces.keys) {
+        if ('.$namespace'.endsWith('.$enrolledNamespace')) {
+          authorisedNamespace = enrolledNamespace;
+          break;
+        }
       }
     }
 
@@ -403,7 +410,10 @@ abstract class AbstractVerbHandler implements VerbHandler {
     /// For example, if the namespace is 'foo.bar', AtKey(key).namespace will return 'bar'. In such cases, authorisedNamespace
     /// cannot be cannot be fetched due to incomplete namespace.
     /// Currently, to authorize such keys, use the full key along with the namespace to perform the authorization check.
-    if (keyWithNamespace != null && authorisedNamespace.isEmpty) {
+    // keyWithNamespace is empty when the key carries no namespace.
+    if (keyWithNamespace != null &&
+        keyWithNamespace.isNotEmpty &&
+        authorisedNamespace.isEmpty) {
       for (String enrolledNamespace in enrollDataStoreValue.namespaces.keys) {
         if (keyWithNamespace.endsWith('.$enrolledNamespace')) {
           authorisedNamespace = enrolledNamespace;

--- a/packages/at_secondary_server/lib/src/verb/handler/abstract_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/abstract_verb_handler.dart
@@ -289,11 +289,19 @@ abstract class AbstractVerbHandler implements VerbHandler {
     }
 
     // If namespace is null or empty, fetch namespace from AtKey.
+    //
+    // AtKey.fromString throws on some key shapes that occur in the keystore and
+    // the commit log, raising Errors as well as Exceptions, so catch
+    // everything. An unresolved namespace is decided by the '*' fallback below.
     String keyWithNamespace = '';
     if ((namespace == null || namespace.isEmpty) && atKey != null) {
-      AtKey atKeyObj = AtKey.fromString(atKey);
-      namespace = atKeyObj.namespace;
-      keyWithNamespace = '${atKeyObj.key}.$namespace';
+      try {
+        AtKey atKeyObj = AtKey.fromString(atKey);
+        namespace = atKeyObj.namespace;
+        keyWithNamespace = '${atKeyObj.key}.$namespace';
+      } catch (_) {
+        namespace = null;
+      }
     }
 
     // All enrollments should have access to read from the __atserver

--- a/packages/at_secondary_server/lib/src/verb/handler/config_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/config_verb_handler.dart
@@ -60,6 +60,16 @@ class ConfigVerbHandler extends AbstractVerbHandler {
     String? setOperation = verbParams[AtConstants.setOperation];
 
     if (operation != null) {
+      // config:block governs who may connect to this atSign, which is an
+      // atSign-level privilege rather than a namespace-scoped one, so it
+      // requires a root enrollment: read-write on '*' and on '__manage'.
+      // Connections with no enrollment id are unaffected.
+      final metadata = atConnection.metaData as InboundConnectionMetadata;
+      if (!await isRootPrivilegedConnection(metadata)) {
+        throw UnAuthorizedException(
+            'Connection with enrollment ID ${metadata.enrollmentId} is not'
+            ' authorized to perform config:block operations');
+      }
       switch (operation) {
         case 'show':
           var blockList = await atConfigInstance.getBlockList();

--- a/packages/at_secondary_server/lib/src/verb/handler/sync_progressive_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/sync_progressive_verb_handler.dart
@@ -72,7 +72,9 @@ class SyncProgressiveVerbHandler extends AbstractVerbHandler {
       }
       try {
         AtKey.fromString(atKey);
-      } on InvalidSyntaxException catch (_) {
+      } catch (_) {
+        // AtKey.fromString raises Errors as well as Exceptions on some key
+        // shapes; skip the entry rather than ending the walk.
         logger.warning(
             'sync filter | found an invalid key "$atKey" in the commit log. Skipping.');
         return false;

--- a/packages/at_secondary_server/test/root_key_authz_test.dart
+++ b/packages/at_secondary_server/test/root_key_authz_test.dart
@@ -1,0 +1,74 @@
+import 'dart:convert';
+
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_secondary/src/verb/handler/update_verb_handler.dart';
+import 'package:at_utils/at_logger.dart';
+import 'package:test/test.dart';
+import 'package:uuid/uuid.dart';
+
+import 'test_utils.dart';
+
+/// Covers authorization of namespace-less keys — keys carrying no namespace
+/// an enrollment can be granted, so the namespace check cannot decide them.
+void main() {
+  AtSignLogger.root_level = 'WARNING';
+
+  group('root key authorization', () {
+    late UpdateVerbHandler updateVerbHandler;
+
+    setUpAll(() async {
+      await verbTestsSetUpAll();
+    });
+
+    setUp(() async {
+      await verbTestsSetUp();
+      updateVerbHandler = UpdateVerbHandler(
+          keyValueStore, statsNotificationService, notificationManager, alice);
+    });
+
+    tearDown(() async {
+      await verbTestsTearDown();
+    });
+
+    /// Binds an approved enrollment with [namespaces] and returns its id.
+    Future<String> bindEnrollment(Map<String, String> namespaces) async {
+      inboundConnection.metadata.isAuthenticated = true;
+      final enrollId = Uuid().v4();
+      inboundConnection.metadata.enrollmentId = enrollId;
+      final enrollJson = {
+        'sessionId': '123',
+        'appName': 'wavi',
+        'deviceName': 'pixel',
+        'namespaces': namespaces,
+        'apkamPublicKey': 'testPublicKeyValue',
+        'requestType': 'newEnrollment',
+        'approval': {'state': 'approved'}
+      };
+      await keyValueStore.put('$enrollId.new.enrollments.__manage$alice',
+          AtData()..data = jsonEncode(enrollJson));
+      return enrollId;
+    }
+
+    Future<String> bindScoped() => bindEnrollment({'wavi': 'rw'});
+
+    test('an unparseable atKey returns rather than throwing', () async {
+      // AtKey.fromString raises Errors as well as Exceptions on these, and the
+      // check runs inside sync's synchronous where: predicate.
+      final enrollId = await bindScoped();
+      final enroll = await enMgr.getEnrollmentById(enrollId);
+      for (final key in [
+        'privatekey:at_secret',
+        'privatekey:privatekey',
+        'configkey',
+        '_latestNotificationIdv2',
+        'cached:shared_key.bob@alice',
+      ]) {
+        expect(
+            () =>
+                updateVerbHandler.isAuthorizedSync(enroll, enrollId, atKey: key),
+            returnsNormally,
+            reason: '$key must not throw out of the authorization check');
+      }
+    });
+  });
+}

--- a/packages/at_secondary_server/test/root_key_authz_test.dart
+++ b/packages/at_secondary_server/test/root_key_authz_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:at_commons/at_commons.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_secondary/src/verb/handler/config_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/delete_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/local_lookup_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/update_verb_handler.dart';
@@ -20,6 +21,7 @@ void main() {
     late UpdateVerbHandler updateVerbHandler;
     late LocalLookupVerbHandler localLookupVerbHandler;
     late DeleteVerbHandler deleteVerbHandler;
+    late ConfigVerbHandler configVerbHandler;
 
     setUpAll(() async {
       await verbTestsSetUpAll();
@@ -32,6 +34,8 @@ void main() {
       localLookupVerbHandler = LocalLookupVerbHandler(keyValueStore, enMgr);
       deleteVerbHandler = DeleteVerbHandler(
           keyValueStore, statsNotificationService, notificationManager);
+      configVerbHandler =
+          ConfigVerbHandler(keyValueStore, commitLog: atCommitLog);
     });
 
     tearDown(() async {
@@ -229,6 +233,25 @@ void main() {
           throwsA(isA<UnAuthorizedException>()));
     });
 
+    test("an enrollment granted the namespace 'null' gets no root access",
+        () async {
+      // A key with no namespace must not match a grant named 'null'.
+      await bindEnrollment({'null': 'rw'});
+      for (final key in ['foo$alice', 'public:foo$alice', '@bob:foo$alice']) {
+        await expectLater(
+            updateVerbHandler.process('update:$key v', inboundConnection),
+            throwsA(isA<UnAuthorizedException>()),
+            reason: '$key has no namespace and must not match a "null" grant');
+      }
+    });
+
+    test("a key whose namespace really is 'null' still resolves", () async {
+      await bindEnrollment({'null': 'rw'});
+      await updateVerbHandler.process(
+          'update:foo.null$alice v', inboundConnection);
+      expect(inboundConnection.lastWrittenData, contains('data:'));
+    });
+
     // ---- matching the key the keystore writes ----
 
     for (final variant in ['public:publickey@alice ', ' public:publickey@alice',
@@ -309,22 +332,34 @@ void main() {
           throwsA(isA<UnAuthorizedException>()));
     });
 
-    test("an enrollment granted the namespace 'null' gets no root access",
-        () async {
-      // A key with no namespace must not match a grant named 'null'.
-      await bindEnrollment({'null': 'rw'});
-      for (final key in ['foo$alice', 'public:foo$alice', '@bob:foo$alice']) {
+    // ---- config:block ----
+
+    test('scoped enrollment cannot read or modify the blocklist', () async {
+      await bindScoped();
+      for (final command in [
+        'config:block:show',
+        'config:block:add:@evil',
+        'config:block:remove:@evil',
+      ]) {
         await expectLater(
-            updateVerbHandler.process('update:$key v', inboundConnection),
+            configVerbHandler.process(command, inboundConnection),
             throwsA(isA<UnAuthorizedException>()),
-            reason: '$key has no namespace and must not match a "null" grant');
+            reason: '$command is an atSign-level privilege');
       }
     });
 
-    test("a key whose namespace really is 'null' still resolves", () async {
-      await bindEnrollment({'null': 'rw'});
-      await updateVerbHandler.process(
-          'update:foo.null$alice v', inboundConnection);
+    test('a *:rw enrollment without __manage cannot modify the blocklist',
+        () async {
+      await bindWildcard();
+      await expectLater(
+          configVerbHandler.process('config:block:add:@evil', inboundConnection),
+          throwsA(isA<UnAuthorizedException>()));
+    });
+
+    test('a root enrollment CAN modify the blocklist', () async {
+      await bindRoot();
+      await configVerbHandler.process(
+          'config:block:add:@evil', inboundConnection);
       expect(inboundConnection.lastWrittenData, contains('data:'));
     });
 

--- a/packages/at_secondary_server/test/root_key_authz_test.dart
+++ b/packages/at_secondary_server/test/root_key_authz_test.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:at_commons/at_commons.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:at_secondary/src/verb/handler/update_verb_handler.dart';
 import 'package:at_utils/at_logger.dart';
@@ -50,6 +51,25 @@ void main() {
     }
 
     Future<String> bindScoped() => bindEnrollment({'wavi': 'rw'});
+
+    test("an enrollment granted the namespace 'null' gets no root access",
+        () async {
+      // A key with no namespace must not match a grant named 'null'.
+      await bindEnrollment({'null': 'rw'});
+      for (final key in ['foo$alice', 'public:foo$alice', '@bob:foo$alice']) {
+        await expectLater(
+            updateVerbHandler.process('update:$key v', inboundConnection),
+            throwsA(isA<UnAuthorizedException>()),
+            reason: '$key has no namespace and must not match a "null" grant');
+      }
+    });
+
+    test("a key whose namespace really is 'null' still resolves", () async {
+      await bindEnrollment({'null': 'rw'});
+      await updateVerbHandler.process(
+          'update:foo.null$alice v', inboundConnection);
+      expect(inboundConnection.lastWrittenData, contains('data:'));
+    });
 
     test('an unparseable atKey returns rather than throwing', () async {
       // AtKey.fromString raises Errors as well as Exceptions on these, and the

--- a/packages/at_secondary_server/test/root_key_authz_test.dart
+++ b/packages/at_secondary_server/test/root_key_authz_test.dart
@@ -2,6 +2,8 @@ import 'dart:convert';
 
 import 'package:at_commons/at_commons.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_secondary/src/verb/handler/delete_verb_handler.dart';
+import 'package:at_secondary/src/verb/handler/local_lookup_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/update_verb_handler.dart';
 import 'package:at_utils/at_logger.dart';
 import 'package:test/test.dart';
@@ -16,6 +18,8 @@ void main() {
 
   group('root key authorization', () {
     late UpdateVerbHandler updateVerbHandler;
+    late LocalLookupVerbHandler localLookupVerbHandler;
+    late DeleteVerbHandler deleteVerbHandler;
 
     setUpAll(() async {
       await verbTestsSetUpAll();
@@ -25,6 +29,9 @@ void main() {
       await verbTestsSetUp();
       updateVerbHandler = UpdateVerbHandler(
           keyValueStore, statsNotificationService, notificationManager, alice);
+      localLookupVerbHandler = LocalLookupVerbHandler(keyValueStore, enMgr);
+      deleteVerbHandler = DeleteVerbHandler(
+          keyValueStore, statsNotificationService, notificationManager);
     });
 
     tearDown(() async {
@@ -51,6 +58,256 @@ void main() {
     }
 
     Future<String> bindScoped() => bindEnrollment({'wavi': 'rw'});
+    Future<String> bindWildcard() => bindEnrollment({'*': 'rw'});
+    Future<String> bindRoot() => bindEnrollment({'*': 'rw', '__manage': 'rw'});
+
+    // ---- the legacy PKAM public key ----
+
+    test('scoped enrollment cannot overwrite the legacy PKAM public key',
+        () async {
+      await bindScoped();
+      await keyValueStore.put(
+          AtConstants.atPkamPublicKey, AtData()..data = 'ORIGINAL_KEY');
+
+      await expectLater(
+          updateVerbHandler.process(
+              'update:${AtConstants.atPkamPublicKey} REPLACEMENT_KEY',
+              inboundConnection),
+          throwsA(isA<UnAuthorizedException>()));
+      // Assert the stored value, not merely that the call threw.
+      final stored = await keyValueStore.get(AtConstants.atPkamPublicKey);
+      expect(stored?.data, 'ORIGINAL_KEY');
+    });
+
+    test('a *:rw enrollment without __manage cannot overwrite the PKAM key',
+        () async {
+      await bindWildcard();
+      await keyValueStore.put(
+          AtConstants.atPkamPublicKey, AtData()..data = 'ORIGINAL_KEY');
+
+      await expectLater(
+          updateVerbHandler.process(
+              'update:${AtConstants.atPkamPublicKey} REPLACEMENT_KEY',
+              inboundConnection),
+          throwsA(isA<UnAuthorizedException>()));
+      final stored = await keyValueStore.get(AtConstants.atPkamPublicKey);
+      expect(stored?.data, 'ORIGINAL_KEY');
+    });
+
+    test('a root enrollment CAN write the PKAM public key', () async {
+      await bindRoot();
+      await updateVerbHandler.process(
+          'update:${AtConstants.atPkamPublicKey} NEW_KEY', inboundConnection);
+      final stored = await keyValueStore.get(AtConstants.atPkamPublicKey);
+      expect(stored?.data, 'NEW_KEY');
+    });
+
+    test('the PKAM key guard is not case-sensitive', () async {
+      // Verb regexes are built caseSensitive:false and the keystore lowercases
+      // on put, so an uppercase spelling addresses the same record.
+      await bindScoped();
+      await expectLater(
+          updateVerbHandler.process(
+              'update:PRIVATEKEY:AT_PKAM_PUBLICKEY REPLACEMENT_KEY',
+              inboundConnection),
+          throwsA(isA<UnAuthorizedException>()));
+    });
+
+    // ---- the atSign's own key material ----
+
+    for (final key in [
+      'public:publickey@alice',
+      'public:signing_publickey@alice',
+      '@alice:signing_privatekey@alice',
+    ]) {
+      test('scoped enrollment cannot overwrite $key', () async {
+        await bindScoped();
+        await keyValueStore.put(key, AtData()..data = 'GENUINE');
+
+        await expectLater(
+            updateVerbHandler.process(
+                'update:$key REPLACEMENT', inboundConnection),
+            throwsA(isA<UnAuthorizedException>()));
+        final stored = await keyValueStore.get(key);
+        expect(stored?.data, 'GENUINE');
+      });
+
+      test('scoped enrollment CAN still read $key', () async {
+        // Reads stay open: sync force-includes these keys and then ANDs the
+        // result with this authorization check.
+        await bindScoped();
+        await keyValueStore.put(key, AtData()..data = 'GENUINE');
+        await localLookupVerbHandler.process(
+            'llookup:$key', inboundConnection);
+        expect(inboundConnection.lastWrittenData, contains('GENUINE'));
+      });
+
+      test('a root enrollment CAN overwrite $key', () async {
+        await bindRoot();
+        await keyValueStore.put(key, AtData()..data = 'GENUINE');
+        await updateVerbHandler.process(
+            'update:$key ROTATED', inboundConnection);
+        final stored = await keyValueStore.get(key);
+        expect(stored?.data, 'ROTATED');
+      });
+    }
+
+    // ---- the two shared_key forms stay reachable ----
+
+    for (final key in [
+      'shared_key.bob@alice',
+      '@bob:shared_key@alice',
+    ]) {
+      test('scoped enrollment CAN create $key', () async {
+        await bindScoped();
+        await updateVerbHandler.process(
+            'update:$key encryptedvalue', inboundConnection);
+        final stored = await keyValueStore.get(key);
+        expect(stored?.data, 'encryptedvalue');
+      });
+
+      test('scoped enrollment CAN read and delete $key', () async {
+        await bindScoped();
+        await keyValueStore.put(key, AtData()..data = 'encryptedvalue');
+        await localLookupVerbHandler.process(
+            'llookup:$key', inboundConnection);
+        expect(inboundConnection.lastWrittenData, contains('encryptedvalue'));
+        await deleteVerbHandler.process('delete:$key', inboundConnection);
+      });
+    }
+
+    // ---- keys that merely contain an allow-listed form ----
+
+    for (final key in [
+      'x.shared_key.bob@alice',
+      'evilshared_key.zz@alice',
+      '@charlie:secret.shared_key.evil@alice',
+    ]) {
+      test('scoped enrollment is denied "$key"', () async {
+        // Not shared keys: they contain an allow-listed form as a substring.
+        await bindScoped();
+        await expectLater(
+            updateVerbHandler.process('update:$key v', inboundConnection),
+            throwsA(isA<UnAuthorizedException>()));
+      });
+    }
+
+    test('the root-key allowlist is anchored, not a substring match', () async {
+      // Asserted against the predicate rather than a verb handler: some of
+      // these are rejected by verb grammar before authorization is reached.
+      final enrollId = await bindScoped();
+      final enroll = await enMgr.getEnrollmentById(enrollId);
+      for (final key in [
+        'x.shared_key.bob@alice',
+        'evilshared_key.zz@alice',
+        '@charlie:secret.shared_key.evil@alice',
+        'notpublic:publickey@alice',
+        'public:publickeyy@alice',
+        'shared_key.bob@alice.evil@alice',
+        'prefix:privatekey:at_pkam_publickey',
+      ]) {
+        expect(
+            updateVerbHandler.isAuthorizedSync(enroll, enrollId, atKey: key),
+            isFalse,
+            reason: '"$key" only contains an exempt form, it is not one');
+      }
+    });
+
+    test('a genuinely namespaced shared_key is still namespace-governed',
+        () async {
+      // @bob:shared_key.wavi@alice has namespace 'wavi', so it is decided by
+      // the grant rather than by the namespace-less rule.
+      await bindScoped();
+      await updateVerbHandler.process(
+          'update:@bob:shared_key.wavi$alice v', inboundConnection);
+      expect(inboundConnection.lastWrittenData, contains('data:'));
+
+      await bindEnrollment({'other': 'rw'});
+      await expectLater(
+          updateVerbHandler.process(
+              'update:@bob:shared_key.wavi$alice v', inboundConnection),
+          throwsA(isA<UnAuthorizedException>()));
+    });
+
+    // ---- matching the key the keystore writes ----
+
+    for (final variant in ['public:publickey@alice ', ' public:publickey@alice',
+      'public:publickey@alice\t', 'PUBLIC:PUBLICKEY@ALICE']) {
+      test('a non-root enrollment is denied ${jsonEncode(variant)}', () async {
+        // HiveKeyStoreHelper.prepareKey normalises with
+        // trim().toLowerCase().replaceAll(' ',''), so these variants all
+        // address the same record. A '*:rw' enrollment is not a root
+        // enrollment.
+        await bindWildcard();
+        await keyValueStore.put(
+            'public:publickey$alice', AtData()..data = 'GENUINE');
+        final params = UpdateParams()
+          ..atKey = variant
+          ..value = 'REPLACEMENT'
+          ..metadata = Metadata();
+        await expectLater(
+            updateVerbHandler.process(
+                'update:json:${jsonEncode(params.toJson())}',
+                inboundConnection),
+            throwsA(isA<UnAuthorizedException>()));
+        final stored = await keyValueStore.get('public:publickey$alice');
+        expect(stored?.data, 'GENUINE');
+      });
+    }
+
+    // ---- the privatekey: prefix ----
+
+    for (final key in [
+      'privatekey:at_secret',
+      'privatekey:at_pkam_privatekey',
+      'privatekey:self_encryption_key',
+    ]) {
+      test('a non-root *:rw enrollment cannot write $key', () async {
+        // These hold the server's own credentials and internal state.
+        await bindWildcard();
+        final params = UpdateParams()
+          ..atKey = key
+          ..value = 'REPLACEMENT'
+          ..metadata = Metadata();
+        await expectLater(
+            updateVerbHandler.process(
+                'update:json:${jsonEncode(params.toJson())}',
+                inboundConnection),
+            throwsA(isA<UnAuthorizedException>()));
+      });
+    }
+
+    test('a root enrollment can still delete the CRAM secret', () async {
+      // Onboarding removes privatekey:at_secret once PKAM is established.
+      await bindRoot();
+      await keyValueStore.put(
+          'privatekey:at_secret', AtData()..data = 'SECRET');
+      await deleteVerbHandler.process(
+          'delete:privatekey:at_secret', inboundConnection);
+    });
+
+    // ---- cached copies of another atSign's public keys ----
+
+    test('a *:rw enrollment can still evict a cached foreign public key',
+        () async {
+      // A cached copy of data that is public at its origin.
+      await bindWildcard();
+      await keyValueStore.put(
+          'cached:public:publickey@bob', AtData()..data = 'BOBKEY');
+      await deleteVerbHandler.process(
+          'delete:cached:public:publickey@bob', inboundConnection);
+    });
+
+    test('a scoped enrollment cannot evict a cached foreign public key',
+        () async {
+      await bindScoped();
+      await keyValueStore.put(
+          'cached:public:publickey@bob', AtData()..data = 'BOBKEY');
+      await expectLater(
+          deleteVerbHandler.process(
+              'delete:cached:public:publickey@bob', inboundConnection),
+          throwsA(isA<UnAuthorizedException>()));
+    });
 
     test("an enrollment granted the namespace 'null' gets no root access",
         () async {


### PR DESCRIPTION
**- What I did**

- Deny, not throw, on an unparseable atKey in authz
- Defensive handling for a namespace named `null`
- Scope namespace-less keys to the legacy `shared_key` forms
  - the atSign's own key material stays readable, and is writable by a root enrollment (`rw` on both `*` and `__manage`)
- Restrict `config:block` to root enrollments

**- How I did it**

See commit & diffs

**- How to verify it**

Tests pass

**- Description for the changelog**

Authorization hygiene for namespace-less keys and `config:block`
