### PR TITLE
superseded by #2739

### DIFF
--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,4 +1,17 @@
 # 3.15.1
+- feat: PKAM verification accepts `signingAlgo:mldsa65`. Without the branch a
+  post-quantum APKAM keypair fell through to the RSA default and could never
+  authenticate at all — the signature was well formed, just interpreted under
+  the wrong algorithm.
+- feat: for an APKAM-authenticated connection, the signing algorithm is now
+  read from the **enrollment record** rather than restated by the client on
+  each connect. It is hardening rather than a fix: the signature is checked
+  against the stored public key either way, so a client that misstates the
+  algorithm only fails its own verification. What it closes off is
+  cross-algorithm confusion, where one key blob parses under more than one
+  algorithm. Legacy PKAM has no enrollment record to be authoritative about and
+  may legitimately present `ecc_secp256r1`, so it continues to use the value on
+  the wire; a legacy enrollment predating the field keeps the existing default.
 - feat: augmented pol challenge
 - perf: sync now pushes `skipDeletesUntil` into the commit-log query rather than
   filtering deletes out of the results. `SyncProgressiveVerbHandler` passed

--- a/packages/at_secondary_server/lib/src/verb/handler/pkam_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/pkam_verb_handler.dart
@@ -18,6 +18,7 @@ class PkamVerbHandler extends AbstractVerbHandler {
   static Pkam pkam = Pkam();
   static const String _eccAlgo = 'ecc_secp256r1';
   static const String _rsa2048Algo = 'rsa2048';
+  static const String _mlDsa65Algo = 'mldsa65';
   static const String _sha256 = 'sha256';
   static const String _sha512 = 'sha512';
   AtChops? atChops;
@@ -43,6 +44,9 @@ class PkamVerbHandler extends AbstractVerbHandler {
     var atSign = AtSecondaryServerImpl.getInstance().currentAtSign;
     AuthType pkamAuthType;
     String? publicKey;
+    // Legacy PKAM has no enrollment record to be authoritative about, and may
+    // legitimately present ecc_secp256r1, so it goes on using the wire value.
+    String? recordSigningAlgo;
 
     // Use APKAM public key for verification if enrollId is passed.
     // Otherwise use legacy pkam public key.
@@ -57,6 +61,15 @@ class PkamVerbHandler extends AbstractVerbHandler {
         return;
       }
       publicKey = apkamResult.publicKey;
+      // Record-authoritative: an APKAM keypair's algorithm is a property of
+      // the enrollment it was registered under, not something the client
+      // restates on each connect. Hardening rather than a fix — the signature
+      // is checked against the stored public key either way, so a client that
+      // misstates the algorithm only fails its own verification — but it
+      // closes off cross-algorithm confusion, where one key blob parses under
+      // more than one algorithm. A legacy enrollment predating the field has
+      // none recorded, so it keeps the existing default.
+      recordSigningAlgo = apkamResult.signingAlgo;
     } else {
       pkamAuthType = AuthType.pkamLegacy;
       var publicKeyData = await keyStore.get(AtConstants.atPkamPublicKey);
@@ -73,6 +86,7 @@ class PkamVerbHandler extends AbstractVerbHandler {
       sessionID,
       atSign,
       publicKey,
+      recordSigningAlgo,
       storedSecretId,
     );
 
@@ -121,6 +135,7 @@ class PkamVerbHandler extends AbstractVerbHandler {
       return apkamResult;
     }
     apkamResult.publicKey = enVal.apkamPublicKey;
+    apkamResult.signingAlgo = enVal.signingAlgo;
     return apkamResult;
   }
 
@@ -155,15 +170,22 @@ class PkamVerbHandler extends AbstractVerbHandler {
     return response;
   }
 
+  /// [recordSigningAlgo] is the algorithm recorded on the enrollment, when
+  /// this connection authenticates as one. It wins over whatever the wire
+  /// says, so the client stops choosing how its own signature is interpreted.
+  /// Null for legacy PKAM — there is no record — in which case the wire value
+  /// still decides, as it always has.
   Future<bool> _validateSignature(
     var verbParams,
     var sessionId,
     String atSign,
     String publicKey,
+    String? recordSigningAlgo,
     String storedSecretId,
   ) async {
     var signature = verbParams[AtConstants.atPkamSignature]!;
-    var signingAlgo = verbParams[AtConstants.atPkamSigningAlgo];
+    var signingAlgo =
+        recordSigningAlgo ?? verbParams[AtConstants.atPkamSigningAlgo];
     var hashingAlgo = verbParams[AtConstants.atPkamHashingAlgo];
     bool isValidSignature = false;
     var storedSecretData = await keyStore.get(storedSecretId);
@@ -204,9 +226,13 @@ class PkamVerbHandler extends AbstractVerbHandler {
     logger.finer('signingAlgo: $signingAlgo');
     if (signingAlgo == _eccAlgo) {
       return SigningAlgoType.ecc_secp256r1;
-      // inputSignature = Uint8List.fromList(signature.codeUnits);
     } else if (signingAlgo == _rsa2048Algo) {
       return SigningAlgoType.rsa2048;
+    } else if (signingAlgo == _mlDsa65Algo) {
+      // Without this branch a post-quantum APKAM keypair falls through to the
+      // RSA default below and can never authenticate at all — the signature is
+      // well-formed, just interpreted under the wrong algorithm.
+      return SigningAlgoType.mldsa65;
     }
     return SigningAlgoType.rsa2048;
   }
@@ -226,4 +252,8 @@ class PkamVerbHandler extends AbstractVerbHandler {
 class ApkamVerificationResult {
   Response response = Response();
   String? publicKey;
+
+  /// The signing algorithm recorded on the enrollment, which is what
+  /// [publicKey] actually is. Null on a legacy enrollment predating the field.
+  String? signingAlgo;
 }


### PR DESCRIPTION
**- What I did**

- Added the `mldsa65` branch to PKAM signature verification. Without it a post-quantum APKAM keypair could never authenticate: an unrecognised `signingAlgo` fell through to the RSA default, so a well-formed signature over a correct public key was simply interpreted under the wrong algorithm.
- Made an APKAM-authenticated connection take its signing algorithm from the **enrollment record** rather than from whatever the client restates on each connect.
  - Hardening, not a fix — the signature is checked against the stored public key either way, so a client that misstates the algorithm only fails its own verification and cannot downgrade anything. What it closes off is cross-algorithm confusion, where one key blob parses under more than one algorithm.
- Left legacy PKAM reading the value from the wire. It has no enrollment record to be authoritative about, and the functional suite authenticates over that path with an `ecc_secp256r1` key — so pinning it to `rsa2048` would have broken working behaviour rather than tightened anything. A legacy enrollment predating the `signingAlgo` field records none and keeps the existing default.

**- How I did it**

See commit & diffs.

**- How to verify it**

Tests pass. `enroll_verb_test.dart` is green (87), and the `at_client_sdk` functional pack runs green (104) against an atServer built from this branch — every enrollment test there authenticates over the APKAM path this changes.

**- Description for the changelog**

PKAM verification accepts `signingAlgo:mldsa65`, and an APKAM connection's signing algorithm is read from its enrollment record rather than from the wire. Legacy PKAM is unchanged.

---

Part of the PQ programme's **SS-3**; the rulings behind it are recorded in `at_client_sdk` `docs/projects/pq/decisions.md` section 21.
