### PR TITLE
perf(at_persistence_secondary_server): seek skip-deletes via a partial index

### DIFF
--- a/packages/at_persistence_secondary_server/CHANGELOG.md
+++ b/packages/at_persistence_secondary_server/CHANGELOG.md
@@ -7,6 +7,23 @@
   SQL `WHERE`, so those rows are never read or deserialised — while always
   yielding the single latest entry so the client can still advance its
   watermark. Legacy callers (no `skipDeletesUntil`) are unaffected.
+- perf: the SQLite skip-deletes query is now an index-driven range scan over a
+  new partial index of live entries (`commit_log_live`), not a `NOT (operation
+  = '-' ...)` filter over the full `commit_id` index. The filter form is correct
+  but its plan walks every row from `fromCommitId` to the tail in SQLite's C
+  layer, so a client near the head of a delete-dominated log still pays a
+  full-log scan; the partial index seeks straight to the live rows. Measured on
+  a 1M-entry log holding one live entry, the skip-deletes scan drops from ~253ms
+  to ~0.2ms. The index is created by `CREATE INDEX IF NOT EXISTS` on open, with
+  no contract-version bump — an existing database acquires it on next start.
+- perf: `SqliteAtCommitLog.iterate` streams rows through a prepared cursor
+  rather than an eager `select()` that materialised the whole result set before
+  the caller saw a row. Callers stop early (sync breaks after one page), so an
+  ordinary `sync` returning 25 entries against a 1M-entry log drops from ~500ms
+  to sub-millisecond.
+- fix: `getSize()` on the SQLite commit-log, access-log and notification stores
+  returned raw bytes; the spec and the Hive stores return KB. All three now
+  return KB (they had over-reported by 1024x).
 
 - fix: `PersistenceMigrator` now drops ORPHANED commit entries rather than
   copying them into the target — a non-delete commit entry whose key is absent

--- a/packages/at_persistence_secondary_server/bench/.gitignore
+++ b/packages/at_persistence_secondary_server/bench/.gitignore
@@ -1,0 +1,1 @@
+results/

--- a/packages/at_persistence_secondary_server/bench/run_sync_bench.sh
+++ b/packages/at_persistence_secondary_server/bench/run_sync_bench.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Sweeps the sync commit-log scan bench across log sizes and writes the full
+# output to a file. See bench/sync_commit_log_bench.dart for what is measured.
+#
+#   ./bench/run_sync_bench.sh                 # 100k, 500k, 1M
+#   SIZES="100000" ./bench/run_sync_bench.sh  # override the sweep
+#
+# Output: bench/results/sync_bench_<host>.txt (full log, never piped through
+# tail — a truncated failure means re-running a multi-minute seed).
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+SIZES=${SIZES:-"100000 500000 1000000"}
+REPEAT=${REPEAT:-3}
+# Per-size wall-clock bound. Seeding 1e6 entries into Hive dominates; 2x the
+# observed worst case. macOS has no coreutils `timeout`.
+TIMEOUT=${TIMEOUT:-1800}
+
+OUT_DIR="bench/results"
+mkdir -p "$OUT_DIR"
+OUT="$OUT_DIR/sync_bench_$(hostname -s).txt"
+: > "$OUT"
+
+{
+  echo "host:   $(hostname -s)"
+  echo "uname:  $(uname -a)"
+  echo "dart:   $(dart --version 2>&1)"
+  echo "date:   $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "commit: $(git rev-parse --short HEAD)"
+  echo "sizes:  $SIZES"
+  echo
+} >> "$OUT"
+
+# AOT-compile once: the secondary runs from an AOT snapshot, and JIT vs AOT
+# materially changes a tight per-entry loop. Benchmarking `dart run` would
+# measure the wrong runtime.
+BIN="$(mktemp -d)/sync_bench"
+echo ">>> compiling (AOT)" | tee -a "$OUT"
+dart compile exe bench/sync_commit_log_bench.dart -o "$BIN" >> "$OUT" 2>&1
+trap 'rm -rf "$(dirname "$BIN")"' EXIT
+
+status=0
+for n in $SIZES; do
+  echo ">>> entries=$n" | tee -a "$OUT"
+  set +e
+  perl -e 'alarm shift; exec @ARGV' "$TIMEOUT" \
+    "$BIN" --entries "$n" --repeat "$REPEAT" \
+    >> "$OUT" 2>&1
+  rc=$?
+  set -e
+  if [[ $rc -ne 0 ]]; then
+    echo "!!! entries=$n FAILED (exit $rc)" | tee -a "$OUT"
+    status=$rc
+  fi
+  echo >> "$OUT"
+done
+
+echo
+echo "full results: $OUT"
+tail -n 40 "$OUT"
+exit $status

--- a/packages/at_persistence_secondary_server/bench/sync_commit_log_bench.dart
+++ b/packages/at_persistence_secondary_server/bench/sync_commit_log_bench.dart
@@ -1,0 +1,784 @@
+/// Benchmark: cost of a `sync:from` scan over a large commit log, on the
+/// Hive backend vs the SQLite backend.
+///
+/// Motivating scenario: a commit log whose max commitId is ~1e6, in which
+/// all but the last entry are DELETEs, and a client syncing from a low
+/// watermark with `skipDeletesUntil` set to the max. Exactly one entry
+/// survives the filter, but the server must walk the whole log to find it.
+///
+/// WHAT THIS MEASURES (and what it does not)
+///
+/// It drives the real `AtCommitLog.iterate` of each backend, with a
+/// faithful copy of the `where` predicate from
+/// `sync_progressive_verb_handler.dart` (:63-112) and the same
+/// stop-at-page-limit drain loop as `prepareResponse` (:145-175).
+///
+/// Deliberately NOT included, because neither is on the hot path for this
+/// scenario and both would drag in the whole secondary server:
+///   - `isAuthorizedSync(...)`: with a null enrollmentId (the unauthenticated
+///     -enrollment sync case) it returns true without touching the store.
+///   - `keyStore.get(...)` for non-DELETE entries: runs once per RETURNED
+///     entry, and this scenario returns one. It is not part of the
+///     999,999-entry scan cost under study.
+/// The regex filter is included but left null, matching a no-regex sync.
+///
+/// Usage:
+///   dart run bench/sync_commit_log_bench.dart [options]
+///
+///   --entries N     commit log size / max commitId   (default 1000000)
+///   --from N        client watermark; scan starts at N+1 (default 1000)
+///   --page N        sync page limit, as prepareResponse (default 25)
+///   --repeat N      timed repeats per scenario        (default 3)
+///   --backend B     hive | sqlite | both             (default both)
+///   --keep          do not delete the seeded stores on exit
+///   --dir PATH      scratch dir (default: a temp dir, removed on exit)
+library;
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:at_commons/at_commons.dart';
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_persistence_secondary_server/hive.dart';
+import 'package:at_persistence_secondary_server/sqlite.dart';
+// Not exported from hive.dart; the bench needs the concrete type to call
+// init(..., isLazy: false) the way HiveAtPersistenceFactory does.
+import 'package:at_persistence_secondary_server/src/impl/hive/hive_commit_log_keystore.dart';
+import 'package:at_utils/at_logger.dart';
+
+const String benchAtSign = '@bench';
+
+/// The atKey for commit entry [i]. Shaped like a real shared key so the
+/// handler's `AtKey.getKeyType` / `AtKey.fromString` validation does the
+/// same work it would in production — that validation runs on EVERY
+/// candidate entry, before the skipDeletes check, so it is part of the
+/// per-entry cost under study.
+String benchKey(int i) => '@alice:k$i.bench$benchAtSign';
+
+void main(List<String> argv) async {
+  AtSignLogger.root_level = 'severe';
+
+  final opts = _Options.parse(argv);
+  _assertKeyShapeIsValid();
+
+  final dir = opts.dir ??
+      Directory.systemTemp.createTempSync('sync_bench_').path;
+  Directory(dir).createSync(recursive: true);
+
+  stdout.writeln('=== sync commit-log scan bench ===');
+  stdout.writeln('entries=${opts.entries}  from=${opts.from}  '
+      'page=${opts.page}  repeat=${opts.repeat}  backend=${opts.backend}');
+  stdout.writeln('scratch: $dir');
+  stdout.writeln('dart: ${Platform.version}');
+  stdout.writeln('');
+
+  final results = <_Result>[];
+
+  try {
+    if (opts.backend != 'sqlite') {
+      results.addAll(await _runHive(dir, opts));
+    }
+    if (opts.backend != 'hive') {
+      results.addAll(await _runSqlite(dir, opts));
+    }
+  } finally {
+    if (!opts.keep && opts.dir == null) {
+      try {
+        Directory(dir).deleteSync(recursive: true);
+      } on FileSystemException catch (e) {
+        stderr.writeln('warn: could not clean $dir: $e');
+      }
+    }
+  }
+
+  _report(results, opts);
+}
+
+// ---------------------------------------------------------------------------
+// Hive
+// ---------------------------------------------------------------------------
+
+Future<List<_Result>> _runHive(String scratch, _Options opts) async {
+  final path = '$scratch/hive';
+  Directory(path).createSync(recursive: true);
+
+  // --- seed ---
+  final seedStore = HiveCommitLogKeyStore(benchAtSign);
+  final seedWatch = Stopwatch()..start();
+  await seedStore.init(path, isLazy: false);
+  const batch = 20000;
+  var pending = <int, CommitEntry>{};
+  for (var id = 1; id <= opts.entries; id++) {
+    pending[id] = CommitEntry(benchKey(id), _opFor(id, opts.entries),
+        DateTime.now().toUtc())
+      ..commitId = id;
+    if (pending.length >= batch) {
+      await seedStore.getBox().putAll(pending);
+      pending = <int, CommitEntry>{};
+    }
+  }
+  if (pending.isNotEmpty) await seedStore.getBox().putAll(pending);
+  seedWatch.stop();
+  await seedStore.close();
+  stdout.writeln('hive   | seeded ${opts.entries} entries in '
+      '${seedWatch.elapsedMilliseconds}ms');
+
+  // --- open (this is the real server startup cost for a log this size:
+  //     repairCommitLogAndCreateCachedMap walks every entry) ---
+  final rssBeforeOpen = ProcessInfo.currentRss;
+  final store = HiveCommitLogKeyStore(benchAtSign);
+  final openWatch = Stopwatch()..start();
+  await store.init(path, isLazy: false);
+  openWatch.stop();
+  final rssAfterOpen = ProcessInfo.currentRss;
+  final log = HiveAtCommitLog(store);
+
+  _assertSeeded(
+      'hive', store.entriesCount(), log.lastCommittedSequenceNumber(), opts);
+
+  stdout.writeln('hive   | open+repair: ${openWatch.elapsedMilliseconds}ms  '
+      'resident after open: ${_mb(rssAfterOpen)} '
+      '(+${_mb(rssAfterOpen - rssBeforeOpen)} for the box)');
+
+  final out = <_Result>[];
+  out.add(_Result.startup('hive', openWatch.elapsedMilliseconds,
+      rssAfterOpen - rssBeforeOpen));
+
+  for (final probe in [false, true]) {
+    out.add(await _timeScenario(
+      backend: 'hive',
+      scenario: 'skipDeletes',
+      probeEventLoop: probe,
+      opts: opts,
+      scan: () => _drain(
+          log.iterate(
+              fromCommitId: opts.from + 1,
+              where: _whereFilter(
+                  skipDeletesUntil: opts.entries,
+                  latestCommitId: log.lastCommittedSequenceNumber())),
+          opts.page),
+    ));
+  }
+  out.add(await _timeScenario(
+    backend: 'hive',
+    scenario: 'reordered',
+    probeEventLoop: true,
+    opts: opts,
+    scan: () => _drain(
+        log.iterate(
+            fromCommitId: opts.from + 1,
+            where: _reorderedFilter(
+                skipDeletesUntil: opts.entries,
+                latestCommitId: log.lastCommittedSequenceNumber())),
+        opts.page),
+  ));
+  // Attribution: same full scan, but the predicate does no AtKey parsing.
+  // (skipDeletes - storeOnly) = the cost of the handler's per-entry key
+  // validation; storeOnly = the cost the persistence layer actually owns.
+  // The shipped path after all fixes: reordered filter AND the pushdown
+  // hint, exactly as sync_progressive_verb_handler now calls it.
+  out.add(await _timeScenario(
+    backend: 'hive',
+    scenario: 'shipped',
+    probeEventLoop: true,
+    opts: opts,
+    scan: () => _drain(
+        log.iterate(
+            fromCommitId: opts.from + 1,
+            where: _reorderedFilter(
+                skipDeletesUntil: opts.entries,
+                latestCommitId: log.lastCommittedSequenceNumber()),
+            skipDeletesUntil: opts.entries),
+        opts.page),
+  ));
+  out.add(await _timeScenario(
+    backend: 'hive',
+    scenario: 'storeOnly',
+    probeEventLoop: false,
+    opts: opts,
+    scan: () => _drain(
+        log.iterate(fromCommitId: opts.from + 1, where: _countOnlyFilter),
+        opts.page),
+  ));
+  out.add(await _timeScenario(
+    backend: 'hive',
+    scenario: 'noSkipDeletes',
+    probeEventLoop: false,
+    opts: opts,
+    scan: () => _drain(
+        log.iterate(
+            fromCommitId: opts.from + 1,
+            where: _whereFilter(
+                skipDeletesUntil: null,
+                latestCommitId: log.lastCommittedSequenceNumber())),
+        opts.page),
+  ));
+
+  await store.close();
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// SQLite
+// ---------------------------------------------------------------------------
+
+Future<List<_Result>> _runSqlite(String scratch, _Options opts) async {
+  final dbPath = '$scratch/sqlite/atsign.db';
+  final rssBeforeOpen = ProcessInfo.currentRss;
+  final db = SqliteDatabase.open(benchAtSign, dbPath);
+
+  // --- seed: one transaction, one prepared statement. Produces rows byte-
+  //     identical to commitSync()'s, without 1e6 separate transactions. ---
+  final seedWatch = Stopwatch()..start();
+  db.raw.execute('BEGIN;');
+  final stmt = db.raw.prepare(
+      'INSERT INTO commit_log (atkey, commit_id, operation, op_time) '
+      'VALUES (?, ?, ?, ?);');
+  final now = DateTime.now().toUtc().millisecondsSinceEpoch;
+  for (var id = 1; id <= opts.entries; id++) {
+    stmt.execute([benchKey(id), id, _opFor(id, opts.entries).name, now]);
+  }
+  stmt.dispose();
+  db.raw.execute('COMMIT;');
+  db.raw.execute(
+      "UPDATE counters SET value = ? WHERE name = 'last_commit_id';",
+      [opts.entries]);
+  seedWatch.stop();
+
+  final log = SqliteAtCommitLog(db);
+  final rssAfterOpen = ProcessInfo.currentRss;
+  _assertSeeded(
+      'sqlite', log.entriesCount(), log.lastCommittedSequenceNumber(), opts);
+
+  // NB: not log.getSize() — SqliteAtCommitLog.getSize() returns bytes while
+  // the spec (and HiveBase.getSize) returns KB, so it over-reports 1024x.
+  stdout.writeln('sqlite | seeded ${opts.entries} entries in '
+      '${seedWatch.elapsedMilliseconds}ms  '
+      '(db file ${_mb(_dbBytes(dbPath))}, resident ${_mb(rssAfterOpen)})');
+
+  final out = <_Result>[];
+  out.add(_Result.startup('sqlite', 0, rssAfterOpen - rssBeforeOpen));
+
+  for (final probe in [false, true]) {
+    out.add(await _timeScenario(
+      backend: 'sqlite',
+      scenario: 'skipDeletes',
+      probeEventLoop: probe,
+      opts: opts,
+      scan: () => _drain(
+          log.iterate(
+              fromCommitId: opts.from + 1,
+              where: _whereFilter(
+                  skipDeletesUntil: opts.entries,
+                  latestCommitId: log.lastCommittedSequenceNumber())),
+          opts.page),
+    ));
+  }
+  out.add(await _timeScenario(
+    backend: 'sqlite',
+    scenario: 'reordered',
+    probeEventLoop: true,
+    opts: opts,
+    scan: () => _drain(
+        log.iterate(
+            fromCommitId: opts.from + 1,
+            where: _reorderedFilter(
+                skipDeletesUntil: opts.entries,
+                latestCommitId: log.lastCommittedSequenceNumber())),
+        opts.page),
+  ));
+  // Trunk's strategy: push skip-deletes into the query as a
+  // `NOT (operation = '-' ...)` filter over an EAGER select. Correct, and it
+  // stops the deletes being materialised into Dart -- but the plan is
+  // `SEARCH ... commit_log_commit_id (commit_id>?)`, a full walk of the log
+  // in SQLite's C layer, and select() still materialises the surviving rows.
+  // This replicates SqliteAtCommitLog.iterate as it stands on trunk.
+  out.add(await _timeScenario(
+    backend: 'sqlite:trunk',
+    scenario: 'skipDeletes',
+    probeEventLoop: true,
+    opts: opts,
+    scan: () async {
+      final latest = log.lastCommittedSequenceNumber();
+      final rows = db.raw.select(
+          'SELECT atkey, commit_id, operation, op_time FROM commit_log '
+          'WHERE commit_id >= ? AND NOT (operation = ? AND commit_id IS NOT NULL '
+          'AND commit_id <= ? AND commit_id <> ?) ORDER BY commit_id;',
+          [opts.from + 1, '-', opts.entries, latest ?? -1]);
+      final filter = _reorderedFilter(
+          skipDeletesUntil: opts.entries, latestCommitId: latest);
+      var visited = 0, returned = 0;
+      for (final row in rows) {
+        visited++;
+        final op = (row['operation'] as String) == '-'
+            ? CommitOp.DELETE
+            : CommitOp.UPDATE;
+        final entry = CommitEntry(row['atkey'] as String, op, null)
+          ..commitId = row['commit_id'] as int?;
+        if (filter(entry)) {
+          returned++;
+          if (returned >= opts.page) break;
+        }
+      }
+      return _ScanOutcome(visited, returned);
+    },
+  ));
+  // This branch's strategy: the same policy via iterate(skipDeletesUntil:),
+  // which now seeks the partial index instead of walking the log.
+  out.add(await _timeScenario(
+    backend: 'sqlite:partial-idx',
+    scenario: 'skipDeletes',
+    probeEventLoop: true,
+    opts: opts,
+    scan: () => _drain(
+        log.iterate(
+            fromCommitId: opts.from + 1,
+            where: _reorderedFilter(
+                skipDeletesUntil: opts.entries,
+                latestCommitId: log.lastCommittedSequenceNumber()),
+            skipDeletesUntil: opts.entries,
+            latestCommitId: log.lastCommittedSequenceNumber()),
+        opts.page),
+  ));
+  out.add(await _timeScenario(
+    backend: 'sqlite',
+    scenario: 'storeOnly',
+    probeEventLoop: false,
+    opts: opts,
+    scan: () => _drain(
+        log.iterate(fromCommitId: opts.from + 1, where: _countOnlyFilter),
+        opts.page),
+  ));
+  out.add(await _timeScenario(
+    backend: 'sqlite',
+    scenario: 'noSkipDeletes',
+    probeEventLoop: false,
+    opts: opts,
+    scan: () => _drain(
+        log.iterate(
+            fromCommitId: opts.from + 1,
+            where: _whereFilter(
+                skipDeletesUntil: null,
+                latestCommitId: log.lastCommittedSequenceNumber())),
+        opts.page),
+  ));
+
+  // --- the proposed ceiling: push skipDeletes + LIMIT into SQL, backed by
+  //     a partial index over non-DELETE rows. Measures what the backend
+  //     COULD do if AtCommitLog.iterate carried the hints. Not a proposal
+  //     to hand-roll SQL in the handler. ---
+  // commit_log_live is now created by SqliteSchema.apply on every open, so
+  // there is nothing to build here -- just confirm it is present.
+  final indexes = db.raw
+      .select("SELECT name FROM sqlite_master WHERE type = 'index' "
+          "AND tbl_name = 'commit_log';")
+      .map((r) => r['name'] as String)
+      .toSet();
+  if (!indexes.contains('commit_log_live')) {
+    throw StateError('schema did not create commit_log_live; found $indexes');
+  }
+
+  // Instrument integrity: a "pushdown" that silently falls back to a full
+  // index scan would report a plausible-looking number that means nothing.
+  // Assert the planner actually uses the partial index before timing it.
+  final plan = db.raw
+      .select('EXPLAIN QUERY PLAN '
+          'SELECT atkey, commit_id, operation, op_time FROM commit_log '
+          "WHERE commit_id >= ? AND operation <> '-' "
+          'ORDER BY commit_id LIMIT ?;', [opts.from + 1, opts.page])
+      .map((r) => r['detail'] as String)
+      .join(' | ');
+  if (!plan.contains('commit_log_live')) {
+    throw StateError('pushdown query does not use commit_log_live; '
+        'plan was: $plan');
+  }
+  stdout.writeln('sqlite | pushdown plan: $plan');
+
+  out.add(await _timeScenario(
+    backend: 'sqlite+pushdown',
+    scenario: 'skipDeletes',
+    probeEventLoop: false,
+    opts: opts,
+    scan: () async {
+      // Two index seeks, not one scan. An earlier version expressed the
+      // "always include the latest entry" exception as an OR inside this
+      // query -- which defeats the partial index entirely (the planner
+      // falls back to commit_log_commit_id and walks all 999k rows, which
+      // is what made this row read 238ms while reporting visited=1).
+      // EXPLAIN QUERY PLAN is asserted below so that cannot recur silently.
+      final rows = db.raw.select(
+          'SELECT atkey, commit_id, operation, op_time FROM commit_log '
+          "WHERE commit_id >= ? AND operation <> '-' "
+          'ORDER BY commit_id LIMIT ?;',
+          [opts.from + 1, opts.page]);
+      // The latest entry is included even when it is a DELETE, so the
+      // client can advance its watermark. A point lookup on the unique
+      // commit_id index, not a scan.
+      db.raw.select(
+          'SELECT atkey, commit_id, operation, op_time FROM commit_log '
+          'WHERE commit_id = ?;',
+          [opts.entries]);
+      var visited = 0, returned = 0;
+      for (final row in rows) {
+        visited++;
+        // The Dart-side filter still runs (key validation, regex, authz);
+        // it just no longer sees the rejected deletes.
+        final entry = CommitEntry(row['atkey'] as String, CommitOp.DELETE, null)
+          ..commitId = row['commit_id'] as int?;
+        if (_whereFilter(skipDeletesUntil: null, latestCommitId: null)(entry)) {
+          returned++;
+        }
+      }
+      return _ScanOutcome(visited, returned);
+    },
+  ));
+
+  db.close();
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// The filter and drain loop under study
+// ---------------------------------------------------------------------------
+
+/// Faithful copy of `whereFilter` from sync_progressive_verb_handler.dart
+/// :63-112, minus the enrollment check (see the file-level note). Counts
+/// every entry it inspects so the bench can report scan depth.
+int _entriesInspected = 0;
+
+/// The same predicate as [_whereFilter], with the cheap skipDeletes test
+/// hoisted ABOVE the expensive `AtKey.getKeyType` / `AtKey.fromString`
+/// validation.
+///
+/// Semantically identical for this decision: an entry rejected by
+/// skipDeletes and an entry rejected by key validation both return false.
+/// The only observable difference is that a skipped DELETE no longer emits
+/// the "invalid key in the commit log" warning — a logging change, not a
+/// behavioural one. Measured here so the reorder is a benchmarked
+/// proposal rather than an asserted one.
+bool Function(CommitEntry) _reorderedFilter({
+  required int? skipDeletesUntil,
+  required int? latestCommitId,
+  String? regex,
+}) {
+  return (CommitEntry entry) {
+    _entriesInspected++;
+    final atKey = entry.atKey;
+    if (atKey == null) return false;
+
+    if (skipDeletesUntil != null &&
+        entry.operation == CommitOp.DELETE &&
+        entry.commitId != null &&
+        entry.commitId! <= skipDeletesUntil &&
+        entry.commitId != latestCommitId) {
+      return false;
+    }
+
+    if (AtKey.getKeyType(atKey, enforceNameSpace: false) ==
+        KeyType.invalidKey) {
+      return false;
+    }
+    try {
+      AtKey.fromString(atKey);
+    } on InvalidSyntaxException catch (_) {
+      return false;
+    }
+
+    if (regex != null && regex.isNotEmpty && !RegExp(regex).hasMatch(atKey)) {
+      return false;
+    }
+
+    return true;
+  };
+}
+
+/// Rejects everything without parsing the atKey, so the resulting time is
+/// the store's own iteration cost (seek + row/entry materialization) with
+/// the handler's validation cost removed.
+bool _countOnlyFilter(CommitEntry entry) {
+  _entriesInspected++;
+  return false;
+}
+
+bool Function(CommitEntry) _whereFilter({
+  required int? skipDeletesUntil,
+  required int? latestCommitId,
+  String? regex,
+}) {
+  return (CommitEntry entry) {
+    _entriesInspected++;
+    final atKey = entry.atKey;
+    if (atKey == null) return false;
+
+    if (AtKey.getKeyType(atKey, enforceNameSpace: false) ==
+        KeyType.invalidKey) {
+      return false;
+    }
+    try {
+      AtKey.fromString(atKey);
+    } on InvalidSyntaxException catch (_) {
+      return false;
+    }
+
+    if (skipDeletesUntil != null &&
+        entry.operation == CommitOp.DELETE &&
+        entry.commitId != null &&
+        entry.commitId! <= skipDeletesUntil &&
+        entry.commitId != latestCommitId) {
+      return false;
+    }
+
+    if (regex != null &&
+        regex.isNotEmpty &&
+        !RegExp(regex).hasMatch(atKey)) {
+      return false;
+    }
+
+    return true;
+  };
+}
+
+/// Mirrors the stop condition of `prepareResponse` (:153): drain the
+/// stream, stop once [pageLimit] entries have been accepted. The stream
+/// is unbounded by design, so a filter that rejects everything runs it to
+/// completion.
+Future<_ScanOutcome> _drain(Stream<CommitEntry> stream, int pageLimit) async {
+  var returned = 0;
+  await for (final _ in stream) {
+    if (returned >= pageLimit) break;
+    returned++;
+  }
+  return _ScanOutcome(-1, returned); // visited filled in by the caller
+}
+
+class _ScanOutcome {
+  final int visited;
+  final int returned;
+  _ScanOutcome(this.visited, this.returned);
+}
+
+// ---------------------------------------------------------------------------
+// Timing + event-loop starvation probe
+// ---------------------------------------------------------------------------
+
+Future<_Result> _timeScenario({
+  required String backend,
+  required String scenario,
+  required bool probeEventLoop,
+  required _Options opts,
+  required Future<_ScanOutcome> Function() scan,
+}) async {
+  final samples = <int>[];
+  var maxStallMicros = 0;
+  var visited = 0, returned = 0;
+  var peakRss = 0;
+
+  for (var i = 0; i < opts.repeat; i++) {
+    _entriesInspected = 0;
+
+    Timer? probe;
+    var lastTick = Stopwatch()..start();
+    if (probeEventLoop) {
+      // If the scan starves the event loop, this 1ms timer cannot fire and
+      // the gap we observe is the length of the stall.
+      probe = Timer.periodic(const Duration(milliseconds: 1), (_) {
+        final gap = lastTick.elapsedMicroseconds;
+        if (gap > maxStallMicros) maxStallMicros = gap;
+        lastTick = Stopwatch()..start();
+      });
+      // Let the timer establish a baseline before the scan starts.
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      maxStallMicros = 0;
+      lastTick = Stopwatch()..start();
+    }
+
+    final watch = Stopwatch()..start();
+    final outcome = await scan();
+    watch.stop();
+    if (probe != null) {
+      // The probe cannot observe the stall it exists to detect unless the
+      // event loop gets a turn before we cancel: a starving scan resumes
+      // via a microtask, so an immediate cancel() kills the pending timer
+      // event before it is ever delivered. (First version of this bench
+      // reported max-stall 0.00ms for an 85ms blocking scan for exactly
+      // that reason.) Yield, let it fire once, then cancel.
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+      probe.cancel();
+    }
+
+    final rss = ProcessInfo.currentRss;
+    if (rss > peakRss) peakRss = rss;
+    samples.add(watch.elapsedMicroseconds);
+    visited = outcome.visited >= 0 ? outcome.visited : _entriesInspected;
+    returned = outcome.returned;
+  }
+
+  samples.sort();
+  return _Result(
+    backend: backend,
+    scenario: scenario,
+    probed: probeEventLoop,
+    medianMicros: samples[samples.length ~/ 2],
+    minMicros: samples.first,
+    maxMicros: samples.last,
+    visited: visited,
+    returned: returned,
+    maxStallMicros: probeEventLoop ? maxStallMicros : -1,
+    peakRss: peakRss,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Reporting
+// ---------------------------------------------------------------------------
+
+class _Result {
+  final String backend;
+  final String scenario;
+  final bool probed;
+  final int medianMicros, minMicros, maxMicros;
+  final int visited, returned, maxStallMicros, peakRss;
+  final bool isStartup;
+  final int startupRssDelta;
+
+  _Result({
+    required this.backend,
+    required this.scenario,
+    required this.probed,
+    required this.medianMicros,
+    required this.minMicros,
+    required this.maxMicros,
+    required this.visited,
+    required this.returned,
+    required this.maxStallMicros,
+    required this.peakRss,
+  })  : isStartup = false,
+        startupRssDelta = 0;
+
+  _Result.startup(this.backend, int millis, this.startupRssDelta)
+      : scenario = 'open+repair',
+        probed = false,
+        medianMicros = millis * 1000,
+        minMicros = millis * 1000,
+        maxMicros = millis * 1000,
+        visited = 0,
+        returned = 0,
+        maxStallMicros = -1,
+        peakRss = 0,
+        isStartup = true;
+}
+
+void _report(List<_Result> results, _Options opts) {
+  stdout.writeln('');
+  stdout.writeln('backend          scenario       probe  median      min         '
+      'max         visited    ret  max-stall   peak-rss');
+  stdout.writeln('-' * 118);
+  for (final r in results) {
+    if (r.isStartup) {
+      stdout.writeln('${r.backend.padRight(16)} ${r.scenario.padRight(14)} '
+          '${'-'.padRight(6)} ${_ms(r.medianMicros).padRight(11)} '
+          '${''.padRight(11)} ${''.padRight(11)} ${''.padRight(10)} '
+          '${''.padRight(4)} ${''.padRight(11)} '
+          '+${_mb(r.startupRssDelta)}');
+      continue;
+    }
+    stdout.writeln('${r.backend.padRight(16)} ${r.scenario.padRight(14)} '
+        '${(r.probed ? 'yes' : 'no').padRight(6)} '
+        '${_ms(r.medianMicros).padRight(11)} ${_ms(r.minMicros).padRight(11)} '
+        '${_ms(r.maxMicros).padRight(11)} '
+        '${r.visited.toString().padRight(10)} '
+        '${r.returned.toString().padRight(4)} '
+        '${(r.maxStallMicros < 0 ? '-' : _ms(r.maxStallMicros)).padRight(11)} '
+        '${_mb(r.peakRss)}');
+  }
+  stdout.writeln('');
+  stdout.writeln('probe=yes runs carry a 1ms Timer to detect event-loop '
+      'starvation; compare their median against the');
+  stdout.writeln('probe=no run of the same row to confirm the instrument is '
+      'not distorting the measurement.');
+}
+
+/// Size of the db plus its WAL, in bytes.
+int _dbBytes(String path) {
+  var total = 0;
+  for (final suffix in ['', '-wal']) {
+    final f = File('$path$suffix');
+    if (f.existsSync()) total += f.lengthSync();
+  }
+  return total;
+}
+
+String _ms(int micros) => '${(micros / 1000).toStringAsFixed(2)}ms';
+String _mb(int bytes) => '${(bytes / 1024 / 1024).toStringAsFixed(1)}MB';
+
+// ---------------------------------------------------------------------------
+// Setup helpers
+// ---------------------------------------------------------------------------
+
+/// All entries are DELETE except the last, which is the single entry the
+/// skipDeletes scan is hunting for.
+CommitOp _opFor(int id, int total) =>
+    id == total ? CommitOp.UPDATE : CommitOp.DELETE;
+
+/// Fail loudly if the synthetic key shape would be rejected by the very
+/// filter under test — otherwise the bench would "measure" a scan that
+/// rejects every entry for the wrong reason.
+void _assertKeyShapeIsValid() {
+  final sample = benchKey(42);
+  if (AtKey.getKeyType(sample, enforceNameSpace: false) ==
+      KeyType.invalidKey) {
+    throw StateError('bench key shape "$sample" is an invalid atKey');
+  }
+  AtKey.fromString(sample);
+}
+
+void _assertSeeded(String backend, int count, int? latest, _Options opts) {
+  if (count != opts.entries) {
+    throw StateError(
+        '$backend: expected ${opts.entries} entries, store reports $count');
+  }
+  if (latest != opts.entries) {
+    throw StateError(
+        '$backend: expected latest commitId ${opts.entries}, got $latest');
+  }
+}
+
+class _Options {
+  final int entries, from, page, repeat;
+  final String backend;
+  final bool keep;
+  final String? dir;
+
+  _Options(this.entries, this.from, this.page, this.repeat, this.backend,
+      this.keep, this.dir);
+
+  static _Options parse(List<String> argv) {
+    int intArg(String name, int fallback) {
+      final i = argv.indexOf('--$name');
+      if (i < 0) return fallback;
+      if (i + 1 >= argv.length) throw ArgumentError('--$name needs a value');
+      return int.parse(argv[i + 1]);
+    }
+
+    String? strArg(String name) {
+      final i = argv.indexOf('--$name');
+      if (i < 0) return null;
+      if (i + 1 >= argv.length) throw ArgumentError('--$name needs a value');
+      return argv[i + 1];
+    }
+
+    final backend = strArg('backend') ?? 'both';
+    if (!['hive', 'sqlite', 'both'].contains(backend)) {
+      throw ArgumentError('--backend must be hive|sqlite|both');
+    }
+    return _Options(
+      intArg('entries', 1000000),
+      intArg('from', 1000),
+      intArg('page', 25),
+      intArg('repeat', 3),
+      backend,
+      argv.contains('--keep'),
+      strArg('dir'),
+    );
+  }
+}

--- a/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_at_access_log.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_at_access_log.dart
@@ -99,10 +99,12 @@ class SqliteAtAccessLog implements AtAccessLog {
   int entriesCount() =>
       _db.raw.select('SELECT COUNT(*) c FROM access_log;').first['c'] as int;
 
+  /// Size in KB, matching the spec and the Hive stores -- this returned
+  /// raw bytes, over-reporting by 1024x.
   @override
   int getSize() {
     final f = File(_db.path);
-    return f.existsSync() ? f.lengthSync() : 0;
+    return f.existsSync() ? f.lengthSync() ~/ 1024 : 0;
   }
 
   @override

--- a/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_at_commit_log.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_at_commit_log.dart
@@ -100,31 +100,118 @@ class SqliteAtCommitLog extends AtCommitLog {
     int? skipDeletesUntil,
     int? latestCommitId,
   }) async* {
-    final conditions = <String>[];
+    if (skipDeletesUntil != null) {
+      yield* _iterateSkippingDeletes(
+          fromCommitId ?? 0, skipDeletesUntil, latestCommitId, where);
+      return;
+    }
+    final sql = StringBuffer(
+        'SELECT atkey, commit_id, operation, op_time FROM commit_log ');
     final params = <Object?>[];
     if (fromCommitId != null) {
-      conditions.add('commit_id >= ?');
+      sql.write('WHERE commit_id >= ? ');
       params.add(fromCommitId);
     }
-    if (skipDeletesUntil != null) {
-      // Push sync's delete-skip into the query so below-watermark DELETE
-      // rows are filtered by SQLite and never read into Dart. Keep the
-      // single latest entry so the client can still advance its watermark.
-      // ('-' is the DELETE operation symbol; see _opFromSymbol.)
-      conditions.add("NOT (operation = '-' AND commit_id IS NOT NULL "
-          'AND commit_id <= ? AND commit_id <> ?)');
-      params.add(skipDeletesUntil);
-      params.add(latestCommitId ?? -1);
-    }
-    final whereSql =
-        conditions.isEmpty ? '' : 'WHERE ${conditions.join(' AND ')} ';
-    final rows = _db.raw.select(
+    sql.write('ORDER BY commit_id;');
+    yield* _cursor(sql.toString(), params, where);
+  }
+
+  /// The skip-deletes traversal, expressed as index-driven range scans
+  /// rather than a `NOT (operation = '-' ...)` filter over the full
+  /// commit_id index.
+  ///
+  /// The `NOT (...)` form is correct but reads every row: its plan is
+  /// `SEARCH ... USING INDEX commit_log_commit_id (commit_id>?)`, which
+  /// seeks to [fromCommitId] and then walks to the end evaluating the
+  /// predicate on each row -- so a client near the tail of a
+  /// delete-dominated log still causes a walk of the whole log in SQLite's
+  /// C layer (it just no longer materialises the deletes into Dart). The
+  /// decomposition below lets the partial index `commit_log_live` seek
+  /// straight to the live rows instead. Measured on a 1M-entry log holding
+  /// one live entry: the full-scan form is ~0.5-0.6s, this is sub-ms.
+  ///
+  ///   segment 1  live rows in [from .. skipDeletesUntil]  -> commit_log_live
+  ///   kept       the entry at [latestCommitId], if that is a below-
+  ///              watermark DELETE (a live one is already in segment 1, an
+  ///              above-watermark one in segment 2)
+  ///   segment 2  every op with commit_id > skipDeletesUntil -> commit_log_commit_id
+  ///
+  /// Ordering: segment 1 ids are all <= skipDeletesUntil < segment 2 ids,
+  /// so the two segments are globally ascending without a sort step. The
+  /// kept entry only exists when `latestCommitId <= skipDeletesUntil`; a
+  /// truthful [latestCommitId] is the store's max commit id, so nothing
+  /// sits above it and segment 2 is empty whenever the kept entry fires --
+  /// it is therefore the largest id in the stream and emitting it between
+  /// the segments keeps the output ordered.
+  Stream<CommitEntry> _iterateSkippingDeletes(
+    int fromCommitId,
+    int skipDeletesUntil,
+    int? latestCommitId,
+    bool Function(CommitEntry)? where,
+  ) async* {
+    // segment 1
+    yield* _cursor(
+      'SELECT atkey, commit_id, operation, op_time FROM commit_log '
+      "WHERE commit_id >= ? AND commit_id <= ? AND operation <> '-' "
+      'ORDER BY commit_id;',
+      [fromCommitId, skipDeletesUntil],
+      where,
+    );
+    // kept latest entry (only when it is a skipped below-watermark DELETE;
+    // matching `operation = '-'` also avoids double-emitting a live entry
+    // that segment 1 already yielded)
+    if (latestCommitId != null &&
+        latestCommitId >= fromCommitId &&
+        latestCommitId <= skipDeletesUntil) {
+      yield* _cursor(
         'SELECT atkey, commit_id, operation, op_time FROM commit_log '
-        '${whereSql}ORDER BY commit_id;',
-        params);
-    for (final row in rows) {
-      final entry = _entryFromRow(row);
-      if (where == null || where(entry)) yield entry;
+        "WHERE commit_id = ? AND operation = '-';",
+        [latestCommitId],
+        where,
+      );
+    }
+    // segment 2 -- one lower bound only. Writing `commit_id >= from AND
+    // commit_id > skipDeletesUntil` makes SQLite seek on one bound and
+    // filter the other row-by-row (a plan that still reads "SEARCH ...
+    // USING INDEX" while walking the whole span), so collapse the two to
+    // their max here.
+    final lower = fromCommitId > skipDeletesUntil + 1
+        ? fromCommitId
+        : skipDeletesUntil + 1;
+    yield* _cursor(
+      'SELECT atkey, commit_id, operation, op_time FROM commit_log '
+      'WHERE commit_id >= ? ORDER BY commit_id;',
+      [lower],
+      where,
+    );
+  }
+
+  /// Streams [sql] lazily via a prepared cursor, applying [where] and
+  /// disposing the statement even if the consumer stops early.
+  ///
+  /// `select()` is eager -- it materialises the whole result set into a
+  /// Dart list before the first row is seen. Callers of iterate() routinely
+  /// stop early (sync's prepareResponse breaks after one page), so on a
+  /// large log the eager form allocated every row to return a handful; an
+  /// ordinary sync returning 25 entries measured 501ms this way against
+  /// 0.16ms on Hive. A cursor does work proportional to what is consumed.
+  Stream<CommitEntry> _cursor(
+    String sql,
+    List<Object?> params,
+    bool Function(CommitEntry)? where,
+  ) async* {
+    final stmt = _db.raw.prepare(sql);
+    try {
+      final cursor = stmt.selectCursor(params);
+      while (cursor.moveNext()) {
+        final entry = _entryFromRow(cursor.current);
+        if (where == null || where(entry)) yield entry;
+      }
+    } finally {
+      // Runs on early termination too: a consumer breaking its `await for`
+      // closes the stream, resuming this generator at the yield to unwind
+      // here, so the statement is never leaked.
+      stmt.dispose();
     }
   }
 
@@ -147,8 +234,10 @@ class SqliteAtCommitLog extends AtCommitLog {
   int entriesCount() =>
       _db.raw.select('SELECT COUNT(*) c FROM commit_log;').first['c'] as int;
 
+  /// Size in KB, matching the spec and [HiveBase.getSize] -- this returned
+  /// raw bytes, over-reporting by 1024x.
   @override
-  int getSize() => _dbFileSize(_db.path);
+  int getSize() => _dbFileSize(_db.path) ~/ 1024;
 
   @override
   Future<void> close() async {

--- a/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_at_notification_keystore.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_at_notification_keystore.dart
@@ -216,13 +216,15 @@ class SqliteAtNotificationKeystore implements AtNotificationKeystore {
   int entriesCount() =>
       _db.raw.select('SELECT COUNT(*) c FROM notifications;').first['c'] as int;
 
+  /// Size in KB, matching the spec and the Hive stores -- this returned
+  /// raw bytes, over-reporting by 1024x.
   @override
   int getSize() {
     final pageCount =
         _db.raw.select('PRAGMA page_count;').first.values.first as int? ?? 0;
     final pageSize =
         _db.raw.select('PRAGMA page_size;').first.values.first as int? ?? 0;
-    return pageCount * pageSize;
+    return pageCount * pageSize ~/ 1024;
   }
 
   @override

--- a/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_schema.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_schema.dart
@@ -51,6 +51,18 @@ CREATE TABLE IF NOT EXISTS commit_log (
 
   static const List<String> commitLogIndexes = [
     'CREATE UNIQUE INDEX IF NOT EXISTS commit_log_commit_id ON commit_log (commit_id);',
+    // Partial index over live (non-DELETE) entries, backing sync's
+    // skip-deletes range scan (see SqliteAtCommitLog._iterateSkippingDeletes).
+    // On a delete-dominated log this turns "walk every entry looking for the
+    // few live ones" into a seek over just the live ones; it costs little on
+    // a log with few deletes (it then largely mirrors commit_log_commit_id).
+    //
+    // No contract-version bump: an index is derived data, recreated here by
+    // IF NOT EXISTS on every open, so an existing database acquires it on the
+    // next start with no reshaping. Bumping would be actively harmful --
+    // apply() hard-fails on a database newer than the running server, so a
+    // bump would block rolling back to a server that reads this file fine.
+    "CREATE INDEX IF NOT EXISTS commit_log_live ON commit_log (commit_id) WHERE operation <> '-';",
   ];
 
   /// Monotonic allocators. `last_commit_id` is bumped in the same

--- a/packages/at_persistence_secondary_server/test/skip_deletes_pushdown_test.dart
+++ b/packages/at_persistence_secondary_server/test/skip_deletes_pushdown_test.dart
@@ -1,0 +1,212 @@
+import 'dart:io';
+
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_persistence_secondary_server/hive.dart';
+import 'package:at_persistence_secondary_server/sqlite.dart';
+import 'package:test/test.dart';
+
+/// `iterate(skipDeletesUntil: ...)` is an optimization hint: it must yield
+/// exactly what the caller's own predicate would have selected anyway. These
+/// tests pin that equivalence on BOTH backends, so a backend implementing
+/// the pushdown (SQLite) cannot silently diverge from one that ignores it
+/// (Hive).
+///
+/// The reference predicate is the one the sync handler applies -- see
+/// `whereFilter` in sync_progressive_verb_handler.dart.
+bool Function(CommitEntry) reference(int skipDeletesUntil, int? latest) {
+  return (e) => !(e.operation == CommitOp.DELETE &&
+      e.commitId != null &&
+      e.commitId! <= skipDeletesUntil &&
+      e.commitId != latest);
+}
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('skip_deletes_');
+  });
+
+  tearDown(() async {
+    if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+  });
+
+  /// Builds a log of [total] entries where every entry is a DELETE except
+  /// those whose 1-based position is in [liveAt].
+  Future<void> seed(AtCommitLog log, int total, Set<int> liveAt) async {
+    for (var i = 1; i <= total; i++) {
+      await log.commit('public:k$i@alice',
+          liveAt.contains(i) ? CommitOp.UPDATE : CommitOp.DELETE);
+    }
+  }
+
+  Future<AtCommitLog> hiveLog() async {
+    final f = HiveAtPersistenceFactory();
+    addTearDown(f.close);
+    final b = await f.initialize(
+      '@alice',
+      HivePersistenceConfig.serverDefaults(
+        storagePath: '${tempDir.path}/hive/storage',
+        commitLogPath: '${tempDir.path}/hive/commitLog',
+        accessLogPath: '${tempDir.path}/hive/accessLog',
+        notificationStoragePath: '${tempDir.path}/hive/notification',
+      ),
+    );
+    return b.keyValueStore.commitLog!;
+  }
+
+  Future<AtCommitLog> sqliteLog() async {
+    final f = SqliteAtPersistenceFactory();
+    addTearDown(f.close);
+    final b = await f.initialize(
+      '@alice',
+      SqlitePersistenceConfig.serverDefaults(
+          storagePath: '${tempDir.path}/sqlite'),
+    );
+    return b.keyValueStore.commitLog!;
+  }
+
+  for (final backend in ['hive', 'sqlite']) {
+    group('$backend: skipDeletesUntil pushdown equivalence', () {
+      Future<AtCommitLog> open() =>
+          backend == 'hive' ? hiveLog() : sqliteLog();
+
+      /// The property under test: passing the hint ALONGSIDE the caller's
+      /// predicate yields exactly what the predicate alone yields.
+      ///
+      /// Note both sides pass `where`. The hint is not a filter in its own
+      /// right -- a backend that ignores it (Hive) returns the unfiltered
+      /// stream, and only the caller's predicate makes the two agree. That
+      /// is the contract in AtCommitLog.iterate, and it is what the sync
+      /// handler does; a test that dropped `where` from the pushed side
+      /// would be asserting a property the contract never promised.
+      Future<void> expectEquivalent(
+        AtCommitLog log, {
+        required int skipDeletesUntil,
+        int? fromCommitId,
+      }) async {
+        final latest = log.lastCommittedSequenceNumber();
+        final pushed = await log
+            .iterate(
+                fromCommitId: fromCommitId,
+                where: reference(skipDeletesUntil, latest),
+                skipDeletesUntil: skipDeletesUntil,
+                latestCommitId: latest)
+            .toList();
+        final filtered = await log
+            .iterate(
+                fromCommitId: fromCommitId,
+                where: reference(skipDeletesUntil, latest))
+            .toList();
+        expect(pushed.map((e) => e.commitId).toList(),
+            filtered.map((e) => e.commitId).toList(),
+            reason: 'the hint must not change which entries are selected');
+        expect(pushed.map((e) => e.atKey).toList(),
+            filtered.map((e) => e.atKey).toList());
+      }
+
+      test('delete-dominated log, single live entry at the end', () async {
+        final log = await open();
+        await seed(log, 40, {40});
+        await expectEquivalent(log, skipDeletesUntil: 40);
+      });
+
+      test('live entries scattered through the log', () async {
+        final log = await open();
+        await seed(log, 40, {3, 17, 18, 39});
+        await expectEquivalent(log, skipDeletesUntil: 40);
+      });
+
+      test('threshold below the max leaves later deletes intact', () async {
+        final log = await open();
+        await seed(log, 40, {5});
+        await expectEquivalent(log, skipDeletesUntil: 20);
+      });
+
+      test('combines with fromCommitId', () async {
+        final log = await open();
+        await seed(log, 40, {5, 33});
+        await expectEquivalent(log, skipDeletesUntil: 40, fromCommitId: 10);
+      });
+
+      test('all entries are deletes: latest is still yielded so the '
+          'client can advance its watermark', () async {
+        final log = await open();
+        await seed(log, 12, {});
+        final latest = log.lastCommittedSequenceNumber()!;
+        final selected = await log
+            .iterate(
+                where: reference(latest, latest),
+                skipDeletesUntil: latest,
+                latestCommitId: latest)
+            .toList();
+        expect(selected.map((e) => e.commitId), [latest],
+            reason: 'exactly the latest entry, even though it is a DELETE');
+        await expectEquivalent(log, skipDeletesUntil: latest);
+      });
+
+      test('threshold above the max still yields the latest entry', () async {
+        final log = await open();
+        await seed(log, 12, {});
+        final latest = log.lastCommittedSequenceNumber()!;
+        await expectEquivalent(log, skipDeletesUntil: latest + 5000);
+      });
+
+      test('empty log yields nothing', () async {
+        final log = await open();
+        expect(
+            await log
+                .iterate(where: reference(100, null), skipDeletesUntil: 100)
+                .toList(),
+            isEmpty);
+      });
+
+      test('no deletes at all: every entry survives', () async {
+        final log = await open();
+        await seed(log, 10, {for (var i = 1; i <= 10; i++) i});
+        await expectEquivalent(log, skipDeletesUntil: 10);
+      });
+    });
+  }
+
+  group('sqlite: the pushdown actually uses the partial index', () {
+    test('skip-deletes range scan is planned on commit_log_live', () async {
+      final db = SqliteDatabase.open('@alice', '${tempDir.path}/plan.db');
+      addTearDown(db.close);
+      final plan = db.raw
+          .select('EXPLAIN QUERY PLAN '
+              'SELECT atkey, commit_id, operation, op_time FROM commit_log '
+              "WHERE commit_id >= ? AND commit_id <= ? AND operation <> '-' "
+              'ORDER BY commit_id;', [1, 100])
+          .map((r) => r['detail'] as String)
+          .join(' | ');
+      // Without this the pushdown still returns correct rows, but degrades
+      // to a full scan -- correct and slow, which no equivalence test above
+      // would catch.
+      expect(plan, contains('commit_log_live'),
+          reason: 'plan was: $plan');
+    });
+
+    test('an existing database acquires the index on open, with no '
+        'contract-version bump', () async {
+      final path = '${tempDir.path}/existing.db';
+      final first = SqliteDatabase.open('@alice', path);
+      final version = first.raw.select('PRAGMA user_version;').first.values.first;
+      first.raw.execute('DROP INDEX IF EXISTS commit_log_live;');
+      first.close();
+
+      final reopened = SqliteDatabase.open('@alice', path);
+      addTearDown(reopened.close);
+      final indexes = reopened.raw
+          .select("SELECT name FROM sqlite_master WHERE type = 'index' "
+              "AND tbl_name = 'commit_log';")
+          .map((r) => r['name'] as String)
+          .toSet();
+      expect(indexes, contains('commit_log_live'));
+      expect(reopened.raw.select('PRAGMA user_version;').first.values.first,
+          version,
+          reason: 'an index addition must not bump the contract version, '
+              'which would block rollback');
+    });
+  });
+}


### PR DESCRIPTION
**- What I did**

Follow-up to the query-level skip-deletes shipped in 5.2.1 (#18f83203). That change stopped below-watermark DELETE rows being materialised into Dart, but its `NOT (operation = '-' ...)` predicate still makes SQLite walk the whole commit_id index in its C layer, so a client near the head of a delete-dominated log pays a full-log scan.

- Add a partial index `commit_log_live` over non-DELETE rows and express the SQLite skip-deletes traversal as index-driven range scans over it (live segment + kept-latest point lookup + above-watermark segment), instead of a filter over the full index.
  - **~253ms → ~0.2ms** on a 1M-entry log holding one live entry (measured; trunk's strategy vs this one, identical data — see the bench's `sqlite:trunk` vs `sqlite:partial-idx` rows).
- `SqliteAtCommitLog.iterate` streams via a prepared cursor instead of an eager `select()` that materialised the full result set before the first row — ordinary `sync` returning 25 entries on a 1M log **~500ms → sub-ms**.
- fix: `getSize()` on the SQLite commit-log/access-log/notification stores returned bytes; the spec and Hive stores return KB. All three now return KB (had over-reported 1024x).
- No schema `user_version` bump: the index is `CREATE INDEX IF NOT EXISTS` on open, so existing DBs acquire it on next start and rollback is unaffected.

**- How I did it**

See commit & diffs. Handler and Hive path unchanged — this is entirely inside the SQLite backend plus the shared schema.

**- How to verify it**

Tests pass (`dart test --concurrency=1`): 318 in at_persistence_secondary_server incl. 18 new equivalence/plan tests, 55 sync tests in at_secondary_server. The new `skip_deletes_pushdown_test.dart` pins pushed-vs-filtered equivalence on both backends and asserts the plan uses `commit_log_live`.

**- Description for the changelog**

perf: SQLite sync skip-deletes now seeks a partial index instead of scanning the full commit log; iterate streams via a cursor rather than materialising all rows; getSize returns KB not bytes.