### PR TITLE
feat(at_secondary_server): client-composed _apsk, and enroll:update with proof of possession

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ packages/at_secondary_server/secondary
 tests/at_end2end_test/config/config.yaml
 
 .DS_Store
+
+# Working docs — audits, plans, drafts. Same convention as at_client_sdk:
+# scaffolding for in-flight work lives here and is never committed.
+/untracked/

--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -64,6 +64,31 @@
   enrollment record is created, never truncated — a truncated signing key would
   be a key nothing can verify against, sitting at the address every verifier
   resolves.
+- refactor: APKAM signature verification now goes through one place,
+  `ApkamSignatureVerifier`, rather than being assembled separately by `pkam:`
+  and by `enroll:update`'s proof-of-possession check. The two have to agree
+  byte-for-byte about how a signature is framed — a key that can authenticate
+  must be installable, and a key installed must then authenticate — and each
+  previously carried its own copy of the `signingAlgo`-token mapping.
+
+  The boundary returns `Future<bool>`. at_chops answers through
+  `AtSigningResult.result`, a `dynamic` holding a `FutureOr<bool>`, and that
+  `dynamic` is what let an unawaited ML-DSA `Future` reach a `bool` at both
+  sites; a typed boundary makes the same promise in a form the analyzer
+  enforces. `mldsa65` is verified through the stateless
+  `MlDsa65PureDartAlgo.verifyBytes`, which is declared `Future<bool>`, so the
+  one algorithm that verifies asynchronously never travels as a `dynamic` at
+  all. A test pins that it answers exactly what the `AtChopsImpl` path it
+  replaced answered, over a genuine signature, a wrong message and a wrong key.
+
+  `rsa2048` and `ecc_secp256r1` deliberately keep the `AtChopsImpl` path.
+  `RsaSignatureAlgo` refuses any modulus that is not exactly 2048 bits, which
+  `PkamSigningAlgo` never checked, so adopting it would stop an enrollment
+  holding an off-size RSA key from authenticating; and at_chops has no
+  `AtSignatureAlgorithm` for ECC at all, its key being hex and its signature
+  compact-hex code units. Both would change what verifies on the
+  authentication path.
+
 - fix: `await` the result of an `AtChops` signature verification. Published
   at_chops 3.5.0 verifies `rsa2048` and `ecc_secp256r1` synchronously but
   `mldsa65` asynchronously, while `AtChopsImpl.verify` is synchronous either

--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,4 +1,69 @@
 # 3.16.0
+- feat: `enroll:update` — an approved enrollment amending its OWN record's
+  `apkamPublicKey`, `signingAlgo`, `apsk` and `metadata`. Self-only: the
+  connection's enrollment id must equal the target's, which is an explicit
+  exception to `isAuthorized`'s "no enrollmentId means full permissions"
+  default, so an owner or legacy-PKAM connection is refused rather than waved
+  through.
+
+  This is what lets an enrollment rotate its APKAM authentication keypair while
+  keeping its id. Before it, the only route was a new enrollment, which strands
+  every record addressed to the old one.
+
+  `namespaces` and the approval state are permanently out of reach, and are
+  refused by name rather than ignored: an enrollment amending itself must not
+  be able to widen its own grant. `metadata` is a per-key set — keys the
+  request does not name survive untouched — because a whole-map replace is
+  read-mutate-write against shared durable state, so a client that does not
+  know about a future sibling field would clobber it. The enrollment's state
+  and TTL are untouched, and an update naming nothing to change is refused
+  rather than accepted as a no-op.
+
+- feat: `enroll:update` changing `apkamPublicKey` requires
+  `EnrollParams.apkamPublicKeySignature` — a signature by the **new** private
+  key over `<enrollmentId>|<apkamPublicKey>|<signingAlgo>`, verified against
+  the new public key carried in the same request.
+
+  The connection proves possession of the enrollment's *current* key, and
+  nothing else proves possession of the new one. Without this check a
+  compromised-but-authenticated client can install a public key whose private
+  half is held by an attacker, locking out the legitimate holder while the
+  record still looks entirely valid.
+
+  Signed and verified with `AtSigningMode.pkam` and SHA-256. Not
+  `AtSigningMode.data`, which signs with the encryption keypair and so cannot
+  express possession of an APKAM signing key at all. No nonce: the operation is
+  self-only and the old key stops authenticating the moment the rotation lands,
+  so a replayed request can only be sent by the current holder, which makes a
+  rollback self-harm rather than an attack.
+
+- **behaviour change**: the atServer no longer composes an enrollment's `_apsk`
+  signing key. It publishes `EnrollParams.apsk` — a value the CLIENT composes
+  and sends on `enroll:request` — verbatim at
+  `public:_apsk.<enrollmentId>.a.__e@<atSign>`, and publishes **nothing** when
+  the request carries no such value. The old behaviour (bare `apkamPublicKey`
+  for `rsa2048`, a `{v, signingAlgo, publicKey}` object composed from the
+  record for anything else) is gone, along with the server's only opinion about
+  how a signing key is spelled.
+
+  PKAM verification reads the enrollment record's `apkamPublicKey` and
+  `signingAlgo`, never `_apsk`, so this key is a client-side artefact the
+  server had no use for. What it *was* doing is bootstrapping: `_apsk` accepts
+  writes only from its own enrollment's connection, and at approval that
+  connection has never existed, while the approver must verify the enrollee's
+  key package against the record and sign signing-chain links over it
+  immediately. The server still does that bootstrapping — it just no longer
+  invents the payload, so a new signing-key shape needs no server release. The
+  value is stored on the enrollment record (`EnrollDataStoreValue.apsk`) at
+  request time and published from there at approval, so an approver cannot
+  substitute a signing key for the enrollment it is approving.
+
+  Requires at_commons with `EnrollParams.apsk`. Capped at
+  `EnrollVerbHandler.maxApskLengthBytes` (20KB, measured on the JSON encoding);
+  an oversized value is refused with `IllegalArgumentException` before the
+  enrollment record is created, never truncated — a truncated signing key would
+  be a key nothing can verify against, sitting at the address every verifier
+  resolves.
 - fix: deny, not throw, on an unparseable atKey in authz
 - fix: defensive code to properly handle a namespace named 'null'
 - fix: scope namespace-less keys to the legacy shared_key forms

--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -64,6 +64,16 @@
   enrollment record is created, never truncated — a truncated signing key would
   be a key nothing can verify against, sitting at the address every verifier
   resolves.
+- fix: `await` the result of an `AtChops` signature verification. Published
+  at_chops 3.5.0 verifies `rsa2048` and `ecc_secp256r1` synchronously but
+  `mldsa65` asynchronously, while `AtChopsImpl.verify` is synchronous either
+  way — so `AtSigningResult.result` carries a `FutureOr<bool>` and an ML-DSA
+  verification handed the caller an unawaited `Future` where it read a `bool`.
+  Every `mldsa65` PKAM authentication died on
+  `type 'Future<bool>' is not a subtype of type 'bool'`, and an `enroll:update`
+  rotating to an ML-DSA key would have died the same way. The at_chops git
+  override this replaced pinned a spike tag whose ML-DSA verifier was
+  synchronous, which is why the two verification sites read `.result` directly.
 - fix: deny, not throw, on an unparseable atKey in authz
 - fix: defensive code to properly handle a namespace named 'null'
 - fix: scope namespace-less keys to the legacy shared_key forms

--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -89,6 +89,15 @@
   compact-hex code units. Both would change what verifies on the
   authentication path.
 
+- fix: a malformed APKAM public key or signature now fails the verification
+  instead of escaping the verb handler. `enroll:update` takes `apkamPublicKey`
+  straight off the request, and `package:elliptic` rejects a bad
+  `ecc_secp256r1` key by throwing a bare `String` — which `on Exception` does
+  not catch — or a `RangeError` for a key under two characters. `base64Decode`
+  of the signature also ran outside both call sites' guards. Verification is
+  now total and fails closed; an `Error`, being a defect in this server rather
+  than a bad signature, is logged at `severe` with its stack rather than at
+  `finer`.
 - fix: `await` the result of an `AtChops` signature verification. Published
   at_chops 3.5.0 verifies `rsa2048` and `ecc_secp256r1` synchronously but
   `mldsa65` asynchronously, while `AtChopsImpl.verify` is synchronous either

--- a/packages/at_secondary_server/lib/src/enroll/enroll_datastore_value.dart
+++ b/packages/at_secondary_server/lib/src/enroll/enroll_datastore_value.dart
@@ -29,6 +29,27 @@ class EnrollDataStoreValue {
   /// `mldsa65` (PQ). Recorded so PKAM verification can be record-authoritative.
   String? signingAlgo;
 
+  /// The client-composed value published at
+  /// `public:_apsk.<enrollmentId>.a.__e@<atSign>` when this enrollment is
+  /// approved, carried on `enroll:request` as `EnrollParams.apsk`.
+  ///
+  /// Opaque, exactly like [metadata]: the server stores it and JSON-encodes it
+  /// into the record it publishes, and has no opinion on the contents. It is
+  /// deliberately NOT composed from [apkamPublicKey] and [signingAlgo] — PKAM
+  /// verification reads this record, so `_apsk` is a client-side artefact and
+  /// the format belongs to the side that reads it.
+  ///
+  /// Null means no `_apsk` is published for this enrollment at all. The
+  /// enrollee publishes its own from its own connection, or goes without.
+  ///
+  /// Why the server writes it at all, given it never reads it: `_apsk` accepts
+  /// writes only from its own enrollment's connection, and at approval that
+  /// connection has never existed. The approver needs the record in place
+  /// immediately — it verifies the enrollee's key package against it and signs
+  /// signing-chain links over it — so the server is the only party that can
+  /// put it there in time.
+  Map<String, dynamic>? apsk;
+
   /// The enrollment whose authenticated connection self-spawned this one
   /// (RF-SRV), or null for every other origin.
   ///

--- a/packages/at_secondary_server/lib/src/enroll/enroll_datastore_value.g.dart
+++ b/packages/at_secondary_server/lib/src/enroll/enroll_datastore_value.g.dart
@@ -26,6 +26,7 @@ EnrollDataStoreValue _$EnrollDataStoreValueFromJson(
           Duration(milliseconds: json['apkamKeysExpiryInMillis'] ?? 0)
       ..metadata = (json['metadata'] as Map<String, dynamic>?)
       ..signingAlgo = json['signingAlgo'] as String?
+      ..apsk = (json['apsk'] as Map<String, dynamic>?)
       ..parentEnrollmentId = json['parentEnrollmentId'] as String?;
 
 Map<String, dynamic> _$EnrollDataStoreValueToJson(
@@ -43,6 +44,7 @@ Map<String, dynamic> _$EnrollDataStoreValueToJson(
           instance.apkamKeysExpiryDuration.inMilliseconds,
       if (instance.metadata != null) 'metadata': instance.metadata,
       if (instance.signingAlgo != null) 'signingAlgo': instance.signingAlgo,
+      if (instance.apsk != null) 'apsk': instance.apsk,
       if (instance.parentEnrollmentId != null)
         'parentEnrollmentId': instance.parentEnrollmentId,
     };

--- a/packages/at_secondary_server/lib/src/utils/apkam_signature_verifier.dart
+++ b/packages/at_secondary_server/lib/src/utils/apkam_signature_verifier.dart
@@ -67,11 +67,11 @@ class ApkamSignatureVerifier {
   /// that is how it is stored on the enrollment record and how it arrives on
   /// the wire.
   ///
-  /// Every argument is chosen by whoever is trying to authenticate, so "this
-  /// did not verify" is the honest answer to a bad signature — including one
-  /// that is not valid base64, which previously escaped both call sites as an
-  /// uncaught [FormatException] because each decoded before entering its
-  /// guard.
+  /// Never throws. Every argument is chosen by whoever is trying to
+  /// authenticate, so "this did not verify" is the honest answer to every
+  /// shape of bad input, including a signature that is not valid base64 —
+  /// which previously escaped both call sites as an uncaught [FormatException]
+  /// because each decoded before entering its guard.
   static Future<bool> verify({
     required Uint8List message,
     required String base64Signature,
@@ -112,8 +112,25 @@ class ApkamSignatureVerifier {
       return await AtChopsImpl(AtChopsKeys.create(null, null))
           .verify(input)
           .result;
-    } on Exception catch (e) {
-      _logger.finer('APKAM signature verification failed: $e');
+    } catch (e, stackTrace) {
+      // Total, deliberately. Every argument here is chosen by whoever is
+      // trying to authenticate — `enroll:update` takes the public key straight
+      // off the request — and at_chops' backends reject bad input in three
+      // different ways: an AtSigningVerificationException, a FormatException
+      // out of base64Decode, and, for ecc_secp256r1, a bare thrown String from
+      // package:elliptic that `on Exception` does not catch at all (plus a
+      // RangeError for a hex key shorter than two characters). A malformed key
+      // has to fail the authentication, not escape the verb handler.
+      //
+      // An Error is a defect in this server rather than a bad signature, so it
+      // is logged at severe with its stack rather than disappearing into
+      // finer. Either way this fails closed: nothing is authenticated by a
+      // verification that crashed.
+      if (e is Error) {
+        _logger.severe('APKAM signature verification threw $e\n$stackTrace');
+      } else {
+        _logger.finer('APKAM signature verification failed: $e');
+      }
       return false;
     }
   }

--- a/packages/at_secondary_server/lib/src/utils/apkam_signature_verifier.dart
+++ b/packages/at_secondary_server/lib/src/utils/apkam_signature_verifier.dart
@@ -1,0 +1,120 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:at_chops/at_chops.dart';
+import 'package:at_utils/at_logger.dart';
+
+/// APKAM signature verification for the whole atServer, behind one type.
+///
+/// Two verbs verify an APKAM signature: `pkam:` authenticates a connection
+/// against the key recorded on its enrollment, and `enroll:update` proves the
+/// sender holds the private half of a key it is asking to install. The two
+/// have to agree byte-for-byte about how a signature is framed — a key that
+/// can authenticate must also be installable, and vice versa — so they share
+/// this one path rather than each assembling at_chops calls of its own.
+///
+/// The return type is the substance of that sharing. at_chops answers a
+/// verification through `AtSigningResult.result`, a `dynamic` holding a
+/// `FutureOr<bool>`: `rsa2048` and `ecc_secp256r1` verify synchronously,
+/// `mldsa65` does not. Reading that field straight into a `bool` compiles
+/// clean, passes an rsa2048-only test suite, and throws
+/// `type 'Future<bool>' is not a subtype of type 'bool'` the first time a
+/// post-quantum key authenticates — which is what shipped, at both sites, and
+/// what no test could see while every test signed with RSA. A `Future<bool>`
+/// here is the same promise made in a form the analyzer enforces, and no
+/// caller meets the `dynamic` again.
+class ApkamSignatureVerifier {
+  ApkamSignatureVerifier._();
+
+  static final AtSignLogger _logger = AtSignLogger('ApkamSignatureVerifier');
+
+  /// The `signingAlgo` tokens the `pkam:` grammar accepts, spelled as they
+  /// travel on the wire and as they are recorded on an enrollment.
+  static const String eccAlgo = 'ecc_secp256r1';
+  static const String rsa2048Algo = 'rsa2048';
+  static const String mlDsa65Algo = 'mldsa65';
+
+  static const String sha256Algo = 'sha256';
+  static const String sha512Algo = 'sha512';
+
+  /// The [SigningAlgoType] a `signingAlgo` token names.
+  ///
+  /// An absent or unrecognised token resolves to `rsa2048`: that is what a
+  /// PKAM message predating the field meant, and what an enrollment record
+  /// written before it carried one still means.
+  static SigningAlgoType signingAlgoTypeOf(String? signingAlgo) =>
+      switch (signingAlgo) {
+        eccAlgo => SigningAlgoType.ecc_secp256r1,
+        // Without this branch a post-quantum APKAM keypair falls through to
+        // the RSA default and can never authenticate at all — the signature is
+        // well formed, just interpreted under the wrong algorithm.
+        mlDsa65Algo => SigningAlgoType.mldsa65,
+        _ => SigningAlgoType.rsa2048,
+      };
+
+  /// The [HashingAlgoType] a `hashingAlgo` token names; SHA-256 by default.
+  static HashingAlgoType hashingAlgoTypeOf(String? hashingAlgo) =>
+      switch (hashingAlgo) {
+        sha512Algo => HashingAlgoType.sha512,
+        _ => HashingAlgoType.sha256,
+      };
+
+  /// True when [base64Signature] was produced over [message] by the private
+  /// half of [publicKey], under [signingAlgo].
+  ///
+  /// [publicKey] is spelled the way its algorithm spells it — base64 X.509 for
+  /// `rsa2048`, hex for `ecc_secp256r1`, base64 raw for `mldsa65` — because
+  /// that is how it is stored on the enrollment record and how it arrives on
+  /// the wire.
+  ///
+  /// Every argument is chosen by whoever is trying to authenticate, so "this
+  /// did not verify" is the honest answer to a bad signature — including one
+  /// that is not valid base64, which previously escaped both call sites as an
+  /// uncaught [FormatException] because each decoded before entering its
+  /// guard.
+  static Future<bool> verify({
+    required Uint8List message,
+    required String base64Signature,
+    required String publicKey,
+    required SigningAlgoType signingAlgo,
+    HashingAlgoType hashingAlgo = HashingAlgoType.sha256,
+  }) async {
+    try {
+      final Uint8List signature = base64Decode(base64Signature);
+
+      if (signingAlgo == SigningAlgoType.mldsa65) {
+        // Straight to the stateless interface, whose verifyBytes is declared
+        // Future<bool> — so the one algorithm that verifies asynchronously
+        // never travels as a dynamic at all. This is what AtChopsImpl does for
+        // mldsa65 anyway: it selects MlDsa65PureDartAlgo, then calls the
+        // deprecated verify(), whose entire body is base64Decode(publicKey)
+        // followed by this same verifyBytes.
+        return await MlDsa65PureDartAlgo().verifyBytes(message,
+            signature: signature, publicKey: base64Decode(publicKey));
+      }
+
+      // rsa2048 and ecc_secp256r1 stay on the compatibility API deliberately.
+      // RsaSignatureAlgo refuses any modulus that is not exactly 2048 bits,
+      // which PkamSigningAlgo does not, so adopting it would stop an
+      // enrollment holding an off-size RSA key from authenticating; and
+      // at_chops has no AtSignatureAlgorithm for ECC at all — an ECC public
+      // key is hex and its signature is compact-hex code units, neither of
+      // which fits verifyBytes' Uint8List parameters. Both are changes to what
+      // verifies on the authentication path, which is not a refactor's to
+      // make.
+      final input = AtSigningVerificationInput(message, signature, publicKey)
+        ..signingAlgoType = signingAlgo
+        ..hashingAlgoType = hashingAlgo
+        // pkam, not data: AtSigningMode.data signs with the ENCRYPTION
+        // keypair, and what is proved here is possession of an APKAM signing
+        // key.
+        ..signingMode = AtSigningMode.pkam;
+      return await AtChopsImpl(AtChopsKeys.create(null, null))
+          .verify(input)
+          .result;
+    } on Exception catch (e) {
+      _logger.finer('APKAM signature verification failed: $e');
+      return false;
+    }
+  }
+}

--- a/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:collection';
 import 'dart:convert';
 
-import 'package:at_chops/at_chops.dart';
 import 'package:at_commons/at_commons.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:at_secondary/src/connection/inbound/inbound_connection_metadata.dart';
@@ -11,6 +10,7 @@ import 'package:at_secondary/src/enroll/enrollment_manager.dart';
 import 'package:at_secondary/src/notification/notification_manager_impl.dart';
 import 'package:at_secondary/src/server/at_secondary_config.dart';
 import 'package:at_secondary/src/server/at_secondary_impl.dart';
+import 'package:at_secondary/src/utils/apkam_signature_verifier.dart';
 import 'package:at_server_spec/at_server_spec.dart';
 import 'package:at_server_spec/at_verb_spec.dart';
 import 'package:meta/meta.dart';
@@ -790,54 +790,24 @@ class EnrollVerbHandler extends AbstractVerbHandler {
           'of the key it is installing');
     }
 
-    // Verified through the same AtChops compatibility API `pkam_verb_handler`
-    // uses, deprecated and all. That is deliberate: PKAM is the other place
-    // that verifies an APKAM signature against a record's algorithm, and two
-    // verification paths that have to agree byte-for-byte about how a
-    // signature is framed is a worse problem than one shared deprecation.
-    // Migrate both to AtSignatureAlgorithm.verifyBytes together, once at_chops
-    // offers a SigningAlgoType-to-algorithm dispatcher.
+    // Verified through ApkamSignatureVerifier, the same path `pkam:` uses.
+    // PKAM is the other place that verifies an APKAM signature against a
+    // record's algorithm, and the two must agree byte-for-byte about how a
+    // signature is framed: a key that can authenticate has to be installable,
+    // and a key installed here has to be able to authenticate afterwards.
     final signable = '$enrollmentId|$apkamPublicKey|$signingAlgo';
-    final verificationInput = AtSigningVerificationInput(
-        utf8.encode(signable), base64Decode(signature), apkamPublicKey)
-      ..signingAlgoType = _signingAlgoTypeOf(signingAlgo)
-      ..hashingAlgoType = HashingAlgoType.sha256
-      // pkam, not data: AtSigningMode.data signs with the ENCRYPTION keypair,
-      // and what is being proved here is possession of an APKAM signing key.
-      // It is also the mode PKAM verification itself uses, so the two agree
-      // about how the bytes are framed.
-      ..signingMode = AtSigningMode.pkam;
-
-    bool verified = false;
-    try {
-      // await, because AtSigningResult.result is a FutureOr<bool>: at_chops
-      // verifies mldsa65 asynchronously and the other algorithms
-      // synchronously, while AtChopsImpl.verify is synchronous either way.
-      // Awaiting a non-Future returns it unchanged, so both arrive as a bool.
-      verified = await AtChopsImpl(AtChopsKeys.create(null, null))
-          .verify(verificationInput)
-          .result;
-    } on Exception catch (e) {
-      logger.finer('apkamPublicKeySignature verification threw: $e');
-    }
+    final verified = await ApkamSignatureVerifier.verify(
+      message: utf8.encode(signable),
+      base64Signature: signature,
+      publicKey: apkamPublicKey,
+      signingAlgo: ApkamSignatureVerifier.signingAlgoTypeOf(signingAlgo),
+    );
     if (!verified) {
       throw AtEnrollmentException(
           'apkamPublicKeySignature does not verify against the '
           'apkamPublicKey being installed');
     }
   }
-
-  /// The [SigningAlgoType] a `signingAlgo` token names.
-  ///
-  /// Defaults to `rsa2048` for an absent token, matching PKAM's own
-  /// resolution, so a record written before the field existed keeps behaving
-  /// as it always did.
-  SigningAlgoType _signingAlgoTypeOf(String? signingAlgo) =>
-      switch (signingAlgo) {
-        'ecc_secp256r1' => SigningAlgoType.ecc_secp256r1,
-        'mldsa65' => SigningAlgoType.mldsa65,
-        _ => SigningAlgoType.rsa2048,
-      };
 
   Future<void> _dropRevokedClientConnection(String enrollmentId, bool forceFlag,
       InboundConnection currentInboundConnection, responseJson) async {

--- a/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
@@ -810,7 +810,11 @@ class EnrollVerbHandler extends AbstractVerbHandler {
 
     bool verified = false;
     try {
-      verified = AtChopsImpl(AtChopsKeys.create(null, null))
+      // await, because AtSigningResult.result is a FutureOr<bool>: at_chops
+      // verifies mldsa65 asynchronously and the other algorithms
+      // synchronously, while AtChopsImpl.verify is synchronous either way.
+      // Awaiting a non-Future returns it unchanged, so both arrive as a bool.
+      verified = await AtChopsImpl(AtChopsKeys.create(null, null))
           .verify(verificationInput)
           .result;
     } on Exception catch (e) {

--- a/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:collection';
 import 'dart:convert';
 
+import 'package:at_chops/at_chops.dart';
 import 'package:at_commons/at_commons.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:at_secondary/src/connection/inbound/inbound_connection_metadata.dart';
@@ -35,6 +36,16 @@ class EnrollVerbHandler extends AbstractVerbHandler {
   int maxDelayInMillis = Duration(
           seconds: AtSecondaryConfig.enrollmentResponseDelayIntervalInSeconds)
       .inMilliseconds;
+
+  /// The largest `EnrollParams.apsk` the atServer will store, measured on its
+  /// JSON encoding — the string that lands in the keystore.
+  ///
+  /// The value is opaque, so nothing about it can be validated; a bound is all
+  /// the server can meaningfully impose. 20KB is far above any signing key
+  /// (ML-DSA-65's public half is ~2.6KB base64-encoded, the largest in play)
+  /// and far below anything that would make the enrollment record awkward to
+  /// store or return from `enroll:listns`.
+  static const int maxApskLengthBytes = 20 * 1024;
 
   final EnrollmentManager enMgr;
   final NotificationManager notifManager;
@@ -167,6 +178,16 @@ class EnrollVerbHandler extends AbstractVerbHandler {
           response,
         );
         break;
+      case 'update':
+        await _handleEnrollmentUpdate(
+          enMgr,
+          (atConnection.metaData as InboundConnectionMetadata),
+          enrollVerbParams!,
+          currentAtSign,
+          responseJson,
+          response,
+        );
+        break;
     }
     response.data = jsonEncode(responseJson);
     return;
@@ -252,6 +273,20 @@ class EnrollVerbHandler extends AbstractVerbHandler {
           'Enrollment requests have exceeded the limit within the specified time frame');
     }
 
+    // Bound the one field the server stores without understanding, before
+    // anything is created or an OTP is spent. Refused rather than truncated:
+    // a truncated signing key is a key nothing can verify against, published
+    // at the address every verifier resolves, and the enrollee would have no
+    // way to tell that from a key it composed wrong.
+    final apskLength = enrollParams.apsk == null
+        ? 0
+        : utf8.encode(jsonEncode(enrollParams.apsk)).length;
+    if (apskLength > maxApskLengthBytes) {
+      throw IllegalArgumentException(
+          'apsk is $apskLength bytes encoded, which exceeds the '
+          '$maxApskLengthBytes byte limit');
+    }
+
     // OTP is sent only in enrollment request which is submitted on
     // unauthenticated connection.
     if (atConnection.metaData.isAuthenticated == false) {
@@ -301,15 +336,18 @@ class EnrollVerbHandler extends AbstractVerbHandler {
     enrollmentValue.namespaces = enrollNamespaces;
     enrollmentValue.requestType = EnrollRequestType.newEnrollment;
 
-    // The X-Wing key package (at `metadata.keyPackage`) and the APKAM
-    // `signingAlgo` ride EnrollParams on enroll:request and are persisted
-    // verbatim onto the enrollment record — there is no separate
-    // enroll:metadata write.
+    // The X-Wing key package (at `metadata.keyPackage`), the APKAM
+    // `signingAlgo` and the client-composed `_apsk` value ride EnrollParams on
+    // enroll:request and are persisted verbatim onto the enrollment record —
+    // there is no separate enroll:metadata write.
     if (enrollParams.metadata != null) {
       enrollmentValue.metadata = enrollParams.metadata;
     }
     if (enrollParams.signingAlgo != null) {
       enrollmentValue.signingAlgo = enrollParams.signingAlgo;
+    }
+    if (enrollParams.apsk != null) {
+      enrollmentValue.apsk = enrollParams.apsk;
     }
 
     if (enrollParams.apkamKeysExpiryDuration != null) {
@@ -332,10 +370,9 @@ class EnrollVerbHandler extends AbstractVerbHandler {
       await keyStore.put(AtConstants.atPkamPublicKey,
           AtData()..data = enrollParams.apkamPublicKey!,
           skipCommit: true);
-      // Keep the enrollment's `_apsk` signing key present for verifiers.
+      // Publish the client-composed `_apsk` signing key, if it sent one.
       await _publishApskSigningKey(
-          newEnrollmentId, enrollParams.apkamPublicKey!, currentAtSign,
-          signingAlgo: enrollmentValue.signingAlgo);
+          newEnrollmentId, enrollmentValue.apsk, currentAtSign);
       AtData enrollData = AtData()..data = jsonEncode(enrollmentValue.toJson());
 
       await enMgr.put(newEnrollmentId, enrollData, EnrollmentStatus.approved);
@@ -412,10 +449,9 @@ class EnrollVerbHandler extends AbstractVerbHandler {
           enrollParams.encryptedAPKAMSymmetricKey;
       responseJson['status'] = 'approved';
 
-      // Keep the enrollment's `_apsk` signing key present for verifiers.
+      // Publish the client-composed `_apsk` signing key, if it sent one.
       await _publishApskSigningKey(
-          newEnrollmentId, enrollParams.apkamPublicKey!, currentAtSign,
-          signingAlgo: enrollmentValue.signingAlgo);
+          newEnrollmentId, enrollmentValue.apsk, currentAtSign);
       // The child's record expires per its (inherited or stated) key-expiry
       // posture, exactly as the ordinary approve path writes it — the
       // retrofit copies the parent's expiry, it does not grant immortality.
@@ -606,12 +642,198 @@ class EnrollVerbHandler extends AbstractVerbHandler {
     // when enrollment is approved store the encrypted encryption keys
     if (operation == 'approve') {
       await _storeEncryptionKeys(enId, enrollParams, enVal);
-      // Keep the enrollment's `_apsk` signing key present for verifiers.
-      await _publishApskSigningKey(enId, enVal.apkamPublicKey, currentAtSign,
-          signingAlgo: enVal.signingAlgo);
+      // Publish the `_apsk` signing key the enrollee composed on its request.
+      // Read off the RECORD, not off these approve params: the value is the
+      // enrollee's, and an approver must not be able to substitute a signing
+      // key for the enrollment it is approving.
+      await _publishApskSigningKey(enId, enVal.apsk, currentAtSign);
     }
     responseJson['enrollmentId'] = enId;
   }
+
+  /// `enroll:update` — an approved enrollment amending its OWN record.
+  ///
+  /// Reaches `apkamPublicKey`, `signingAlgo`, `apsk` and `metadata`, and
+  /// nothing else. `namespaces` and the approval state are permanently out of
+  /// reach: this operation is self-only, so an enrollment that could reach
+  /// them could widen its own grant, which is privilege escalation with a
+  /// valid signature on it.
+  ///
+  /// Replacing `apkamPublicKey` is how an enrollment rotates its
+  /// authentication keypair while keeping its id. Before this existed the only
+  /// route was a new enrollment, which strands every record addressed to the
+  /// old id.
+  ///
+  /// Metadata is a per-key set, never a whole-map replace: keys the request
+  /// does not name survive untouched. A whole-map replace is read-mutate-write
+  /// against shared durable state, so a client that does not know about a
+  /// future sibling field would clobber it.
+  Future<void> _handleEnrollmentUpdate(
+    EnrollmentManager enMgr,
+    InboundConnectionMetadata connectionMetadata,
+    EnrollParams enrollParams,
+    String currentAtSign,
+    Map<dynamic, dynamic> responseJson,
+    Response response,
+  ) async {
+    final enId = enrollParams.enrollmentId!;
+
+    // Self-only. An explicit exception to `isAuthorized`'s "no enrollmentId
+    // means full permissions" default: an owner or legacy-PKAM connection is
+    // refused here, not waved through. An owner cannot sign anything with this
+    // enrollment's APKAM private, so anything it wrote would fail every
+    // reader's verification and buys only a denial of service — and self-only
+    // is what makes replace semantics safe, because the only party who can
+    // reinstate a stale value is the holder of the key it was signed with.
+    if (connectionMetadata.enrollmentId != enId) {
+      throw AtEnrollmentException(
+          'enroll:update is self-only: this connection is authenticated as '
+          '${connectionMetadata.enrollmentId ?? "the owner"}, not $enId');
+    }
+
+    final enVal = await enMgr.getEnrollmentById(enId);
+    final status = EnrollmentStatus.values.byName(enVal.approval!.state);
+    if (status != EnrollmentStatus.approved) {
+      throw AtEnrollmentException(
+          'enroll:update requires an approved enrollment; $enId is '
+          '${status.name}');
+    }
+
+    // Same cap and the same reason as enroll:request: an oversized value is
+    // refused before anything is written, never truncated, because a truncated
+    // signing key is a key nothing can verify against sitting at the address
+    // every verifier resolves.
+    if (enrollParams.apsk != null) {
+      final apskLength = utf8.encode(jsonEncode(enrollParams.apsk)).length;
+      if (apskLength > maxApskLengthBytes) {
+        throw IllegalArgumentException(
+            'apsk is $apskLength bytes encoded, which exceeds the '
+            '$maxApskLengthBytes byte limit');
+      }
+    }
+
+    if (enrollParams.apkamPublicKey != null) {
+      final newSigningAlgo = enrollParams.signingAlgo ?? enVal.signingAlgo;
+      await _verifyApkamPublicKeyPossession(
+        enrollmentId: enId,
+        apkamPublicKey: enrollParams.apkamPublicKey!,
+        signingAlgo: newSigningAlgo,
+        signature: enrollParams.apkamPublicKeySignature,
+      );
+      enVal.apkamPublicKey = enrollParams.apkamPublicKey!;
+      if (enrollParams.signingAlgo != null) {
+        enVal.signingAlgo = enrollParams.signingAlgo;
+      }
+    } else if (enrollParams.signingAlgo != null) {
+      // The algorithm describes the key, so moving one without the other would
+      // leave the record claiming a spelling its key is not in — and PKAM
+      // verification is record-authoritative, so that record is what every
+      // later authentication is judged against.
+      throw IllegalArgumentException(
+          'signingAlgo cannot be changed without apkamPublicKey: the '
+          'algorithm describes the key');
+    }
+
+    if (enrollParams.apsk != null) {
+      enVal.apsk = enrollParams.apsk;
+    }
+
+    if (enrollParams.metadata != null) {
+      final merged = Map<String, dynamic>.from(enVal.metadata ?? {});
+      merged.addAll(enrollParams.metadata!);
+      enVal.metadata = merged;
+    }
+
+    // The state and TTL are untouched: this is the same put the approve path
+    // uses, with an already-approved status, so nothing about the enrollment's
+    // lifecycle moves.
+    await enMgr.put(
+        enId, AtData()..data = jsonEncode(enVal), EnrollmentStatus.approved);
+
+    // Republish only when the request carried a new value. An update that says
+    // nothing about apsk leaves the published record exactly as it was.
+    if (enrollParams.apsk != null) {
+      await _publishApskSigningKey(enId, enVal.apsk, currentAtSign);
+    }
+
+    responseJson['enrollmentId'] = enId;
+    responseJson['status'] = EnrollmentStatus.approved.name;
+  }
+
+  /// Verifies that whoever sent this `enroll:update` holds the private half of
+  /// the [apkamPublicKey] it is asking to install.
+  ///
+  /// The connection proves possession of the enrollment's **current** key;
+  /// nothing else proves possession of the new one. Without this check a
+  /// compromised-but-authenticated client can install a public key whose
+  /// private half is held by an attacker, locking out the legitimate holder
+  /// while the enrollment record still looks entirely valid.
+  ///
+  /// The signature covers `<enrollmentId>|<apkamPublicKey>|<signingAlgo>` and
+  /// is verified against the new public key carried in the same request —
+  /// a self-signature, which is exactly what proof of possession is.
+  ///
+  /// No nonce, deliberately: the operation is self-only over an authenticated
+  /// connection, and the old key stops authenticating the moment the rotation
+  /// lands, so a replayed request can only be sent by the current holder. That
+  /// makes a rollback self-harm rather than an attack.
+  Future<void> _verifyApkamPublicKeyPossession({
+    required String enrollmentId,
+    required String apkamPublicKey,
+    required String? signingAlgo,
+    required String? signature,
+  }) async {
+    if (signature == null || signature.isEmpty) {
+      throw AtEnrollmentException(
+          'enroll:update changing apkamPublicKey requires '
+          'apkamPublicKeySignature: proof the sender holds the private half '
+          'of the key it is installing');
+    }
+
+    // Verified through the same AtChops compatibility API `pkam_verb_handler`
+    // uses, deprecated and all. That is deliberate: PKAM is the other place
+    // that verifies an APKAM signature against a record's algorithm, and two
+    // verification paths that have to agree byte-for-byte about how a
+    // signature is framed is a worse problem than one shared deprecation.
+    // Migrate both to AtSignatureAlgorithm.verifyBytes together, once at_chops
+    // offers a SigningAlgoType-to-algorithm dispatcher.
+    final signable = '$enrollmentId|$apkamPublicKey|$signingAlgo';
+    final verificationInput = AtSigningVerificationInput(
+        utf8.encode(signable), base64Decode(signature), apkamPublicKey)
+      ..signingAlgoType = _signingAlgoTypeOf(signingAlgo)
+      ..hashingAlgoType = HashingAlgoType.sha256
+      // pkam, not data: AtSigningMode.data signs with the ENCRYPTION keypair,
+      // and what is being proved here is possession of an APKAM signing key.
+      // It is also the mode PKAM verification itself uses, so the two agree
+      // about how the bytes are framed.
+      ..signingMode = AtSigningMode.pkam;
+
+    bool verified = false;
+    try {
+      verified = AtChopsImpl(AtChopsKeys.create(null, null))
+          .verify(verificationInput)
+          .result;
+    } on Exception catch (e) {
+      logger.finer('apkamPublicKeySignature verification threw: $e');
+    }
+    if (!verified) {
+      throw AtEnrollmentException(
+          'apkamPublicKeySignature does not verify against the '
+          'apkamPublicKey being installed');
+    }
+  }
+
+  /// The [SigningAlgoType] a `signingAlgo` token names.
+  ///
+  /// Defaults to `rsa2048` for an absent token, matching PKAM's own
+  /// resolution, so a record written before the field existed keeps behaving
+  /// as it always did.
+  SigningAlgoType _signingAlgoTypeOf(String? signingAlgo) =>
+      switch (signingAlgo) {
+        'ecc_secp256r1' => SigningAlgoType.ecc_secp256r1,
+        'mldsa65' => SigningAlgoType.mldsa65,
+        _ => SigningAlgoType.rsa2048,
+      };
 
   Future<void> _dropRevokedClientConnection(String enrollmentId, bool forceFlag,
       InboundConnection currentInboundConnection, responseJson) async {
@@ -688,35 +910,33 @@ class EnrollVerbHandler extends AbstractVerbHandler {
         skipCommit: true);
   }
 
-  /// Publishes the enrollment's APKAM public key as its `_apsk` signing key at
-  /// `public:_apsk.<enrollmentId>.a.__e@<atSign>` (the location the at_client
-  /// `ApkamSigning` mixin reads). The atServer keeps this key present — rather
-  /// than leaving it to the client-side `publishPublicSigningKey` — so a
-  /// verifier can always fetch it to verify APKAM signatures on `__ssenv`
-  /// envelopes and on advertised recipient keys (key package, `nskey` public,
-  /// `pqpublickey`). World-readable so a same-atSign or a peer-atSign verifier
-  /// can reach it via plookup. Idempotent: a re-publish is a harmless overwrite
-  /// with the same value.
+  /// Publishes [apsk] — the value the CLIENT composed and sent on
+  /// `enroll:request` — at `public:_apsk.<enrollmentId>.a.__e@<atSign>`, the
+  /// location the at_client `ApkamSigning` mixin reads.
+  ///
+  /// A no-op when [apsk] is null. The atServer composes nothing: PKAM
+  /// verification reads the enrollment record's `apkamPublicKey` and
+  /// `signingAlgo`, so `_apsk` is a client-side artefact and its format
+  /// belongs to the side that parses it. An enrollment that sent no value
+  /// publishes its own signing key from its own connection, or goes without.
+  ///
+  /// The server writes it despite never reading it because `_apsk` accepts
+  /// writes only from its own enrollment's connection, and at approval that
+  /// connection has never existed. The approver needs the record immediately —
+  /// it verifies the enrollee's key package against it and signs signing-chain
+  /// links over it — so this is the only party that can put it there in time.
+  ///
+  /// World-readable, so a same-atSign or peer-atSign verifier can reach it via
+  /// plookup. Idempotent: a re-publish is a harmless overwrite with the same
+  /// value.
   Future<void> _publishApskSigningKey(
-      String enrollmentId, String apkamPublicKey, currentAtSign,
-      {String? signingAlgo}) async {
+      String enrollmentId, Map<String, dynamic>? apsk, currentAtSign) async {
+    if (apsk == null) {
+      return;
+    }
     final apskKey = 'public:_apsk.$enrollmentId'
         '.${EnrollmentConstants.perEnrollmentApproved}$currentAtSign';
-    // A legacy (rsa2048) enrollment publishes the bare value exactly as
-    // today, since deployed apps parse it as an RSA key. Any other algorithm
-    // publishes the tagged, self-describing form composed from the
-    // enrollment record's own (apkamPublicKey, signingAlgo) — the record
-    // PKAM reads stays the single source. The tagged shape is unmistakable
-    // to a bare-RSA parser: base64-decoding JSON throws, so an old consumer
-    // fails loudly rather than mis-reading the key.
-    final String value;
-    if (signingAlgo == null || signingAlgo == 'rsa2048') {
-      value = apkamPublicKey;
-    } else {
-      value = jsonEncode(
-          {'v': 1, 'signingAlgo': signingAlgo, 'publicKey': apkamPublicKey});
-    }
-    await keyStore.put(apskKey, AtData()..data = value);
+    await keyStore.put(apskKey, AtData()..data = jsonEncode(apsk));
   }
 
   EnrollmentStatus _getEnrollStatusEnum(String? enrollmentOperation) {
@@ -1015,6 +1235,33 @@ class EnrollVerbHandler extends AbstractVerbHandler {
         if (enrollParams!.enrollmentId.isNullOrEmpty) {
           throw IllegalArgumentException(
               'enrollmentId is mandatory for enroll:$operation');
+        }
+        break;
+      case 'update':
+        if (enrollParams!.enrollmentId.isNullOrEmpty) {
+          throw IllegalArgumentException(
+              'enrollmentId is mandatory for enroll:update');
+        }
+        // An update that names nothing to change is a caller bug, not a no-op
+        // worth accepting: it costs a write and a sync round for nothing, and
+        // it usually means the field the caller meant to set is misspelled.
+        if (enrollParams.apkamPublicKey == null &&
+            enrollParams.signingAlgo == null &&
+            enrollParams.apsk == null &&
+            enrollParams.metadata == null) {
+          throw IllegalArgumentException(
+              'enroll:update must name at least one of apkamPublicKey, '
+              'signingAlgo, apsk or metadata');
+        }
+        // Named explicitly rather than silently ignored. These are the two
+        // fields the operation must never reach — an enrollment amending
+        // itself must not be able to widen its own grant or change its own
+        // approval — so a request that asks is told why, not quietly obeyed
+        // in part.
+        if (enrollParams.namespaces != null) {
+          throw IllegalArgumentException(
+              'enroll:update cannot change namespaces: an enrollment amending '
+              'itself must not be able to widen its own grant');
         }
         break;
       // list / listns carry no enrollParams; listns validates its namespace

--- a/packages/at_secondary_server/lib/src/verb/handler/pkam_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/pkam_verb_handler.dart
@@ -1,13 +1,12 @@
 import 'dart:collection';
 import 'dart:convert';
-import 'dart:typed_data';
 
-import 'package:at_chops/at_chops.dart';
 import 'package:at_commons/at_commons.dart';
 import 'package:at_secondary/src/connection/inbound/inbound_connection_metadata.dart';
 import 'package:at_secondary/src/enroll/enroll_datastore_value.dart';
 import 'package:at_secondary/src/enroll/enrollment_manager.dart';
 import 'package:at_secondary/src/server/at_secondary_impl.dart';
+import 'package:at_secondary/src/utils/apkam_signature_verifier.dart';
 import 'package:at_secondary/src/verb/handler/abstract_verb_handler.dart';
 import 'package:at_secondary/src/verb/verb_enum.dart';
 import 'package:at_server_spec/at_server_spec.dart';
@@ -16,12 +15,6 @@ import 'package:meta/meta.dart';
 
 class PkamVerbHandler extends AbstractVerbHandler {
   static Pkam pkam = Pkam();
-  static const String _eccAlgo = 'ecc_secp256r1';
-  static const String _rsa2048Algo = 'rsa2048';
-  static const String _mlDsa65Algo = 'mldsa65';
-  static const String _sha256 = 'sha256';
-  static const String _sha512 = 'sha512';
-  AtChops? atChops;
 
   PkamVerbHandler(super.keyStore);
 
@@ -74,7 +67,8 @@ class PkamVerbHandler extends AbstractVerbHandler {
       // that predate the field (an RSA record verified as ML-DSA fails a
       // legitimate legacy client; the wire fallback exists for legacy
       // no-enrollment PKAM, which may present ecc_secp256r1).
-      recordSigningAlgo = apkamResult.signingAlgo ?? _rsa2048Algo;
+      recordSigningAlgo =
+          apkamResult.signingAlgo ?? ApkamSignatureVerifier.rsa2048Algo;
     } else {
       pkamAuthType = AuthType.pkamLegacy;
       var publicKeyData = await keyStore.get(AtConstants.atPkamPublicKey);
@@ -200,62 +194,16 @@ class PkamVerbHandler extends AbstractVerbHandler {
       return false;
     }
 
-    Uint8List? inputSignature = base64Decode(signature);
-    SigningAlgoType signingAlgoEnum = _getSigningAlgoType(signingAlgo);
-    logger.finer('signingAlgoEnum: $signingAlgoEnum');
-
-    HashingAlgoType hashingAlgoEnum = _getHashingAlgoType(hashingAlgo);
-    logger.finer('hashingAlgoEnum: $hashingAlgoEnum');
-
-    final verificationInput = AtSigningVerificationInput(
-        utf8.encode('$sessionId$atSign:$storedSecret'),
-        inputSignature,
-        publicKey);
-    verificationInput.signingAlgoType = signingAlgoEnum;
-    verificationInput.hashingAlgoType = hashingAlgoEnum;
-    verificationInput.signingMode = AtSigningMode.pkam;
-    try {
-      atChops ??= AtChopsImpl(AtChopsKeys.create(null, null));
-      final verificationResult = atChops!.verify(verificationInput);
-      // AtSigningResult.result carries a FutureOr<bool>: at_chops verifies
-      // rsa2048 and ecc_secp256r1 synchronously but mldsa65 asynchronously,
-      // and AtChopsImpl.verify is synchronous, so the Future reaches us
-      // unawaited. `await` on a non-Future returns it unchanged, so this
-      // handles both without asking which algorithm ran.
-      isValidSignature = await verificationResult.result;
-    } on Exception catch (e) {
-      logger.finer('Exception in pkam signature verification: ${e.toString()}');
-    }
+    logger.finer('signingAlgo: $signingAlgo, hashingAlgo: $hashingAlgo');
+    isValidSignature = await ApkamSignatureVerifier.verify(
+      message: utf8.encode('$sessionId$atSign:$storedSecret'),
+      base64Signature: signature,
+      publicKey: publicKey,
+      signingAlgo: ApkamSignatureVerifier.signingAlgoTypeOf(signingAlgo),
+      hashingAlgo: ApkamSignatureVerifier.hashingAlgoTypeOf(hashingAlgo),
+    );
     logger.finer('PKAM auth: $isValidSignature');
     return isValidSignature;
-  }
-
-  SigningAlgoType _getSigningAlgoType(String? signingAlgo) {
-    // if no signature algorithm is passed, default to RSA verification. This preserves
-    // backward compatibility for old pkam messages without signing algo.
-    logger.finer('signingAlgo: $signingAlgo');
-    if (signingAlgo == _eccAlgo) {
-      return SigningAlgoType.ecc_secp256r1;
-    } else if (signingAlgo == _rsa2048Algo) {
-      return SigningAlgoType.rsa2048;
-    } else if (signingAlgo == _mlDsa65Algo) {
-      // Without this branch a post-quantum APKAM keypair falls through to the
-      // RSA default below and can never authenticate at all — the signature is
-      // well-formed, just interpreted under the wrong algorithm.
-      return SigningAlgoType.mldsa65;
-    }
-    return SigningAlgoType.rsa2048;
-  }
-
-  HashingAlgoType _getHashingAlgoType(String? hashingAlgo) {
-    logger.finer('hashingAlgo: $hashingAlgo');
-    if (hashingAlgo == _sha256) {
-      return HashingAlgoType.sha256;
-    } else if (hashingAlgo == _sha512) {
-      return HashingAlgoType.sha512;
-    }
-    // defaults to SHA-256
-    return HashingAlgoType.sha256;
   }
 }
 

--- a/packages/at_secondary_server/lib/src/verb/handler/pkam_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/pkam_verb_handler.dart
@@ -217,7 +217,12 @@ class PkamVerbHandler extends AbstractVerbHandler {
     try {
       atChops ??= AtChopsImpl(AtChopsKeys.create(null, null));
       final verificationResult = atChops!.verify(verificationInput);
-      isValidSignature = verificationResult.result;
+      // AtSigningResult.result carries a FutureOr<bool>: at_chops verifies
+      // rsa2048 and ecc_secp256r1 synchronously but mldsa65 asynchronously,
+      // and AtChopsImpl.verify is synchronous, so the Future reaches us
+      // unawaited. `await` on a non-Future returns it unchanged, so this
+      // handles both without asking which algorithm ran.
+      isValidSignature = await verificationResult.result;
     } on Exception catch (e) {
       logger.finer('Exception in pkam signature verification: ${e.toString()}');
     }

--- a/packages/at_secondary_server/pubspec.lock
+++ b/packages/at_secondary_server/pubspec.lock
@@ -296,7 +296,7 @@ packages:
     source: hosted
     version: "0.1.2"
   elliptic:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: elliptic
       sha256: "67931d408faa353bdebac9f7a1df0c3f6f828f4e8439cdf084573cd1601a2f4b"

--- a/packages/at_secondary_server/pubspec.lock
+++ b/packages/at_secondary_server/pubspec.lock
@@ -60,11 +60,10 @@ packages:
   at_chops:
     dependency: "direct main"
     description:
-      path: "packages/at_chops"
-      ref: at_chops-pq-spike-1
-      resolved-ref: "55a78f161e91e9dfe1f168247e26b8af09ff073f"
-      url: "https://github.com/atsign-foundation/at_client_sdk.git"
-    source: git
+      name: at_chops
+      sha256: "0ed0084d583f4cf7d2fb0290a7d4e941e83f537b79fffd33247199b715fb7ca1"
+      url: "https://pub.dev"
+    source: hosted
     version: "3.5.0"
   at_commons:
     dependency: "direct main"

--- a/packages/at_secondary_server/pubspec.lock
+++ b/packages/at_secondary_server/pubspec.lock
@@ -69,9 +69,11 @@ packages:
   at_commons:
     dependency: "direct main"
     description:
-      path: "../../../at_client_sdk-wt-apsk/packages/at_commons"
-      relative: true
-    source: path
+      path: "packages/at_commons"
+      ref: at_commons-apsk-1
+      resolved-ref: "54ccffdd01ae2106c96edbbacb7fac444b15fe38"
+      url: "https://github.com/atsign-foundation/at_client_sdk.git"
+    source: git
     version: "5.14.0"
   at_lookup:
     dependency: "direct main"

--- a/packages/at_secondary_server/pubspec.lock
+++ b/packages/at_secondary_server/pubspec.lock
@@ -69,11 +69,10 @@ packages:
   at_commons:
     dependency: "direct main"
     description:
-      name: at_commons
-      sha256: fd878c65d9628f0fbba9e724ead7995412394ae614ff0eac33384235c5494286
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.13.0"
+      path: "../../../at_client_sdk-wt-apsk/packages/at_commons"
+      relative: true
+    source: path
+    version: "5.14.0"
   at_lookup:
     dependency: "direct main"
     description:

--- a/packages/at_secondary_server/pubspec.lock
+++ b/packages/at_secondary_server/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "1b0e6a07425a3e460666e88bf1c949ccc7bb0116ad562ce94a1eca60fe820725"
+      sha256: "9a3386eea899815698dd55995277cf7cb8572ee52b399a6edfb7ae2b50e5fc19"
       url: "https://pub.dev"
     source: hosted
-    version: "103.0.0"
+    version: "105.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "61c04d0c1bfed555c681ea079519933f071a5a026578ff73c4ff0df2d3462e5e"
+      sha256: "62993bed6eadbe9596c5c20d5c167e7bc563c5fe266657a04ddeb93bdb84f4c9"
       url: "https://pub.dev"
     source: hosted
-    version: "13.3.0"
+    version: "14.1.0"
   archive:
     dependency: transitive
     description:
@@ -68,20 +68,19 @@ packages:
   at_commons:
     dependency: "direct main"
     description:
-      path: "packages/at_commons"
-      ref: at_commons-apsk-1
-      resolved-ref: "54ccffdd01ae2106c96edbbacb7fac444b15fe38"
-      url: "https://github.com/atsign-foundation/at_client_sdk.git"
-    source: git
+      name: at_commons
+      sha256: "89f2ae24d69ab5151351f7b747be0edc1ca61eeb005b65f801dc8f031efacb21"
+      url: "https://pub.dev"
+    source: hosted
     version: "5.14.0"
   at_lookup:
     dependency: "direct main"
     description:
       name: at_lookup
-      sha256: "9785cc5adacdfdc287dbc73f656fc3ed3672db13ade0434f9c6b0b2f03dd1f58"
+      sha256: b0de98ac917e1ca35c50ec8d29917fa6c9e244470e0eed589564883bbfe49d58
       url: "https://pub.dev"
     source: hosted
-    version: "3.6.0"
+    version: "3.6.1"
   at_persistence_secondary_server:
     dependency: "direct main"
     description:
@@ -140,34 +139,34 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: "59f99162d27dff3620f1d21165ce802237eb4556fed563c0902403f8207a7c00"
+      sha256: b94f5da9ed3d081fd4ecc426c260998b5f4f4eb2f6d89b7e5472edef0b2b2a1b
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.8"
+    version: "4.0.10"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      sha256: "4070d2a59f8eec34c97c86ceb44403834899075f66e8a9d59706f8e7834f6f71"
+      sha256: "94eaf6708fe64408c632ef2689ca3777b112f9421306ccf4f8c84d7c5c9f83f8"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.2"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: bf05f6e12cfea92d3c09308d7bcdab1906cd8a179b023269eed00c071004b957
+      sha256: "79e05eaf15a48d7230b053a4363b8eaac0cc234bbd0134c3229455481f55cbc6"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.1"
+    version: "4.1.5"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: be46e59dcfefd6c6c7127df9f1be6c1f89219fee22ae02a923463e0f286ce652
+      sha256: "90363d438bd9f84a4d5bbb83352251f57d2d9d771bc95a44e6a33fe25fa52774"
       url: "https://pub.dev"
     source: hosted
-    version: "2.15.2"
+    version: "2.16.0"
   built_collection:
     dependency: transitive
     description:
@@ -180,10 +179,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: "34e4067d30ce212937df995f03b69992eea683539ceeac7f679a1f1eba055b56"
+      sha256: "31b24be6615ec7fcf70b3aa5a7469fe35826485e639a16dd7eb83ba30e4cc6a8"
       url: "https://pub.dev"
     source: hosted
-    version: "8.12.6"
+    version: "8.12.7"
   chalkdart:
     dependency: transitive
     description:
@@ -284,10 +283,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "59d53ef8eaed9d288ed9767618e2b31c4fa0383a127db59d5eb2e737a7638a60"
+      sha256: "3f88fc9c96c568d631356507355a2d1e983ee000c9ac008bdcb39b5bf53ce777"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.9"
+    version: "3.1.12"
   ecdsa:
     dependency: "direct main"
     description:
@@ -500,10 +499,10 @@ packages:
     dependency: transitive
     description:
       name: package_config
-      sha256: f096c55ebb7deb7e384101542bfba8c52696c1b56fca2eb62827989ef2353bbc
+      sha256: ffcf4cf3d6c0b74ac43708d9f56625506e8a68aa935abe9d267a7330f320eb5d
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "3.0.0"
   path:
     dependency: transitive
     description:
@@ -540,18 +539,18 @@ packages:
     dependency: transitive
     description:
       name: posix
-      sha256: "185ef7606574f789b40f289c233efa52e96dead518aed988e040a10737febb07"
+      sha256: bc1bad54ad2b735816e31f8d4600cfde6c7839975085ddfbca48b6c9f7c4044e
       url: "https://pub.dev"
     source: hosted
-    version: "6.5.0"
+    version: "6.5.2"
   pqcrypto:
     dependency: transitive
     description:
       name: pqcrypto
-      sha256: "36fc4126fb18e841127bfcc6c0c3ed85e1a1b04dc333737eeab7a505683e0ac4"
+      sha256: fa8bd7eac5ccb4389f4003715a79b1b601ca9439cb81d1174a1e06da75306b39
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "0.3.1"
   process:
     dependency: transitive
     description:

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -41,6 +41,10 @@ dev_dependencies:
   coverage: ^1.15.1
   lints: ^6.1.0
   mocktail: ^1.0.5
+  # Generating an secp256r1 keypair to sign an ecc_secp256r1 APKAM signature
+  # with, in apkam_signature_verifier_test. Declared rather than leaned on
+  # transitively through ecdsa, matching tests/at_functional_test.
+  elliptic: ^0.3.11
 
 dependency_overrides:
   at_persistence_secondary_server:

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -45,20 +45,20 @@ dev_dependencies:
 dependency_overrides:
   at_persistence_secondary_server:
     path: ../at_persistence_secondary_server
-  # TEMPORARY, MUST NOT MERGE AS A PATH: at_commons carries EnrollParams.apsk,
-  # the client-composed signing-key value this server stores and publishes,
-  # plus EnrollParams.apkamPublicKeySignature and EnrollOperationEnum.update.
-  # Replace with a git ref on an at_client_sdk TAG (see the at_chops note
-  # below for why a tag and not a branch), and remove entirely when at_commons
-  # 5.14.0 publishes.
+  # TEMPORARY: at_commons carries EnrollParams.apsk, the client-composed
+  # signing-key value this server stores and publishes, plus
+  # EnrollParams.apkamPublicKeySignature and EnrollOperationEnum.update.
+  # Remove entirely when at_commons 5.14.0 publishes.
   #
-  # Points at the wt-apsk worktree rather than the main at_client_sdk checkout:
-  # that checkout follows whichever branch is in flight there, so a path into
-  # it silently resolves to whatever at_commons that branch happens to carry.
-  # The worktree is pinned to gkc-apsk-auto-publish, which is the branch this
-  # server's at_commons dependency actually comes from.
+  # A TAG, not a path and not a branch: a path escapes the Docker build
+  # context so the VE image cannot be built from it, and a branch ref strands
+  # the pin when the head moves (pub fetches a git ref shallowly, reaching
+  # only branch and tag tips).
   at_commons:
-    path: ../../../at_client_sdk-wt-apsk/packages/at_commons
+    git:
+      url: https://github.com/atsign-foundation/at_client_sdk.git
+      path: packages/at_commons
+      ref: at_commons-apsk-1 # at_client_sdk 54ccffdd0, off gkc-apsk-auto-publish
   # at_chops carries the synchronous mldsa65 verification dispatch PKAM's
   # record-authoritative verify needs; published at_chops (<=3.4.1) either
   # lacks the branch or returns an async verifier whose Future poisons the

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   basic_utils: ^5.7.0
   ecdsa: ^0.1.2
   encrypt: ^5.0.3
-  at_commons: ^5.13.0
+  at_commons: ^5.14.0
   at_utils: ^3.4.0
   at_chops: ^3.5.0
   at_lookup: ^3.6.0
@@ -45,17 +45,3 @@ dev_dependencies:
 dependency_overrides:
   at_persistence_secondary_server:
     path: ../at_persistence_secondary_server
-  # TEMPORARY: at_commons carries EnrollParams.apsk, the client-composed
-  # signing-key value this server stores and publishes, plus
-  # EnrollParams.apkamPublicKeySignature and EnrollOperationEnum.update.
-  # Remove entirely when at_commons 5.14.0 publishes.
-  #
-  # A TAG, not a path and not a branch: a path escapes the Docker build
-  # context so the VE image cannot be built from it, and a branch ref strands
-  # the pin when the head moves (pub fetches a git ref shallowly, reaching
-  # only branch and tag tips).
-  at_commons:
-    git:
-      url: https://github.com/atsign-foundation/at_client_sdk.git
-      path: packages/at_commons
-      ref: at_commons-apsk-1 # at_client_sdk 54ccffdd0, off gkc-apsk-auto-publish

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -45,6 +45,20 @@ dev_dependencies:
 dependency_overrides:
   at_persistence_secondary_server:
     path: ../at_persistence_secondary_server
+  # TEMPORARY, MUST NOT MERGE AS A PATH: at_commons carries EnrollParams.apsk,
+  # the client-composed signing-key value this server stores and publishes,
+  # plus EnrollParams.apkamPublicKeySignature and EnrollOperationEnum.update.
+  # Replace with a git ref on an at_client_sdk TAG (see the at_chops note
+  # below for why a tag and not a branch), and remove entirely when at_commons
+  # 5.14.0 publishes.
+  #
+  # Points at the wt-apsk worktree rather than the main at_client_sdk checkout:
+  # that checkout follows whichever branch is in flight there, so a path into
+  # it silently resolves to whatever at_commons that branch happens to carry.
+  # The worktree is pinned to gkc-apsk-auto-publish, which is the branch this
+  # server's at_commons dependency actually comes from.
+  at_commons:
+    path: ../../../at_client_sdk-wt-apsk/packages/at_commons
   # at_chops carries the synchronous mldsa65 verification dispatch PKAM's
   # record-authoritative verify needs; published at_chops (<=3.4.1) either
   # lacks the branch or returns an async verifier whose Future poisons the

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   encrypt: ^5.0.3
   at_commons: ^5.13.0
   at_utils: ^3.4.0
-  at_chops: ^3.4.2
+  at_chops: ^3.5.0
   at_lookup: ^3.6.0
   at_server_spec: ^5.1.0
   at_persistence_secondary_server: ^5.2.1
@@ -59,19 +59,3 @@ dependency_overrides:
       url: https://github.com/atsign-foundation/at_client_sdk.git
       path: packages/at_commons
       ref: at_commons-apsk-1 # at_client_sdk 54ccffdd0, off gkc-apsk-auto-publish
-  # at_chops carries the synchronous mldsa65 verification dispatch PKAM's
-  # record-authoritative verify needs; published at_chops (<=3.4.1) either
-  # lacks the branch or returns an async verifier whose Future poisons the
-  # bool result. Remove when it publishes.
-  #
-  # ref is a TAG, deliberately: pub fetches a git ref shallowly, reaching only
-  # branch and tag tips. A branch ref strands this pin the moment the branch
-  # head moves (the locked commit is then absent from a cold pub-cache, though
-  # it keeps resolving on any machine whose cache predates the move), and a
-  # bare commit SHA is worse — unresolvable as soon as it stops being a tip
-  # ("fatal: bad object"). A tag is both immutable and fetchable.
-  at_chops:
-    git:
-      url: https://github.com/atsign-foundation/at_client_sdk.git
-      path: packages/at_chops
-      ref: at_chops-pq-spike-1 # at_client_sdk 55a78f16, off gkc-pq-d1-spike

--- a/packages/at_secondary_server/test/apkam_self_enrollment_test.dart
+++ b/packages/at_secondary_server/test/apkam_self_enrollment_test.dart
@@ -59,6 +59,7 @@ void main() {
     String deviceName = 'selfdevice',
     String? signingAlgo,
     Duration? apkamKeysExpiryDuration,
+    Map<String, dynamic>? apsk,
   }) async {
     final ep = EnrollParams()
       ..appName = appName
@@ -66,6 +67,7 @@ void main() {
       ..apkamPublicKey = 'pq apkam public key $appName $deviceName'
       ..signingAlgo = signingAlgo
       ..apkamKeysExpiryDuration = apkamKeysExpiryDuration
+      ..apsk = apsk
       ..namespaces = namespaces;
     inboundConnection.metaData
       ..isAuthenticated = true
@@ -422,42 +424,51 @@ void main() {
   });
 
   test(
-      'an mldsa65 self-enrollment publishes the tagged _apsk; an rsa one '
-      'stays bare', () async {
+      'a self-enrollment publishes the apsk it composed, and none when it '
+      'composes none', () async {
     final parentId = (await etu.createEnrollments(n: 1)).$1.first;
 
+    // The child composes its own value. signingAlgo is set too and is
+    // deliberately NOT what gets published: it is the record PKAM reads, and
+    // the two are now independent.
+    final composed = {
+      'v': 1,
+      'signingAlgo': 'mldsa65',
+      'publicKey': 'cHEtYXBrYW0tcHVibGlj',
+    };
     final r = await selfEnroll(
         parentEnrollmentId: parentId,
         namespaces: {'app_1': 'rw'},
-        signingAlgo: 'mldsa65');
+        signingAlgo: 'mldsa65',
+        apsk: composed);
     expect(r.isError, false, reason: '${r.errorMessage}');
     final childId = jsonDecode(r.data!)['enrollmentId'] as String;
 
     final childApsk = (await keyValueStore.get(
             'public:_apsk.$childId.${EnrollmentConstants.perEnrollmentApproved}$alice'))!
         .data!;
-    final tagged = jsonDecode(childApsk) as Map<String, dynamic>;
-    expect(tagged['signingAlgo'], 'mldsa65',
-        reason: 'a verifier fetching this _apsk must learn the algorithm '
-            'from the value itself, or it would parse a raw ML-DSA key as '
-            'RSA and fail on every signature');
-    expect(tagged['publicKey'], 'pq apkam public key selfapp selfdevice');
-    expect(tagged['v'], 1);
+    expect(jsonDecode(childApsk), composed,
+        reason: 'the value is opaque, so it is published exactly as sent — '
+            'not recomposed from the record\'s apkamPublicKey, which here is '
+            'a different string entirely');
 
-    // Control: an enrollment without signingAlgo publishes the bare value
-    // exactly as today — deployed apps parse it as an RSA key.
+    // The record still carries the algorithm PKAM verifies under, unchanged
+    // by any of this.
+    expect((await enMgr.getEnrollmentById(childId)).signingAlgo, 'mldsa65');
+
+    // Control: a self-enrollment that sends no apsk gets no record. The
+    // server does not fall back to composing one.
     final r2 = await selfEnroll(
         parentEnrollmentId: parentId,
         namespaces: {'app_1': 'rw'},
         appName: 'selfapp2',
-        deviceName: 'selfdevice2');
+        deviceName: 'selfdevice2',
+        signingAlgo: 'mldsa65');
     final child2Id = jsonDecode(r2.data!)['enrollmentId'] as String;
-    final bareApsk = (await keyValueStore.get(
-            'public:_apsk.$child2Id.${EnrollmentConstants.perEnrollmentApproved}$alice'))!
-        .data!;
-    expect(bareApsk, 'pq apkam public key selfapp2 selfdevice2',
-        reason: 'the bare form is frozen for rsa2048 — the tagged form is '
-            'only for algorithms no deployed parser could read anyway');
+    expect(
+        await keyValueStore.exists(
+            'public:_apsk.$child2Id.${EnrollmentConstants.perEnrollmentApproved}$alice'),
+        false);
   });
 
   test(

--- a/packages/at_secondary_server/test/apkam_signature_verifier_test.dart
+++ b/packages/at_secondary_server/test/apkam_signature_verifier_test.dart
@@ -235,6 +235,36 @@ void main() {
     });
   });
 
+  group('malformed input is refused, never thrown', () {
+    // Every one of these arrives from whoever is trying to authenticate. Before
+    // the verifier existed, base64Decode ran outside each call site's guard, so
+    // a signature that was not valid base64 escaped as an uncaught
+    // FormatException instead of failing the authentication.
+    for (final algo in SigningAlgoType.values) {
+      test('a signature that is not base64 — ${algo.name}', () async {
+        expect(
+            await ApkamSignatureVerifier.verify(
+              message: message,
+              base64Signature: 'not!valid!base64!',
+              publicKey: 'irrelevant',
+              signingAlgo: algo,
+            ),
+            false);
+      });
+
+      test('a public key the algorithm cannot parse — ${algo.name}', () async {
+        expect(
+            await ApkamSignatureVerifier.verify(
+              message: message,
+              base64Signature: base64Encode(Uint8List.fromList([1, 2, 3])),
+              publicKey: 'not a key of any kind',
+              signingAlgo: algo,
+            ),
+            false);
+      });
+    }
+  });
+
   group('algorithm token resolution', () {
     // Raw literals deliberately: these tokens are the wire vocabulary, shared
     // with at_client and recorded on enrollment records. Asserting them against

--- a/packages/at_secondary_server/test/apkam_signature_verifier_test.dart
+++ b/packages/at_secondary_server/test/apkam_signature_verifier_test.dart
@@ -1,0 +1,269 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:at_chops/at_chops.dart';
+import 'package:at_secondary/src/utils/apkam_signature_verifier.dart';
+import 'package:crypton/crypton.dart';
+import 'package:elliptic/elliptic.dart' as elliptic;
+import 'package:test/test.dart';
+
+/// The verifier is the single boundary both `pkam:` and `enroll:update` reach
+/// APKAM signature verification through, so it is tested against every
+/// algorithm the `pkam:` grammar accepts — not just the one the rest of the
+/// suite happens to sign with.
+///
+/// That gap is the whole reason this file exists: every APKAM test in the
+/// package signed `rsa2048`, which at_chops verifies synchronously, so a
+/// verification path that returned an unawaited `Future<bool>` for `mldsa65`
+/// sat green through a full unit suite and died on the wire.
+void main() {
+  final message = Uint8List.fromList(utf8.encode('a-session@alice:a-secret'));
+  final otherMessage =
+      Uint8List.fromList(utf8.encode('a-session@alice:a-different-secret'));
+
+  group('rsa2048', () {
+    late RSAKeypair keyPair;
+    late String publicKey;
+    late String signature;
+
+    setUpAll(() {
+      keyPair = RSAKeypair.fromRandom();
+      publicKey = keyPair.publicKey.toString();
+      signature =
+          base64Encode(keyPair.privateKey.createSHA256Signature(message));
+    });
+
+    test('a genuine signature verifies', () async {
+      expect(
+          await ApkamSignatureVerifier.verify(
+            message: message,
+            base64Signature: signature,
+            publicKey: publicKey,
+            signingAlgo: SigningAlgoType.rsa2048,
+          ),
+          true);
+    });
+
+    test('the same signature over different bytes does not', () async {
+      expect(
+          await ApkamSignatureVerifier.verify(
+            message: otherMessage,
+            base64Signature: signature,
+            publicKey: publicKey,
+            signingAlgo: SigningAlgoType.rsa2048,
+          ),
+          false);
+    });
+
+    test('a signature by a different key does not', () async {
+      final impostor = RSAKeypair.fromRandom();
+      expect(
+          await ApkamSignatureVerifier.verify(
+            message: message,
+            base64Signature: base64Encode(
+                impostor.privateKey.createSHA256Signature(message)),
+            publicKey: publicKey,
+            signingAlgo: SigningAlgoType.rsa2048,
+          ),
+          false);
+    });
+  });
+
+  group('ecc_secp256r1', () {
+    // ECC had no coverage at all before this file, and it is the algorithm
+    // least like the others: at_chops spells its public key as hex and its
+    // signature as compact-hex code units rather than bytes, so it is the one
+    // most likely to break under a change to how the verifier frames things.
+    late elliptic.PrivateKey privateKey;
+    late String publicKey;
+    late String signature;
+
+    String signWith(elliptic.PrivateKey key, Uint8List data) {
+      final algo = EccSigningAlgo()..privateKey = key;
+      return base64Encode(algo.sign(data));
+    }
+
+    setUpAll(() {
+      privateKey = elliptic.getSecp256r1().generatePrivateKey();
+      publicKey = privateKey.publicKey.toHex();
+      signature = signWith(privateKey, message);
+    });
+
+    test('a genuine signature verifies', () async {
+      expect(
+          await ApkamSignatureVerifier.verify(
+            message: message,
+            base64Signature: signature,
+            publicKey: publicKey,
+            signingAlgo: SigningAlgoType.ecc_secp256r1,
+          ),
+          true);
+    });
+
+    test('the same signature over different bytes does not', () async {
+      expect(
+          await ApkamSignatureVerifier.verify(
+            message: otherMessage,
+            base64Signature: signature,
+            publicKey: publicKey,
+            signingAlgo: SigningAlgoType.ecc_secp256r1,
+          ),
+          false);
+    });
+
+    test('a signature by a different key does not', () async {
+      final impostor = elliptic.getSecp256r1().generatePrivateKey();
+      expect(
+          await ApkamSignatureVerifier.verify(
+            message: message,
+            base64Signature: signWith(impostor, message),
+            publicKey: publicKey,
+            signingAlgo: SigningAlgoType.ecc_secp256r1,
+          ),
+          false);
+    });
+  });
+
+  group('mldsa65', () {
+    // The algorithm at_chops verifies ASYNCHRONOUSLY. If the verifier ever
+    // stops awaiting, these are the tests that go red rather than the wire.
+    late ({Uint8List publicKey, Uint8List secretKey}) keyPair;
+    late String publicKey;
+    late String signature;
+
+    setUpAll(() async {
+      keyPair = await MlDsa65PureDartAlgo().generateKeyPair();
+      publicKey = base64Encode(keyPair.publicKey);
+      signature = base64Encode(await MlDsa65PureDartAlgo()
+          .signBytes(message, secretKey: keyPair.secretKey));
+    });
+
+    test('a genuine signature verifies', () async {
+      expect(
+          await ApkamSignatureVerifier.verify(
+            message: message,
+            base64Signature: signature,
+            publicKey: publicKey,
+            signingAlgo: SigningAlgoType.mldsa65,
+          ),
+          true);
+    });
+
+    test('the same signature over different bytes does not', () async {
+      expect(
+          await ApkamSignatureVerifier.verify(
+            message: otherMessage,
+            base64Signature: signature,
+            publicKey: publicKey,
+            signingAlgo: SigningAlgoType.mldsa65,
+          ),
+          false);
+    });
+
+    test('a signature by a different key does not', () async {
+      final impostor = await MlDsa65PureDartAlgo().generateKeyPair();
+      expect(
+          await ApkamSignatureVerifier.verify(
+            message: message,
+            base64Signature: base64Encode(await MlDsa65PureDartAlgo()
+                .signBytes(message, secretKey: impostor.secretKey)),
+            publicKey: publicKey,
+            signingAlgo: SigningAlgoType.mldsa65,
+          ),
+          false);
+    });
+
+    test('answers exactly what the AtChops path it replaced answered',
+        () async {
+      // mldsa65 is the ONE algorithm this verifier routes to a different
+      // at_chops API (the stateless verifyBytes) instead of the compatibility
+      // AtChopsImpl.verify that rsa2048 and ecc_secp256r1 still use. So it is
+      // the one where equivalence has to be observed rather than reasoned
+      // about: AtChopsImpl for mldsa65 selects MlDsa65PureDartAlgo and calls
+      // its deprecated verify(), whose entire body is base64Decode(publicKey)
+      // followed by verifyBytes — this asserts that instead of trusting it.
+      Future<bool> throughAtChops(Uint8List msg, String base64Sig) async {
+        final input =
+            AtSigningVerificationInput(msg, base64Decode(base64Sig), publicKey)
+              ..signingAlgoType = SigningAlgoType.mldsa65
+              ..hashingAlgoType = HashingAlgoType.sha256
+              ..signingMode = AtSigningMode.pkam;
+        return await AtChopsImpl(AtChopsKeys.create(null, null))
+            .verify(input)
+            .result;
+      }
+
+      final impostor = await MlDsa65PureDartAlgo().generateKeyPair();
+      final wrongKeySignature = base64Encode(await MlDsa65PureDartAlgo()
+          .signBytes(message, secretKey: impostor.secretKey));
+
+      // Both polarities, so the agreement below cannot be two paths that
+      // happen to answer false to everything.
+      final cases = <({Uint8List msg, String sig, bool expected})>[
+        (msg: message, sig: signature, expected: true),
+        (msg: otherMessage, sig: signature, expected: false),
+        (msg: message, sig: wrongKeySignature, expected: false),
+      ];
+
+      for (final c in cases) {
+        final viaVerifier = await ApkamSignatureVerifier.verify(
+          message: c.msg,
+          base64Signature: c.sig,
+          publicKey: publicKey,
+          signingAlgo: SigningAlgoType.mldsa65,
+        );
+        expect(viaVerifier, c.expected);
+        expect(viaVerifier, await throughAtChops(c.msg, c.sig),
+            reason: 'the new path must answer exactly what the old one did');
+      }
+    });
+
+    test('verify() answers a real bool, not a Future the caller must unwrap',
+        () async {
+      // The regression pin. `expect(result, true)` above would also catch it,
+      // but only by accident of how Future compares to true — this says what
+      // is actually being guarded, so a later reader does not "simplify" the
+      // await away.
+      final Object result = await ApkamSignatureVerifier.verify(
+        message: message,
+        base64Signature: signature,
+        publicKey: publicKey,
+        signingAlgo: SigningAlgoType.mldsa65,
+      );
+      expect(result, isA<bool>());
+      expect(result, isNot(isA<Future>()));
+    });
+  });
+
+  group('algorithm token resolution', () {
+    // Raw literals deliberately: these tokens are the wire vocabulary, shared
+    // with at_client and recorded on enrollment records. Asserting them against
+    // the constants that define them would follow a rename silently.
+    test('the pkam: grammar tokens resolve to their algorithms', () {
+      expect(ApkamSignatureVerifier.signingAlgoTypeOf('rsa2048'),
+          SigningAlgoType.rsa2048);
+      expect(ApkamSignatureVerifier.signingAlgoTypeOf('ecc_secp256r1'),
+          SigningAlgoType.ecc_secp256r1);
+      expect(ApkamSignatureVerifier.signingAlgoTypeOf('mldsa65'),
+          SigningAlgoType.mldsa65);
+    });
+
+    test('an absent or unknown token means rsa2048', () {
+      // What a PKAM message predating the field meant, and what an enrollment
+      // record written before it carried one still means.
+      expect(ApkamSignatureVerifier.signingAlgoTypeOf(null),
+          SigningAlgoType.rsa2048);
+      expect(ApkamSignatureVerifier.signingAlgoTypeOf('ed25519'),
+          SigningAlgoType.rsa2048);
+    });
+
+    test('hashing tokens resolve, defaulting to sha256', () {
+      expect(ApkamSignatureVerifier.hashingAlgoTypeOf('sha256'),
+          HashingAlgoType.sha256);
+      expect(ApkamSignatureVerifier.hashingAlgoTypeOf('sha512'),
+          HashingAlgoType.sha512);
+      expect(ApkamSignatureVerifier.hashingAlgoTypeOf(null),
+          HashingAlgoType.sha256);
+    });
+  });
+}

--- a/packages/at_secondary_server/test/enroll_verb_test.dart
+++ b/packages/at_secondary_server/test/enroll_verb_test.dart
@@ -1,6 +1,7 @@
 import 'dart:collection';
 import 'dart:convert';
 
+import 'package:at_chops/at_chops.dart';
 import 'package:at_commons/at_commons.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:at_persistence_secondary_server/hive.dart';
@@ -3082,29 +3083,157 @@ void main() {
           throwsA(isA<UnAuthorizedException>()));
     });
 
-    test('_apsk signing key is published on approval (CRAM + enroll:approve)',
+    test(
+        'the client-composed apsk is published VERBATIM on approval '
+        '(CRAM + enroll:approve)', () async {
+      // A shape the server has no code for, deliberately: the value is opaque,
+      // so what comes back out must be what went in and nothing the server
+      // could have composed from (apkamPublicKey, signingAlgo).
+      final composed = {
+        'v': 7,
+        'signingAlgo': 'some-algo-this-server-never-heard-of',
+        'publicKey': 'Y2xpZW50LWNvbXBvc2Vk',
+        'extraFieldTheServerMustNotDrop': ['a', 'b'],
+      };
+
+      // The CRAM auto-approve path.
+      final cramEnId = await etu.createPrimaryEnrollment(apsk: composed);
+      final cramKey = 'public:_apsk.$cramEnId'
+          '.${EnrollmentConstants.perEnrollmentApproved}$alice';
+      expect(await keyValueStore.exists(cramKey), true);
+      expect(jsonDecode((await keyValueStore.get(cramKey))!.data!), composed);
+
+      // The standard enroll:approve path.
+      final pendingEnId = await etu.createPendingEnrollment(
+          appName: 'apskApp',
+          deviceName: 'd',
+          namespaces: {'wavi': 'rw'},
+          apkamKeysExpiryDuration: null,
+          apsk: composed);
+      final pendingKey = 'public:_apsk.$pendingEnId'
+          '.${EnrollmentConstants.perEnrollmentApproved}$alice';
+      expect(await keyValueStore.exists(pendingKey), false,
+          reason: 'nothing is published while the enrollment is only pending');
+
+      await etu.approveEnrollment(etu.primaryEnId, pendingEnId);
+      expect(await keyValueStore.exists(pendingKey), true);
+      expect(jsonDecode((await keyValueStore.get(pendingKey))!.data!), composed);
+    });
+
+    test('an enrollment that sends no apsk gets no _apsk record at all',
         () async {
-      // primary was CRAM auto-approved in ETU.init()
+      // The server composes nothing from (apkamPublicKey, signingAlgo): PKAM
+      // verification reads the record, so an unsent signing key is the
+      // enrollee's own to publish, or to go without.
+      final (enIds, _) = await etu.createEnrollments(n: 1);
+      final apskKey = 'public:_apsk.${enIds[0]}'
+          '.${EnrollmentConstants.perEnrollmentApproved}$alice';
+      expect(await keyValueStore.exists(apskKey), false);
+
+      // Including on the CRAM path, which is where an atSign's very first
+      // enrollment is auto-approved.
       final primaryApsk = 'public:_apsk.${etu.primaryEnId}'
           '.${EnrollmentConstants.perEnrollmentApproved}$alice';
-      expect(await keyValueStore.exists(primaryApsk), true);
-      expect((await keyValueStore.get(primaryApsk))?.data, 'apkam public key');
+      expect(await keyValueStore.exists(primaryApsk), false);
+    });
 
-      // a standard enroll:approve path
-      final (enIds, _) = await etu.createEnrollments(n: 1);
-      final apsk = 'public:_apsk.${enIds[0]}'
-          '.${EnrollmentConstants.perEnrollmentApproved}$alice';
-      expect(await keyValueStore.exists(apsk), true);
+    test('an apsk over the 20KB cap is refused, and creates no enrollment',
+        () async {
+      // Sized on the ENCODED length, which is what lands in the keystore.
+      final overCap = {
+        'publicKey': 'x' * (EnrollVerbHandler.maxApskLengthBytes + 1)
+      };
       expect(
-          (await keyValueStore.get(apsk))?.data, 'apkam public key app_1 test');
+          jsonEncode(overCap).length > EnrollVerbHandler.maxApskLengthBytes,
+          true,
+          reason: 'the arm only tests the cap if it actually exceeds it');
+
+      final before = (await enMgr.getEnrollmentsAsJson()).length;
+      inboundConnection.metaData.isAuthenticated = true;
+      final ep = EnrollParams()
+        ..appName = 'tooBig'
+        ..deviceName = 'd'
+        ..apkamPublicKey = 'apkam pub'
+        ..namespaces = {'wavi': 'rw'}
+        ..apsk = overCap
+        ..otp = await etu.getOtp();
+      inboundConnection.metaData.isAuthenticated = false;
+      inboundConnection.metaData.authType = null;
+      inboundConnection.metaData.sessionID =
+          DateTime.now().millisecondsSinceEpoch.toString();
+
+      await expectLater(
+          etu.evh.processVerb(
+              Response(),
+              getVerbParam(
+                  VerbSyntax.enroll, 'enroll:request:${jsonEncode(ep.toJson())}'),
+              inboundConnection),
+          throwsA(isA<IllegalArgumentException>()));
+
+      expect((await enMgr.getEnrollmentsAsJson()).length, before,
+          reason: 'the refusal lands before the record is created, so an '
+              'oversized value cannot leave a half-made enrollment behind');
+    });
+
+    test('an apsk exactly at the 20KB cap is accepted', () async {
+      // The boundary is inclusive; pinned so a later ">= vs >" edit is caught.
+      final filler = 'x' *
+          (EnrollVerbHandler.maxApskLengthBytes -
+              jsonEncode({'publicKey': ''}).length);
+      final atCap = {'publicKey': filler};
+      expect(jsonEncode(atCap).length, EnrollVerbHandler.maxApskLengthBytes);
+
+      final enId = await etu.createPendingEnrollment(
+          appName: 'atCap',
+          deviceName: 'd',
+          namespaces: {'wavi': 'rw'},
+          apkamKeysExpiryDuration: null,
+          apsk: atCap);
+      await etu.approveEnrollment(etu.primaryEnId, enId);
+      final apskKey = 'public:_apsk.$enId'
+          '.${EnrollmentConstants.perEnrollmentApproved}$alice';
+      expect(jsonDecode((await keyValueStore.get(apskKey))!.data!), atCap);
+    });
+
+    test('an approver cannot substitute the apsk it publishes for an enrollee',
+        () async {
+      // The publish reads the RECORD, so an approve-time value is ignored:
+      // the signing key an enrollment advertises is the enrollee's alone.
+      final enrolleeApsk = {'v': 1, 'publicKey': 'the-enrollees-own-key'};
+      final enId = await etu.createPendingEnrollment(
+          appName: 'substApp',
+          deviceName: 'd',
+          namespaces: {'wavi': 'rw'},
+          apkamKeysExpiryDuration: null,
+          apsk: enrolleeApsk);
+
+      inboundConnection.metaData.isAuthenticated = true;
+      inboundConnection.metaData.enrollmentId = etu.primaryEnId;
+      final approve = EnrollParams()
+        ..enrollmentId = enId
+        ..encryptedDefaultEncryptionPrivateKey = 'encrypted priv'
+        ..encryptedDefaultSelfEncryptionKey = 'encrypted self'
+        ..apsk = {'v': 1, 'publicKey': 'an-approver-substituted-key'};
+      final r = Response();
+      await etu.evh.processVerb(
+          r,
+          getVerbParam(
+              VerbSyntax.enroll, 'enroll:approve:${jsonEncode(approve.toJson())}'),
+          inboundConnection);
+      expect(r.isError, false);
+
+      final apskKey = 'public:_apsk.$enId'
+          '.${EnrollmentConstants.perEnrollmentApproved}$alice';
+      expect(jsonDecode((await keyValueStore.get(apskKey))!.data!), enrolleeApsk);
     });
 
     test('metadata + signingAlgo on enroll:request are persisted on the record',
         () async {
       inboundConnection.metaData.isAuthenticated = true;
       final otp = await etu.getOtp();
-      // The pinned at_commons EnrollParams does not type metadata/signingAlgo,
-      // so append them to the raw request JSON tail (the server persists them).
+      // Built as raw request JSON rather than through EnrollParams: these are
+      // the wire spellings the server reads, and going through the typed
+      // builder would let a field rename pass unnoticed on both sides.
       final reqJson = {
         'appName': 'metaApp',
         'deviceName': 'd',
@@ -3113,6 +3242,7 @@ void main() {
         'namespaces': {'wavi': 'rw'},
         'otp': otp,
         'signingAlgo': 'mldsa65',
+        'apsk': {'v': 1, 'signingAlgo': 'mldsa65', 'publicKey': 'bWxkc2E='},
         'metadata': {
           'keyPackage': {
             'v': 1,
@@ -3136,6 +3266,8 @@ void main() {
       final enId = jsonDecode(r.data!)['enrollmentId'];
       final ev = await enMgr.getEnrollmentById(enId);
       expect(ev.signingAlgo, 'mldsa65');
+      expect(ev.apsk,
+          {'v': 1, 'signingAlgo': 'mldsa65', 'publicKey': 'bWxkc2E='});
       expect(ev.metadata, {
         'keyPackage': {
           'v': 1,
@@ -3144,6 +3276,172 @@ void main() {
           ]
         }
       });
+    });
+  });
+
+  group('enroll:update', () {
+    final etu = ETU();
+    setUp(() async {
+      await verbTestsSetUp();
+      await etu.init();
+    });
+
+    tearDown(() async {
+      await verbTestsTearDown();
+    });
+
+    /// Signs `<enrollmentId>|<apkamPublicKey>|<signingAlgo>` with [keyPair]'s
+    /// private half, the way a client rotating its key must. Real crypto, not
+    /// a stand-in: a fake string would make the accept arm pass for the wrong
+    /// reason and the reject arm pass for no reason at all.
+    String popSignature(
+        AtPkamKeyPair keyPair, String enId, String pub, String algo) {
+      final input = AtSigningInput('$enId|$pub|$algo')
+        ..signingAlgoType = SigningAlgoType.rsa2048
+        ..hashingAlgoType = HashingAlgoType.sha256
+        ..signingMode = AtSigningMode.pkam;
+      return AtChopsImpl(AtChopsKeys.create(null, keyPair)).sign(input).result;
+    }
+
+    Future<Response> sendUpdate(String asEnrollmentId, EnrollParams p) async {
+      inboundConnection.metaData.isAuthenticated = true;
+      inboundConnection.metaData.enrollmentId = asEnrollmentId;
+      final r = Response();
+      await etu.evh.processVerb(
+        r,
+        getVerbParam(VerbSyntax.enroll, 'enroll:update:${jsonEncode(p.toJson())}'),
+        inboundConnection,
+      );
+      return r;
+    }
+
+    test('a valid rotation replaces the key, and an invalid one does not', () async {
+      // Both arms in one test deliberately: the accept arm is the control that
+      // proves the reject arm is refusing the signature rather than refusing
+      // everything.
+      final enId = (await etu.createEnrollments(n: 1)).$1.first;
+      final newPair = AtChopsUtil.generateAtPkamKeyPair();
+      final newPub = newPair.atPublicKey.publicKey;
+
+      // Reject arm: signed by a DIFFERENT key than the one being installed.
+      final wrongPair = AtChopsUtil.generateAtPkamKeyPair();
+      await expectLater(
+        sendUpdate(
+            enId,
+            EnrollParams()
+              ..enrollmentId = enId
+              ..apkamPublicKey = newPub
+              ..signingAlgo = 'rsa2048'
+              ..apkamPublicKeySignature =
+                  popSignature(wrongPair, enId, newPub, 'rsa2048')),
+        throwsA(isA<AtEnrollmentException>()),
+      );
+      expect((await etu.evh.enMgr.getEnrollmentById(enId)).apkamPublicKey,
+          isNot(newPub),
+          reason: 'a refused rotation must not have written anything');
+
+      // Accept arm: signed by the key being installed.
+      final r = await sendUpdate(
+          enId,
+          EnrollParams()
+            ..enrollmentId = enId
+            ..apkamPublicKey = newPub
+            ..signingAlgo = 'rsa2048'
+            ..apkamPublicKeySignature =
+                popSignature(newPair, enId, newPub, 'rsa2048'));
+      expect(r.isError, false);
+      final enVal = await etu.evh.enMgr.getEnrollmentById(enId);
+      expect(enVal.apkamPublicKey, newPub);
+      expect(enVal.signingAlgo, 'rsa2048');
+      expect(enVal.approval!.state, EnrollmentStatus.approved.name,
+          reason: 'a rotation must not move the enrollment lifecycle');
+    });
+
+    test('changing apkamPublicKey without a signature is refused', () async {
+      final enId = (await etu.createEnrollments(n: 1)).$1.first;
+      await expectLater(
+        sendUpdate(
+            enId,
+            EnrollParams()
+              ..enrollmentId = enId
+              ..apkamPublicKey = 'a key nobody proved they hold'),
+        throwsA(isA<AtEnrollmentException>()),
+      );
+    });
+
+    test('enroll:update is self-only', () async {
+      final enIds = (await etu.createEnrollments(n: 2)).$1;
+      await expectLater(
+        sendUpdate(
+            enIds[0],
+            EnrollParams()
+              ..enrollmentId = enIds[1]
+              ..metadata = {'anything': 'at all'}),
+        throwsA(isA<AtEnrollmentException>()),
+        reason: 'one enrollment must not amend another',
+      );
+    });
+
+    test('enroll:update cannot change namespaces', () async {
+      // The privilege-escalation guard: self-only plus reachable namespaces
+      // would let an enrollment widen its own grant.
+      final enId = (await etu.createEnrollments(n: 1)).$1.first;
+      await expectLater(
+        sendUpdate(
+            enId,
+            EnrollParams()
+              ..enrollmentId = enId
+              ..namespaces = {'__manage': 'rw'}),
+        throwsA(isA<IllegalArgumentException>()),
+      );
+    });
+
+    test('metadata is a per-key set, not a whole-map replace', () async {
+      final enId = (await etu.createEnrollments(n: 1)).$1.first;
+
+      await sendUpdate(
+          enId,
+          EnrollParams()
+            ..enrollmentId = enId
+            ..metadata = {'first': 'one', 'second': 'two'});
+      await sendUpdate(
+          enId,
+          EnrollParams()
+            ..enrollmentId = enId
+            ..metadata = {'second': 'changed'});
+
+      final md = (await etu.evh.enMgr.getEnrollmentById(enId)).metadata!;
+      expect(md['second'], 'changed');
+      expect(md['first'], 'one',
+          reason: 'a key the second request did not name must survive: a '
+              'whole-map replace would clobber a sibling field the caller '
+              'does not know about');
+    });
+
+    test('an update naming nothing to change is refused', () async {
+      final enId = (await etu.createEnrollments(n: 1)).$1.first;
+      await expectLater(
+        sendUpdate(enId, EnrollParams()..enrollmentId = enId),
+        throwsA(isA<IllegalArgumentException>()),
+      );
+    });
+
+    test('apsk is republished when the update carries one', () async {
+      final enId = (await etu.createEnrollments(n: 1)).$1.first;
+      final apsk = {
+        'v': 1,
+        'keys': [
+          {'use': 'sign', 'alg': 'mldsa65', 'pub': 'bmV3', 'status': 'active'}
+        ]
+      };
+
+      final r = await sendUpdate(
+          enId, EnrollParams()..enrollmentId = enId..apsk = apsk);
+      expect(r.isError, false);
+
+      final published = await etu.evh.keyStore.get(
+          'public:_apsk.$enId.${EnrollmentConstants.perEnrollmentApproved}$alice');
+      expect(jsonDecode(published!.data!), apsk);
     });
   });
 }

--- a/packages/at_secondary_server/test/enroll_verb_test.dart
+++ b/packages/at_secondary_server/test/enroll_verb_test.dart
@@ -3357,6 +3357,46 @@ void main() {
           reason: 'a rotation must not move the enrollment lifecycle');
     });
 
+    test('an mldsa65 rotation proves possession of the ML-DSA key', () async {
+      // The rsa2048 arms above cannot reach this: at_chops verifies rsa2048
+      // synchronously and mldsa65 asynchronously, so only the ML-DSA path
+      // hands the handler a Future where it reads a bool. Real ML-DSA
+      // material for the same reason the rsa2048 test uses real keys.
+      final enId = (await etu.createEnrollments(n: 1)).$1.first;
+      final newKey = await MlDsa65PureDartAlgo().generateKeyPair();
+      final wrongKey = await MlDsa65PureDartAlgo().generateKeyPair();
+      final newPub = base64Encode(newKey.publicKey);
+      final signable = utf8.encode('$enId|$newPub|mldsa65');
+
+      EnrollParams rotation(String signature) => EnrollParams()
+        ..enrollmentId = enId
+        ..apkamPublicKey = newPub
+        ..signingAlgo = 'mldsa65'
+        ..apkamPublicKeySignature = signature;
+
+      // Reject arm: signed by a different ML-DSA key than the one installed.
+      await expectLater(
+        sendUpdate(
+            enId,
+            rotation(base64Encode(await MlDsa65PureDartAlgo()
+                .signBytes(signable, secretKey: wrongKey.secretKey)))),
+        throwsA(isA<AtEnrollmentException>()),
+      );
+      expect((await etu.evh.enMgr.getEnrollmentById(enId)).apkamPublicKey,
+          isNot(newPub),
+          reason: 'a refused rotation must not have written anything');
+
+      // Accept arm: the control proving the refusal was about the signature.
+      final r = await sendUpdate(
+          enId,
+          rotation(base64Encode(await MlDsa65PureDartAlgo()
+              .signBytes(signable, secretKey: newKey.secretKey))));
+      expect(r.isError, false);
+      final enVal = await etu.evh.enMgr.getEnrollmentById(enId);
+      expect(enVal.apkamPublicKey, newPub);
+      expect(enVal.signingAlgo, 'mldsa65');
+    });
+
     test('changing apkamPublicKey without a signature is refused', () async {
       final enId = (await etu.createEnrollments(n: 1)).$1.first;
       await expectLater(

--- a/packages/at_secondary_server/test/enrollment_test_utils.dart
+++ b/packages/at_secondary_server/test/enrollment_test_utils.dart
@@ -51,11 +51,14 @@ class ETU {
     return r.data!;
   }
 
+  /// [apsk] is the client-composed signing-key value; leaving it null is the
+  /// ordinary case and means no `_apsk` is published for this enrollment.
   Future<String> createPendingEnrollment(
       {required String appName,
       required String deviceName,
       required Map<String, String> namespaces,
-      required Duration? apkamKeysExpiryDuration}) async {
+      required Duration? apkamKeysExpiryDuration,
+      Map<String, dynamic>? apsk}) async {
     final EnrollParams ep = EnrollParams()
       ..appName = appName
       ..deviceName = deviceName
@@ -64,6 +67,7 @@ class ETU {
           'encrypted apkam aes key $appName $deviceName'
       ..namespaces = namespaces
       ..apkamKeysExpiryDuration = apkamKeysExpiryDuration
+      ..apsk = apsk
       ..otp = await getOtp();
 
     final String enrollmentRequest = 'enroll:request:'
@@ -159,12 +163,13 @@ class ETU {
     expect(m['enrollmentId'], enIdToDelete);
   }
 
-  Future<String> createPrimaryEnrollment() async {
+  Future<String> createPrimaryEnrollment({Map<String, dynamic>? apsk}) async {
     EnrollParams ep = EnrollParams()
       ..appName = 'primary'
       ..deviceName = 'primary'
       ..apkamPublicKey = 'apkam public key'
       ..encryptedAPKAMSymmetricKey = 'encrypted apkam aes key'
+      ..apsk = apsk
       ..namespaces = {'*': 'rw'};
     String enrollmentRequest = 'enroll:request:'
         '${jsonEncode(ep.toJson())}';

--- a/tests/at_functional_test/test/apkam_self_enrollment_test.dart
+++ b/tests/at_functional_test/test/apkam_self_enrollment_test.dart
@@ -90,7 +90,8 @@ void main() {
       String? appName,
       String? deviceName,
       int? apkamKeysExpiryInMillis,
-      String? signingAlgo}) async {
+      String? signingAlgo,
+      Map<String, dynamic>? apsk}) async {
     OutboundConnectionFactory parent = await newConnection();
     expect(
         (await parent.authenticateConnection(
@@ -102,8 +103,9 @@ void main() {
         ? ''
         : ',"apkamKeysExpiryInMillis":$apkamKeysExpiryInMillis';
     String algo = signingAlgo == null ? '' : ',"signingAlgo":"$signingAlgo"';
+    String apskField = apsk == null ? '' : ',"apsk":${jsonEncode(apsk)}';
     return (await parent.sendRequestToServer(
-            'enroll:request:{"appName":"${appName ?? 'child-${Uuid().v4().hashCode}'}","deviceName":"${deviceName ?? 'device-${Uuid().v4().hashCode}'}","namespaces":${jsonEncode(namespaces)},"apkamPublicKey":"$apkamPublicKey"$expiry$algo}'))
+            'enroll:request:{"appName":"${appName ?? 'child-${Uuid().v4().hashCode}'}","deviceName":"${deviceName ?? 'device-${Uuid().v4().hashCode}'}","namespaces":${jsonEncode(namespaces)},"apkamPublicKey":"$apkamPublicKey"$expiry$algo$apskField}'))
         .trim();
   }
 
@@ -113,13 +115,15 @@ void main() {
       String? appName,
       String? deviceName,
       int? apkamKeysExpiryInMillis,
-      String? signingAlgo}) async {
+      String? signingAlgo,
+      Map<String, dynamic>? apsk}) async {
     String response = await selfEnroll(parentId,
         namespaces: namespaces,
         appName: appName,
         deviceName: deviceName,
         apkamKeysExpiryInMillis: apkamKeysExpiryInMillis,
-        signingAlgo: signingAlgo);
+        signingAlgo: signingAlgo,
+        apsk: apsk);
     Map decoded = jsonDecode(response.replaceFirst('data:', ''));
     expect(decoded['status'], 'approved',
         reason: 'a self-enrollment is auto-approved with no human step');
@@ -459,7 +463,7 @@ void main() {
     });
   });
 
-  group('The published _apsk describes its own algorithm', () {
+  group('The published _apsk is whatever the client composed', () {
     Future<String> apskValue(
         OutboundConnectionFactory owner, String enrollmentId) async {
       return (await owner
@@ -468,31 +472,40 @@ void main() {
           .replaceFirst('data:', '');
     }
 
-    test('an rsa2048 enrollment publishes the bare public key', () async {
-      // Deployed apps parse the bare value as an RSA key, so this one may not
-      // change shape.
+    test('the value sent on enroll:request is published verbatim', () async {
+      // A shape with a field the atServer has no code for, on purpose: the
+      // value is opaque, so what a verifier resolves must be what the enrollee
+      // composed and nothing the server could have derived from the record.
+      Map<String, dynamic> composed = {
+        'v': 1,
+        'signingAlgo': 'mldsa65',
+        'publicKey': 'Y2xpZW50LWNvbXBvc2VkLWtleQ==',
+        'extraFieldTheServerMustNotDrop': ['a', 'b'],
+      };
+
       OutboundConnectionFactory owner = await ownerConnection();
       String parentId =
           await createApprovedEnrollment(owner, namespaces: {'wavi': 'rw'});
-      String childId = await selfEnrollId(parentId, namespaces: {'wavi': 'r'});
+      String childId = await selfEnrollId(parentId,
+          namespaces: {'wavi': 'r'}, signingAlgo: 'mldsa65', apsk: composed);
 
-      expect(await apskValue(owner, childId), apkamPublicKey);
+      expect(jsonDecode(await apskValue(owner, childId)), composed);
     });
 
-    test('a non-rsa2048 enrollment publishes the tagged, self-describing form',
-        () async {
-      // Without the tag a verifier reads a raw ML-DSA key as RSA and every
-      // signature from the enrollment fails.
+    test('an enrollment that sends no apsk gets no _apsk record', () async {
+      // The atServer composes nothing from (apkamPublicKey, signingAlgo):
+      // PKAM verification reads the enrollment record, so this key is the
+      // enrollee's to publish from its own connection, or to go without.
       OutboundConnectionFactory owner = await ownerConnection();
       String parentId =
           await createApprovedEnrollment(owner, namespaces: {'wavi': 'rw'});
       String childId = await selfEnrollId(parentId,
           namespaces: {'wavi': 'r'}, signingAlgo: 'mldsa65');
 
-      Map published = jsonDecode(await apskValue(owner, childId));
-      expect(published['v'], 1);
-      expect(published['signingAlgo'], 'mldsa65');
-      expect(published['publicKey'], apkamPublicKey);
+      expect(
+          await apskValue(owner, childId),
+          contains('key not found : public:_apsk.$childId.a.__e$atSign '
+              'does not exist in keystore'));
     });
   });
 

--- a/tests/at_functional_test/test/enroll_update_test.dart
+++ b/tests/at_functional_test/test/enroll_update_test.dart
@@ -89,14 +89,21 @@ void main() {
   ///
   /// Its own fresh connection each time, because a failed authentication is
   /// not something a connection is expected to survive.
+  ///
+  /// The challenge handling mirrors `_apkamAuthentication` in
+  /// outbound_connection_wrapper.dart EXACTLY — same clientConfig, and
+  /// `replaceAll('data:', '')` and nothing more. Trimming it or stripping the
+  /// `@<atSign>@` prompt changes the bytes the digest covers, and the only
+  /// symptom is an authentication that fails for a reason having nothing to
+  /// do with the key. This helper exists at all because the library helper
+  /// signs with the demo-data key, and half the point here is authenticating
+  /// with a key that was minted during the test.
   Future<bool> canAuthenticate(String enrollmentId, String privateKey) async {
     OutboundConnectionFactory c = await newConnection();
-    String fromResponse =
-        await c.sendRequestToServer('from:$atSign:clientConfig:{}');
-    String challenge =
-        fromResponse.replaceAll('data:', '').replaceAll('@$atSign@', '').trim();
-    String signature =
-        AuthenticationUtils.generatePKAMDigest(privateKey, challenge);
+    String fromResponse = await c.sendRequestToServer(
+        'from:$atSign:clientConfig:${jsonEncode({'version': '3.0.57'})}');
+    String signature = AuthenticationUtils.generatePKAMDigest(
+        privateKey, fromResponse.replaceAll('data:', ''));
     try {
       String r = await c
           .sendRequestToServer('pkam:enrollmentId:$enrollmentId:$signature');

--- a/tests/at_functional_test/test/enroll_update_test.dart
+++ b/tests/at_functional_test/test/enroll_update_test.dart
@@ -1,0 +1,243 @@
+import 'dart:convert';
+
+import 'package:at_chops/at_chops.dart';
+import 'package:at_demo_data/at_demo_data.dart';
+import 'package:at_functional_test/conf/config_util.dart';
+import 'package:at_functional_test/connection/outbound_connection_wrapper.dart';
+import 'package:at_functional_test/utils/auth_utils.dart';
+import 'package:at_functional_test/utils/encryption_util.dart';
+import 'package:test/test.dart';
+import 'package:uuid/uuid.dart';
+
+/// Functional coverage of `enroll:update` — an approved enrollment amending
+/// its own record, and in particular rotating its APKAM authentication
+/// keypair while keeping its enrollment id.
+///
+/// The unit suite in `at_secondary_server` pins the handler's decisions
+/// directly. What only the wire can show is the thing the whole operation
+/// exists for: after a rotation the NEW key authenticates and the OLD one
+/// does not. A unit test can assert the record changed; it cannot assert that
+/// PKAM now judges a different key.
+void main() {
+  String atSign = ConfigUtil.getYaml()!['firstAtSignServer']['firstAtSignName'];
+  String host = ConfigUtil.getYaml()!['firstAtSignServer']['firstAtSignUrl'];
+  int port = ConfigUtil.getYaml()!['firstAtSignServer']['firstAtSignPort'];
+
+  String apkamPublicKey = apkamPublicKeyMap[atSign]!;
+  String apkamPrivateKey = apkamPrivateKeyMap[atSign]!;
+  String encryptedPrivateKey = EncryptionUtil.encryptValue(
+      encryptionPrivateKeyMap[atSign]!, apkamSymmetricKeyMap[atSign]!);
+  String encryptedSelfKey = EncryptionUtil.encryptValue(
+      aesKeyMap[atSign]!, apkamSymmetricKeyMap[atSign]!);
+  String encryptedApkamSymmetricKey = EncryptionUtil.encryptKey(
+      apkamSymmetricKeyMap[atSign]!, encryptionPublicKeyMap[atSign]!);
+
+  List<OutboundConnectionFactory> open = [];
+
+  Future<OutboundConnectionFactory> newConnection() async {
+    OutboundConnectionFactory c = await OutboundConnectionFactory()
+        .initiateConnectionWithListener(atSign, host, port);
+    open.add(c);
+    return c;
+  }
+
+  Future<OutboundConnectionFactory> ownerConnection() async {
+    OutboundConnectionFactory c = await newConnection();
+    expect((await c.authenticateConnection(authType: AuthType.cram)).trim(),
+        'data:success');
+    return c;
+  }
+
+  /// An approved enrollment holding [namespaces], via the ordinary OTP flow.
+  ///
+  /// Run-unique app/device names: an approved `(appName, deviceName)` pair
+  /// cannot be re-used, so fixed names pass once and collide on the next run
+  /// against the same virtualenv.
+  Future<String> createApprovedEnrollment(OutboundConnectionFactory owner,
+      {required Map<String, String> namespaces}) async {
+    String otp = (await owner.sendRequestToServer('otp:get'))
+        .replaceFirst('data:', '')
+        .trim();
+    String appName = 'upd-app-${Uuid().v4().hashCode}';
+    String deviceName = 'upd-dev-${Uuid().v4().hashCode}';
+    // One enroll:request per connection: the rate limiter is per-connection.
+    OutboundConnectionFactory requester = await newConnection();
+    String response = await requester.sendRequestToServer(
+        'enroll:request:{"appName":"$appName","deviceName":"$deviceName","namespaces":${jsonEncode(namespaces)},"otp":"$otp","apkamPublicKey":"$apkamPublicKey","encryptedAPKAMSymmetricKey":"$encryptedApkamSymmetricKey"}');
+    String enrollmentId =
+        jsonDecode(response.replaceFirst('data:', ''))['enrollmentId'];
+    String approval = await owner.sendRequestToServer(
+        'enroll:approve:{"enrollmentId":"$enrollmentId","encryptedDefaultEncryptionPrivateKey":"$encryptedPrivateKey","encryptedDefaultSelfEncryptionKey":"$encryptedSelfKey"}');
+    expect(jsonDecode(approval.replaceFirst('data:', ''))['status'], 'approved');
+    return enrollmentId;
+  }
+
+  /// The proof-of-possession a rotation must carry: a signature by the NEW
+  /// private key over `<enrollmentId>|<apkamPublicKey>|<signingAlgo>`.
+  ///
+  /// `AtSigningMode.pkam` rather than `data` — `data` signs with the
+  /// encryption keypair, so it cannot express possession of a signing key.
+  String popSignature(AtPkamKeyPair pair, String enId, String algo) {
+    final input = AtSigningInput('$enId|${pair.atPublicKey.publicKey}|$algo')
+      ..signingAlgoType = SigningAlgoType.rsa2048
+      ..hashingAlgoType = HashingAlgoType.sha256
+      ..signingMode = AtSigningMode.pkam;
+    return AtChopsImpl(AtChopsKeys.create(null, pair)).sign(input).result;
+  }
+
+  /// Whether [privateKey] can PKAM-authenticate as [enrollmentId] right now.
+  ///
+  /// Its own fresh connection each time, because a failed authentication is
+  /// not something a connection is expected to survive.
+  Future<bool> canAuthenticate(String enrollmentId, String privateKey) async {
+    OutboundConnectionFactory c = await newConnection();
+    String fromResponse =
+        await c.sendRequestToServer('from:$atSign:clientConfig:{}');
+    String challenge =
+        fromResponse.replaceAll('data:', '').replaceAll('@$atSign@', '').trim();
+    String signature =
+        AuthenticationUtils.generatePKAMDigest(privateKey, challenge);
+    try {
+      String r = await c
+          .sendRequestToServer('pkam:enrollmentId:$enrollmentId:$signature');
+      return r.trim() == 'data:success';
+    } on Exception {
+      return false;
+    }
+  }
+
+  tearDown(() async {
+    for (final c in open) {
+      c.close();
+    }
+    open.clear();
+  });
+
+  group('enroll:update', () {
+    test('a rotation moves authentication to the new key and off the old one',
+        () async {
+      final owner = await ownerConnection();
+      final enId =
+          await createApprovedEnrollment(owner, namespaces: {'buzz': 'rw'});
+
+      expect(await canAuthenticate(enId, apkamPrivateKey), true,
+          reason: 'the enrollment must authenticate before the rotation, or '
+              'the after-check proves nothing');
+
+      final newPair = AtChopsUtil.generateAtPkamKeyPair();
+      final newPub = newPair.atPublicKey.publicKey;
+
+      final self = await newConnection();
+      expect(
+          (await self.authenticateConnection(
+                  authType: AuthType.apkam, enrollmentId: enId))
+              .trim(),
+          'data:success');
+
+      final response = await self.sendRequestToServer(
+          'enroll:update:{"enrollmentId":"$enId","apkamPublicKey":"$newPub",'
+          '"signingAlgo":"rsa2048","apkamPublicKeySignature":'
+          '"${popSignature(newPair, enId, 'rsa2048')}"}');
+      expect(jsonDecode(response.replaceFirst('data:', ''))['status'],
+          'approved');
+
+      // The point of the whole operation, and the part no unit test reaches.
+      expect(
+          await canAuthenticate(enId, newPair.atPrivateKey.privateKey), true,
+          reason: 'the rotated-in key must authenticate as the SAME '
+              'enrollment id');
+      expect(await canAuthenticate(enId, apkamPrivateKey), false,
+          reason: 'the rotated-out key must stop authenticating');
+    });
+
+    test('a rotation with an invalid proof is refused and changes nothing',
+        () async {
+      final owner = await ownerConnection();
+      final enId =
+          await createApprovedEnrollment(owner, namespaces: {'buzz': 'rw'});
+
+      final newPair = AtChopsUtil.generateAtPkamKeyPair();
+      final wrongPair = AtChopsUtil.generateAtPkamKeyPair();
+
+      final self = await newConnection();
+      expect(
+          (await self.authenticateConnection(
+                  authType: AuthType.apkam, enrollmentId: enId))
+              .trim(),
+          'data:success');
+
+      // Signed by a key OTHER than the one being installed.
+      final response = await self.sendRequestToServer(
+          'enroll:update:{"enrollmentId":"$enId",'
+          '"apkamPublicKey":"${newPair.atPublicKey.publicKey}",'
+          '"signingAlgo":"rsa2048","apkamPublicKeySignature":'
+          '"${popSignature(wrongPair, enId, 'rsa2048')}"}');
+      expect(response.trim(), startsWith('error:'),
+          reason: 'a proof that does not verify against the key being '
+              'installed must be refused');
+
+      // The differential half: the refusal left the record alone.
+      expect(await canAuthenticate(enId, apkamPrivateKey), true,
+          reason: 'the original key must still authenticate after a refused '
+              'rotation');
+      expect(
+          await canAuthenticate(enId, newPair.atPrivateKey.privateKey), false,
+          reason: 'the refused key must not have been installed');
+    });
+
+    test('one enrollment cannot update another', () async {
+      final owner = await ownerConnection();
+      final target =
+          await createApprovedEnrollment(owner, namespaces: {'buzz': 'rw'});
+      final other =
+          await createApprovedEnrollment(owner, namespaces: {'buzz': 'rw'});
+
+      final c = await newConnection();
+      expect(
+          (await c.authenticateConnection(
+                  authType: AuthType.apkam, enrollmentId: other))
+              .trim(),
+          'data:success');
+
+      final response = await c.sendRequestToServer(
+          'enroll:update:{"enrollmentId":"$target","metadata":{"x":"y"}}');
+      expect(response.trim(), startsWith('error:'),
+          reason: 'enroll:update is self-only');
+    });
+
+    test('an update carrying apsk republishes the record', () async {
+      final owner = await ownerConnection();
+      final enId =
+          await createApprovedEnrollment(owner, namespaces: {'buzz': 'rw'});
+
+      final apsk = {
+        'v': 1,
+        'keys': [
+          {
+            'use': 'sign',
+            'alg': 'mldsa65',
+            'pub': 'ZnVuY3Rpb25hbC10ZXN0LWtleQ==',
+            'status': 'active'
+          }
+        ]
+      };
+
+      final self = await newConnection();
+      expect(
+          (await self.authenticateConnection(
+                  authType: AuthType.apkam, enrollmentId: enId))
+              .trim(),
+          'data:success');
+      final response = await self.sendRequestToServer(
+          'enroll:update:{"enrollmentId":"$enId","apsk":${jsonEncode(apsk)}}');
+      expect(jsonDecode(response.replaceFirst('data:', ''))['status'],
+          'approved');
+
+      // Read it back the way a verifier does, not out of the enrollment
+      // record: the published key is what every signature check resolves.
+      final published =
+          await owner.sendRequestToServer('llookup:public:_apsk.$enId.a.__e$atSign');
+      expect(jsonDecode(published.replaceFirst('data:', '').trim()), apsk);
+    });
+  });
+}


### PR DESCRIPTION
**- What I did**
- The atServer no longer composes an enrollment's `_apsk`. It publishes `EnrollParams.apsk` — a value the client composes and sends on `enroll:request` — verbatim, and publishes nothing when the request carries no such value. Capped at 20KB encoded, refused rather than truncated.
  - PKAM verification reads the enrollment record, never `_apsk`, so this was always a client-side artefact; moving the format to the side that parses it means a new signing-key shape needs no server release.
- Added `enroll:update`: an approved enrollment amending its OWN record's `apkamPublicKey`, `signingAlgo`, `apsk` and `metadata`, so a client can rotate its APKAM authentication keypair while keeping its enrollment id. Before this the only route was a new enrollment, which strands every record addressed to the old one.
  - self-only and approved-state only; `namespaces` and approval state are refused by name rather than ignored, since an enrollment amending itself must not be able to widen its own grant
  - `metadata` is a per-key set, never a whole-map replace, so a client that doesn't know about a future sibling field can't clobber it
- Changing `apkamPublicKey` requires `EnrollParams.apkamPublicKeySignature` — a signature by the **new** private key over `<enrollmentId>|<apkamPublicKey>|<signingAlgo>`, `AtSigningMode.pkam`. The connection only proves possession of the *current* key; without this a compromised-but-authenticated client can install a key whose private half it doesn't hold.
- `await` the result of an `AtChops` signature verification. at_chops 3.5.0 verifies `rsa2048` and `ecc_secp256r1` synchronously but `mldsa65` asynchronously, while `AtChopsImpl.verify` is synchronous either way — so `AtSigningResult.result` carries a `FutureOr<bool>` and both verification sites read an unawaited `Future` as a `bool`. Every `mldsa65` PKAM died on `type 'Future<bool>' is not a subtype of type 'bool'`, and an `enroll:update` rotating to an ML-DSA key would have died the same way.
- Unit and functional tests throughout, including an `mldsa65` rotation over real ML-DSA material — the proof-of-possession path had only ever been tested with `rsa2048`, the synchronous one.
- Dependency bumps, both now published: at_chops `^3.5.0`, at_commons `^5.14.0`. Both git overrides are gone.

**- How I did it**
See commit & diffs

**- How to verify it**
Tests pass — `at_secondary_server` unit 920/920 and the full functional pack 210/210 locally, plus CI.
