### PR TITLE
feat(pq): post-quantum enrollment — self-enrollment, ML-DSA PKAM, and expiry bounds

### DIFF
--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -3,6 +3,19 @@
 - fix: defensive code to properly handle a namespace named 'null'
 - fix: scope namespace-less keys to the legacy shared_key forms
 - fix: restrict config:block to root enrollments
+- feat: PKAM verification accepts `signingAlgo:mldsa65`. Without the branch a
+  post-quantum APKAM keypair fell through to the RSA default and could never
+  authenticate at all — the signature was well formed, just interpreted under
+  the wrong algorithm.
+- feat: for an APKAM-authenticated connection, the signing algorithm is now
+  read from the **enrollment record** rather than restated by the client on
+  each connect. It is hardening rather than a fix: the signature is checked
+  against the stored public key either way, so a client that misstates the
+  algorithm only fails its own verification. What it closes off is
+  cross-algorithm confusion, where one key blob parses under more than one
+  algorithm. Legacy PKAM has no enrollment record to be authoritative about and
+  may legitimately present `ecc_secp256r1`, so it continues to use the value on
+  the wire; a legacy enrollment predating the field keeps the existing default.
 - feat: augmented pol challenge
 - perf: sync now pushes `skipDeletesUntil` into the commit-log query rather than
   filtering deletes out of the results. `SyncProgressiveVerbHandler` passed

--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 3.15.1
+# 3.16.0
 - fix: deny, not throw, on an unparseable atKey in authz
 - fix: defensive code to properly handle a namespace named 'null'
 - fix: scope namespace-less keys to the legacy shared_key forms

--- a/packages/at_secondary_server/lib/src/enroll/enroll_datastore_value.dart
+++ b/packages/at_secondary_server/lib/src/enroll/enroll_datastore_value.dart
@@ -29,6 +29,18 @@ class EnrollDataStoreValue {
   /// `mldsa65` (PQ). Recorded so PKAM verification can be record-authoritative.
   String? signingAlgo;
 
+  /// The enrollment whose authenticated connection self-spawned this one
+  /// (RF-SRV), or null for every other origin.
+  ///
+  /// Recorded so revocation can CASCADE: self-enrollment makes enrollments a
+  /// parent/child graph, and a stolen keyfile can spawn a child before the
+  /// theft is noticed — a child that survives its parent's revocation would
+  /// defeat revocation via the very feature that created it
+  /// (at_client_sdk docs/projects/pq/decisions.md 40). The cascade itself is
+  /// the revoke path's to implement; this field is what makes it possible on
+  /// records that already exist by then.
+  String? parentEnrollmentId;
+
   EnrollDataStoreValue(
       this.sessionId, this.appName, this.deviceName, this.apkamPublicKey);
 

--- a/packages/at_secondary_server/lib/src/enroll/enroll_datastore_value.g.dart
+++ b/packages/at_secondary_server/lib/src/enroll/enroll_datastore_value.g.dart
@@ -25,7 +25,8 @@ EnrollDataStoreValue _$EnrollDataStoreValueFromJson(
       ..apkamKeysExpiryDuration =
           Duration(milliseconds: json['apkamKeysExpiryInMillis'] ?? 0)
       ..metadata = (json['metadata'] as Map<String, dynamic>?)
-      ..signingAlgo = json['signingAlgo'] as String?;
+      ..signingAlgo = json['signingAlgo'] as String?
+      ..parentEnrollmentId = json['parentEnrollmentId'] as String?;
 
 Map<String, dynamic> _$EnrollDataStoreValueToJson(
         EnrollDataStoreValue instance) =>
@@ -42,6 +43,8 @@ Map<String, dynamic> _$EnrollDataStoreValueToJson(
           instance.apkamKeysExpiryDuration.inMilliseconds,
       if (instance.metadata != null) 'metadata': instance.metadata,
       if (instance.signingAlgo != null) 'signingAlgo': instance.signingAlgo,
+      if (instance.parentEnrollmentId != null)
+        'parentEnrollmentId': instance.parentEnrollmentId,
     };
 
 const _$EnrollRequestTypeEnumMap = {

--- a/packages/at_secondary_server/lib/src/server/at_secondary_config.dart
+++ b/packages/at_secondary_server/lib/src/server/at_secondary_config.dart
@@ -757,7 +757,8 @@ class AtSecondaryConfig {
   /// the window recovers via an ordinary OTP enrollment.
   static int get apkamSelfEnrollmentGraceHours {
     return _getIntEnvVar('apkamSelfEnrollmentGraceHours') ??
-        getNullableIntFromYaml(['enrollment', 'apkamSelfEnrollmentGraceHours']) ??
+        getNullableIntFromYaml(
+            ['enrollment', 'apkamSelfEnrollmentGraceHours']) ??
         720;
   }
 

--- a/packages/at_secondary_server/lib/src/server/at_secondary_config.dart
+++ b/packages/at_secondary_server/lib/src/server/at_secondary_config.dart
@@ -750,10 +750,11 @@ class AtSecondaryConfig {
   /// WITHOUT being removed, so sibling clones of the same keyfile can still
   /// retrofit until the cap elapses.
   ///
-  /// The default is deliberately generous: cloned keyfiles upgrade on
-  /// schedules measured in whenever-each-device-next-runs, and a short grace
-  /// strands the laggards (at_client_sdk docs/projects/pq/decisions.md 41
-  /// item 3 — the value is still to be ratified).
+  /// The default (30 days) is deliberately generous, and the cap RE-ARMS on
+  /// every sibling retrofit: cloned keyfiles upgrade on schedules measured in
+  /// whenever-each-device-next-runs, so the parent retires one grace period
+  /// after the LAST clone upgrades, not the first. A laggard stranded past
+  /// the window recovers via an ordinary OTP enrollment.
   static int get apkamSelfEnrollmentGraceHours {
     return _getIntEnvVar('apkamSelfEnrollmentGraceHours') ??
         getNullableIntFromYaml(['enrollment', 'apkamSelfEnrollmentGraceHours']) ??

--- a/packages/at_secondary_server/lib/src/server/at_secondary_config.dart
+++ b/packages/at_secondary_server/lib/src/server/at_secondary_config.dart
@@ -744,6 +744,22 @@ class AtSecondaryConfig {
         48;
   }
 
+  /// How long a parent enrollment keeps authenticating after one of its
+  /// APKAM-authenticated connections self-enrolls a fresh enrollment
+  /// (RF-SRV). The parent is capped to `min(now + this, its existing expiry)`
+  /// WITHOUT being removed, so sibling clones of the same keyfile can still
+  /// retrofit until the cap elapses.
+  ///
+  /// The default is deliberately generous: cloned keyfiles upgrade on
+  /// schedules measured in whenever-each-device-next-runs, and a short grace
+  /// strands the laggards (at_client_sdk docs/projects/pq/decisions.md 41
+  /// item 3 — the value is still to be ratified).
+  static int get apkamSelfEnrollmentGraceHours {
+    return _getIntEnvVar('apkamSelfEnrollmentGraceHours') ??
+        getNullableIntFromYaml(['enrollment', 'apkamSelfEnrollmentGraceHours']) ??
+        720;
+  }
+
   static final int _enrollmentResponseDelayIntervalInSeconds = 55;
 
   static int? _maxEnrollRequestsAllowed;

--- a/packages/at_secondary_server/lib/src/server/persistence_backend.dart
+++ b/packages/at_secondary_server/lib/src/server/persistence_backend.dart
@@ -59,7 +59,8 @@ class PersistenceBackendMarker {
   static PersistenceBackendMarker? read(String path) {
     final file = File(path);
     if (!file.existsSync()) return null;
-    return fromJson(jsonDecode(file.readAsStringSync()) as Map<String, dynamic>);
+    return fromJson(
+        jsonDecode(file.readAsStringSync()) as Map<String, dynamic>);
   }
 
   /// Writes the marker to [path] (creating parent dirs).
@@ -161,9 +162,9 @@ class PersistenceBackendManager {
     final currentBackend = marker?.activeBackend ?? hive;
     if (currentBackend == targetBackend) return;
 
-    _logger.warning(
-        'Persistence backend change for $atSign: $currentBackend -> '
-        '$targetBackend. Migrating (abort-on-failure)...');
+    _logger
+        .warning('Persistence backend change for $atSign: $currentBackend -> '
+            '$targetBackend. Migrating (abort-on-failure)...');
 
     final sourceFactory = factoryFor(currentBackend);
     final targetFactory = factoryFor(targetBackend);
@@ -203,8 +204,7 @@ class PersistenceBackendManager {
         migratedAt: DateTime.now(),
       ),
     );
-    _logger.warning(
-        'Persistence backend for $atSign is now $targetBackend '
+    _logger.warning('Persistence backend for $atSign is now $targetBackend '
         '(previous $currentBackend data retained).');
   }
 

--- a/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
@@ -387,6 +387,26 @@ class EnrollVerbHandler extends AbstractVerbHandler {
         enrollmentValue.apkamKeysExpiryDuration =
             parent.apkamKeysExpiryDuration;
       }
+      // A stated posture may narrow the parent's, never widen it.
+      // `verifyNoEscalation` covers namespaces; TIME is the other axis a
+      // stolen keyfile would want to widen, and this branch is the one
+      // enrollment path with no human in the loop to notice. Zero is the
+      // keystore's "never expires" and a negative value skips the ttl write
+      // altogether, so both are ways of asking for a permanent credential —
+      // against a time-bound parent, neither is honoured.
+      final parentExpiryMs = parent.apkamKeysExpiryDuration.inMilliseconds;
+      final statedExpiryMs =
+          enrollmentValue.apkamKeysExpiryDuration.inMilliseconds;
+      if (statedExpiryMs < 0 ||
+          (parentExpiryMs > 0 &&
+              (statedExpiryMs <= 0 || statedExpiryMs > parentExpiryMs))) {
+        logger.warning(
+            'Self-enrollment under $parentEnrollmentId asked for a key-expiry '
+            'of ${statedExpiryMs}ms against a parent bound to '
+            '${parentExpiryMs}ms; using the parent\'s');
+        enrollmentValue.apkamKeysExpiryDuration =
+            parent.apkamKeysExpiryDuration;
+      }
       // May be absent: a PQ self-enrollment conveys its legacy material
       // client-side, sealed to its own new key package.
       enrollmentValue.encryptedAPKAMSymmetricKey =
@@ -397,8 +417,17 @@ class EnrollVerbHandler extends AbstractVerbHandler {
       await _publishApskSigningKey(
           newEnrollmentId, enrollParams.apkamPublicKey!, currentAtSign,
           signingAlgo: enrollmentValue.signingAlgo);
-      await enMgr.put(newEnrollmentId,
-          AtData()..data = jsonEncode(enrollmentValue.toJson()),
+      // The child's record expires per its (inherited or stated) key-expiry
+      // posture, exactly as the ordinary approve path writes it — the
+      // retrofit copies the parent's expiry, it does not grant immortality.
+      // A ttl of zero is the keystore's "never expires", matching a parent
+      // with no posture.
+      await enMgr.put(
+          newEnrollmentId,
+          AtData()
+            ..data = jsonEncode(enrollmentValue.toJson())
+            ..metaData = (AtMetaData()
+              ..ttl = enrollmentValue.apkamKeysExpiryDuration.inMilliseconds),
           EnrollmentStatus.approved);
 
       // Cap the parent WITHOUT removing it, re-arming the cap on every

--- a/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
@@ -334,7 +334,8 @@ class EnrollVerbHandler extends AbstractVerbHandler {
           skipCommit: true);
       // Keep the enrollment's `_apsk` signing key present for verifiers.
       await _publishApskSigningKey(
-          newEnrollmentId, enrollParams.apkamPublicKey!, currentAtSign);
+          newEnrollmentId, enrollParams.apkamPublicKey!, currentAtSign,
+          signingAlgo: enrollmentValue.signingAlgo);
       AtData enrollData = AtData()..data = jsonEncode(enrollmentValue.toJson());
 
       await enMgr.put(newEnrollmentId, enrollData, EnrollmentStatus.approved);
@@ -394,7 +395,8 @@ class EnrollVerbHandler extends AbstractVerbHandler {
 
       // Keep the enrollment's `_apsk` signing key present for verifiers.
       await _publishApskSigningKey(
-          newEnrollmentId, enrollParams.apkamPublicKey!, currentAtSign);
+          newEnrollmentId, enrollParams.apkamPublicKey!, currentAtSign,
+          signingAlgo: enrollmentValue.signingAlgo);
       await enMgr.put(newEnrollmentId,
           AtData()..data = jsonEncode(enrollmentValue.toJson()),
           EnrollmentStatus.approved);
@@ -577,7 +579,8 @@ class EnrollVerbHandler extends AbstractVerbHandler {
     if (operation == 'approve') {
       await _storeEncryptionKeys(enId, enrollParams, enVal);
       // Keep the enrollment's `_apsk` signing key present for verifiers.
-      await _publishApskSigningKey(enId, enVal.apkamPublicKey, currentAtSign);
+      await _publishApskSigningKey(enId, enVal.apkamPublicKey, currentAtSign,
+          signingAlgo: enVal.signingAlgo);
     }
     responseJson['enrollmentId'] = enId;
   }
@@ -667,10 +670,25 @@ class EnrollVerbHandler extends AbstractVerbHandler {
   /// can reach it via plookup. Idempotent: a re-publish is a harmless overwrite
   /// with the same value.
   Future<void> _publishApskSigningKey(
-      String enrollmentId, String apkamPublicKey, currentAtSign) async {
+      String enrollmentId, String apkamPublicKey, currentAtSign,
+      {String? signingAlgo}) async {
     final apskKey = 'public:_apsk.$enrollmentId'
         '.${EnrollmentConstants.perEnrollmentApproved}$currentAtSign';
-    await keyStore.put(apskKey, AtData()..data = apkamPublicKey);
+    // A legacy (rsa2048) enrollment publishes the bare value exactly as
+    // today, since deployed apps parse it as an RSA key. Any other algorithm
+    // publishes the tagged, self-describing form composed from the
+    // enrollment record's own (apkamPublicKey, signingAlgo) — the record
+    // PKAM reads stays the single source. The tagged shape is unmistakable
+    // to a bare-RSA parser: base64-decoding JSON throws, so an old consumer
+    // fails loudly rather than mis-reading the key.
+    final String value;
+    if (signingAlgo == null || signingAlgo == 'rsa2048') {
+      value = apkamPublicKey;
+    } else {
+      value = jsonEncode(
+          {'v': 1, 'signingAlgo': signingAlgo, 'publicKey': apkamPublicKey});
+    }
+    await keyStore.put(apskKey, AtData()..data = value);
   }
 
   EnrollmentStatus _getEnrollStatusEnum(String? enrollmentOperation) {

--- a/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
@@ -767,8 +767,16 @@ class EnrollVerbHandler extends AbstractVerbHandler {
         }
 
         if (enrollParams.otp != null) {
-          //encryptedAPKAMSymmetricKey is mandatory for new client enrollments
-          if (enrollParams.encryptedAPKAMSymmetricKey.isNullOrEmpty) {
+          // encryptedAPKAMSymmetricKey is mandatory for new client enrollments,
+          // except when the request advertises a key package. Such a client
+          // never generates the symmetric key: the approver mints it and
+          // encapsulates it to the advertised public half, so the request has
+          // no RSA-wrapped secret to carry. Absence alongside a key package is
+          // therefore the signal that conveyance is expected, and the field
+          // stays mandatory for every other client so a legacy one still fails
+          // here rather than enrolling into a state it cannot decrypt.
+          if (enrollParams.encryptedAPKAMSymmetricKey.isNullOrEmpty &&
+              enrollParams.metadata?['keyPackage'] == null) {
             throw IllegalArgumentException(
                 'encrypted apkam symmetric key is mandatory for new client enroll:request');
           }

--- a/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
@@ -269,15 +269,22 @@ class EnrollVerbHandler extends AbstractVerbHandler {
       }
     }
 
-    if (atConnection.metaData.authType != AuthType.cram) {
-      // If this is not a CRAM-authenticated connection, then we need to ensure
-      // that there is not an existing enrollment with the same info.
-      await preventDuplicateEnrollRequest(enrollParams);
-    } else {
-      // However, if it is a CRAM-authenticated connection, then we should
-      // allow a 'duplicate' enrollment request. See #2208
+    if (atConnection.metaData.authType == AuthType.cram) {
+      // A CRAM-authenticated connection is allowed a 'duplicate' enrollment
+      // request. See #2208
       logger.warning('CRAM-authenticated connection - i.e. initial enrollment;'
           ' will replace the existing initial enrollment, if any');
+    } else if (atConnection.metaData.authType == AuthType.apkam) {
+      // An APKAM self-enrollment keeps its app's own (appName, deviceName):
+      // a retrofit is the same app re-enrolling itself, and sibling clones of
+      // one keyfile share those names, each needing to coexist with the
+      // approved enrollments the others already spawned. Uniqueness of
+      // (appName, deviceName) among live enrollments therefore ends on this
+      // branch by design.
+    } else {
+      // Every other connection must not duplicate an existing enrollment's
+      // (appName, deviceName).
+      await preventDuplicateEnrollRequest(enrollParams);
     }
 
     var enrollNamespaces = enrollParams.namespaces ?? {};
@@ -392,12 +399,11 @@ class EnrollVerbHandler extends AbstractVerbHandler {
           AtData()..data = jsonEncode(enrollmentValue.toJson()),
           EnrollmentStatus.approved);
 
-      // Cap the parent to min(now + grace, its existing expiry) WITHOUT
-      // removing it. The grace default is deliberately generous — cloned
-      // keyfiles upgrade whenever each device next runs, and a short grace
-      // strands the laggards; the value is to-define (at_client_sdk
-      // docs/projects/pq/decisions.md 41 item 3).
-      await _capEnrollmentExpiry(parentEnrollmentId);
+      // Cap the parent WITHOUT removing it, re-arming the cap on every
+      // sibling retrofit: the legacy credential retires one grace period
+      // after the LAST clone upgrades, never past the expiry its own
+      // posture already imposes.
+      await _capEnrollmentExpiry(parentEnrollmentId, parent);
       return;
     }
 
@@ -448,9 +454,24 @@ class EnrollVerbHandler extends AbstractVerbHandler {
     }
   }
 
-  /// Caps [enrollmentId]'s expiry to `min(now + grace, its existing expiry)`,
-  /// leaving the record in place.
-  Future<void> _capEnrollmentExpiry(String enrollmentId) async {
+  /// Caps [enrollmentId] to expire `min(now + grace, its own expiry)` from
+  /// this moment, leaving the record in place.
+  ///
+  /// Re-applied on EVERY self-enrollment, computed fresh from the record's
+  /// own posture rather than folded into a previously written cap: sibling
+  /// clones of one keyfile retrofit whenever each device next runs, so the
+  /// cap must RE-ARM with each retrofit — a deadline fixed by the first
+  /// sibling's upgrade would strand every laggard whose next run falls
+  /// outside that first window. "Its own expiry" is re-derived from
+  /// [EnrollDataStoreValue.apkamKeysExpiryDuration], anchored at the
+  /// record's creation, so a key-expiry posture shorter than the grace
+  /// still wins.
+  ///
+  /// A written ttl anchors at the write (`expiresAt = now + ttl` in the
+  /// metadata builder), so the grace is written as-is — offsetting it by the
+  /// record's age would extend the cap by the enrollment's whole lifetime.
+  Future<void> _capEnrollmentExpiry(
+      String enrollmentId, EnrollDataStoreValue enrollment) async {
     final key = enMgr.buildEnrollmentKey(enrollmentId);
     final AtData? atData;
     try {
@@ -459,17 +480,22 @@ class EnrollVerbHandler extends AbstractVerbHandler {
       return;
     }
     if (atData == null) return;
-    final createdAt = atData.metaData?.createdAt ?? DateTime.now().toUtc();
-    final capFromNow = DateTime.now()
-            .toUtc()
-            .difference(createdAt.toUtc())
-            .inMilliseconds +
+    final now = DateTime.now().toUtc();
+    int cappedTtl =
         Duration(hours: AtSecondaryConfig.apkamSelfEnrollmentGraceHours)
             .inMilliseconds;
-    final existingTtl = atData.metaData?.ttl;
-    final cappedTtl = (existingTtl == null || existingTtl <= 0)
-        ? capFromNow
-        : (existingTtl < capFromNow ? existingTtl : capFromNow);
+    final ownMs = enrollment.apkamKeysExpiryDuration.inMilliseconds;
+    if (ownMs > 0) {
+      final createdAt = (atData.metaData?.createdAt ?? now).toUtc();
+      final ownRemainingMs = createdAt
+          .add(Duration(milliseconds: ownMs))
+          .difference(now)
+          .inMilliseconds;
+      if (ownRemainingMs < cappedTtl) cappedTtl = ownRemainingMs;
+    }
+    // A ttl of zero means "never expires", and a spent posture must not
+    // become immortality — floor at one millisecond.
+    if (cappedTtl < 1) cappedTtl = 1;
     atData.metaData = (atData.metaData ?? AtMetaData())..ttl = cappedTtl;
     await enMgr.put(enrollmentId, atData, EnrollmentStatus.approved);
   }
@@ -885,6 +911,18 @@ class EnrollVerbHandler extends AbstractVerbHandler {
         if (enrollParams.apkamPublicKey.isNullOrEmpty) {
           throw IllegalArgumentException(
               'apkam public key is mandatory for enroll:request');
+        }
+
+        if (inboundConnection.metaData.authType == AuthType.apkam &&
+            (enrollParams.namespaces == null ||
+                enrollParams.namespaces!.isEmpty)) {
+          // A self-enrollment names its grants explicitly: the child holds
+          // exactly what it requests, at most what the parent holds. An
+          // empty set would mint an approved credential that can do nothing,
+          // which is always a caller bug — refuse it loudly.
+          throw IllegalArgumentException(
+              'At least one namespace must be specified for an '
+              'APKAM-authenticated enroll:request');
         }
 
         if (enrollParams.otp != null) {

--- a/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
@@ -375,8 +375,7 @@ class EnrollVerbHandler extends AbstractVerbHandler {
       // fully privileged enrollment.
       verifyNoEscalation(parent.namespaces, enrollNamespaces);
 
-      enrollmentValue.approval =
-          EnrollApproval(EnrollmentStatus.approved.name);
+      enrollmentValue.approval = EnrollApproval(EnrollmentStatus.approved.name);
       // The child records its parent so revocation can CASCADE: a stolen
       // keyfile must not spawn a child that survives the parent's
       // revocation. (The cascade itself is the revoke path's to implement.)

--- a/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
@@ -334,6 +334,73 @@ class EnrollVerbHandler extends AbstractVerbHandler {
       return;
     }
 
+    // An APKAM-authenticated connection self-enrolls a FRESH enrollment —
+    // RF-SRV, the "upgrade the enrollment" step every migration scenario in
+    // at_client_sdk docs/projects/pq/decisions.md 36-40 conjugates. Auto-
+    // approved with no human step and no OTP: the connection's existing
+    // approved enrollment is the authority, and the child can hold at most
+    // what the parent holds. The parent is capped, not removed, so sibling
+    // clones of the same keyfile can still retrofit until the cap elapses.
+    if (atConnection.metaData.authType == AuthType.apkam) {
+      final inboundConnectionMetadata =
+          atConnection.metaData as InboundConnectionMetadata;
+      final parentEnrollmentId = inboundConnectionMetadata.enrollmentId;
+      if (parentEnrollmentId == null) {
+        throw UnAuthorizedException(
+            'An APKAM-authenticated self-enrollment needs a resolvable '
+            'enrollment id on the connection');
+      }
+      final EnrollDataStoreValue parent;
+      try {
+        parent = await enMgr.getEnrollmentById(parentEnrollmentId);
+      } on KeyNotFoundException {
+        throw UnAuthorizedException(
+            'Parent enrollment $parentEnrollmentId does not exist or has '
+            'expired');
+      }
+      if (parent.approval?.state != EnrollmentStatus.approved.name) {
+        throw UnAuthorizedException(
+            'Parent enrollment $parentEnrollmentId is not approved');
+      }
+      // Reject escalation: every requested grant must be one the parent
+      // itself holds. Without this, any scoped keyfile could self-spawn a
+      // fully privileged enrollment.
+      verifyNoEscalation(parent.namespaces, enrollNamespaces);
+
+      enrollmentValue.approval =
+          EnrollApproval(EnrollmentStatus.approved.name);
+      // The child records its parent so revocation can CASCADE: a stolen
+      // keyfile must not spawn a child that survives the parent's
+      // revocation. (The cascade itself is the revoke path's to implement.)
+      enrollmentValue.parentEnrollmentId = parentEnrollmentId;
+      // The child inherits the parent's key-expiry posture unless the
+      // request states its own.
+      if (enrollParams.apkamKeysExpiryDuration == null) {
+        enrollmentValue.apkamKeysExpiryDuration =
+            parent.apkamKeysExpiryDuration;
+      }
+      // May be absent: a PQ self-enrollment conveys its legacy material
+      // client-side, sealed to its own new key package.
+      enrollmentValue.encryptedAPKAMSymmetricKey =
+          enrollParams.encryptedAPKAMSymmetricKey;
+      responseJson['status'] = 'approved';
+
+      // Keep the enrollment's `_apsk` signing key present for verifiers.
+      await _publishApskSigningKey(
+          newEnrollmentId, enrollParams.apkamPublicKey!, currentAtSign);
+      await enMgr.put(newEnrollmentId,
+          AtData()..data = jsonEncode(enrollmentValue.toJson()),
+          EnrollmentStatus.approved);
+
+      // Cap the parent to min(now + grace, its existing expiry) WITHOUT
+      // removing it. The grace default is deliberately generous — cloned
+      // keyfiles upgrade whenever each device next runs, and a short grace
+      // strands the laggards; the value is to-define (at_client_sdk
+      // docs/projects/pq/decisions.md 41 item 3).
+      await _capEnrollmentExpiry(parentEnrollmentId);
+      return;
+    }
+
     // OK it's a standard enrollment request.
     // - send a notification to be received by an approver app
     // - store the enrollment in 'pending' state
@@ -351,6 +418,60 @@ class EnrollVerbHandler extends AbstractVerbHandler {
       ..metaData = (AtMetaData()..ttl = enrollmentExpiryInMills);
 
     await enMgr.put(newEnrollmentId, enrollData, EnrollmentStatus.pending);
+  }
+
+  /// Rejects any requested grant the parent enrollment does not itself hold.
+  ///
+  /// Subset per namespace and per access letter: `r` fits under `rw`, never
+  /// the reverse. A parent's `*` grant covers any ordinary namespace at the
+  /// letters it carries — mirroring the server's own authorisation — but
+  /// `__manage` and `*` themselves must be held literally: `*` does not imply
+  /// `__manage` anywhere else in the server, and it must not here.
+  @visibleForTesting
+  void verifyNoEscalation(
+      Map<String, String> parentGrants, Map<String, String> requested) {
+    for (final entry in requested.entries) {
+      String? parentAccess = parentGrants[entry.key];
+      final isSpecial = entry.key == EnrollmentConstants.allNamespaces ||
+          entry.key == EnrollmentConstants.enrollManageNamespace;
+      if (parentAccess == null && !isSpecial) {
+        parentAccess = parentGrants[EnrollmentConstants.allNamespaces];
+      }
+      final held = parentAccess;
+      if (held == null ||
+          !entry.value.split('').every(held.split('').contains)) {
+        throw UnAuthorizedException(
+            'Requested namespace "${entry.key}:${entry.value}" exceeds the '
+            'parent enrollment\'s grants — a self-enrollment can hold at '
+            'most what its parent holds');
+      }
+    }
+  }
+
+  /// Caps [enrollmentId]'s expiry to `min(now + grace, its existing expiry)`,
+  /// leaving the record in place.
+  Future<void> _capEnrollmentExpiry(String enrollmentId) async {
+    final key = enMgr.buildEnrollmentKey(enrollmentId);
+    final AtData? atData;
+    try {
+      atData = await keyStore.get(key);
+    } on KeyNotFoundException {
+      return;
+    }
+    if (atData == null) return;
+    final createdAt = atData.metaData?.createdAt ?? DateTime.now().toUtc();
+    final capFromNow = DateTime.now()
+            .toUtc()
+            .difference(createdAt.toUtc())
+            .inMilliseconds +
+        Duration(hours: AtSecondaryConfig.apkamSelfEnrollmentGraceHours)
+            .inMilliseconds;
+    final existingTtl = atData.metaData?.ttl;
+    final cappedTtl = (existingTtl == null || existingTtl <= 0)
+        ? capFromNow
+        : (existingTtl < capFromNow ? existingTtl : capFromNow);
+    atData.metaData = (atData.metaData ?? AtMetaData())..ttl = cappedTtl;
+    await enMgr.put(enrollmentId, atData, EnrollmentStatus.approved);
   }
 
   /// Handles enrollment approve, deny, revoke and unrevoke requests.

--- a/packages/at_secondary_server/lib/src/verb/handler/monitor_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/monitor_verb_handler.dart
@@ -119,6 +119,14 @@ class MonitorVerbHandler extends AbstractVerbHandler {
       AtConnection atConnection, AtNotification notification) async {
     if (!(await isAuthorized(atConnection.metaData as InboundConnectionMetadata,
         atKey: notification.notification))) {
+      // A dropped notification is indistinguishable from one that was never
+      // sent, so a receiver-side refusal presents as "the sender didn't
+      // send" and gets attributed to the wrong side. Name what was dropped
+      // and for whom, at a level an operator sees.
+      logger.warning('Not delivering notification'
+          ' ${notification.notification} to enrollment'
+          ' ${(atConnection.metaData as InboundConnectionMetadata).enrollmentId}'
+          ' — not authorized for that key');
       return;
     }
 

--- a/packages/at_secondary_server/lib/src/verb/handler/pkam_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/pkam_verb_handler.dart
@@ -68,8 +68,13 @@ class PkamVerbHandler extends AbstractVerbHandler {
       // misstates the algorithm only fails its own verification — but it
       // closes off cross-algorithm confusion, where one key blob parses under
       // more than one algorithm. A legacy enrollment predating the field has
-      // none recorded, so it keeps the existing default.
-      recordSigningAlgo = apkamResult.signingAlgo;
+      // none recorded, so it keeps the existing default EXPLICITLY here: a
+      // null must not fall through to the wire claim in _validateSignature,
+      // or the claim picks the verify routine for exactly the enrollments
+      // that predate the field (an RSA record verified as ML-DSA fails a
+      // legitimate legacy client; the wire fallback exists for legacy
+      // no-enrollment PKAM, which may present ecc_secp256r1).
+      recordSigningAlgo = apkamResult.signingAlgo ?? _rsa2048Algo;
     } else {
       pkamAuthType = AuthType.pkamLegacy;
       var publicKeyData = await keyStore.get(AtConstants.atPkamPublicKey);

--- a/packages/at_secondary_server/lib/src/verb/handler/pkam_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/pkam_verb_handler.dart
@@ -18,6 +18,7 @@ class PkamVerbHandler extends AbstractVerbHandler {
   static Pkam pkam = Pkam();
   static const String _eccAlgo = 'ecc_secp256r1';
   static const String _rsa2048Algo = 'rsa2048';
+  static const String _mlDsa65Algo = 'mldsa65';
   static const String _sha256 = 'sha256';
   static const String _sha512 = 'sha512';
   AtChops? atChops;
@@ -43,6 +44,9 @@ class PkamVerbHandler extends AbstractVerbHandler {
     var atSign = AtSecondaryServerImpl.getInstance().currentAtSign;
     AuthType pkamAuthType;
     String? publicKey;
+    // Legacy PKAM has no enrollment record to be authoritative about, and may
+    // legitimately present ecc_secp256r1, so it goes on using the wire value.
+    String? recordSigningAlgo;
 
     // Use APKAM public key for verification if enrollId is passed.
     // Otherwise use legacy pkam public key.
@@ -57,6 +61,15 @@ class PkamVerbHandler extends AbstractVerbHandler {
         return;
       }
       publicKey = apkamResult.publicKey;
+      // Record-authoritative: an APKAM keypair's algorithm is a property of
+      // the enrollment it was registered under, not something the client
+      // restates on each connect. Hardening rather than a fix — the signature
+      // is checked against the stored public key either way, so a client that
+      // misstates the algorithm only fails its own verification — but it
+      // closes off cross-algorithm confusion, where one key blob parses under
+      // more than one algorithm. A legacy enrollment predating the field has
+      // none recorded, so it keeps the existing default.
+      recordSigningAlgo = apkamResult.signingAlgo;
     } else {
       pkamAuthType = AuthType.pkamLegacy;
       var publicKeyData = await keyStore.get(AtConstants.atPkamPublicKey);
@@ -73,6 +86,7 @@ class PkamVerbHandler extends AbstractVerbHandler {
       sessionID,
       atSign,
       publicKey,
+      recordSigningAlgo,
       storedSecretId,
     );
 
@@ -121,6 +135,7 @@ class PkamVerbHandler extends AbstractVerbHandler {
       return apkamResult;
     }
     apkamResult.publicKey = enVal.apkamPublicKey;
+    apkamResult.signingAlgo = enVal.signingAlgo;
     return apkamResult;
   }
 
@@ -155,15 +170,22 @@ class PkamVerbHandler extends AbstractVerbHandler {
     return response;
   }
 
+  /// [recordSigningAlgo] is the algorithm recorded on the enrollment, when
+  /// this connection authenticates as one. It wins over whatever the wire
+  /// says, so the client stops choosing how its own signature is interpreted.
+  /// Null for legacy PKAM — there is no record — in which case the wire value
+  /// still decides, as it always has.
   Future<bool> _validateSignature(
     var verbParams,
     var sessionId,
     String atSign,
     String publicKey,
+    String? recordSigningAlgo,
     String storedSecretId,
   ) async {
     var signature = verbParams[AtConstants.atPkamSignature]!;
-    var signingAlgo = verbParams[AtConstants.atPkamSigningAlgo];
+    var signingAlgo =
+        recordSigningAlgo ?? verbParams[AtConstants.atPkamSigningAlgo];
     var hashingAlgo = verbParams[AtConstants.atPkamHashingAlgo];
     bool isValidSignature = false;
     var storedSecretData = await keyStore.get(storedSecretId);
@@ -204,9 +226,13 @@ class PkamVerbHandler extends AbstractVerbHandler {
     logger.finer('signingAlgo: $signingAlgo');
     if (signingAlgo == _eccAlgo) {
       return SigningAlgoType.ecc_secp256r1;
-      // inputSignature = Uint8List.fromList(signature.codeUnits);
     } else if (signingAlgo == _rsa2048Algo) {
       return SigningAlgoType.rsa2048;
+    } else if (signingAlgo == _mlDsa65Algo) {
+      // Without this branch a post-quantum APKAM keypair falls through to the
+      // RSA default below and can never authenticate at all — the signature is
+      // well-formed, just interpreted under the wrong algorithm.
+      return SigningAlgoType.mldsa65;
     }
     return SigningAlgoType.rsa2048;
   }
@@ -226,4 +252,8 @@ class PkamVerbHandler extends AbstractVerbHandler {
 class ApkamVerificationResult {
   Response response = Response();
   String? publicKey;
+
+  /// The signing algorithm recorded on the enrollment, which is what
+  /// [publicKey] actually is. Null on a legacy enrollment predating the field.
+  String? signingAlgo;
 }

--- a/packages/at_secondary_server/pubspec.lock
+++ b/packages/at_secondary_server/pubspec.lock
@@ -62,7 +62,7 @@ packages:
     description:
       path: "packages/at_chops"
       ref: gkc-pq-d1-spike
-      resolved-ref: f0c28fe16c57386bfd735d970fb317b0cc195d64
+      resolved-ref: "9c061470e12044031f755805905c3ae2cb4914d8"
       url: "https://github.com/atsign-foundation/at_client_sdk.git"
     source: git
     version: "3.5.0"

--- a/packages/at_secondary_server/pubspec.lock
+++ b/packages/at_secondary_server/pubspec.lock
@@ -61,8 +61,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/at_chops"
-      ref: gkc-pq-d1-spike
-      resolved-ref: "9c061470e12044031f755805905c3ae2cb4914d8"
+      ref: at_chops-pq-spike-1
+      resolved-ref: "55a78f161e91e9dfe1f168247e26b8af09ff073f"
       url: "https://github.com/atsign-foundation/at_client_sdk.git"
     source: git
     version: "3.5.0"

--- a/packages/at_secondary_server/pubspec.lock
+++ b/packages/at_secondary_server/pubspec.lock
@@ -60,11 +60,10 @@ packages:
   at_chops:
     dependency: "direct main"
     description:
-      name: at_chops
-      sha256: "4d6ab2cbf9fb87e0d575ffe0cc0622075677b679ea875d5ac39e475ae4be188a"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.3.0"
+      path: "../../../at_client_sdk/packages/at_chops"
+      relative: true
+    source: path
+    version: "3.4.2"
   at_commons:
     dependency: "direct main"
     description:
@@ -91,11 +90,10 @@ packages:
   at_server_spec:
     dependency: "direct main"
     description:
-      name: at_server_spec
-      sha256: c128bc00c8bde819ff547b2a7baf9788723f9d87c36eddc30fd18042c64060cf
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.1.0"
+      path: "../at_server_spec"
+      relative: true
+    source: path
+    version: "5.2.0"
   at_utf7:
     dependency: transitive
     description:

--- a/packages/at_secondary_server/pubspec.lock
+++ b/packages/at_secondary_server/pubspec.lock
@@ -60,10 +60,12 @@ packages:
   at_chops:
     dependency: "direct main"
     description:
-      path: "../../../at_client_sdk/packages/at_chops"
-      relative: true
-    source: path
-    version: "3.4.2"
+      path: "packages/at_chops"
+      ref: gkc-pq-d1-spike
+      resolved-ref: f0c28fe16c57386bfd735d970fb317b0cc195d64
+      url: "https://github.com/atsign-foundation/at_client_sdk.git"
+    source: git
+    version: "3.5.0"
   at_commons:
     dependency: "direct main"
     description:

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_secondary
 description: Implementation of secondary server.
-version: 3.15.1
+version: 3.16.0
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://www.example.com
 publish_to: none

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   encrypt: ^5.0.3
   at_commons: ^5.13.0
   at_utils: ^3.4.0
-  at_chops: ^3.3.0
+  at_chops: ^3.4.2
   at_lookup: ^3.6.0
   at_server_spec: ^5.1.0
   at_persistence_secondary_server: ^5.2.1
@@ -45,3 +45,10 @@ dev_dependencies:
 dependency_overrides:
   at_persistence_secondary_server:
     path: ../at_persistence_secondary_server
+  # at_chops 3.4.2 is in progress in the at_client_sdk workspace and carries
+  # the synchronous mldsa65 verification dispatch PKAM's record-authoritative
+  # verify needs; published at_chops (<=3.4.1) either lacks the branch or
+  # returns an async verifier whose Future poisons the bool result. Remove
+  # when 3.4.2 publishes.
+  at_chops:
+    path: ../../../at_client_sdk/packages/at_chops

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -48,11 +48,16 @@ dependency_overrides:
   # at_chops carries the synchronous mldsa65 verification dispatch PKAM's
   # record-authoritative verify needs; published at_chops (<=3.4.1) either
   # lacks the branch or returns an async verifier whose Future poisons the
-  # bool result. Pinned to the spike branch rather than a local path so the
-  # override resolves for anyone building this, not just a clone that happens
-  # to sit beside an at_client_sdk checkout. Remove when it publishes.
+  # bool result. Remove when it publishes.
+  #
+  # ref is a TAG, deliberately: pub fetches a git ref shallowly, reaching only
+  # branch and tag tips. A branch ref strands this pin the moment the branch
+  # head moves (the locked commit is then absent from a cold pub-cache, though
+  # it keeps resolving on any machine whose cache predates the move), and a
+  # bare commit SHA is worse — unresolvable as soon as it stops being a tip
+  # ("fatal: bad object"). A tag is both immutable and fetchable.
   at_chops:
     git:
       url: https://github.com/atsign-foundation/at_client_sdk.git
       path: packages/at_chops
-      ref: gkc-pq-d1-spike
+      ref: at_chops-pq-spike-1 # at_client_sdk 55a78f16, off gkc-pq-d1-spike

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -45,10 +45,14 @@ dev_dependencies:
 dependency_overrides:
   at_persistence_secondary_server:
     path: ../at_persistence_secondary_server
-  # at_chops 3.4.2 is in progress in the at_client_sdk workspace and carries
-  # the synchronous mldsa65 verification dispatch PKAM's record-authoritative
-  # verify needs; published at_chops (<=3.4.1) either lacks the branch or
-  # returns an async verifier whose Future poisons the bool result. Remove
-  # when 3.4.2 publishes.
+  # at_chops carries the synchronous mldsa65 verification dispatch PKAM's
+  # record-authoritative verify needs; published at_chops (<=3.4.1) either
+  # lacks the branch or returns an async verifier whose Future poisons the
+  # bool result. Pinned to the spike branch rather than a local path so the
+  # override resolves for anyone building this, not just a clone that happens
+  # to sit beside an at_client_sdk checkout. Remove when it publishes.
   at_chops:
-    path: ../../../at_client_sdk/packages/at_chops
+    git:
+      url: https://github.com/atsign-foundation/at_client_sdk.git
+      path: packages/at_chops
+      ref: gkc-pq-d1-spike

--- a/packages/at_secondary_server/test/apkam_self_enrollment_test.dart
+++ b/packages/at_secondary_server/test/apkam_self_enrollment_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:at_commons/at_commons.dart';
+import 'package:at_secondary/src/enroll/enroll_datastore_value.dart';
 import 'package:at_secondary/src/server/at_secondary_config.dart';
 import 'package:at_secondary/src/utils/handler_util.dart';
 import 'package:at_server_spec/at_server_spec.dart';
@@ -22,8 +23,9 @@ import 'test_utils.dart';
 ///   self-spawn a fully privileged enrollment.
 /// - **The parent survives, capped**: sibling clones of the same keyfile
 ///   retrofit on their own schedules, so the parent keeps authenticating
-///   until `min(now + grace, its existing expiry)` — and the child records
-///   its parent so revocation can cascade.
+///   until one grace period after the NEWEST retrofit (the cap re-arms each
+///   time, never past the parent's own key-expiry posture) — and the child
+///   records its parent so revocation can cascade.
 void main() {
   verbTestsSetUpLogging();
 
@@ -170,6 +172,89 @@ void main() {
     expect(child.namespaces['__manage'], 'rw',
         reason: 'and __manage passes here only because the primary holds it '
             'LITERALLY — the wildcard test above is the control');
+  });
+
+  test('a retrofit may keep its own (appName, deviceName)', () async {
+    final parentId = (await etu.createEnrollments(n: 1)).$1.first;
+    final parent = await enMgr.getEnrollmentById(parentId);
+
+    final r = await selfEnroll(
+        parentEnrollmentId: parentId,
+        namespaces: {'app_1': 'rw'},
+        appName: parent.appName,
+        deviceName: parent.deviceName);
+
+    expect(r.isError, false,
+        reason: 'a retrofit is the same app re-enrolling itself, and sibling '
+            'clones of one keyfile share names — the (appName, deviceName) '
+            'duplicate refusal must not apply to the self-enrollment branch: '
+            '${r.errorMessage}');
+    final childId = jsonDecode(r.data!)['enrollmentId'] as String;
+    expect(childId, isNot(parentId));
+    expect((await enMgr.getEnrollmentById(childId)).approval?.state,
+        EnrollmentStatus.approved.name);
+  });
+
+  test('empty namespaces are refused', () async {
+    final parentId = (await etu.createEnrollments(n: 1)).$1.first;
+
+    await expectLater(
+        () => selfEnroll(parentEnrollmentId: parentId, namespaces: {}),
+        throwsA(isA<IllegalArgumentException>()),
+        reason: 'an approved credential that can do nothing is always a '
+            'caller bug — the child holds exactly what it names');
+  });
+
+  test('the cap re-arms on each sibling retrofit rather than keeping the '
+      'first deadline', () async {
+    final parentId = (await etu.createEnrollments(n: 1)).$1.first;
+    await selfEnroll(parentEnrollmentId: parentId, namespaces: {'app_1': 'rw'});
+
+    // Simulate that first retrofit having happened long ago by shrinking the
+    // parent's remaining ttl directly.
+    final key = enMgr.buildEnrollmentKey(parentId);
+    final aged = await keyValueStore.get(key);
+    aged!.metaData!.ttl = 60000;
+    await enMgr.put(parentId, aged, EnrollmentStatus.approved);
+
+    final r = await selfEnroll(
+        parentEnrollmentId: parentId,
+        namespaces: {'app_1': 'rw'},
+        appName: 'selfapp2',
+        deviceName: 'selfdevice2');
+    expect(r.isError, false, reason: '${r.errorMessage}');
+
+    final graceMillis =
+        Duration(hours: AtSecondaryConfig.apkamSelfEnrollmentGraceHours)
+            .inMilliseconds;
+    final ttl = (await keyValueStore.get(key))!.metaData!.ttl!;
+    expect(ttl, greaterThan(60000),
+        reason: 'a min-fold against the previously capped ttl keeps the '
+            'first sibling\'s deadline and strands every later one — the cap '
+            'must re-arm to a full grace period from now');
+    expect(ttl, lessThanOrEqualTo(graceMillis));
+  });
+
+  test('the cap never extends past the expiry the parent\'s own posture '
+      'imposes', () async {
+    final parentId = (await etu.createEnrollments(n: 1)).$1.first;
+    // Give the parent a key-expiry posture far shorter than the grace.
+    final key = enMgr.buildEnrollmentKey(parentId);
+    final atData = await keyValueStore.get(key);
+    final value = EnrollDataStoreValue.fromJson(jsonDecode(atData!.data!));
+    value.apkamKeysExpiryDuration = Duration(hours: 1);
+    atData.data = jsonEncode(value.toJson());
+    await enMgr.put(parentId, atData, EnrollmentStatus.approved);
+
+    final r = await selfEnroll(
+        parentEnrollmentId: parentId, namespaces: {'app_1': 'rw'});
+    expect(r.isError, false, reason: '${r.errorMessage}');
+
+    final ttl = (await keyValueStore.get(key))!.metaData!.ttl!;
+    expect(ttl, lessThanOrEqualTo(Duration(hours: 1).inMilliseconds),
+        reason: 'the re-arm applies only within the enrollment\'s own '
+            'key-expiry posture — a 1h apkamKeysExpiryDuration must not '
+            'become a 30-day grace');
   });
 
   test('an unapproved parent is refused', () async {

--- a/packages/at_secondary_server/test/apkam_self_enrollment_test.dart
+++ b/packages/at_secondary_server/test/apkam_self_enrollment_test.dart
@@ -1,0 +1,189 @@
+import 'dart:convert';
+
+import 'package:at_commons/at_commons.dart';
+import 'package:at_secondary/src/server/at_secondary_config.dart';
+import 'package:at_secondary/src/utils/handler_util.dart';
+import 'package:at_server_spec/at_server_spec.dart';
+import 'package:test/test.dart';
+
+import 'enrollment_test_utils.dart';
+import 'test_utils.dart';
+
+/// RF-SRV: an APKAM-authenticated connection self-enrolls a FRESH enrollment.
+///
+/// This is the "upgrade the enrollment" step every migration scenario in
+/// `at_client_sdk docs/projects/pq/decisions.md` 36-40 conjugates — a keyfile
+/// upgrades itself with no human step and no OTP, the connection's existing
+/// approved enrollment being the whole authority. The two properties that
+/// make it safe rather than a privilege-escalation verb:
+///
+/// - **No escalation**: the child's grants must be a subset of the parent's,
+///   per namespace and per access letter, or any scoped keyfile could
+///   self-spawn a fully privileged enrollment.
+/// - **The parent survives, capped**: sibling clones of the same keyfile
+///   retrofit on their own schedules, so the parent keeps authenticating
+///   until `min(now + grace, its existing expiry)` — and the child records
+///   its parent so revocation can cascade.
+void main() {
+  verbTestsSetUpLogging();
+
+  setUpAll(() async {
+    await verbTestsSetUpAll();
+  });
+
+  final etu = ETU();
+
+  setUp(() async {
+    await verbTestsSetUp();
+    await etu.init();
+  });
+
+  tearDown(() async {
+    await verbTestsTearDown();
+  });
+
+  /// Issues `enroll:request` on an APKAM-authenticated connection carrying
+  /// [parentEnrollmentId], with no OTP.
+  Future<Response> selfEnroll({
+    required String parentEnrollmentId,
+    required Map<String, String> namespaces,
+    String appName = 'selfapp',
+    String deviceName = 'selfdevice',
+  }) async {
+    final ep = EnrollParams()
+      ..appName = appName
+      ..deviceName = deviceName
+      ..apkamPublicKey = 'pq apkam public key $appName $deviceName'
+      ..namespaces = namespaces;
+    inboundConnection.metaData
+      ..isAuthenticated = true
+      ..authType = AuthType.apkam
+      ..sessionID = DateTime.now().millisecondsSinceEpoch.toString();
+    inboundConnection.metadata.enrollmentId = parentEnrollmentId;
+
+    final r = Response();
+    await etu.evh.processVerb(
+      r,
+      getVerbParam(VerbSyntax.enroll, 'enroll:request:${jsonEncode(ep.toJson())}'),
+      inboundConnection,
+    );
+    return r;
+  }
+
+  test('an approved enrollment self-enrolls a subset child, auto-approved, '
+      'no OTP', () async {
+    // The parent: an ordinary approved enrollment with scoped grants.
+    final parentId = (await etu.createEnrollments(n: 1)).$1.first;
+    final parentBefore = await enMgr.getEnrollmentById(parentId);
+    expect(parentBefore.namespaces, {'app_1': 'rw', 'test': 'r'},
+        reason: 'precondition: the parent grants this test relies on');
+
+    final r = await selfEnroll(
+        parentEnrollmentId: parentId, namespaces: {'app_1': 'rw', 'test': 'r'});
+
+    expect(r.isError, false, reason: '${r.errorMessage}');
+    final m = jsonDecode(r.data!);
+    expect(m['status'], EnrollmentStatus.approved.name,
+        reason: 'auto-approved: no human step, no OTP — the authenticated '
+            'parent is the authority');
+    final childId = m['enrollmentId'] as String;
+    expect(childId, isNot(parentId));
+
+    final child = await enMgr.getEnrollmentById(childId);
+    expect(child.approval?.state, EnrollmentStatus.approved.name);
+    expect(child.parentEnrollmentId, parentId,
+        reason: 'the child records its parent so revocation can CASCADE — a '
+            'stolen keyfile must not spawn a child that survives the '
+            'parent\'s revocation');
+    expect(child.namespaces.containsKey('__manage'), isFalse,
+        reason: 'auto-approve must NOT carry the CRAM branch\'s __manage/* '
+            'grant — that grant is what makes CRAM the atSign\'s root, and a '
+            'self-enrollment is not that');
+    expect(child.namespaces.containsKey('*'), isFalse);
+
+    // The parent survives — capped, not removed.
+    final parentAfter = await enMgr.getEnrollmentById(parentId);
+    expect(parentAfter.approval?.state, EnrollmentStatus.approved.name,
+        reason: 'sibling clones of the same keyfile still authenticate as the '
+            'parent until the cap elapses');
+    final parentData =
+        await keyValueStore.get(enMgr.buildEnrollmentKey(parentId));
+    final graceMillis =
+        Duration(hours: AtSecondaryConfig.apkamSelfEnrollmentGraceHours)
+            .inMilliseconds;
+    expect(parentData?.metaData?.ttl, isNotNull,
+        reason: 'the cap is real: the parent record now carries an expiry');
+    expect(parentData!.metaData!.ttl!, lessThanOrEqualTo(graceMillis + 60000),
+        reason: 'and it is min(now + grace, existing expiry), not unbounded');
+  });
+
+  test('escalation is refused: a namespace the parent does not hold',
+      () async {
+    final parentId = (await etu.createEnrollments(n: 1)).$1.first;
+
+    await expectLater(
+        () => selfEnroll(
+            parentEnrollmentId: parentId, namespaces: {'other_ns': 'rw'}),
+        throwsA(isA<UnAuthorizedException>().having(
+            (e) => e.message, 'message', contains('exceeds the parent'))),
+        reason: 'a scoped keyfile must not self-spawn grants it never held');
+  });
+
+  test('escalation is refused: broader access letters on a held namespace',
+      () async {
+    final parentId = (await etu.createEnrollments(n: 1)).$1.first;
+    // The parent holds test:'r'.
+
+    await expectLater(
+        () =>
+            selfEnroll(parentEnrollmentId: parentId, namespaces: {'test': 'rw'}),
+        throwsA(isA<UnAuthorizedException>()),
+        reason: 'r under rw fits; rw under r is an escalation — per letter, '
+            'not merely per namespace');
+  });
+
+  test('escalation is refused: __manage via a wildcard parent', () async {
+    // The primary enrollment holds *:rw (CRAM adds __manage too, but the
+    // point here is that a * grant alone must never imply __manage).
+    final parentId = (await etu.createEnrollments(n: 1)).$1.first;
+
+    await expectLater(
+        () => selfEnroll(
+            parentEnrollmentId: parentId, namespaces: {'__manage': 'rw'}),
+        throwsA(isA<UnAuthorizedException>()),
+        reason: '__manage must be held literally — * does not imply it '
+            'anywhere else in the server, and must not here');
+  });
+
+  test('a wildcard parent covers ordinary namespaces it never named',
+      () async {
+    // The primary (CRAM) enrollment holds *:rw and __manage:rw.
+    final r = await selfEnroll(
+        parentEnrollmentId: etu.primaryEnId,
+        namespaces: {'brand_new_ns': 'rw', '__manage': 'rw'});
+
+    expect(r.isError, false, reason: '${r.errorMessage}');
+    final child = await enMgr
+        .getEnrollmentById(jsonDecode(r.data!)['enrollmentId'] as String);
+    expect(child.namespaces['brand_new_ns'], 'rw',
+        reason: 'a * parent can grant any ordinary namespace at its letters');
+    expect(child.namespaces['__manage'], 'rw',
+        reason: 'and __manage passes here only because the primary holds it '
+            'LITERALLY — the wildcard test above is the control');
+  });
+
+  test('an unapproved parent is refused', () async {
+    final pendingId = await etu.createPendingEnrollment(
+        appName: 'pending_app',
+        deviceName: 'pending_device',
+        namespaces: {'app_x': 'rw'},
+        apkamKeysExpiryDuration: null);
+
+    await expectLater(
+        () => selfEnroll(
+            parentEnrollmentId: pendingId, namespaces: {'app_x': 'rw'}),
+        throwsA(isA<UnAuthorizedException>()),
+        reason: 'a pending enrollment cannot vouch for anything — only an '
+            'approved parent is an authority');
+  });
+}

--- a/packages/at_secondary_server/test/apkam_self_enrollment_test.dart
+++ b/packages/at_secondary_server/test/apkam_self_enrollment_test.dart
@@ -58,12 +58,14 @@ void main() {
     String appName = 'selfapp',
     String deviceName = 'selfdevice',
     String? signingAlgo,
+    Duration? apkamKeysExpiryDuration,
   }) async {
     final ep = EnrollParams()
       ..appName = appName
       ..deviceName = deviceName
       ..apkamPublicKey = 'pq apkam public key $appName $deviceName'
       ..signingAlgo = signingAlgo
+      ..apkamKeysExpiryDuration = apkamKeysExpiryDuration
       ..namespaces = namespaces;
     inboundConnection.metaData
       ..isAuthenticated = true
@@ -263,6 +265,155 @@ void main() {
         reason: 'the re-arm applies only within the enrollment\'s own '
             'key-expiry posture — a 1h apkamKeysExpiryDuration must not '
             'become a 30-day grace');
+  });
+
+  test('the child record expires per the posture it inherited', () async {
+    final parentId = (await etu.createEnrollments(n: 1)).$1.first;
+    // The parent lives under a 1h key-expiry posture.
+    final key = enMgr.buildEnrollmentKey(parentId);
+    final atData = await keyValueStore.get(key);
+    final value = EnrollDataStoreValue.fromJson(jsonDecode(atData!.data!));
+    value.apkamKeysExpiryDuration = Duration(hours: 1);
+    atData.data = jsonEncode(value.toJson());
+    await enMgr.put(parentId, atData, EnrollmentStatus.approved);
+
+    final r = await selfEnroll(
+        parentEnrollmentId: parentId, namespaces: {'app_1': 'rw'});
+    expect(r.isError, false, reason: '${r.errorMessage}');
+    final childId = jsonDecode(r.data!)['enrollmentId'] as String;
+
+    final child = await enMgr.getEnrollmentById(childId);
+    expect(child.apkamKeysExpiryDuration, Duration(hours: 1),
+        reason: 'precondition: the inheritance itself, recorded in the value');
+
+    final childTtl = (await keyValueStore.get(enMgr.buildEnrollmentKey(childId)))
+        ?.metaData
+        ?.ttl;
+    expect(childTtl, Duration(hours: 1).inMilliseconds,
+        reason: 'the retrofit copies the parent\'s expiry to the child — a '
+            'posture recorded only in the JSON value while the record carries '
+            'no ttl means the child never physically expires, which turns a '
+            '1h key-expiry policy into immortality for every retrofitted '
+            'enrollment');
+  });
+
+  test('a child expiry the request states wins over the inherited one',
+      () async {
+    final parentId = (await etu.createEnrollments(n: 1)).$1.first;
+
+    final r = await selfEnroll(
+        parentEnrollmentId: parentId,
+        namespaces: {'app_1': 'rw'},
+        apkamKeysExpiryDuration: Duration(hours: 2));
+    expect(r.isError, false, reason: '${r.errorMessage}');
+    final childId = jsonDecode(r.data!)['enrollmentId'] as String;
+
+    final childTtl = (await keyValueStore.get(enMgr.buildEnrollmentKey(childId)))
+        ?.metaData
+        ?.ttl;
+    expect(childTtl, Duration(hours: 2).inMilliseconds,
+        reason: 'the request may state its own posture instead of inheriting '
+            '— and the record must expire per whichever applied');
+
+    // Control: a parent with no posture begets a child with none — ttl 0 is
+    // the keystore\'s "never expires", exactly what the ordinary approve
+    // path writes for an enrollment without apkamKeysExpiryDuration.
+    final r2 = await selfEnroll(
+        parentEnrollmentId: parentId,
+        namespaces: {'app_1': 'rw'},
+        appName: 'selfapp2',
+        deviceName: 'selfdevice2');
+    final child2Id = jsonDecode(r2.data!)['enrollmentId'] as String;
+    final child2Ttl =
+        (await keyValueStore.get(enMgr.buildEnrollmentKey(child2Id)))
+            ?.metaData
+            ?.ttl;
+    expect(child2Ttl ?? 0, 0,
+        reason: 'no posture anywhere must not manufacture an expiry');
+  });
+
+  test('a child may not state an expiry that outlives its parent\'s posture',
+      () async {
+    final parentId = (await etu.createEnrollments(n: 1)).$1.first;
+    final key = enMgr.buildEnrollmentKey(parentId);
+    final atData = await keyValueStore.get(key);
+    final value = EnrollDataStoreValue.fromJson(jsonDecode(atData!.data!));
+    value.apkamKeysExpiryDuration = Duration(hours: 1);
+    atData.data = jsonEncode(value.toJson());
+    await enMgr.put(parentId, atData, EnrollmentStatus.approved);
+
+    final r = await selfEnroll(
+        parentEnrollmentId: parentId,
+        namespaces: {'app_1': 'rw'},
+        apkamKeysExpiryDuration: Duration(days: 3650));
+    expect(r.isError, false, reason: '${r.errorMessage}');
+    final childId = jsonDecode(r.data!)['enrollmentId'] as String;
+
+    final child = await enMgr.getEnrollmentById(childId);
+    expect(child.apkamKeysExpiryDuration, Duration(hours: 1),
+        reason: 'verifyNoEscalation covers namespaces; TIME is the other axis '
+            'a stolen keyfile would widen, and this is the one enrollment '
+            'path with no human in the loop to notice. A child that outlives '
+            'its parent defeats the very posture the parent was issued under');
+    expect(
+        (await keyValueStore.get(enMgr.buildEnrollmentKey(childId)))
+            ?.metaData
+            ?.ttl,
+        Duration(hours: 1).inMilliseconds);
+  });
+
+  test('a child may not state "never expires" against a bounded parent',
+      () async {
+    final parentId = (await etu.createEnrollments(n: 1)).$1.first;
+    final key = enMgr.buildEnrollmentKey(parentId);
+    final atData = await keyValueStore.get(key);
+    final value = EnrollDataStoreValue.fromJson(jsonDecode(atData!.data!));
+    value.apkamKeysExpiryDuration = Duration(hours: 1);
+    atData.data = jsonEncode(value.toJson());
+    await enMgr.put(parentId, atData, EnrollmentStatus.approved);
+
+    // Zero is the keystore's "never expires" — the most valuable thing a
+    // thief could ask for, and the cheapest to ask for.
+    final r = await selfEnroll(
+        parentEnrollmentId: parentId,
+        namespaces: {'app_1': 'rw'},
+        apkamKeysExpiryDuration: Duration.zero);
+    expect(r.isError, false, reason: '${r.errorMessage}');
+    final childId = jsonDecode(r.data!)['enrollmentId'] as String;
+
+    final childTtl = (await keyValueStore.get(enMgr.buildEnrollmentKey(childId)))
+        ?.metaData
+        ?.ttl;
+    expect(childTtl, Duration(hours: 1).inMilliseconds,
+        reason: 'ttl 0 means never-expires at both layers (_getExpiresAt '
+            'returns null), so honouring a stated zero against a time-bound '
+            'parent hands out a permanent credential for the asking');
+  });
+
+  test('a negative stated expiry is not honoured', () async {
+    final parentId = (await etu.createEnrollments(n: 1)).$1.first;
+
+    // A negative ttl skips the metadata builder's ttl >= 0 branch entirely,
+    // leaving expiresAt null — immortality by a different route.
+    final r = await selfEnroll(
+        parentEnrollmentId: parentId,
+        namespaces: {'app_1': 'rw'},
+        apkamKeysExpiryDuration: Duration(milliseconds: -1));
+    expect(r.isError, false, reason: '${r.errorMessage}');
+    final childId = jsonDecode(r.data!)['enrollmentId'] as String;
+
+    // The raw ttl, NOT `?? 0`: with the whole change reverted the child
+    // record carries no metadata at all, and a `?? 0` would read that absence
+    // as a written zero and pass for the very state this pins against.
+    final childTtl =
+        (await keyValueStore.get(enMgr.buildEnrollmentKey(childId)))
+            ?.metaData
+            ?.ttl;
+    expect(childTtl, 0,
+        reason: 'a negative posture is not a posture; it must fall back to '
+            'the parent\'s (unbounded, written as 0) rather than reaching the '
+            'keystore, where a negative ttl skips the expiry write entirely '
+            'and leaves the record immortal');
   });
 
   test(

--- a/packages/at_secondary_server/test/apkam_self_enrollment_test.dart
+++ b/packages/at_secondary_server/test/apkam_self_enrollment_test.dart
@@ -76,13 +76,15 @@ void main() {
     final r = Response();
     await etu.evh.processVerb(
       r,
-      getVerbParam(VerbSyntax.enroll, 'enroll:request:${jsonEncode(ep.toJson())}'),
+      getVerbParam(
+          VerbSyntax.enroll, 'enroll:request:${jsonEncode(ep.toJson())}'),
       inboundConnection,
     );
     return r;
   }
 
-  test('an approved enrollment self-enrolls a subset child, auto-approved, '
+  test(
+      'an approved enrollment self-enrolls a subset child, auto-approved, '
       'no OTP', () async {
     // The parent: an ordinary approved enrollment with scoped grants.
     final parentId = (await etu.createEnrollments(n: 1)).$1.first;
@@ -129,8 +131,7 @@ void main() {
         reason: 'and it is min(now + grace, existing expiry), not unbounded');
   });
 
-  test('escalation is refused: a namespace the parent does not hold',
-      () async {
+  test('escalation is refused: a namespace the parent does not hold', () async {
     final parentId = (await etu.createEnrollments(n: 1)).$1.first;
 
     await expectLater(
@@ -147,8 +148,8 @@ void main() {
     // The parent holds test:'r'.
 
     await expectLater(
-        () =>
-            selfEnroll(parentEnrollmentId: parentId, namespaces: {'test': 'rw'}),
+        () => selfEnroll(
+            parentEnrollmentId: parentId, namespaces: {'test': 'rw'}),
         throwsA(isA<UnAuthorizedException>()),
         reason: 'r under rw fits; rw under r is an escalation — per letter, '
             'not merely per namespace');
@@ -167,8 +168,7 @@ void main() {
             'anywhere else in the server, and must not here');
   });
 
-  test('a wildcard parent covers ordinary namespaces it never named',
-      () async {
+  test('a wildcard parent covers ordinary namespaces it never named', () async {
     // The primary (CRAM) enrollment holds *:rw and __manage:rw.
     final r = await selfEnroll(
         parentEnrollmentId: etu.primaryEnId,
@@ -215,7 +215,8 @@ void main() {
             'caller bug — the child holds exactly what it names');
   });
 
-  test('the cap re-arms on each sibling retrofit rather than keeping the '
+  test(
+      'the cap re-arms on each sibling retrofit rather than keeping the '
       'first deadline', () async {
     final parentId = (await etu.createEnrollments(n: 1)).$1.first;
     await selfEnroll(parentEnrollmentId: parentId, namespaces: {'app_1': 'rw'});
@@ -245,7 +246,8 @@ void main() {
     expect(ttl, lessThanOrEqualTo(graceMillis));
   });
 
-  test('the cap never extends past the expiry the parent\'s own posture '
+  test(
+      'the cap never extends past the expiry the parent\'s own posture '
       'imposes', () async {
     final parentId = (await etu.createEnrollments(n: 1)).$1.first;
     // Give the parent a key-expiry posture far shorter than the grace.
@@ -286,9 +288,10 @@ void main() {
     expect(child.apkamKeysExpiryDuration, Duration(hours: 1),
         reason: 'precondition: the inheritance itself, recorded in the value');
 
-    final childTtl = (await keyValueStore.get(enMgr.buildEnrollmentKey(childId)))
-        ?.metaData
-        ?.ttl;
+    final childTtl =
+        (await keyValueStore.get(enMgr.buildEnrollmentKey(childId)))
+            ?.metaData
+            ?.ttl;
     expect(childTtl, Duration(hours: 1).inMilliseconds,
         reason: 'the retrofit copies the parent\'s expiry to the child — a '
             'posture recorded only in the JSON value while the record carries '
@@ -308,9 +311,10 @@ void main() {
     expect(r.isError, false, reason: '${r.errorMessage}');
     final childId = jsonDecode(r.data!)['enrollmentId'] as String;
 
-    final childTtl = (await keyValueStore.get(enMgr.buildEnrollmentKey(childId)))
-        ?.metaData
-        ?.ttl;
+    final childTtl =
+        (await keyValueStore.get(enMgr.buildEnrollmentKey(childId)))
+            ?.metaData
+            ?.ttl;
     expect(childTtl, Duration(hours: 2).inMilliseconds,
         reason: 'the request may state its own posture instead of inheriting '
             '— and the record must expire per whichever applied');
@@ -381,9 +385,10 @@ void main() {
     expect(r.isError, false, reason: '${r.errorMessage}');
     final childId = jsonDecode(r.data!)['enrollmentId'] as String;
 
-    final childTtl = (await keyValueStore.get(enMgr.buildEnrollmentKey(childId)))
-        ?.metaData
-        ?.ttl;
+    final childTtl =
+        (await keyValueStore.get(enMgr.buildEnrollmentKey(childId)))
+            ?.metaData
+            ?.ttl;
     expect(childTtl, Duration(hours: 1).inMilliseconds,
         reason: 'ttl 0 means never-expires at both layers (_getExpiresAt '
             'returns null), so honouring a stated zero against a time-bound '
@@ -511,8 +516,7 @@ void main() {
       inboundConnection,
     );
 
-    expect(pkamResponse.isError, false,
-        reason: '${pkamResponse.errorMessage}');
+    expect(pkamResponse.isError, false, reason: '${pkamResponse.errorMessage}');
     expect(pkamResponse.data, 'success',
         reason: 'record-authoritative ML-DSA verification through the real '
             'at_chops dispatch — the whole point of the retrofit is that '

--- a/packages/at_secondary_server/test/apkam_self_enrollment_test.dart
+++ b/packages/at_secondary_server/test/apkam_self_enrollment_test.dart
@@ -1,6 +1,12 @@
 import 'dart:convert';
 
+import 'dart:typed_data';
+
+import 'package:at_chops/at_chops.dart'
+    show AtChopsUtil, HashingAlgoType, MlDsa65PureDartAlgo, PkamSigningAlgo;
 import 'package:at_commons/at_commons.dart';
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_secondary/src/verb/handler/pkam_verb_handler.dart';
 import 'package:at_secondary/src/enroll/enroll_datastore_value.dart';
 import 'package:at_secondary/src/server/at_secondary_config.dart';
 import 'package:at_secondary/src/utils/handler_util.dart';
@@ -51,11 +57,13 @@ void main() {
     required Map<String, String> namespaces,
     String appName = 'selfapp',
     String deviceName = 'selfdevice',
+    String? signingAlgo,
   }) async {
     final ep = EnrollParams()
       ..appName = appName
       ..deviceName = deviceName
       ..apkamPublicKey = 'pq apkam public key $appName $deviceName'
+      ..signingAlgo = signingAlgo
       ..namespaces = namespaces;
     inboundConnection.metaData
       ..isAuthenticated = true
@@ -255,6 +263,185 @@ void main() {
         reason: 'the re-arm applies only within the enrollment\'s own '
             'key-expiry posture — a 1h apkamKeysExpiryDuration must not '
             'become a 30-day grace');
+  });
+
+  test(
+      'an mldsa65 self-enrollment publishes the tagged _apsk; an rsa one '
+      'stays bare', () async {
+    final parentId = (await etu.createEnrollments(n: 1)).$1.first;
+
+    final r = await selfEnroll(
+        parentEnrollmentId: parentId,
+        namespaces: {'app_1': 'rw'},
+        signingAlgo: 'mldsa65');
+    expect(r.isError, false, reason: '${r.errorMessage}');
+    final childId = jsonDecode(r.data!)['enrollmentId'] as String;
+
+    final childApsk = (await keyValueStore.get(
+            'public:_apsk.$childId.${EnrollmentConstants.perEnrollmentApproved}$alice'))!
+        .data!;
+    final tagged = jsonDecode(childApsk) as Map<String, dynamic>;
+    expect(tagged['signingAlgo'], 'mldsa65',
+        reason: 'a verifier fetching this _apsk must learn the algorithm '
+            'from the value itself, or it would parse a raw ML-DSA key as '
+            'RSA and fail on every signature');
+    expect(tagged['publicKey'], 'pq apkam public key selfapp selfdevice');
+    expect(tagged['v'], 1);
+
+    // Control: an enrollment without signingAlgo publishes the bare value
+    // exactly as today — deployed apps parse it as an RSA key.
+    final r2 = await selfEnroll(
+        parentEnrollmentId: parentId,
+        namespaces: {'app_1': 'rw'},
+        appName: 'selfapp2',
+        deviceName: 'selfdevice2');
+    final child2Id = jsonDecode(r2.data!)['enrollmentId'] as String;
+    final bareApsk = (await keyValueStore.get(
+            'public:_apsk.$child2Id.${EnrollmentConstants.perEnrollmentApproved}$alice'))!
+        .data!;
+    expect(bareApsk, 'pq apkam public key selfapp2 selfdevice2',
+        reason: 'the bare form is frozen for rsa2048 — the tagged form is '
+            'only for algorithms no deployed parser could read anyway');
+  });
+
+  test(
+      'an mldsa65 self-enrollment then AUTHENTICATES with a genuine ML-DSA '
+      'signature through the production verify dispatch', () async {
+    // The first end-to-end ML-DSA PKAM in this package: earlier coverage
+    // asserted record storage and enrollment status only, which is how a
+    // resolved at_chops without an mldsa65 verification branch could sit
+    // green while the live wire died in RSA ASN1 parsing of a raw ML-DSA
+    // key (caught 2026-08-05 by the at_client_sdk retrofit live test).
+    final parentId = (await etu.createEnrollments(n: 1)).$1.first;
+    final mlDsa = await MlDsa65PureDartAlgo().generateKeyPair();
+
+    final ep = EnrollParams()
+      ..appName = 'mldsa-auth-app'
+      ..deviceName = 'mldsa-auth-device'
+      ..apkamPublicKey = base64Encode(mlDsa.publicKey)
+      ..signingAlgo = 'mldsa65'
+      ..namespaces = {'app_1': 'rw'};
+    inboundConnection.metaData
+      ..isAuthenticated = true
+      ..authType = AuthType.apkam
+      ..sessionID = DateTime.now().millisecondsSinceEpoch.toString();
+    inboundConnection.metadata.enrollmentId = parentId;
+    final enrollResponse = Response();
+    await etu.evh.processVerb(
+      enrollResponse,
+      getVerbParam(
+          VerbSyntax.enroll, 'enroll:request:${jsonEncode(ep.toJson())}'),
+      inboundConnection,
+    );
+    expect(enrollResponse.isError, false,
+        reason: '${enrollResponse.errorMessage}');
+    final childId = jsonDecode(enrollResponse.data!)['enrollmentId'] as String;
+
+    // Seed the challenge the from: verb would have stored, sign it with the
+    // child's ML-DSA secret key, and authenticate.
+    const sessionId = 'mldsa-auth-session';
+    const challenge = 'a-per-connection-challenge';
+    await keyValueStore.put(
+        'private:$sessionId$alice', AtData()..data = challenge);
+    final signature = await MlDsa65PureDartAlgo().signBytes(
+        Uint8List.fromList(utf8.encode('$sessionId$alice:$challenge')),
+        secretKey: mlDsa.secretKey);
+
+    inboundConnection.metaData
+      ..isAuthenticated = false
+      ..sessionID = sessionId;
+    final pkamResponse = Response();
+    await PkamVerbHandler(keyValueStore).processVerb(
+      pkamResponse,
+      getVerbParam(
+          VerbSyntax.pkam,
+          'pkam:signingAlgo:mldsa65:enrollmentId:$childId:'
+          '${base64Encode(signature)}'),
+      inboundConnection,
+    );
+
+    expect(pkamResponse.isError, false,
+        reason: '${pkamResponse.errorMessage}');
+    expect(pkamResponse.data, 'success',
+        reason: 'record-authoritative ML-DSA verification through the real '
+            'at_chops dispatch — the whole point of the retrofit is that '
+            'the new enrollment can authenticate');
+    expect(inboundConnection.metaData.authType, AuthType.apkam);
+    expect(inboundConnection.metadata.enrollmentId, childId);
+
+    // Control: a tampered signature must be refused, or the assertion above
+    // proves routing rather than verification.
+    await keyValueStore.put(
+        'private:$sessionId$alice', AtData()..data = challenge);
+    final tampered = Uint8List.fromList(signature)..[0] ^= 0xff;
+    inboundConnection.metaData.isAuthenticated = false;
+    await expectLater(
+        () => PkamVerbHandler(keyValueStore).processVerb(
+              Response(),
+              getVerbParam(
+                  VerbSyntax.pkam,
+                  'pkam:signingAlgo:mldsa65:enrollmentId:$childId:'
+                  '${base64Encode(tampered)}'),
+              inboundConnection,
+            ),
+        throwsA(isA<UnAuthenticatedException>()));
+  });
+
+  test(
+      'an enrollment with NO recorded signingAlgo keeps the rsa2048 default '
+      'even when the wire claims mldsa65', () async {
+    // A legacy enrollment predates the signingAlgo field, so its record has
+    // none — and record-authoritative means ABSENT resolves to the rsa2048
+    // default, never to the wire claim. Before this was explicit, the null
+    // fell through to the claim, which picked the verify routine for
+    // exactly the enrollments that predate the field; the hole was masked
+    // while at_chops had no mldsa65 routine to mis-pick.
+    final parentId = (await etu.createEnrollments(n: 1)).$1.first;
+    final rsaPair = AtChopsUtil.generateAtPkamKeyPair();
+
+    final ep = EnrollParams()
+      ..appName = 'legacy-claim-app'
+      ..deviceName = 'legacy-claim-device'
+      ..apkamPublicKey = rsaPair.atPublicKey.publicKey
+      ..namespaces = {'app_1': 'rw'};
+    inboundConnection.metaData
+      ..isAuthenticated = true
+      ..authType = AuthType.apkam
+      ..sessionID = DateTime.now().millisecondsSinceEpoch.toString();
+    inboundConnection.metadata.enrollmentId = parentId;
+    final enrollResponse = Response();
+    await etu.evh.processVerb(
+      enrollResponse,
+      getVerbParam(
+          VerbSyntax.enroll, 'enroll:request:${jsonEncode(ep.toJson())}'),
+      inboundConnection,
+    );
+    final childId = jsonDecode(enrollResponse.data!)['enrollmentId'] as String;
+
+    const sessionId = 'legacy-claim-session';
+    const challenge = 'another-per-connection-challenge';
+    await keyValueStore.put(
+        'private:$sessionId$alice', AtData()..data = challenge);
+    final signature = PkamSigningAlgo(rsaPair, HashingAlgoType.sha256)
+        .sign(Uint8List.fromList(utf8.encode('$sessionId$alice:$challenge')));
+
+    inboundConnection.metaData
+      ..isAuthenticated = false
+      ..sessionID = sessionId;
+    final pkamResponse = Response();
+    await PkamVerbHandler(keyValueStore).processVerb(
+      pkamResponse,
+      getVerbParam(
+          VerbSyntax.pkam,
+          'pkam:signingAlgo:mldsa65:enrollmentId:$childId:'
+          '${base64Encode(signature)}'),
+      inboundConnection,
+    );
+
+    expect(pkamResponse.data, 'success',
+        reason: 'the record decides: absent signingAlgo = the rsa2048 '
+            'default, and the lying wire claim changes nothing — a legacy '
+            'client must not be locked out by a claim it never made');
   });
 
   test('an unapproved parent is refused', () async {

--- a/packages/at_secondary_server/test/cram_secret_bootstrap_test.dart
+++ b/packages/at_secondary_server/test/cram_secret_bootstrap_test.dart
@@ -69,7 +69,8 @@ void main() {
           'real-secret');
     });
 
-    test('does NOT resurrect a deleted secret (deleted-marker suppresses plant)',
+    test(
+        'does NOT resurrect a deleted secret (deleted-marker suppresses plant)',
         () async {
       // Onboarding deleted the secret and left the tombstone marker behind.
       await keyValueStore.put(

--- a/packages/at_secondary_server/test/enroll_verb_test.dart
+++ b/packages/at_secondary_server/test/enroll_verb_test.dart
@@ -2198,14 +2198,16 @@ void main() {
           throwsA(isA<UnAuthorizedException>()));
     }
 
-    test('enroll:fetch — a caller can fetch its OWN enrollment without __manage',
+    test(
+        'enroll:fetch — a caller can fetch its OWN enrollment without __manage',
         () async {
       await seedEnrollment('self1', {'wavi': 'rw'});
       final r = await fetchAs('self1', 'self1');
       expect(r['encryptedAPKAMSymmetricKey'], 'secret-self1');
     });
 
-    test('enroll:fetch — fetching ANOTHER enrollment without __manage is denied',
+    test(
+        'enroll:fetch — fetching ANOTHER enrollment without __manage is denied',
         () async {
       await seedEnrollment('caller1', {'wavi': 'rw'});
       await seedEnrollment('target1', {'wavi': 'rw'});

--- a/packages/at_secondary_server/test/enroll_verb_test.dart
+++ b/packages/at_secondary_server/test/enroll_verb_test.dart
@@ -2324,6 +2324,39 @@ void main() {
               e.message ==
                   'encrypted apkam symmetric key is mandatory for new client enroll:request')));
     });
+    test(
+        'A test to validate a request advertising a key package may omit the '
+        'encrypted apkam symmetric key', () async {
+      Response response = Response();
+      inboundConnection.metaData.isAuthenticated = true;
+      inboundConnection.metaData.sessionID = 'dummy_session';
+      // OTP Verb
+      HashMap<String, String?> otpVerbParams =
+          getVerbParam(VerbSyntax.otp, 'otp:get');
+      OtpVerbHandler otpVerbHandler = OtpVerbHandler(keyValueStore);
+      await otpVerbHandler.processVerb(
+          response, otpVerbParams, inboundConnection);
+      // No encryptedAPKAMSymmetricKey: the approver mints the symmetric key and
+      // encapsulates it to the advertised key package, so the request carries
+      // no RSA-wrapped secret at all.
+      String enrollmentRequest =
+          'enroll:request:{"appName":"wavi1","deviceName":"mydevice1","namespaces":{"buzz":"r"},"otp":"${response.data}","apkamPublicKey":"dummy_apkam_public_key","metadata":{"keyPackage":{"v":1,"keys":[]}}}';
+      HashMap<String, String?> enrollmentRequestVerbParams =
+          getVerbParam(VerbSyntax.enroll, enrollmentRequest);
+      inboundConnection.metaData.isAuthenticated = false;
+      EnrollVerbHandler enrollVerbHandler =
+          EnrollVerbHandler(keyValueStore, enMgr, notificationManager);
+      await enrollVerbHandler.processVerb(
+          response, enrollmentRequestVerbParams, inboundConnection);
+
+      final decoded = jsonDecode(response.data!);
+      expect(decoded['status'], 'pending');
+      final stored = await enMgr.getEnrollmentById(decoded['enrollmentId']);
+      expect(stored.encryptedAPKAMSymmetricKey, isNull);
+      expect(stored.metadata, {
+        'keyPackage': {'v': 1, 'keys': []}
+      });
+    });
     test('A test to validate namespace is mandatory for new client enrollment',
         () async {
       Response response = Response();

--- a/packages/at_secondary_server/test/enrollment_authz_tightening_test.dart
+++ b/packages/at_secondary_server/test/enrollment_authz_tightening_test.dart
@@ -95,8 +95,8 @@ void main() {
           throwsA(isA<UnAuthorizedException>()),
           reason:
               'a *:rw enrollment must not read another enrollment\'s a.__e');
-      expect(
-          inboundConnection.lastWrittenData ?? '', isNot(contains('topsecret')));
+      expect(inboundConnection.lastWrittenData ?? '',
+          isNot(contains('topsecret')));
     });
 
     test('*:rw enrollment CAN update its OWN a.__e key', () async {
@@ -116,8 +116,7 @@ void main() {
       await bindWildcardEnrollment();
       final foreignEnId = Uuid().v4();
       // The encrypted default-encryption-private-key (PEK) of another enrollment.
-      final pekKey =
-          '$foreignEnId.default_enc_private_key.__manage$alice';
+      final pekKey = '$foreignEnId.default_enc_private_key.__manage$alice';
 
       await expectLater(
           updateVerbHandler.process(
@@ -130,8 +129,7 @@ void main() {
         () async {
       await bindWildcardEnrollment();
       final foreignEnId = Uuid().v4();
-      final pekKey =
-          '$foreignEnId.default_enc_private_key.__manage$alice';
+      final pekKey = '$foreignEnId.default_enc_private_key.__manage$alice';
       await keyValueStore.put(pekKey, AtData()..data = 'ciphertext');
 
       await expectLater(

--- a/packages/at_secondary_server/test/enrollment_notification_delivery_test.dart
+++ b/packages/at_secondary_server/test/enrollment_notification_delivery_test.dart
@@ -1,0 +1,96 @@
+import 'dart:convert';
+
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_secondary/src/verb/handler/local_lookup_verb_handler.dart';
+import 'package:at_utils/at_logger.dart';
+import 'package:test/test.dart';
+import 'package:uuid/uuid.dart';
+
+import 'test_utils.dart';
+
+/// Which notifications reach a SCOPED enrollment's monitor.
+///
+/// `MonitorVerbHandler._sendNotification` gates every delivery on
+/// `isAuthorized(connectionMetadata, atKey: notification.notification)` and
+/// drops a failing one by bare `return` — no log at any level. A dropped
+/// notification is indistinguishable from one that was never sent, so a
+/// receiver-side authorization mismatch presents as "the sender didn't
+/// send".
+///
+/// Provoked by a live observation (at_client_sdk
+/// `docs/projects/pq/decisions.md` 44.3): a self-notification for a key in
+/// the enrollment's OWN granted namespace never reached that enrollment's
+/// monitor, while statsNotifications flowed.
+///
+/// **What these pin: the authorization gate is NOT the cause.** It permits
+/// exactly what it should — the enrollment's own namespace through, another
+/// namespace refused. Whatever drops that notification is upstream of here
+/// (creation, or the notification manager's dispatch), and the silent
+/// `return` is why it presents as a sender-side absence either way.
+void main() {
+  AtSignLogger.root_level = 'WARNING';
+
+  group('notification delivery authorization for a scoped enrollment', () {
+    late LocalLookupVerbHandler handler;
+
+    setUpAll(() async {
+      await verbTestsSetUpAll();
+    });
+
+    setUp(() async {
+      await verbTestsSetUp();
+      handler = LocalLookupVerbHandler(keyValueStore, enMgr);
+    });
+
+    tearDown(() async {
+      await verbTestsTearDown();
+    });
+
+    /// An approved enrollment holding exactly `buzz:rw`, bound to the
+    /// connection — the shape a PQ self-retrofit produces.
+    Future<String> bindBuzzEnrollment() async {
+      inboundConnection.metadata.isAuthenticated = true;
+      final enrollId = Uuid().v4();
+      inboundConnection.metadata.enrollmentId = enrollId;
+      final enrollJson = {
+        'sessionId': '123',
+        'appName': 'rf2c',
+        'deviceName': 'device',
+        'namespaces': {'buzz': 'rw'},
+        'apkamPublicKey': 'pk',
+        'requestType': 'newEnrollment',
+        'approval': {'state': 'approved'}
+      };
+      await keyValueStore.put('$enrollId.new.enrollments.__manage$alice',
+          AtData()..data = jsonEncode(enrollJson));
+      return enrollId;
+    }
+
+    test('a self-notification in the enrollment\'s own namespace IS delivered',
+        () async {
+      await bindBuzzEnrollment();
+
+      // What the monitor sees for a self notify: sharedWith:key@sharedBy,
+      // both halves the same atSign.
+      expect(
+          await handler.isAuthorized(inboundConnection.metadata,
+              atKey: '$alice:rf2cmon-1.buzz$alice'),
+          isTrue,
+          reason: 'the enrollment holds buzz:rw and the key is in buzz — if '
+              'this is false, every notification for the enrollment\'s own '
+              'data is dropped silently at the monitor');
+    });
+
+    test('a notification outside the granted namespace is NOT delivered',
+        () async {
+      await bindBuzzEnrollment();
+
+      expect(
+          await handler.isAuthorized(inboundConnection.metadata,
+              atKey: '$alice:secret.wavi$alice'),
+          isFalse,
+          reason: 'control: the gate must actually gate, or the assertion '
+              'above proves nothing');
+    });
+  });
+}

--- a/packages/at_secondary_server/test/keys_verb_authorization_test.dart
+++ b/packages/at_secondary_server/test/keys_verb_authorization_test.dart
@@ -165,7 +165,8 @@ void main() {
           keysVerbHandler.process(
               'keys:delete:keyName:$foreignKey', inboundConnection),
           throwsA(isA<UnAuthorizedException>()),
-          reason: 'must not delete a keys-verb key owned by another enrollment');
+          reason:
+              'must not delete a keys-verb key owned by another enrollment');
       expect(await keyValueStore.exists(foreignKey), isTrue);
     });
   });

--- a/packages/at_secondary_server/test/persistence_migration_test.dart
+++ b/packages/at_secondary_server/test/persistence_migration_test.dart
@@ -54,7 +54,8 @@ void main() {
     expect(read.migratedAt!.toUtc(), now.toUtc());
   });
 
-  test('migrateIfNeeded hive -> sqlite migrates, verifies, flips marker, '
+  test(
+      'migrateIfNeeded hive -> sqlite migrates, verifies, flips marker, '
       'retains source', () async {
     const atSign = '@migrate_alice';
 
@@ -72,13 +73,13 @@ void main() {
     await PersistenceBackendManager.migrateIfNeeded(atSign, 'sqlite');
 
     // Marker flipped, source retained.
-    final marker =
-        PersistenceBackendMarker.read('$tmp/.persistence_backend')!;
+    final marker = PersistenceBackendMarker.read('$tmp/.persistence_backend')!;
     expect(marker.activeBackend, 'sqlite');
     expect(marker.previousBackend, 'hive');
     expect(marker.previousPaths, isNotEmpty);
     expect(marker.migratedAt, isNotNull);
-    expect(Directory('$tmp/hive').existsSync(), true, reason: 'source retained');
+    expect(Directory('$tmp/hive').existsSync(), true,
+        reason: 'source retained');
 
     // The SQLite target has the data.
     final sqliteFactory = SqliteAtPersistenceFactory();
@@ -109,16 +110,15 @@ void main() {
 
     await PersistenceBackendManager.migrateIfNeeded(atSign, 'hive');
 
-    final marker =
-        PersistenceBackendMarker.read('$tmp/.persistence_backend')!;
+    final marker = PersistenceBackendMarker.read('$tmp/.persistence_backend')!;
     expect(marker.activeBackend, 'hive');
     expect(marker.previousBackend, 'sqlite');
 
     final hiveFactory = PersistenceBackendManager.factoryFor('hive');
     final hiveBundle = await hiveFactory.initialize(
         atSign, PersistenceBackendManager.configFor('hive'));
-    expect((await hiveBundle.keyValueStore.get('loc.wavi$atSign'))!.data,
-        'paris');
+    expect(
+        (await hiveBundle.keyValueStore.get('loc.wavi$atSign'))!.data, 'paris');
     await hiveFactory.close();
   });
 

--- a/packages/at_secondary_server/test/root_key_authz_test.dart
+++ b/packages/at_secondary_server/test/root_key_authz_test.dart
@@ -141,8 +141,7 @@ void main() {
         // result with this authorization check.
         await bindScoped();
         await keyValueStore.put(key, AtData()..data = 'GENUINE');
-        await localLookupVerbHandler.process(
-            'llookup:$key', inboundConnection);
+        await localLookupVerbHandler.process('llookup:$key', inboundConnection);
         expect(inboundConnection.lastWrittenData, contains('GENUINE'));
       });
 
@@ -173,8 +172,7 @@ void main() {
       test('scoped enrollment CAN read and delete $key', () async {
         await bindScoped();
         await keyValueStore.put(key, AtData()..data = 'encryptedvalue');
-        await localLookupVerbHandler.process(
-            'llookup:$key', inboundConnection);
+        await localLookupVerbHandler.process('llookup:$key', inboundConnection);
         expect(inboundConnection.lastWrittenData, contains('encryptedvalue'));
         await deleteVerbHandler.process('delete:$key', inboundConnection);
       });
@@ -210,8 +208,7 @@ void main() {
         'shared_key.bob@alice.evil@alice',
         'prefix:privatekey:at_pkam_publickey',
       ]) {
-        expect(
-            updateVerbHandler.isAuthorizedSync(enroll, enrollId, atKey: key),
+        expect(updateVerbHandler.isAuthorizedSync(enroll, enrollId, atKey: key),
             isFalse,
             reason: '"$key" only contains an exempt form, it is not one');
       }
@@ -254,8 +251,12 @@ void main() {
 
     // ---- matching the key the keystore writes ----
 
-    for (final variant in ['public:publickey@alice ', ' public:publickey@alice',
-      'public:publickey@alice\t', 'PUBLIC:PUBLICKEY@ALICE']) {
+    for (final variant in [
+      'public:publickey@alice ',
+      ' public:publickey@alice',
+      'public:publickey@alice\t',
+      'PUBLIC:PUBLICKEY@ALICE'
+    ]) {
       test('a non-root enrollment is denied ${jsonEncode(variant)}', () async {
         // HiveKeyStoreHelper.prepareKey normalises with
         // trim().toLowerCase().replaceAll(' ',''), so these variants all
@@ -341,8 +342,7 @@ void main() {
         'config:block:add:@evil',
         'config:block:remove:@evil',
       ]) {
-        await expectLater(
-            configVerbHandler.process(command, inboundConnection),
+        await expectLater(configVerbHandler.process(command, inboundConnection),
             throwsA(isA<UnAuthorizedException>()),
             reason: '$command is an atSign-level privilege');
       }
@@ -352,7 +352,8 @@ void main() {
         () async {
       await bindWildcard();
       await expectLater(
-          configVerbHandler.process('config:block:add:@evil', inboundConnection),
+          configVerbHandler.process(
+              'config:block:add:@evil', inboundConnection),
           throwsA(isA<UnAuthorizedException>()));
     });
 
@@ -376,8 +377,8 @@ void main() {
         'cached:shared_key.bob@alice',
       ]) {
         expect(
-            () =>
-                updateVerbHandler.isAuthorizedSync(enroll, enrollId, atKey: key),
+            () => updateVerbHandler.isAuthorizedSync(enroll, enrollId,
+                atKey: key),
             returnsNormally,
             reason: '$key must not throw out of the authorization check');
       }

--- a/packages/at_secondary_server/test/scan_verb_test.dart
+++ b/packages/at_secondary_server/test/scan_verb_test.dart
@@ -469,7 +469,8 @@ void main() {
           scanResponseList[0], '$enrollmentId.new.enrollments.__manage$alice');
     });
 
-    test('A test to verify a *:rw enrollment does NOT see __manage keys in scan',
+    test(
+        'A test to verify a *:rw enrollment does NOT see __manage keys in scan',
         () async {
       var enrollmentId = Uuid().v4();
       inboundConnection.metaData.isAuthenticated = true;

--- a/tests/at_end2end_test/test/app_metadata_test.dart
+++ b/tests/at_end2end_test/test/app_metadata_test.dart
@@ -1,0 +1,93 @@
+import 'dart:convert';
+
+import 'package:test/test.dart';
+// ignore: depend_on_referenced_packages
+import 'package:uuid/uuid.dart';
+import 'package:version/version.dart';
+
+import 'e2e_test_utils.dart' as e2e;
+
+/// Does `appMetadata` survive a CROSS-atSign `lookup:all`?
+///
+/// The functional pack covers the same-server paths — an llookup round trip
+/// and sync. This drives the remote one: @first shares a key carrying
+/// appMetadata with @second, and @second looks it up through its OWN server,
+/// which pol-authenticates to @first's server and relays the response.
+void main() {
+  late String atSign_1;
+  late e2e.SimpleOutboundConnection sh1;
+
+  late String atSign_2;
+  late e2e.SimpleOutboundConnection sh2;
+
+  final appMetadataJson = {
+    'providerId': 'acme_provider',
+    'keyId': 'k-123',
+    'mode': 'hpke',
+  };
+  final encodedAppMetadata =
+      base64Encode(utf8.encode(jsonEncode(appMetadataJson)));
+
+  setUpAll(() async {
+    List<String> atSigns = e2e.knownAtSigns();
+    atSign_1 = atSigns[0];
+    sh1 = await e2e.getSocketHandler(atSign_1);
+    atSign_2 = atSigns[1];
+    sh2 = await e2e.getSocketHandler(atSign_2);
+  });
+
+  tearDownAll(() {
+    sh1.close();
+    sh2.close();
+  });
+
+  setUp(() async {
+    print("Clearing socket response queues");
+    sh1.clear();
+    sh2.clear();
+  });
+
+  test('cross-atSign lookup:all relays appMetadata', () async {
+    // appMetadata landed in atServer 3.14.0. This pack runs against
+    // long-lived atSigns which may be older, and the sharing server parses
+    // the `:appMetadata:` fragment while the looking-up server relays the
+    // response, so both have to support it.
+    Version atSign1ServerVersion = Version.parse(await sh1.getVersion());
+    if (atSign1ServerVersion < Version(3, 14, 0)) {
+      print(
+          'Found $atSign_1 with server version: $atSign1ServerVersion. This test is only applicable for server version at least 3.14.0. Skipping the test');
+      return;
+    }
+    Version atSign2ServerVersion = Version.parse(await sh2.getVersion());
+    if (atSign2ServerVersion < Version(3, 14, 0)) {
+      print(
+          'Found $atSign_2 with server version: $atSign2ServerVersion. This test is only applicable for server version at least 3.14.0. Skipping the test');
+      return;
+    }
+
+    final key = 'appmeta-x-${Uuid().v4()}';
+
+    // @first shares a key with @second, carrying appMetadata.
+    await sh1.writeCommand(
+        'update:appMetadata:$encodedAppMetadata:$atSign_2:$key$atSign_1'
+        ' shared-value');
+    String response = await sh1.read();
+    print('update verb response : $response');
+    expect(response, contains(RegExp(r'data:\d+')),
+        reason: 'shared-key update should return a commitId');
+
+    // @second looks it up through its own server — the real remote path.
+    await sh2.writeCommand('lookup:all:$key$atSign_1');
+    response = (await sh2.read(timeoutMillis: 10000)).replaceFirst('data:', '');
+    print('lookup:all verb response : $response');
+    final atData = jsonDecode(response);
+    expect(atData['data'], 'shared-value');
+
+    final appMetadata = atData['metaData']['appMetadata'];
+    expect(appMetadata, isNotNull,
+        reason: 'appMetadata absent from cross-atSign lookup:all response');
+    expect(appMetadata['providerId'], 'acme_provider');
+    expect(appMetadata['keyId'], 'k-123');
+    expect(appMetadata['mode'], 'hpke');
+  }, timeout: Timeout(Duration(minutes: 3)));
+}

--- a/tests/at_functional_test/pubspec.yaml
+++ b/tests/at_functional_test/pubspec.yaml
@@ -9,11 +9,19 @@ environment:
 dependency_overrides:
   at_persistence_secondary_server:
     path: ../../packages/at_persistence_secondary_server
+  # Same tag the atServer itself resolves. The ML-DSA PKAM test needs to
+  # GENERATE an ML-DSA keypair and sign with it, which published at_chops
+  # cannot do. Drop this when at_chops publishes ML-DSA support.
+  at_chops:
+    git:
+      url: https://github.com/atsign-foundation/at_client_sdk.git
+      path: packages/at_chops
+      ref: at_chops-pq-spike-1 # at_client_sdk 55a78f16, off gkc-pq-d1-spike
 dependencies:
   hex: ^0.2.0
   at_persistence_secondary_server: ^4.3.5
   at_demo_data: ^1.2.0
-  at_chops: ^2.2.0
+  at_chops: ^3.5.0
   at_lookup: ^3.3.0
   at_commons: ^5.11.0
   at_utils: ^3.3.0

--- a/tests/at_functional_test/test/apkam_self_enrollment_test.dart
+++ b/tests/at_functional_test/test/apkam_self_enrollment_test.dart
@@ -1,0 +1,526 @@
+import 'dart:convert';
+
+import 'package:at_demo_data/at_demo_data.dart';
+import 'package:at_functional_test/conf/config_util.dart';
+import 'package:at_functional_test/connection/outbound_connection_wrapper.dart';
+import 'package:at_functional_test/utils/auth_utils.dart';
+import 'package:at_functional_test/utils/encryption_util.dart';
+import 'package:test/test.dart';
+import 'package:uuid/uuid.dart';
+
+/// Functional coverage of the APKAM self-enrollment branch (RF-SRV): an
+/// `enroll:request` arriving on an APKAM-authenticated connection resolves
+/// that connection's enrollment as the PARENT and auto-approves a child that
+/// can hold at most what the parent holds.
+///
+/// The unit suite in `at_secondary_server` pins the handler's decisions
+/// directly. These tests drive the same decisions over the wire, which is the
+/// only place the surrounding machinery — the enrollment record's ttl, the
+/// published `_apsk`, and whether the child can actually PKAM-authenticate —
+/// is observable.
+void main() {
+  String atSign = ConfigUtil.getYaml()!['firstAtSignServer']['firstAtSignName'];
+  String host = ConfigUtil.getYaml()!['firstAtSignServer']['firstAtSignUrl'];
+  int port = ConfigUtil.getYaml()!['firstAtSignServer']['firstAtSignPort'];
+
+  String apkamPublicKey = apkamPublicKeyMap[atSign]!;
+  String encryptedPrivateKey = EncryptionUtil.encryptValue(
+      encryptionPrivateKeyMap[atSign]!, apkamSymmetricKeyMap[atSign]!);
+  String encryptedSelfKey = EncryptionUtil.encryptValue(
+      aesKeyMap[atSign]!, apkamSymmetricKeyMap[atSign]!);
+  String encryptedApkamSymmetricKey = EncryptionUtil.encryptKey(
+      apkamSymmetricKeyMap[atSign]!, encryptionPublicKeyMap[atSign]!);
+
+  /// Connections opened by a test, closed in tearDown.
+  List<OutboundConnectionFactory> open = [];
+
+  Future<OutboundConnectionFactory> newConnection() async {
+    OutboundConnectionFactory c = await OutboundConnectionFactory()
+        .initiateConnectionWithListener(atSign, host, port);
+    open.add(c);
+    return c;
+  }
+
+  /// A CRAM-authenticated connection: the atSign's own, used to issue OTPs,
+  /// approve enrollments and read enrollment records back.
+  Future<OutboundConnectionFactory> ownerConnection() async {
+    OutboundConnectionFactory c = await newConnection();
+    expect((await c.authenticateConnection(authType: AuthType.cram)).trim(),
+        'data:success');
+    return c;
+  }
+
+  /// Creates an APPROVED enrollment holding exactly [namespaces] via the
+  /// ordinary OTP flow, and returns its enrollment id. This is the parent a
+  /// self-enrollment runs under.
+  ///
+  /// [appName] and [deviceName] default to run-unique values: an approved
+  /// (appName, deviceName) pair may not be re-used by the ordinary path, so
+  /// fixed names would pass once and collide on the next run.
+  Future<String> createApprovedEnrollment(OutboundConnectionFactory owner,
+      {required Map<String, String> namespaces,
+      String? appName,
+      String? deviceName,
+      int? apkamKeysExpiryInMillis}) async {
+    String otp = (await owner.sendRequestToServer('otp:get'))
+        .replaceFirst('data:', '')
+        .trim();
+    appName ??= 'app-${Uuid().v4().hashCode}';
+    deviceName ??= 'device-${Uuid().v4().hashCode}';
+    String expiry = apkamKeysExpiryInMillis == null
+        ? ''
+        : ',"apkamKeysExpiryInMillis":$apkamKeysExpiryInMillis';
+    // One enroll:request per connection: the rate limiter is per-connection,
+    // and another test file lowers maxRequestsPerTimeFrame server-wide.
+    OutboundConnectionFactory requester = await newConnection();
+    String response = await requester.sendRequestToServer(
+        'enroll:request:{"appName":"$appName","deviceName":"$deviceName","namespaces":${jsonEncode(namespaces)},"otp":"$otp","apkamPublicKey":"$apkamPublicKey","encryptedAPKAMSymmetricKey":"$encryptedApkamSymmetricKey"$expiry}');
+    String enrollmentId =
+        jsonDecode(response.replaceFirst('data:', ''))['enrollmentId'];
+    String approval = await owner.sendRequestToServer(
+        'enroll:approve:{"enrollmentId":"$enrollmentId","encryptedDefaultEncryptionPrivateKey":"$encryptedPrivateKey","encryptedDefaultSelfEncryptionKey":"$encryptedSelfKey"}');
+    expect(jsonDecode(approval.replaceFirst('data:', ''))['status'], 'approved');
+    return enrollmentId;
+  }
+
+  /// Sends one `enroll:request` on a connection APKAM-authenticated as
+  /// [parentId], and returns the raw server response.
+  Future<String> selfEnroll(String parentId,
+      {required Map<String, String> namespaces,
+      String? appName,
+      String? deviceName,
+      int? apkamKeysExpiryInMillis,
+      String? signingAlgo}) async {
+    OutboundConnectionFactory parent = await newConnection();
+    expect(
+        (await parent.authenticateConnection(
+                authType: AuthType.apkam, enrollmentId: parentId))
+            .trim(),
+        'data:success',
+        reason: 'the parent must be able to authenticate before it self-enrols');
+    String expiry = apkamKeysExpiryInMillis == null
+        ? ''
+        : ',"apkamKeysExpiryInMillis":$apkamKeysExpiryInMillis';
+    String algo = signingAlgo == null ? '' : ',"signingAlgo":"$signingAlgo"';
+    return (await parent.sendRequestToServer(
+            'enroll:request:{"appName":"${appName ?? 'child-${Uuid().v4().hashCode}'}","deviceName":"${deviceName ?? 'device-${Uuid().v4().hashCode}'}","namespaces":${jsonEncode(namespaces)},"apkamPublicKey":"$apkamPublicKey"$expiry$algo}'))
+        .trim();
+  }
+
+  /// [selfEnroll] for the cases that are expected to succeed.
+  Future<String> selfEnrollId(String parentId,
+      {required Map<String, String> namespaces,
+      String? appName,
+      String? deviceName,
+      int? apkamKeysExpiryInMillis,
+      String? signingAlgo}) async {
+    String response = await selfEnroll(parentId,
+        namespaces: namespaces,
+        appName: appName,
+        deviceName: deviceName,
+        apkamKeysExpiryInMillis: apkamKeysExpiryInMillis,
+        signingAlgo: signingAlgo);
+    Map decoded = jsonDecode(response.replaceFirst('data:', ''));
+    expect(decoded['status'], 'approved',
+        reason: 'a self-enrollment is auto-approved with no human step');
+    expect(decoded['enrollmentId'], isNotEmpty);
+    return decoded['enrollmentId'];
+  }
+
+  /// The enrollment record as stored, including its metadata — the only place
+  /// the written ttl and the recorded parent are observable.
+  Future<({Map<String, dynamic> value, Map<String, dynamic> metaData})>
+      enrollmentRecord(OutboundConnectionFactory owner, String id) async {
+    String response = (await owner.sendRequestToServer(
+            'llookup:all:$id.new.enrollments.__manage$atSign'))
+        .trim()
+        .replaceFirst('data:', '');
+    Map decoded = jsonDecode(response);
+    return (
+      value: jsonDecode(decoded['data']) as Map<String, dynamic>,
+      metaData: decoded['metaData'] as Map<String, dynamic>,
+    );
+  }
+
+  tearDown(() async {
+    for (final c in open) {
+      await c.close();
+    }
+    open = [];
+  });
+
+  group('A self-enrollment is auto-approved and usable', () {
+    test('an approved parent self-enrolls a subset child that can authenticate',
+        () async {
+      OutboundConnectionFactory owner = await ownerConnection();
+      String parentId =
+          await createApprovedEnrollment(owner, namespaces: {'wavi': 'rw'});
+
+      String childId =
+          await selfEnrollId(parentId, namespaces: {'wavi': 'r'});
+
+      // The child is not merely recorded: it authenticates.
+      OutboundConnectionFactory child = await newConnection();
+      expect(
+          (await child.authenticateConnection(
+                  authType: AuthType.apkam, enrollmentId: childId))
+              .trim(),
+          'data:success');
+    });
+
+    test('the child records its parent, so a revoke can cascade later',
+        () async {
+      OutboundConnectionFactory owner = await ownerConnection();
+      String parentId =
+          await createApprovedEnrollment(owner, namespaces: {'wavi': 'rw'});
+      String childId = await selfEnrollId(parentId, namespaces: {'wavi': 'r'});
+
+      final child = await enrollmentRecord(owner, childId);
+      expect(child.value['parentEnrollmentId'], parentId);
+      expect(child.value['namespaces'], {'wavi': 'r'});
+      expect(child.value['approval']['state'], 'approved');
+    });
+
+    test('a self-enrolled child needs no encrypted APKAM symmetric key',
+        () async {
+      // A PQ self-enrollment conveys its legacy material client-side, sealed
+      // to its own new key package, so the field the ordinary path demands is
+      // absent here.
+      OutboundConnectionFactory owner = await ownerConnection();
+      String parentId =
+          await createApprovedEnrollment(owner, namespaces: {'wavi': 'rw'});
+      String childId = await selfEnrollId(parentId, namespaces: {'wavi': 'r'});
+
+      final child = await enrollmentRecord(owner, childId);
+      expect(child.value['encryptedAPKAMSymmetricKey'], isNull);
+    });
+
+    test(
+        'a retrofit keeps its own (appName, deviceName) where the ordinary path may not',
+        () async {
+      // Uniqueness of (appName, deviceName) among live enrollments ends on
+      // this branch by design: a retrofit is the same app re-enrolling itself,
+      // and sibling clones of one keyfile share those names.
+      OutboundConnectionFactory owner = await ownerConnection();
+      String appName = 'retrofit-${Uuid().v4().hashCode}';
+      String deviceName = 'device-${Uuid().v4().hashCode}';
+      String parentId = await createApprovedEnrollment(owner,
+          namespaces: {'wavi': 'rw'},
+          appName: appName,
+          deviceName: deviceName);
+
+      // Same names, twice, on the self-enrollment branch: both approved.
+      await selfEnrollId(parentId,
+          namespaces: {'wavi': 'r'},
+          appName: appName,
+          deviceName: deviceName);
+      await selfEnrollId(parentId,
+          namespaces: {'wavi': 'r'},
+          appName: appName,
+          deviceName: deviceName);
+
+      // Control: the ORDINARY path still refuses those same names, so the
+      // assertions above record a difference between the two branches rather
+      // than a duplicate check that never fires.
+      String otp = (await owner.sendRequestToServer('otp:get'))
+          .replaceFirst('data:', '')
+          .trim();
+      OutboundConnectionFactory ordinary = await newConnection();
+      String response = await ordinary.sendRequestToServer(
+          'enroll:request:{"appName":"$appName","deviceName":"$deviceName","namespaces":{"wavi":"rw"},"otp":"$otp","apkamPublicKey":"$apkamPublicKey","encryptedAPKAMSymmetricKey":"$encryptedApkamSymmetricKey"}');
+      expect(response.trim(), startsWith('error:'),
+          reason: 'the ordinary path must still reject duplicate names');
+    });
+  });
+
+  group('A self-enrollment may not escalate beyond its parent', () {
+    test('a namespace the parent does not hold is refused', () async {
+      OutboundConnectionFactory owner = await ownerConnection();
+      String parentId =
+          await createApprovedEnrollment(owner, namespaces: {'wavi': 'rw'});
+
+      String response =
+          await selfEnroll(parentId, namespaces: {'buzz': 'rw'});
+      Map error = jsonDecode(response.replaceFirst('error:', ''));
+      expect(error['errorCode'], 'AT0009');
+      expect(
+          error['errorDescription'],
+          contains('Requested namespace "buzz:rw" exceeds the parent '
+              'enrollment\'s grants'));
+    });
+
+    test('broader access letters on a held namespace are refused', () async {
+      OutboundConnectionFactory owner = await ownerConnection();
+      String parentId = await createApprovedEnrollment(owner,
+          namespaces: {'atmosphere': 'r'});
+
+      String response =
+          await selfEnroll(parentId, namespaces: {'atmosphere': 'rw'});
+      Map error = jsonDecode(response.replaceFirst('error:', ''));
+      expect(error['errorCode'], 'AT0009');
+      expect(error['errorDescription'],
+          contains('Requested namespace "atmosphere:rw" exceeds'));
+    });
+
+    test('a wildcard parent cannot mint __manage', () async {
+      // `*` does not imply `__manage` anywhere else in the server, and it must
+      // not here — otherwise any `*` keyfile could self-spawn an enrollment
+      // that administers every other enrollment.
+      OutboundConnectionFactory owner = await ownerConnection();
+      String parentId =
+          await createApprovedEnrollment(owner, namespaces: {'*': 'rw'});
+
+      String response =
+          await selfEnroll(parentId, namespaces: {'__manage': 'rw'});
+      Map error = jsonDecode(response.replaceFirst('error:', ''));
+      expect(error['errorCode'], 'AT0009');
+      expect(error['errorDescription'],
+          contains('Requested namespace "__manage:rw" exceeds'));
+    });
+
+    test('a wildcard parent does cover an ordinary namespace it never named',
+        () async {
+      // The positive half of the rule above: without this, the refusal test
+      // would pass just as well against a branch that refused everything.
+      OutboundConnectionFactory owner = await ownerConnection();
+      String parentId =
+          await createApprovedEnrollment(owner, namespaces: {'*': 'rw'});
+
+      String childId = await selfEnrollId(parentId,
+          namespaces: {'a-namespace-never-named': 'rw'});
+      final child = await enrollmentRecord(owner, childId);
+      expect(child.value['namespaces'], {'a-namespace-never-named': 'rw'});
+    });
+
+    test('an empty namespace set is refused', () async {
+      // An approved credential that can do nothing is always a caller bug.
+      OutboundConnectionFactory owner = await ownerConnection();
+      String parentId =
+          await createApprovedEnrollment(owner, namespaces: {'wavi': 'rw'});
+
+      String response = await selfEnroll(parentId, namespaces: {});
+      Map error = jsonDecode(response.replaceFirst('error:', ''));
+      expect(error['errorCode'], 'AT0022');
+      expect(
+          error['errorDescription'],
+          contains('At least one namespace must be specified for an '
+              'APKAM-authenticated enroll:request'));
+    });
+  });
+
+  group('A self-enrolled child expires, and may not outlive its parent', () {
+    // One hour, so a child asking for longer, for "never", or for a negative
+    // value has something to be clamped against.
+    const int oneHourMs = 3600000;
+
+    test('a child inherits the parent\'s key-expiry posture', () async {
+      OutboundConnectionFactory owner = await ownerConnection();
+      String parentId = await createApprovedEnrollment(owner,
+          namespaces: {'wavi': 'rw'}, apkamKeysExpiryInMillis: oneHourMs);
+
+      String childId = await selfEnrollId(parentId, namespaces: {'wavi': 'r'});
+      final child = await enrollmentRecord(owner, childId);
+      expect(child.value['apkamKeysExpiryInMillis'], oneHourMs);
+      // The posture is not merely recorded, it is written as the record's ttl
+      // — the hole that made an inherited expiry into immortality.
+      expect(child.metaData['ttl'], oneHourMs);
+      expect(child.metaData['expiresAt'], isNotNull);
+    });
+
+    test('a child may state a SHORTER expiry than its parent', () async {
+      OutboundConnectionFactory owner = await ownerConnection();
+      String parentId = await createApprovedEnrollment(owner,
+          namespaces: {'wavi': 'rw'}, apkamKeysExpiryInMillis: oneHourMs);
+
+      String childId = await selfEnrollId(parentId,
+          namespaces: {'wavi': 'r'}, apkamKeysExpiryInMillis: 60000);
+      final child = await enrollmentRecord(owner, childId);
+      expect(child.value['apkamKeysExpiryInMillis'], 60000);
+      expect(child.metaData['ttl'], 60000);
+    });
+
+    test('a child may not state an expiry that outlives its parent', () async {
+      OutboundConnectionFactory owner = await ownerConnection();
+      String parentId = await createApprovedEnrollment(owner,
+          namespaces: {'wavi': 'rw'}, apkamKeysExpiryInMillis: oneHourMs);
+
+      String childId = await selfEnrollId(parentId,
+          namespaces: {'wavi': 'r'}, apkamKeysExpiryInMillis: 999999999);
+      final child = await enrollmentRecord(owner, childId);
+      // Clamped to the parent's, not refused: a client asking for longer
+      // without knowing is corrected rather than broken.
+      expect(child.value['apkamKeysExpiryInMillis'], oneHourMs);
+      expect(child.metaData['ttl'], oneHourMs);
+    });
+
+    test('a child may not state "never expires" against a bounded parent',
+        () async {
+      // Zero is the keystore's "never expires" — the route by which a stolen,
+      // hour-bound keyfile would mint itself a permanent credential.
+      OutboundConnectionFactory owner = await ownerConnection();
+      String parentId = await createApprovedEnrollment(owner,
+          namespaces: {'wavi': 'rw'}, apkamKeysExpiryInMillis: oneHourMs);
+
+      String childId = await selfEnrollId(parentId,
+          namespaces: {'wavi': 'r'}, apkamKeysExpiryInMillis: 0);
+      final child = await enrollmentRecord(owner, childId);
+      expect(child.value['apkamKeysExpiryInMillis'], oneHourMs);
+      expect(child.metaData['ttl'], oneHourMs);
+    });
+
+    test('a negative stated expiry is not honoured', () async {
+      // A negative value skips the ttl write altogether, so it is the same
+      // ask as "never expires" by a different route.
+      OutboundConnectionFactory owner = await ownerConnection();
+      String parentId = await createApprovedEnrollment(owner,
+          namespaces: {'wavi': 'rw'}, apkamKeysExpiryInMillis: oneHourMs);
+
+      String childId = await selfEnrollId(parentId,
+          namespaces: {'wavi': 'r'}, apkamKeysExpiryInMillis: -1);
+      final child = await enrollmentRecord(owner, childId);
+      expect(child.value['apkamKeysExpiryInMillis'], oneHourMs);
+      expect(child.metaData['ttl'], oneHourMs);
+    });
+  });
+
+  group('The parent survives a retrofit, capped rather than removed', () {
+    test('the parent still authenticates after a child self-enrolls',
+        () async {
+      OutboundConnectionFactory owner = await ownerConnection();
+      String parentId =
+          await createApprovedEnrollment(owner, namespaces: {'wavi': 'rw'});
+      await selfEnrollId(parentId, namespaces: {'wavi': 'r'});
+
+      OutboundConnectionFactory parent = await newConnection();
+      expect(
+          (await parent.authenticateConnection(
+                  authType: AuthType.apkam, enrollmentId: parentId))
+              .trim(),
+          'data:success',
+          reason: 'sibling clones must still be able to retrofit');
+    });
+
+    test('the cap re-arms on each sibling retrofit', () async {
+      // A deadline fixed by the first sibling's upgrade would strand every
+      // laggard whose next run fell outside that window.
+      OutboundConnectionFactory owner = await ownerConnection();
+      String parentId =
+          await createApprovedEnrollment(owner, namespaces: {'wavi': 'rw'});
+
+      await selfEnrollId(parentId, namespaces: {'wavi': 'r'});
+      final afterFirst = await enrollmentRecord(owner, parentId);
+      DateTime firstCap = DateTime.parse(afterFirst.metaData['expiresAt']);
+
+      await Future.delayed(Duration(seconds: 2));
+
+      await selfEnrollId(parentId, namespaces: {'wavi': 'r'});
+      final afterSecond = await enrollmentRecord(owner, parentId);
+      DateTime secondCap = DateTime.parse(afterSecond.metaData['expiresAt']);
+
+      expect(secondCap.isAfter(firstCap), isTrue,
+          reason: 'the second retrofit must push the parent\'s expiry out, '
+              'not leave the first retrofit\'s deadline in place');
+    });
+  });
+
+  group('A key-package request may omit the RSA-wrapped symmetric key', () {
+    test('a request advertising a key package is accepted without one',
+        () async {
+      OutboundConnectionFactory owner = await ownerConnection();
+      String otp = (await owner.sendRequestToServer('otp:get'))
+          .replaceFirst('data:', '')
+          .trim();
+
+      OutboundConnectionFactory requester = await newConnection();
+      String response = await requester.sendRequestToServer(
+          'enroll:request:{"appName":"kp-${Uuid().v4().hashCode}","deviceName":"device-${Uuid().v4().hashCode}","namespaces":{"wavi":"rw"},"otp":"$otp","apkamPublicKey":"$apkamPublicKey","metadata":{"keyPackage":"a-key-package"}}');
+      Map decoded = jsonDecode(response.replaceFirst('data:', ''));
+      expect(decoded['status'], 'pending');
+      expect(decoded['enrollmentId'], isNotEmpty);
+    });
+
+    test('without a key package the symmetric key is still mandatory',
+        () async {
+      // The control: a client that sends neither has no route to a symmetric
+      // key at all, and failing here beats enrolling into a state it cannot
+      // decrypt.
+      OutboundConnectionFactory owner = await ownerConnection();
+      String otp = (await owner.sendRequestToServer('otp:get'))
+          .replaceFirst('data:', '')
+          .trim();
+
+      OutboundConnectionFactory requester = await newConnection();
+      String response = await requester.sendRequestToServer(
+          'enroll:request:{"appName":"kp-${Uuid().v4().hashCode}","deviceName":"device-${Uuid().v4().hashCode}","namespaces":{"wavi":"rw"},"otp":"$otp","apkamPublicKey":"$apkamPublicKey"}');
+      expect(
+          response.trim(),
+          contains(
+              'encrypted apkam symmetric key is mandatory for new client enroll:request'));
+    });
+  });
+
+  group('The published _apsk describes its own algorithm', () {
+    Future<String> apskValue(
+        OutboundConnectionFactory owner, String enrollmentId) async {
+      return (await owner
+              .sendRequestToServer('llookup:public:_apsk.$enrollmentId.a.__e$atSign'))
+          .trim()
+          .replaceFirst('data:', '');
+    }
+
+    test('an rsa2048 enrollment publishes the bare public key', () async {
+      // Deployed apps parse the bare value as an RSA key, so this one may not
+      // change shape.
+      OutboundConnectionFactory owner = await ownerConnection();
+      String parentId =
+          await createApprovedEnrollment(owner, namespaces: {'wavi': 'rw'});
+      String childId = await selfEnrollId(parentId, namespaces: {'wavi': 'r'});
+
+      expect(await apskValue(owner, childId), apkamPublicKey);
+    });
+
+    test('a non-rsa2048 enrollment publishes the tagged, self-describing form',
+        () async {
+      // Without the tag a verifier reads a raw ML-DSA key as RSA and every
+      // signature from the enrollment fails.
+      OutboundConnectionFactory owner = await ownerConnection();
+      String parentId =
+          await createApprovedEnrollment(owner, namespaces: {'wavi': 'rw'});
+      String childId = await selfEnrollId(parentId,
+          namespaces: {'wavi': 'r'}, signingAlgo: 'mldsa65');
+
+      Map published = jsonDecode(await apskValue(owner, childId));
+      expect(published['v'], 1);
+      expect(published['signingAlgo'], 'mldsa65');
+      expect(published['publicKey'], apkamPublicKey);
+    });
+  });
+
+  group('PKAM trusts the enrollment record over the wire claim', () {
+    test('an enrollment with no recorded signingAlgo stays rsa2048 even when '
+        'the wire claims mldsa65', () async {
+      // The record is authoritative for an APKAM connection. If the claim
+      // picked the verify routine, this legitimate RSA enrollment would be
+      // verified as ML-DSA and fail.
+      OutboundConnectionFactory owner = await ownerConnection();
+      String enrollmentId =
+          await createApprovedEnrollment(owner, namespaces: {'wavi': 'rw'});
+      final record = await enrollmentRecord(owner, enrollmentId);
+      expect(record.value['signingAlgo'], isNull,
+          reason: 'the enrollment under test must have no recorded algorithm');
+
+      OutboundConnectionFactory client = await newConnection();
+      String challenge = (await client.sendRequestToServer(
+              'from:$atSign:clientConfig:${jsonEncode({'version': '3.0.57'})}'))
+          .replaceAll('data:', '');
+      String signature = AuthenticationUtils.generatePKAMDigest(
+          apkamPrivateKeyMap[atSign]!, challenge);
+
+      expect(
+          (await client.sendRequestToServer(
+                  'pkam:signingAlgo:mldsa65:enrollmentId:$enrollmentId:$signature'))
+              .trim(),
+          'data:success');
+    });
+  });
+}

--- a/tests/at_functional_test/test/enroll_listns_test.dart
+++ b/tests/at_functional_test/test/enroll_listns_test.dart
@@ -67,6 +67,12 @@ void main() {
 
       // enroll:request on a CRAM connection is auto-approved. metadata and
       // signingAlgo ride the request and are persisted on the record.
+      //
+      // This is the enrollment under inspection, not the one we authenticate
+      // as. It is labelled mldsa65 while carrying an RSA key, and PKAM reads
+      // the algorithm from the enrollment record rather than the wire, so it
+      // cannot authenticate — correctly, since the record is what a verifier
+      // would trust. The roster it appears in is what this test is about.
       final enrollRequest = 'enroll:request:${jsonEncode({
             'appName': 'listns-app',
             'deviceName': 'device-${Uuid().v4().hashCode}',
@@ -82,9 +88,38 @@ void main() {
       expect(enrollmentId, isNotEmpty);
       expect(enrollJson['status'], 'approved');
 
-      // APKAM-authenticate as the new enrollment, then query the roster.
-      await firstAtSignConnection.authenticateConnection(
-          authType: AuthType.pkam, enrollmentId: enrollmentId);
+      // A second, unlabelled (so rsa2048) enrollment on the same namespace is
+      // the CALLER: listns needs an APKAM-authenticated connection holding at
+      // least read access to the namespace.
+      //
+      // On its own connection: the enrollment rate limiter is per-connection,
+      // and another file in this pack lowers maxRequestsPerTimeFrame to 1
+      // server-wide without restoring it, so a second request on the
+      // connection above would fail depending on run order.
+      final callerConnection = await OutboundConnectionFactory()
+          .initiateConnectionWithListener(
+              firstAtSign, firstAtSignHost, firstAtSignPort);
+      await callerConnection.authenticateConnection(authType: AuthType.cram);
+      final callerRequest = 'enroll:request:${jsonEncode({
+            'appName': 'listns-caller',
+            'deviceName': 'device-${Uuid().v4().hashCode}',
+            'namespaces': {namespace: 'rw'},
+            'apkamPublicKey': apkamPublicKey,
+          })}\n';
+      final callerJson = jsonDecode(
+          (await callerConnection.sendRequestToServer(callerRequest))
+              .replaceFirst('data:', ''));
+      expect(callerJson['status'], 'approved');
+      await callerConnection.close();
+
+      // Assert the authentication itself: without this a failure here surfaces
+      // much later as a JSON parse error on an unrelated line.
+      expect(
+          (await firstAtSignConnection.authenticateConnection(
+                  authType: AuthType.pkam,
+                  enrollmentId: callerJson['enrollmentId']))
+              .trim(),
+          'data:success');
 
       final roster = jsonDecode(
           (await firstAtSignConnection

--- a/tests/at_functional_test/test/enroll_verb_test.dart
+++ b/tests/at_functional_test/test/enroll_verb_test.dart
@@ -613,6 +613,80 @@ void main() {
     });
 
     test(
+        'A test to verify a revoked enrollment cannot APKAM authenticate on subsequent connections',
+        () async {
+      // Send an enrollment request on the authenticated connection
+      await firstAtSignConnection.authenticateConnection(
+          authType: AuthType.cram);
+      String enrollRequest =
+          'enroll:request:{"appName":"wavi-${Uuid().v4().hashCode}","deviceName":"pixel","namespaces":{"wavi":"rw"},"apkamPublicKey":"${pkamPublicKeyMap[firstAtSign]!}"}\n';
+      String enrollResponse =
+          (await firstAtSignConnection.sendRequestToServer(enrollRequest))
+              .replaceAll('data:', '');
+      expect(jsonDecode(enrollResponse)['status'], 'approved');
+
+      String otpResponse =
+          (await firstAtSignConnection.sendRequestToServer('otp:get'))
+              .replaceFirst('data:', '')
+              .trim();
+
+      // connect to the second client and send an enroll request with the otp
+      OutboundConnectionFactory secondConnection =
+          await OutboundConnectionFactory().initiateConnectionWithListener(
+              firstAtSign, firstAtSignHost, firstAtSignPort);
+      String secondEnrollRequest =
+          'enroll:request:{"appName":"buzz","deviceName":"pixel-${Uuid().v4().hashCode}","namespaces":{"buzz":"rw"},"otp":"$otpResponse","apkamPublicKey":"${apkamPublicKeyMap[firstAtSign]!}","encryptedAPKAMSymmetricKey" : "${apkamEncryptedKeysMap['encryptedAPKAMSymmetricKey']}"}\n';
+      String secondEnrollResponse =
+          (await secondConnection.sendRequestToServer(secondEnrollRequest))
+              .replaceAll('data:', '');
+      var enrollJson = jsonDecode(secondEnrollResponse);
+      expect(enrollJson['status'], 'pending');
+      String secondEnrollmentId = enrollJson['enrollmentId'];
+
+      // approve the enroll request from the first client
+      String approveResponse = (await firstAtSignConnection.sendRequestToServer(
+              'enroll:approve:{"enrollmentId":"$secondEnrollmentId","encryptedDefaultEncryptionPrivateKey":"${apkamEncryptedKeysMap["encryptedDefaultEncPrivateKey"]}","encryptedDefaultSelfEncryptionKey": "${apkamEncryptedKeysMap["encryptedSelfEncKey"]}"}'))
+          .replaceAll('data:', '');
+      expect(jsonDecode(approveResponse)['status'], 'approved');
+
+      // Assert the enrollment can APKAM authenticate before the revoke, so the
+      // refusal below is attributable to the revoke and not to a broken setup.
+      await secondConnection.close();
+      OutboundConnectionFactory beforeRevokeConnection =
+          await OutboundConnectionFactory().initiateConnectionWithListener(
+              firstAtSign, firstAtSignHost, firstAtSignPort);
+      expect(
+          await beforeRevokeConnection.authenticateConnection(
+              authType: AuthType.apkam, enrollmentId: secondEnrollmentId),
+          'data:success');
+      await beforeRevokeConnection.close();
+
+      // Revoke the enrollment - no force flag; this is another client's
+      // enrollment, not the revoking connection's own.
+      String revokeEnrollmentResponse = (await firstAtSignConnection
+              .sendRequestToServer(
+                  'enroll:revoke:{"enrollmentId":"$secondEnrollmentId"}'))
+          .replaceAll('data:', '');
+      var revokeEnrollmentMap = jsonDecode(revokeEnrollmentResponse);
+      expect(revokeEnrollmentMap['status'], 'revoked');
+      expect(revokeEnrollmentMap['enrollmentId'], secondEnrollmentId);
+
+      // Every subsequent APKAM authentication on a fresh connection is refused
+      for (int attempt = 1; attempt <= 2; attempt++) {
+        OutboundConnectionFactory afterRevokeConnection =
+            await OutboundConnectionFactory().initiateConnectionWithListener(
+                firstAtSign, firstAtSignHost, firstAtSignPort);
+        String apkamAuthResponse =
+            await afterRevokeConnection.authenticateConnection(
+                authType: AuthType.apkam, enrollmentId: secondEnrollmentId);
+        await afterRevokeConnection.close();
+        expect(apkamAuthResponse.trim(),
+            'error:AT0027:enrollment_id: $secondEnrollmentId is revoked',
+            reason: 'APKAM attempt $attempt after revoke should be refused');
+      }
+    });
+
+    test(
         'A test to verify revoke operation cannot be performed on an unauthenticated connection',
         () async {
       // Send an enrollment request on the authenticated connection

--- a/tests/at_functional_test/test/enrollment_notification_delivery_test.dart
+++ b/tests/at_functional_test/test/enrollment_notification_delivery_test.dart
@@ -1,0 +1,146 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:at_demo_data/at_demo_data.dart';
+import 'package:at_functional_test/conf/config_util.dart';
+import 'package:at_functional_test/connection/outbound_connection_wrapper.dart';
+import 'package:at_functional_test/utils/auth_utils.dart';
+import 'package:at_functional_test/utils/encryption_util.dart';
+import 'package:test/test.dart';
+import 'package:uuid/uuid.dart';
+
+/// Functional coverage of the notification authorization gate
+/// ([MonitorVerbHandler._sendNotification]): a monitor belonging to a scoped
+/// enrollment is delivered notifications for the namespaces that enrollment
+/// holds, and not for the ones it does not.
+///
+/// A monitor is read over a RAW socket rather than [OutboundConnectionFactory].
+/// That wrapper's listener only surfaces responses beginning `data:`,
+/// `stream:`, `error:` or `@...@` (`OutboundMessageListener._isValidResponse`),
+/// and a monitor frame begins `notification:` — so the wrapper structurally
+/// cannot read one, and a test built on it reports a delivery that did happen
+/// as a timeout.
+void main() {
+  String atSign = ConfigUtil.getYaml()!['firstAtSignServer']['firstAtSignName'];
+  String host = ConfigUtil.getYaml()!['firstAtSignServer']['firstAtSignUrl'];
+  int port = ConfigUtil.getYaml()!['firstAtSignServer']['firstAtSignPort'];
+
+  String apkamPublicKey = apkamPublicKeyMap[atSign]!;
+  String encryptedPrivateKey = EncryptionUtil.encryptValue(
+      encryptionPrivateKeyMap[atSign]!, apkamSymmetricKeyMap[atSign]!);
+  String encryptedSelfKey = EncryptionUtil.encryptValue(
+      aesKeyMap[atSign]!, apkamSymmetricKeyMap[atSign]!);
+  String encryptedApkamSymmetricKey = EncryptionUtil.encryptKey(
+      apkamSymmetricKeyMap[atSign]!, encryptionPublicKeyMap[atSign]!);
+
+  List<OutboundConnectionFactory> open = [];
+
+  Future<OutboundConnectionFactory> newConnection() async {
+    OutboundConnectionFactory c = await OutboundConnectionFactory()
+        .initiateConnectionWithListener(atSign, host, port);
+    open.add(c);
+    return c;
+  }
+
+  tearDown(() async {
+    for (final c in open) {
+      await c.close();
+    }
+    open = [];
+  });
+
+  /// Opens a monitor APKAM-authenticated as [enrollmentId], replaying the
+  /// backlog from [since], and returns everything the server wrote.
+  ///
+  /// Chunks are accumulated and matched against the whole buffer: the '@'
+  /// prompt and the `from:` challenge can arrive coalesced in one read, so a
+  /// `startsWith` on an individual chunk misses them.
+  Future<String> monitorAs(String enrollmentId, int since) async {
+    StringBuffer buffer = StringBuffer();
+    SecureSocket socket = await SecureSocket.connect(host, port);
+    bool pkamSent = false;
+    bool monitorSent = false;
+
+    socket.listen((data) {
+      buffer.write(utf8.decode(data));
+      String all = buffer.toString();
+      if (!pkamSent && all.contains('data:_')) {
+        pkamSent = true;
+        int start = all.indexOf('data:_') + 'data:'.length;
+        int end = all.indexOf('\n', start);
+        String challenge =
+            all.substring(start, end == -1 ? all.length : end).trim();
+        String digest = AuthenticationUtils.generatePKAMDigest(
+            apkamPrivateKeyMap[atSign]!, challenge);
+        socket.write('pkam:enrollmentId:$enrollmentId:$digest\n');
+      } else if (pkamSent && !monitorSent && all.contains('data:success')) {
+        monitorSent = true;
+        socket.write('monitor:selfNotifications:$since\n');
+      }
+    });
+
+    socket.write('from:$atSign\n');
+    // The backlog is served immediately on the monitor command; this window is
+    // for the server to work through it, not for anything to be produced.
+    await Future.delayed(Duration(seconds: 8));
+    await socket.close();
+    return buffer.toString();
+  }
+
+  test('a scoped enrollment\'s monitor is given its own namespace and not another',
+      () async {
+    OutboundConnectionFactory owner = await newConnection();
+    expect((await owner.authenticateConnection(authType: AuthType.cram)).trim(),
+        'data:success');
+
+    // An enrollment scoped to `wavi` only.
+    String otp = (await owner.sendRequestToServer('otp:get'))
+        .replaceFirst('data:', '')
+        .trim();
+    OutboundConnectionFactory requester = await newConnection();
+    String enrollResponse = await requester.sendRequestToServer(
+        'enroll:request:{"appName":"notify-app-${Uuid().v4().hashCode}","deviceName":"device-${Uuid().v4().hashCode}","namespaces":{"wavi":"rw"},"otp":"$otp","apkamPublicKey":"$apkamPublicKey","encryptedAPKAMSymmetricKey":"$encryptedApkamSymmetricKey"}');
+    String enrollmentId =
+        jsonDecode(enrollResponse.replaceFirst('data:', ''))['enrollmentId'];
+    String approval = await owner.sendRequestToServer(
+        'enroll:approve:{"enrollmentId":"$enrollmentId","encryptedDefaultEncryptionPrivateKey":"$encryptedPrivateKey","encryptedDefaultSelfEncryptionKey":"$encryptedSelfKey"}');
+    expect(jsonDecode(approval.replaceFirst('data:', ''))['status'], 'approved');
+
+    // Both notifications are created BEFORE the monitor connects and are
+    // replayed from a timestamp, so this does not race the monitor's socket
+    // becoming ready. @alice -> @alice, so both are typed `received`, which is
+    // what the monitor backlog serves.
+    int since = DateTime.now().toUtc().millisecondsSinceEpoch - 1000;
+    String unique = Uuid().v4().hashCode.toString();
+    String grantedKey = 'granted-$unique.wavi';
+    String ungrantedKey = 'ungranted-$unique.buzz';
+
+    expect(
+        (await owner.sendRequestToServer(
+                'notify:update:ttr:-1:$atSign:$grantedKey$atSign:granted-value'))
+            .trim(),
+        startsWith('data:'));
+    expect(
+        (await owner.sendRequestToServer(
+                'notify:update:ttr:-1:$atSign:$ungrantedKey$atSign:ungranted-value'))
+            .trim(),
+        startsWith('data:'));
+
+    String delivered = await monitorAs(enrollmentId, since);
+
+    // Establish the monitor got as far as being a monitor at all, so the
+    // absence asserted below is a refusal and not a broken connection.
+    expect(delivered, contains('data:success'),
+        reason: 'the monitor must have APKAM-authenticated as the enrollment');
+
+    // The positive arm is what makes the negative arm meaningful: the monitor
+    // demonstrably reached this point of the backlog.
+    expect(delivered, contains(grantedKey),
+        reason: 'a notification in the enrollment\'s own namespace must reach '
+            'its monitor');
+    expect(delivered, isNot(contains(ungrantedKey)),
+        reason: 'a notification outside the granted namespace must not reach '
+            'it — and a drop must not be indistinguishable from a send that '
+            'never happened');
+  }, timeout: Timeout(Duration(minutes: 3)));
+}

--- a/tests/at_functional_test/test/http_test.dart
+++ b/tests/at_functional_test/test/http_test.dart
@@ -215,6 +215,7 @@ class _FixedSecondaryAddressFinder implements SecondaryAddressFinder {
   _FixedSecondaryAddressFinder(this.host, this.port);
 
   @override
-  Future<SecondaryAddress> findSecondary(String atSign) async =>
+  Future<SecondaryAddress> findSecondary(String atSign,
+          {Duration? timeout}) async =>
       SecondaryAddress(host, port);
 }

--- a/tests/at_functional_test/test/mldsa_pkam_test.dart
+++ b/tests/at_functional_test/test/mldsa_pkam_test.dart
@@ -1,0 +1,115 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:at_chops/at_chops.dart' show MlDsa65PureDartAlgo;
+import 'package:at_demo_data/at_demo_data.dart';
+import 'package:at_functional_test/conf/config_util.dart';
+import 'package:at_functional_test/connection/outbound_connection_wrapper.dart';
+import 'package:at_functional_test/utils/encryption_util.dart';
+import 'package:test/test.dart';
+import 'package:uuid/uuid.dart';
+
+/// End-to-end ML-DSA PKAM over the real wire.
+///
+/// The unit suite verifies an ML-DSA signature through the production
+/// dispatch, but in-process. This drives the whole path: a genuine ML-DSA
+/// keypair is generated here, enrolled over the wire, and used to answer a
+/// real `from:` challenge on a fresh connection.
+///
+/// That distinction has bitten before — a resolved at_chops with no mldsa65
+/// verification branch sat green against tests that only asserted record
+/// storage, while the live wire died parsing a raw ML-DSA key as RSA.
+void main() {
+  String atSign = ConfigUtil.getYaml()!['firstAtSignServer']['firstAtSignName'];
+  String host = ConfigUtil.getYaml()!['firstAtSignServer']['firstAtSignUrl'];
+  int port = ConfigUtil.getYaml()!['firstAtSignServer']['firstAtSignPort'];
+
+  String encryptedPrivateKey = EncryptionUtil.encryptValue(
+      encryptionPrivateKeyMap[atSign]!, apkamSymmetricKeyMap[atSign]!);
+  String encryptedSelfKey = EncryptionUtil.encryptValue(
+      aesKeyMap[atSign]!, apkamSymmetricKeyMap[atSign]!);
+  String encryptedApkamSymmetricKey = EncryptionUtil.encryptKey(
+      apkamSymmetricKeyMap[atSign]!, encryptionPublicKeyMap[atSign]!);
+
+  List<OutboundConnectionFactory> open = [];
+
+  Future<OutboundConnectionFactory> newConnection() async {
+    OutboundConnectionFactory c = await OutboundConnectionFactory()
+        .initiateConnectionWithListener(atSign, host, port);
+    open.add(c);
+    return c;
+  }
+
+  tearDown(() async {
+    for (final c in open) {
+      await c.close();
+    }
+    open = [];
+  });
+
+  /// Answers a real `from:` challenge with an ML-DSA signature over
+  /// [secretKey], and returns the server's response to `pkam:`.
+  Future<String> authenticateWithMlDsa(String enrollmentId, Uint8List secretKey,
+      {bool tamper = false}) async {
+    OutboundConnectionFactory client = await newConnection();
+    String challenge = (await client.sendRequestToServer(
+            'from:$atSign:clientConfig:${jsonEncode({'version': '3.0.57'})}'))
+        .replaceAll('data:', '')
+        .trim();
+
+    Uint8List signature = await MlDsa65PureDartAlgo()
+        .signBytes(Uint8List.fromList(utf8.encode(challenge)),
+            secretKey: secretKey);
+    if (tamper) {
+      signature = Uint8List.fromList(signature)..[0] ^= 0xff;
+    }
+
+    return (await client.sendRequestToServer(
+            'pkam:signingAlgo:mldsa65:enrollmentId:$enrollmentId:'
+            '${base64Encode(signature)}'))
+        .trim();
+  }
+
+  test('an ML-DSA enrollment authenticates over the wire', () async {
+    final mlDsa = await MlDsa65PureDartAlgo().generateKeyPair();
+
+    OutboundConnectionFactory owner = await newConnection();
+    expect((await owner.authenticateConnection(authType: AuthType.cram)).trim(),
+        'data:success');
+
+    // Enrolled through the OTP path deliberately, NOT by auto-approval on the
+    // CRAM connection: that path also writes the request's key as the atSign's
+    // default pkam public key, which would leave every later legacy PKAM in
+    // this suite trying to verify an RSA signature against an ML-DSA key.
+    String otp = (await owner.sendRequestToServer('otp:get'))
+        .replaceFirst('data:', '')
+        .trim();
+    OutboundConnectionFactory requester = await newConnection();
+    String enrollResponse = await requester.sendRequestToServer(
+        'enroll:request:{"appName":"mldsa-app-${Uuid().v4().hashCode}","deviceName":"device-${Uuid().v4().hashCode}","namespaces":{"wavi":"rw"},"otp":"$otp","apkamPublicKey":"${base64Encode(mlDsa.publicKey)}","signingAlgo":"mldsa65","encryptedAPKAMSymmetricKey":"$encryptedApkamSymmetricKey"}');
+    Map enrollJson = jsonDecode(enrollResponse.replaceFirst('data:', ''));
+    expect(enrollJson['status'], 'pending');
+    String enrollmentId = enrollJson['enrollmentId'];
+
+    String approval = await owner.sendRequestToServer(
+        'enroll:approve:{"enrollmentId":"$enrollmentId","encryptedDefaultEncryptionPrivateKey":"$encryptedPrivateKey","encryptedDefaultSelfEncryptionKey":"$encryptedSelfKey"}');
+    expect(jsonDecode(approval.replaceFirst('data:', ''))['status'], 'approved');
+
+    // The signature is produced here from the generated secret key and
+    // verified by the server through its real at_chops dispatch.
+    expect(await authenticateWithMlDsa(enrollmentId, mlDsa.secretKey),
+        'data:success');
+
+    // Control: a tampered signature must be refused. Without it, the success
+    // above would show the request was routed, not that anything was verified.
+    // Asserted against the exact refusal, observed reaching
+    // PkamMlDsa65SigningAlgo and failing verification there, so this cannot
+    // pass by way of some unrelated error.
+    expect(
+        await authenticateWithMlDsa(enrollmentId, mlDsa.secretKey,
+            tamper: true),
+        'error:{"errorCode":"AT0401","errorDescription":"Exception: pkam '
+            'authentication failed"}',
+        reason: 'a corrupted ML-DSA signature must not authenticate');
+  }, timeout: Timeout(Duration(minutes: 3)));
+}

--- a/tests/at_functional_test/test/pkam_verb_test.dart
+++ b/tests/at_functional_test/test/pkam_verb_test.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
-import 'package:at_chops/src/algorithm/ecc_signing_algo.dart';
+import 'package:at_chops/at_chops.dart';
 import 'package:at_demo_data/at_demo_data.dart';
 import 'package:at_functional_test/conf/config_util.dart';
 import 'package:at_functional_test/connection/outbound_connection_wrapper.dart';


### PR DESCRIPTION
**- What I did**

Post-quantum enrollment support in the atServer, and the test coverage for it.

- **PKAM can verify post-quantum signatures.** An enrollment using an ML-DSA key could never authenticate: the server did not recognise `signingAlgo:mldsa65`, fell back to the RSA default, and so checked a perfectly good signature with the wrong algorithm.
- **PKAM takes the signing algorithm from the enrollment record rather than from the client.** An APKAM connection used to restate its algorithm on every connect. The stored record is now authoritative, which rules out one key being interpreted under two different algorithms. Legacy PKAM is unchanged — it has no enrollment record to consult, and may legitimately present an ECC key.
- **An enrollment can now enrol itself a replacement.** A client already authenticated with an approved enrollment can send `enroll:request` and get a second enrollment back, auto-approved, with no OTP and nobody approving it by hand. This is how a device upgrades its own credential to post-quantum keys without going through onboarding again. The new enrollment can hold at most what the existing one holds, and the old one is kept alive for a grace period so that other devices sharing the same keyfile can still upgrade.
- **A self-enrolled enrollment expires, and cannot outlive the one that created it.** It was being written with no expiry at all, and the requesting client could name its own — including "never expires" — so a stolen keyfile that was deliberately limited to an hour could have minted itself a permanent credential. It now inherits the original's expiry and may only shorten it.
- **An enrollment request may leave out the RSA-wrapped symmetric key when it offers a key package instead.** That field is the one part of enrollment a quantum computer would break, because the client wraps a secret to the atSign's long-lived RSA key. If the approver mints that secret instead and encrypts it to the client's post-quantum key package, the client has nothing to put in the field. It stays mandatory for every other request.
- **The published signing key now says which algorithm it is.** An enrollment's signing key is published at `_apsk` as a bare RSA key. A raw ML-DSA key published the same way would be read as RSA and fail every signature, so non-RSA enrollments now publish a small tagged JSON object naming the algorithm. RSA enrollments are untouched, so existing apps keep parsing what they always did.
- **A notification the server refuses to deliver is now logged.** The authorization check dropped it with no log at any level, so a refusal on the receiving side was indistinguishable from the sender never having sent it — and got blamed on the wrong side.
- **Tests.** Functional coverage over a real connection for all of the above; a revoked enrollment is now proven unable to re-authenticate on the ordinary revoke path, not just one variant; and one existing `enroll:listns` test is fixed, because its fixture relied on an enrollment that the record-authoritative change above correctly stops from authenticating.
- **Unrelated test, carried here for convenience.** An end-to-end test that `appMetadata` survives a cross-atSign `lookup:all`. The existing `appMetadata` tests only cover same-server paths, so nothing checked that it survives the hop where one atSign's server relays another's response.
- **Build.** `at_chops` is resolved from a tag on `at_client_sdk` until the version carrying ML-DSA verification is published — by the atServer, and now by the functional test pack too, which needs to generate an ML-DSA keypair and sign with it.
- **Version.** The in-progress version becomes a minor rather than a patch, since this carries features and not only fixes.

**- How I did it**

Review the commits one by one.

**- How to verify it**

Tests pass — `at_secondary_server` unit suite and the functional suite.

Unit (`packages/at_secondary_server`):

- Self-enrollment: a subset child is auto-approved; a wildcard parent covers namespaces it never named; a retrofit may keep its own `(appName, deviceName)`; the child expires per the posture it inherited; a stated expiry wins over the inherited one.
- Refusals: a namespace the parent does not hold; broader access letters on a held namespace; `__manage` via a wildcard parent; empty namespaces; an unapproved parent.
- Expiry cap: re-arms on each retrofit; never extends past the parent's own posture; a child may not outlive its parent, may not claim "never expires" against a bounded parent, and a negative value is not honoured.
- ML-DSA: an `mldsa65` enrollment publishes the tagged `_apsk` while an RSA one stays bare; it then authenticates with a genuine ML-DSA signature through the production verify path, with a tampered signature as the control; an enrollment with no recorded algorithm keeps the RSA default even when the wire claims `mldsa65`.
- Key package: a request offering one may omit the encrypted symmetric key.
- Notification gate: a self-notification in the enrollment's own namespace is delivered; one outside it is not.

Functional (`tests/at_functional_test`), driving the real wire:

- `apkam_self_enrollment_test.dart` — the self-enrollment rules above, end to end: the child authenticates; it records its parent; it needs no encrypted symmetric key; escalation is refused on every axis, with a positive control so the refusals are not passing vacuously; every expiry clamp is checked against the stored record; the parent survives and its cap re-arms; `_apsk` is bare for RSA and tagged otherwise; and PKAM keeps the record's RSA default when the wire claims `mldsa65`.
- `mldsa_pkam_test.dart` — a real ML-DSA keypair is generated in the test, enrolled over the wire, and used to answer a real `from:` challenge, with a one-byte-corrupted signature as the control. This is the whole path rather than the in-process one; a resolved at_chops with no ML-DSA branch once sat green against tests that asserted record storage only, while the live wire died parsing a raw ML-DSA key as RSA.
- `enrollment_notification_delivery_test.dart` — a scoped enrollment's monitor receives its own namespace and not another, read over a raw socket.
- `enroll_verb_test.dart` — a revoked enrollment cannot re-authenticate on subsequent connections, asserting success *before* the revoke so the refusal after it is attributable.

End-to-end (`tests/at_end2end_test`):

- `app_metadata_test.dart` — `appMetadata` survives a cross-atSign `lookup:all`, guarded on both servers being 3.14.0 or newer since this pack runs against long-lived atSigns.

Each new test was checked against the code before the change and fails there, so it detects the behaviour rather than merely passing alongside it.
