### PR TITLE
feat(at_secondary_server): honour apskLegacy, and bound the whole enrollment record

### DIFF
--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 3.16.1
+- feat: honour `EnrollParams.apskLegacy` — the bare RSA `_apsk` string,
+  published verbatim rather than JSON-encoded. A request carrying both it and
+  `apsk` is refused.
+- feat: one 500KB limit on the whole enrollment record, replacing the
+  per-field `apsk` cap. `metadata` was uncapped, so the old bound sat on the
+  one field nobody would use to make a record big.
+- fix: fix race in enrollment manager
+
 # 3.16.0
 - feat: `enroll:update` — an approved enrollment amending its OWN record's
   `apkamPublicKey`, `signingAlgo`, `apsk` and `metadata`. Self-only: the

--- a/packages/at_secondary_server/lib/src/enroll/enroll_datastore_value.dart
+++ b/packages/at_secondary_server/lib/src/enroll/enroll_datastore_value.dart
@@ -50,6 +50,23 @@ class EnrollDataStoreValue {
   /// put it there in time.
   Map<String, dynamic>? apsk;
 
+  /// The **bare** `_apsk` value — an RSA public key string exactly as the
+  /// record has always carried it — carried on `enroll:request` as
+  /// `EnrollParams.apskLegacy` and published verbatim, NOT JSON-encoded.
+  ///
+  /// It exists because every deployed `_apsk` consumer base64-decodes the
+  /// value as an RSA key, so a JSON one fails their parse. That is fail-closed
+  /// but service-breaking for anything already running, so a plain-legacy
+  /// enrollment publishes the shape they expect through the same verb every
+  /// other enrollment uses.
+  ///
+  /// Mutually exclusive with [apsk], on the wire and at rest: one record
+  /// publishes one value, and a record holding both would make the published
+  /// value depend on a precedence rule nobody stated. The request that carries
+  /// both is refused, and an `enroll:update` that sets either one clears the
+  /// other.
+  String? apskLegacy;
+
   /// The enrollment whose authenticated connection self-spawned this one
   /// (RF-SRV), or null for every other origin.
   ///

--- a/packages/at_secondary_server/lib/src/enroll/enroll_datastore_value.g.dart
+++ b/packages/at_secondary_server/lib/src/enroll/enroll_datastore_value.g.dart
@@ -27,6 +27,7 @@ EnrollDataStoreValue _$EnrollDataStoreValueFromJson(
       ..metadata = (json['metadata'] as Map<String, dynamic>?)
       ..signingAlgo = json['signingAlgo'] as String?
       ..apsk = (json['apsk'] as Map<String, dynamic>?)
+      ..apskLegacy = json['apskLegacy'] as String?
       ..parentEnrollmentId = json['parentEnrollmentId'] as String?;
 
 Map<String, dynamic> _$EnrollDataStoreValueToJson(
@@ -45,6 +46,7 @@ Map<String, dynamic> _$EnrollDataStoreValueToJson(
       if (instance.metadata != null) 'metadata': instance.metadata,
       if (instance.signingAlgo != null) 'signingAlgo': instance.signingAlgo,
       if (instance.apsk != null) 'apsk': instance.apsk,
+      if (instance.apskLegacy != null) 'apskLegacy': instance.apskLegacy,
       if (instance.parentEnrollmentId != null)
         'parentEnrollmentId': instance.parentEnrollmentId,
     };

--- a/packages/at_secondary_server/lib/src/enroll/enrollment_manager.dart
+++ b/packages/at_secondary_server/lib/src/enroll/enrollment_manager.dart
@@ -91,10 +91,6 @@ class EnrollmentManager {
       String enId, AtData atData, EnrollmentStatus newStatus) async {
     String ek = buildEnrollmentKey(enId);
 
-    // invalidate the cache
-    cacheInvalidations++;
-    atDataCache.remove(ek);
-
     switch (newStatus) {
       case EnrollmentStatus.approved:
         await movePerEnrollmentData(enId,
@@ -109,6 +105,10 @@ class EnrollmentManager {
     }
 
     await keyStore.put(ek, atData, skipCommit: true);
+
+    // invalidate the cache
+    cacheInvalidations++;
+    atDataCache.remove(ek);
   }
 
   RegExp reForPerEnrollmentNamespaces =
@@ -244,11 +244,11 @@ class EnrollmentManager {
     }
     String ek = buildEnrollmentKey(enId);
 
+    await keyStore.remove(ek, skipCommit: true);
+
     // invalidate the cache
     cacheInvalidations++;
     atDataCache.remove(ek);
-
-    await keyStore.remove(ek, skipCommit: true);
   }
 
   Future<List<String>> getAllEnrollmentKeys() async {

--- a/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
@@ -37,15 +37,32 @@ class EnrollVerbHandler extends AbstractVerbHandler {
           seconds: AtSecondaryConfig.enrollmentResponseDelayIntervalInSeconds)
       .inMilliseconds;
 
-  /// The largest `EnrollParams.apsk` the atServer will store, measured on its
+  /// The largest enrollment record the atServer will store, measured on its
   /// JSON encoding — the string that lands in the keystore.
   ///
-  /// The value is opaque, so nothing about it can be validated; a bound is all
-  /// the server can meaningfully impose. 20KB is far above any signing key
-  /// (ML-DSA-65's public half is ~2.6KB base64-encoded, the largest in play)
-  /// and far below anything that would make the enrollment record awkward to
-  /// store or return from `enroll:listns`.
-  static const int maxApskLengthBytes = 20 * 1024;
+  /// One bound on the whole record rather than one per opaque field. A
+  /// per-field cap bounds nothing while a sibling field is uncapped, and that
+  /// was the state this replaced: `apsk` was capped while `metadata` — which
+  /// carries the enrollment's key package, the largest blob in play — was not,
+  /// so the cap sat on the one field nobody would use to make a record big.
+  /// It also means a field added later is covered without anyone remembering
+  /// to cap it.
+  ///
+  /// The record's contents are opaque, so nothing about them can be validated;
+  /// a bound is all the server can meaningfully impose. What it protects is
+  /// not disk: the record is read on every verb command and held in
+  /// [EnrollmentManager]'s cache, which is evicted only on write, so an
+  /// oversized record occupies server memory for the process's life. It is
+  /// also returned whole by `enroll:list`, and its `metadata` by
+  /// `enroll:listns` for every approved enrollment in a namespace — so one fat
+  /// record inflates every discovery response, for every caller.
+  ///
+  /// 500KB is far above any legitimate record (ML-DSA-65's public half, the
+  /// largest key in play, is ~2.6KB base64-encoded, and a record holds a
+  /// handful) and far below the ~10MB an inbound connection will buffer, which
+  /// is otherwise the only ceiling on a request that reaches this path with
+  /// nothing but an OTP.
+  static const int maxEnrollmentRecordBytes = 500 * 1024;
 
   final EnrollmentManager enMgr;
   final NotificationManager notifManager;
@@ -273,19 +290,9 @@ class EnrollVerbHandler extends AbstractVerbHandler {
           'Enrollment requests have exceeded the limit within the specified time frame');
     }
 
-    // Bound the one field the server stores without understanding, before
-    // anything is created or an OTP is spent. Refused rather than truncated:
-    // a truncated signing key is a key nothing can verify against, published
-    // at the address every verifier resolves, and the enrollee would have no
-    // way to tell that from a key it composed wrong.
-    final apskLength = enrollParams.apsk == null
-        ? 0
-        : utf8.encode(jsonEncode(enrollParams.apsk)).length;
-    if (apskLength > maxApskLengthBytes) {
-      throw IllegalArgumentException(
-          'apsk is $apskLength bytes encoded, which exceeds the '
-          '$maxApskLengthBytes byte limit');
-    }
+    // Structural checks plus a size pre-filter, before anything is created
+    // or an OTP is spent. The record itself is bounded at each write.
+    _validateEnrollParams(enrollParams);
 
     // OTP is sent only in enrollment request which is submitted on
     // unauthenticated connection.
@@ -346,8 +353,13 @@ class EnrollVerbHandler extends AbstractVerbHandler {
     if (enrollParams.signingAlgo != null) {
       enrollmentValue.signingAlgo = enrollParams.signingAlgo;
     }
+    // At most one of the two is set — _validateEnrollParams refused the request
+    // that carried both, above.
     if (enrollParams.apsk != null) {
       enrollmentValue.apsk = enrollParams.apsk;
+    }
+    if (enrollParams.apskLegacy != null) {
+      enrollmentValue.apskLegacy = enrollParams.apskLegacy;
     }
 
     if (enrollParams.apkamKeysExpiryDuration != null) {
@@ -365,6 +377,10 @@ class EnrollVerbHandler extends AbstractVerbHandler {
       final inboundConnectionMetadata =
           atConnection.metaData as InboundConnectionMetadata;
       inboundConnectionMetadata.enrollmentId = newEnrollmentId;
+      // Before any write: a refusal must not leave a published _apsk or a
+      // rewritten default pkam public key behind for an enrollment that was
+      // never created.
+      _validateRecordSize(enrollmentValue);
       // store this apkam as default pkam public key for old clients
       // The keys with AT_PKAM_PUBLIC_KEY does not sync to client.
       await keyStore.put(AtConstants.atPkamPublicKey,
@@ -372,7 +388,7 @@ class EnrollVerbHandler extends AbstractVerbHandler {
           skipCommit: true);
       // Publish the client-composed `_apsk` signing key, if it sent one.
       await _publishApskSigningKey(
-          newEnrollmentId, enrollmentValue.apsk, currentAtSign);
+          newEnrollmentId, enrollmentValue, currentAtSign);
       AtData enrollData = AtData()..data = jsonEncode(enrollmentValue.toJson());
 
       await enMgr.put(newEnrollmentId, enrollData, EnrollmentStatus.approved);
@@ -449,9 +465,12 @@ class EnrollVerbHandler extends AbstractVerbHandler {
           enrollParams.encryptedAPKAMSymmetricKey;
       responseJson['status'] = 'approved';
 
+      // Before any write, so a refusal leaves no published _apsk behind for an
+      // enrollment that was never created.
+      _validateRecordSize(enrollmentValue);
       // Publish the client-composed `_apsk` signing key, if it sent one.
       await _publishApskSigningKey(
-          newEnrollmentId, enrollmentValue.apsk, currentAtSign);
+          newEnrollmentId, enrollmentValue, currentAtSign);
       // The child's record expires per its (inherited or stated) key-expiry
       // posture, exactly as the ordinary approve path writes it — the
       // retrofit copies the parent's expiry, it does not grant immortality.
@@ -481,6 +500,7 @@ class EnrollVerbHandler extends AbstractVerbHandler {
     enrollmentValue.approval = EnrollApproval(EnrollmentStatus.pending.name);
     await _storeNotification(enrollmentKey, enrollParams, currentAtSign);
     responseJson['status'] = 'pending';
+    _validateRecordSize(enrollmentValue);
     AtData enrollData = AtData()
       ..data = jsonEncode(enrollmentValue.toJson())
       // Set TTL to the pending enrollments.
@@ -646,7 +666,7 @@ class EnrollVerbHandler extends AbstractVerbHandler {
       // Read off the RECORD, not off these approve params: the value is the
       // enrollee's, and an approver must not be able to substitute a signing
       // key for the enrollment it is approving.
-      await _publishApskSigningKey(enId, enVal.apsk, currentAtSign);
+      await _publishApskSigningKey(enId, enVal, currentAtSign);
     }
     responseJson['enrollmentId'] = enId;
   }
@@ -699,18 +719,9 @@ class EnrollVerbHandler extends AbstractVerbHandler {
           '${status.name}');
     }
 
-    // Same cap and the same reason as enroll:request: an oversized value is
-    // refused before anything is written, never truncated, because a truncated
-    // signing key is a key nothing can verify against sitting at the address
-    // every verifier resolves.
-    if (enrollParams.apsk != null) {
-      final apskLength = utf8.encode(jsonEncode(enrollParams.apsk)).length;
-      if (apskLength > maxApskLengthBytes) {
-        throw IllegalArgumentException(
-            'apsk is $apskLength bytes encoded, which exceeds the '
-            '$maxApskLengthBytes byte limit');
-      }
-    }
+    // Same checks and the same reasons as enroll:request, applied before
+    // anything is written.
+    _validateEnrollParams(enrollParams);
 
     if (enrollParams.apkamPublicKey != null) {
       final newSigningAlgo = enrollParams.signingAlgo ?? enVal.signingAlgo;
@@ -734,8 +745,16 @@ class EnrollVerbHandler extends AbstractVerbHandler {
           'algorithm describes the key');
     }
 
+    // Setting either shape clears the other: one record publishes one value,
+    // and this is the operation that moves an enrollment between them — a
+    // retrofit that gains a structured key must stop the record claiming the
+    // bare one it used to publish.
     if (enrollParams.apsk != null) {
       enVal.apsk = enrollParams.apsk;
+      enVal.apskLegacy = null;
+    } else if (enrollParams.apskLegacy != null) {
+      enVal.apskLegacy = enrollParams.apskLegacy;
+      enVal.apsk = null;
     }
 
     if (enrollParams.metadata != null) {
@@ -744,6 +763,10 @@ class EnrollVerbHandler extends AbstractVerbHandler {
       enVal.metadata = merged;
     }
 
+    // Measured AFTER the merge: metadata merges rather than replaces, so a
+    // request nowhere near the cap can still push the record past it.
+    _validateRecordSize(enVal);
+
     // The state and TTL are untouched: this is the same put the approve path
     // uses, with an already-approved status, so nothing about the enrollment's
     // lifecycle moves.
@@ -751,9 +774,9 @@ class EnrollVerbHandler extends AbstractVerbHandler {
         enId, AtData()..data = jsonEncode(enVal), EnrollmentStatus.approved);
 
     // Republish only when the request carried a new value. An update that says
-    // nothing about apsk leaves the published record exactly as it was.
-    if (enrollParams.apsk != null) {
-      await _publishApskSigningKey(enId, enVal.apsk, currentAtSign);
+    // nothing about either shape leaves the published record exactly as it was.
+    if (enrollParams.apsk != null || enrollParams.apskLegacy != null) {
+      await _publishApskSigningKey(enId, enVal, currentAtSign);
     }
 
     responseJson['enrollmentId'] = enId;
@@ -884,15 +907,93 @@ class EnrollVerbHandler extends AbstractVerbHandler {
         skipCommit: true);
   }
 
-  /// Publishes [apsk] — the value the CLIENT composed and sent on
-  /// `enroll:request` — at `public:_apsk.<enrollmentId>.a.__e@<atSign>`, the
+  /// Refuses a request carrying both `_apsk` shapes, and refuses one whose
+  /// payload cannot fit in an enrollment record.
+  ///
+  /// Both shapes at once is a client error rather than a precedence question:
+  /// one record publishes one value, and the server has no basis for choosing
+  /// between two the client disagreed with itself about. Refusing is also what
+  /// keeps the choice observable — silently preferring one would publish a
+  /// signing key the enrollee did not think it had asked for.
+  ///
+  /// The size check here is a **pre-filter**, not the authority. It runs
+  /// before the OTP is validated so an oversized request does not spend a
+  /// one-shot passcode on its way to being refused, and it is safe to do early
+  /// because these params are strictly larger than the part of the record they
+  /// become. [_validateRecordSize] is what actually holds the bound, because
+  /// `enroll:update` merges `metadata` and so can grow a record past the cap
+  /// with a request that is nowhere near it.
+  void _validateEnrollParams(EnrollParams enrollParams) {
+    if (enrollParams.apsk != null && enrollParams.apskLegacy != null) {
+      throw IllegalArgumentException(
+          'apsk and apskLegacy are mutually exclusive: one enrollment '
+          'publishes one _apsk value');
+    }
+
+    final length = utf8.encode(jsonEncode(enrollParams.toJson())).length;
+    if (length > maxEnrollmentRecordBytes) {
+      throw IllegalArgumentException(
+          'enroll params are $length bytes encoded, which exceeds the '
+          '$maxEnrollmentRecordBytes byte enrollment record limit');
+    }
+  }
+
+  /// Refuses an enrollment record over [maxEnrollmentRecordBytes], measured on
+  /// the JSON that would land in the keystore.
+  ///
+  /// Called before every write of a record, on the record as it will be
+  /// stored — after any merge — because that is the only measurement the
+  /// bound can be stated in. Refused rather than truncated: a truncated record
+  /// is unparseable, and the enrollment it describes would be unusable with
+  /// nothing to say why.
+  ///
+  /// On the `enroll:request` path the pre-filter in [_validateEnrollParams]
+  /// almost always refuses first, because `EnrollParams.toJson()` emits every
+  /// field including the null ones and so encodes larger than the record it
+  /// becomes. `enroll:update` is where this check does the work: `metadata`
+  /// merges rather than replaces, so a request nowhere near the cap can still
+  /// leave a record past it, and no measurement of the request can see that.
+  void _validateRecordSize(EnrollDataStoreValue enVal) {
+    final length = utf8.encode(jsonEncode(enVal.toJson())).length;
+    if (length > maxEnrollmentRecordBytes) {
+      throw IllegalArgumentException(
+          'enrollment record is $length bytes encoded, which exceeds the '
+          '$maxEnrollmentRecordBytes byte limit');
+    }
+  }
+
+  /// The exact string this enrollment publishes as its `_apsk`, or null when
+  /// it publishes none.
+  ///
+  /// The two shapes are stored differently because they are read differently.
+  /// [EnrollDataStoreValue.apskLegacy] goes out **verbatim**: every deployed
+  /// `_apsk` consumer base64-decodes the value as an RSA key, and a JSON string
+  /// — quotes and all — is not what that parser reads. [EnrollDataStoreValue.apsk]
+  /// is JSON-encoded, which is what makes it unmistakable to those same
+  /// consumers: they fail loudly on it rather than mis-reading it.
+  ///
+  /// The two are mutually exclusive on the wire, so the order here decides
+  /// nothing; it is written as a chain only so the null case has one answer.
+  static String? _apskRecordValue(EnrollDataStoreValue enVal) {
+    if (enVal.apskLegacy != null) {
+      return enVal.apskLegacy;
+    }
+    if (enVal.apsk != null) {
+      return jsonEncode(enVal.apsk);
+    }
+    return null;
+  }
+
+  /// Publishes the `_apsk` value the CLIENT composed and sent on
+  /// `enroll:request` at `public:_apsk.<enrollmentId>.a.__e@<atSign>`, the
   /// location the at_client `ApkamSigning` mixin reads.
   ///
-  /// A no-op when [apsk] is null. The atServer composes nothing: PKAM
-  /// verification reads the enrollment record's `apkamPublicKey` and
-  /// `signingAlgo`, so `_apsk` is a client-side artefact and its format
-  /// belongs to the side that parses it. An enrollment that sent no value
-  /// publishes its own signing key from its own connection, or goes without.
+  /// A no-op when [enVal] carries neither shape. The atServer composes
+  /// nothing: PKAM verification reads the enrollment record's
+  /// `apkamPublicKey` and `signingAlgo`, so `_apsk` is a client-side artefact
+  /// and its format belongs to the side that parses it. An enrollment that
+  /// sent no value publishes its own signing key from its own connection, or
+  /// goes without.
   ///
   /// The server writes it despite never reading it because `_apsk` accepts
   /// writes only from its own enrollment's connection, and at approval that
@@ -900,17 +1001,22 @@ class EnrollVerbHandler extends AbstractVerbHandler {
   /// it verifies the enrollee's key package against it and signs signing-chain
   /// links over it — so this is the only party that can put it there in time.
   ///
+  /// Takes the RECORD rather than a value, so every call site publishes what
+  /// the enrollee asked for: an approver handing its own value in would be
+  /// substituting a signing key for the enrollment it is approving.
+  ///
   /// World-readable, so a same-atSign or peer-atSign verifier can reach it via
   /// plookup. Idempotent: a re-publish is a harmless overwrite with the same
   /// value.
   Future<void> _publishApskSigningKey(
-      String enrollmentId, Map<String, dynamic>? apsk, currentAtSign) async {
-    if (apsk == null) {
+      String enrollmentId, EnrollDataStoreValue enVal, currentAtSign) async {
+    final value = _apskRecordValue(enVal);
+    if (value == null) {
       return;
     }
     final apskKey = 'public:_apsk.$enrollmentId'
         '.${EnrollmentConstants.perEnrollmentApproved}$currentAtSign';
-    await keyStore.put(apskKey, AtData()..data = jsonEncode(apsk));
+    await keyStore.put(apskKey, AtData()..data = value);
   }
 
   EnrollmentStatus _getEnrollStatusEnum(String? enrollmentOperation) {
@@ -1222,10 +1328,11 @@ class EnrollVerbHandler extends AbstractVerbHandler {
         if (enrollParams.apkamPublicKey == null &&
             enrollParams.signingAlgo == null &&
             enrollParams.apsk == null &&
+            enrollParams.apskLegacy == null &&
             enrollParams.metadata == null) {
           throw IllegalArgumentException(
               'enroll:update must name at least one of apkamPublicKey, '
-              'signingAlgo, apsk or metadata');
+              'signingAlgo, apsk, apskLegacy or metadata');
         }
         // Named explicitly rather than silently ignored. These are the two
         // fields the operation must never reach — an enrollment amending

--- a/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
@@ -139,9 +139,9 @@ class EnrollVerbHandler extends AbstractVerbHandler {
           response,
         );
         if (responseJson['status'] == EnrollmentStatus.revoked.name) {
-          logger.finer(
-              'Dropping connection for enrollmentId: $enrollmentIdFromParams');
-          await _dropRevokedClientConnection(enrollmentIdFromParams!,
+          logger.info(
+              'Dropping any open connections for enrollmentId: $enrollmentIdFromParams');
+          await _dropRevokedClientConnections(enrollmentIdFromParams!,
               forceFlag != null, atConnection, responseJson);
         }
         break;
@@ -809,7 +809,7 @@ class EnrollVerbHandler extends AbstractVerbHandler {
     }
   }
 
-  Future<void> _dropRevokedClientConnection(String enrollmentId, bool forceFlag,
+  Future<void> _dropRevokedClientConnections(String enrollmentId, bool forceFlag,
       InboundConnection currentInboundConnection, responseJson) async {
     final inboundPool =
         AtSecondaryServerImpl.getInstance().inboundConnectionManager.pool;

--- a/packages/at_secondary_server/pubspec.lock
+++ b/packages/at_secondary_server/pubspec.lock
@@ -69,10 +69,10 @@ packages:
     dependency: "direct main"
     description:
       name: at_commons
-      sha256: "89f2ae24d69ab5151351f7b747be0edc1ca61eeb005b65f801dc8f031efacb21"
+      sha256: "1613e02e69206f2e864a73a15be529e73469135c21ef33b132b4761112fde3e4"
       url: "https://pub.dev"
     source: hosted
-    version: "5.14.0"
+    version: "5.15.0"
   at_lookup:
     dependency: "direct main"
     description:

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_secondary
 description: Implementation of secondary server.
-version: 3.16.0
+version: 3.16.1
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://www.example.com
 publish_to: none
@@ -19,7 +19,7 @@ dependencies:
   basic_utils: ^5.7.0
   ecdsa: ^0.1.2
   encrypt: ^5.0.3
-  at_commons: ^5.14.0
+  at_commons: ^5.15.0
   at_utils: ^3.4.0
   at_chops: ^3.5.0
   at_lookup: ^3.6.0

--- a/packages/at_secondary_server/test/enroll_data_store_value_test.dart
+++ b/packages/at_secondary_server/test/enroll_data_store_value_test.dart
@@ -55,5 +55,35 @@ void main() {
       expect(enrollValueObject.apkamPublicKey, 'mykey');
       expect(enrollValueObject.requestType, EnrollRequestType.newEnrollment);
     });
+
+    test('the two _apsk shapes survive a round trip under their own names', () {
+      // The record is what survives a restart, so a shape that does not
+      // round-trip is a signing key the enrollment silently stops publishing
+      // the next time the server comes up. Asserted on the RAW wire names
+      // because the serialisation is hand-maintained here — there is no
+      // json_serializable dev dependency to regenerate it, so a typo in
+      // enroll_datastore_value.g.dart has nothing else to catch it.
+      final array = {
+        'v': 1,
+        'keys': [
+          {'kid': 'k', 'use': 'sign', 'alg': 'mldsa65', 'pub': 'bWxkc2E='}
+        ]
+      };
+      final withArray =
+          EnrollDataStoreValue('123', 'testclient', 'iphone', 'mykey')
+            ..apsk = array;
+      expect(withArray.toJson()['apsk'], array);
+      expect(withArray.toJson().containsKey('apskLegacy'), false,
+          reason: 'an absent shape is omitted, not written as null');
+      expect(EnrollDataStoreValue.fromJson(withArray.toJson()).apsk, array);
+
+      const bare = 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A';
+      final withBare =
+          EnrollDataStoreValue('123', 'testclient', 'iphone', 'mykey')
+            ..apskLegacy = bare;
+      expect(withBare.toJson()['apskLegacy'], bare);
+      expect(withBare.toJson().containsKey('apsk'), false);
+      expect(EnrollDataStoreValue.fromJson(withBare.toJson()).apskLegacy, bare);
+    });
   });
 }

--- a/packages/at_secondary_server/test/enroll_verb_test.dart
+++ b/packages/at_secondary_server/test/enroll_verb_test.dart
@@ -3137,54 +3137,134 @@ void main() {
       expect(await keyValueStore.exists(primaryApsk), false);
     });
 
-    test('an apsk over the 20KB cap is refused, and creates no enrollment',
-        () async {
-      // Sized on the ENCODED length, which is what lands in the keystore.
-      final overCap = {
-        'publicKey': 'x' * (EnrollVerbHandler.maxApskLengthBytes + 1)
-      };
-      expect(
-          jsonEncode(overCap).length > EnrollVerbHandler.maxApskLengthBytes,
-          true,
-          reason: 'the arm only tests the cap if it actually exceeds it');
-
-      final before = (await enMgr.getEnrollmentsAsJson()).length;
-      inboundConnection.metaData.isAuthenticated = true;
-      final ep = EnrollParams()
-        ..appName = 'tooBig'
-        ..deviceName = 'd'
-        ..apkamPublicKey = 'apkam pub'
-        ..namespaces = {'wavi': 'rw'}
-        ..apsk = overCap
-        ..otp = await etu.getOtp();
+    /// Submits an unauthenticated `enroll:request` built from [ep] and returns
+    /// the future, so a caller can assert on how it is refused.
+    Future<void> submitRequest(EnrollParams ep) async {
       inboundConnection.metaData.isAuthenticated = false;
       inboundConnection.metaData.authType = null;
       inboundConnection.metaData.sessionID =
           DateTime.now().millisecondsSinceEpoch.toString();
+      await etu.evh.processVerb(
+          Response(),
+          getVerbParam(
+              VerbSyntax.enroll, 'enroll:request:${jsonEncode(ep.toJson())}'),
+          inboundConnection);
+    }
 
-      await expectLater(
-          etu.evh.processVerb(
-              Response(),
-              getVerbParam(
-                  VerbSyntax.enroll, 'enroll:request:${jsonEncode(ep.toJson())}'),
-              inboundConnection),
-          throwsA(isA<IllegalArgumentException>()));
+    /// An `enroll:request` params object with everything mandatory filled in
+    /// and a fresh OTP, ready for a size arm to load up.
+    ///
+    /// `encryptedAPKAMSymmetricKey` is not optional dressing here: without it
+    /// `_validateParams` refuses the request — as an IllegalArgumentException,
+    /// the same class the size refusal throws — before the size check is ever
+    /// reached. Every arm below therefore matches on the MESSAGE too, or it
+    /// goes green on a refusal that has nothing to do with the cap.
+    Future<EnrollParams> sizedRequest(String appName) async {
+      inboundConnection.metaData.isAuthenticated = true;
+      final otp = await etu.getOtp();
+      return EnrollParams()
+        ..appName = appName
+        ..deviceName = 'd'
+        ..apkamPublicKey = 'apkam pub'
+        ..encryptedAPKAMSymmetricKey = 'encrypted apkam aes key'
+        ..namespaces = {'wavi': 'rw'}
+        ..otp = otp;
+    }
+
+    /// Matches only a refusal that names the size bound.
+    final refusedForSize = throwsA(isA<IllegalArgumentException>().having(
+        (e) => e.message,
+        'message',
+        anyOf(contains('enrollment record is'), contains('enroll params are'))));
+
+    test('a record over the cap is refused, and creates no enrollment',
+        () async {
+      final before = (await enMgr.getEnrollmentsAsJson()).length;
+      final ep = await sizedRequest('tooBig')
+        ..apsk = {
+          'publicKey': 'x' * (EnrollVerbHandler.maxEnrollmentRecordBytes + 1)
+        };
+
+      await expectLater(submitRequest(ep), refusedForSize);
 
       expect((await enMgr.getEnrollmentsAsJson()).length, before,
           reason: 'the refusal lands before the record is created, so an '
               'oversized value cannot leave a half-made enrollment behind');
     });
 
-    test('an apsk exactly at the 20KB cap is accepted', () async {
-      // The boundary is inclusive; pinned so a later ">= vs >" edit is caught.
-      final filler = 'x' *
-          (EnrollVerbHandler.maxApskLengthBytes -
-              jsonEncode({'publicKey': ''}).length);
-      final atCap = {'publicKey': filler};
-      expect(jsonEncode(atCap).length, EnrollVerbHandler.maxApskLengthBytes);
+    test('an oversized request does not spend the OTP', () async {
+      // What the params pre-filter buys, and the only thing that distinguishes
+      // it from the record check that follows: the size refusal lands before
+      // isPasscodeValid, which deletes the OTP on use. Without it a client
+      // that sent too much would have to go back to the user for a new
+      // passcode to retry.
+      final ep = await sizedRequest('otpPreserved')
+        ..apsk = {
+          'publicKey': 'x' * (EnrollVerbHandler.maxEnrollmentRecordBytes + 1)
+        };
+      final otp = ep.otp!;
+
+      await expectLater(submitRequest(ep), refusedForSize);
+
+      // The same one-shot OTP still works, which it would not had the
+      // oversized request reached isPasscodeValid.
+      await submitRequest(EnrollParams()
+        ..appName = 'otpPreserved'
+        ..deviceName = 'd2'
+        ..apkamPublicKey = 'apkam pub'
+        ..encryptedAPKAMSymmetricKey = 'encrypted apkam aes key'
+        ..namespaces = {'wavi': 'rw'}
+        ..otp = otp);
+    });
+
+    test('the cap covers metadata, not just apsk', () async {
+      // The reason the cap moved from the field to the record. metadata
+      // carries the enrollment's key package — the largest blob in play — and
+      // was uncapped while apsk was capped, so the bound applied to the one
+      // field nobody would use to make a record big.
+      final before = (await enMgr.getEnrollmentsAsJson()).length;
+      final ep = await sizedRequest('bigMetadata')
+        ..metadata = {
+          'keyPackage': {
+            'pub': 'x' * (EnrollVerbHandler.maxEnrollmentRecordBytes + 1)
+          }
+        };
+
+      await expectLater(submitRequest(ep), refusedForSize);
+      expect((await enMgr.getEnrollmentsAsJson()).length, before);
+    });
+
+    test('the cap counts the whole record, not each field separately',
+        () async {
+      // Neither field is over the cap on its own; together they are. A
+      // per-field bound goes green here, which is exactly the hole that made
+      // the old one worth replacing.
+      final half = EnrollVerbHandler.maxEnrollmentRecordBytes ~/ 2;
+      final before = (await enMgr.getEnrollmentsAsJson()).length;
+      final ep = await sizedRequest('sumOverCap')
+        ..apsk = {'publicKey': 'x' * half}
+        ..metadata = {
+          'keyPackage': {'pub': 'x' * half}
+        };
+      expect(utf8.encode(jsonEncode(ep.apsk)).length <
+              EnrollVerbHandler.maxEnrollmentRecordBytes,
+          true,
+          reason: 'neither field alone may exceed the cap, or the arm is '
+              'testing the per-field bound it is meant to distinguish from');
+
+      await expectLater(submitRequest(ep), refusedForSize);
+      expect((await enMgr.getEnrollmentsAsJson()).length, before);
+    });
+
+    test('a record comfortably under the cap is accepted and published',
+        () async {
+      // The other arm of the bound: a large-but-legitimate value goes through
+      // untouched. ~100KB is far more than any real key package and well
+      // inside 500KB.
+      final atCap = {'publicKey': 'x' * (100 * 1024)};
 
       final enId = await etu.createPendingEnrollment(
-          appName: 'atCap',
+          appName: 'underCap',
           deviceName: 'd',
           namespaces: {'wavi': 'rw'},
           apkamKeysExpiryDuration: null,
@@ -3225,6 +3305,89 @@ void main() {
       final apskKey = 'public:_apsk.$enId'
           '.${EnrollmentConstants.perEnrollmentApproved}$alice';
       expect(jsonDecode((await keyValueStore.get(apskKey))!.data!), enrolleeApsk);
+    });
+
+    test('apskLegacy is published as the BARE string, never JSON-encoded',
+        () async {
+      // The whole point of the second field: every deployed _apsk consumer
+      // base64-decodes the value as an RSA key, and a JSON string — quotes and
+      // all — is not what that parser reads. So the assertion is on the raw
+      // stored bytes, and it explicitly rejects the jsonEncode spelling: an
+      // `expect(jsonDecode(stored), bare)` would pass on BOTH, which is the
+      // mistake this pins against.
+      const bare = 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtestkey';
+
+      // The CRAM auto-approve path.
+      final cramEnId = await etu.createPrimaryEnrollment(apskLegacy: bare);
+      final cramKey = 'public:_apsk.$cramEnId'
+          '.${EnrollmentConstants.perEnrollmentApproved}$alice';
+      final cramStored = (await keyValueStore.get(cramKey))!.data!;
+      expect(cramStored, bare);
+      expect(cramStored, isNot(jsonEncode(bare)),
+          reason: 'a quoted string is not what a bare-RSA parser reads');
+
+      // The standard enroll:approve path.
+      final pendingEnId = await etu.createPendingEnrollment(
+          appName: 'apskLegacyApp',
+          deviceName: 'd',
+          namespaces: {'wavi': 'rw'},
+          apkamKeysExpiryDuration: null,
+          apskLegacy: bare);
+      final pendingKey = 'public:_apsk.$pendingEnId'
+          '.${EnrollmentConstants.perEnrollmentApproved}$alice';
+      expect(await keyValueStore.exists(pendingKey), false,
+          reason: 'nothing is published while the enrollment is only pending');
+
+      await etu.approveEnrollment(etu.primaryEnId, pendingEnId);
+      expect((await keyValueStore.get(pendingKey))!.data!, bare);
+
+      // And it is on the record, so it survives a restart rather than living
+      // only in the published copy.
+      final enVal = await enMgr.getEnrollmentById(pendingEnId);
+      expect(enVal.apskLegacy, bare);
+      expect(enVal.apsk, isNull);
+    });
+
+    test('a request carrying BOTH apsk and apskLegacy is refused, and creates '
+        'no enrollment', () async {
+      // Not a precedence question: one record publishes one value, and the
+      // server has no basis for choosing between two the client disagreed with
+      // itself about. Refusing is also what keeps the choice observable.
+      final before = (await enMgr.getEnrollmentsAsJson()).length;
+
+      await expectLater(
+          etu.createPendingEnrollment(
+              appName: 'bothShapes',
+              deviceName: 'd',
+              namespaces: {'wavi': 'rw'},
+              apkamKeysExpiryDuration: null,
+              apsk: {'v': 1, 'keys': []},
+              apskLegacy: 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A'),
+          // Matched on the message, not just the type: several unrelated
+          // refusals on this path are also IllegalArgumentException, so a
+          // type-only matcher would go green on the wrong one.
+          throwsA(isA<IllegalArgumentException>().having(
+              (e) => e.message, 'message', contains('mutually exclusive'))));
+
+      expect((await enMgr.getEnrollmentsAsJson()).length, before,
+          reason: 'the refusal lands before the record is created');
+    });
+
+    test('an apskLegacy over the cap is refused, and creates no enrollment',
+        () async {
+      final overCap = 'x' * (EnrollVerbHandler.maxEnrollmentRecordBytes + 1);
+      final before = (await enMgr.getEnrollmentsAsJson()).length;
+
+      await expectLater(
+          etu.createPendingEnrollment(
+              appName: 'legacyTooBig',
+              deviceName: 'd',
+              namespaces: {'wavi': 'rw'},
+              apkamKeysExpiryDuration: null,
+              apskLegacy: overCap),
+          refusedForSize);
+
+      expect((await enMgr.getEnrollmentsAsJson()).length, before);
     });
 
     test('metadata + signingAlgo on enroll:request are persisted on the record',
@@ -3482,6 +3645,115 @@ void main() {
       final published = await etu.evh.keyStore.get(
           'public:_apsk.$enId.${EnrollmentConstants.perEnrollmentApproved}$alice');
       expect(jsonDecode(published!.data!), apsk);
+    });
+
+    test('an update that moves an enrollment between the two shapes clears the '
+        'one it left', () async {
+      // This is the operation that moves an enrollment across: a retrofit that
+      // gains a structured key must stop the record claiming the bare one, or
+      // the record holds both and the published value depends on a precedence
+      // rule nobody stated.
+      const bare = 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A';
+      final array = {
+        'v': 1,
+        'keys': [
+          {'kid': 'k', 'use': 'sign', 'alg': 'mldsa65', 'pub': 'bmV3'}
+        ]
+      };
+      final apskKey =
+          'public:_apsk.\$id.${EnrollmentConstants.perEnrollmentApproved}$alice';
+
+      final enId = (await etu.createEnrollments(n: 1)).$1.first;
+      final key = apskKey.replaceFirst('\$id', enId);
+
+      // bare, then array
+      expect(
+          (await sendUpdate(
+                  enId, EnrollParams()..enrollmentId = enId..apskLegacy = bare))
+              .isError,
+          false);
+      expect((await etu.evh.keyStore.get(key))!.data!, bare);
+      expect((await enMgr.getEnrollmentById(enId)).apskLegacy, bare);
+
+      expect(
+          (await sendUpdate(
+                  enId, EnrollParams()..enrollmentId = enId..apsk = array))
+              .isError,
+          false);
+      expect(jsonDecode((await etu.evh.keyStore.get(key))!.data!), array);
+      final afterArray = await enMgr.getEnrollmentById(enId);
+      expect(afterArray.apsk, array);
+      expect(afterArray.apskLegacy, isNull,
+          reason: 'the shape it left must not linger on the record');
+
+      // and back again
+      expect(
+          (await sendUpdate(
+                  enId, EnrollParams()..enrollmentId = enId..apskLegacy = bare))
+              .isError,
+          false);
+      expect((await etu.evh.keyStore.get(key))!.data!, bare);
+      final afterBare = await enMgr.getEnrollmentById(enId);
+      expect(afterBare.apskLegacy, bare);
+      expect(afterBare.apsk, isNull);
+    });
+
+    test('an update carrying BOTH shapes is refused', () async {
+      final enId = (await etu.createEnrollments(n: 1)).$1.first;
+      await expectLater(
+        sendUpdate(
+            enId,
+            EnrollParams()
+              ..enrollmentId = enId
+              ..apsk = {'v': 1, 'keys': []}
+              ..apskLegacy = 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A'),
+        // On the message, not just the type: enroll:update's own "names
+        // nothing to change" refusal is the same exception class, and this
+        // arm has to fail for the reason it is testing.
+        throwsA(isA<IllegalArgumentException>().having(
+            (e) => e.message, 'message', contains('mutually exclusive'))),
+      );
+    });
+
+    test('an update is refused when the MERGED record would exceed the cap',
+        () async {
+      // Why the record check is the authority and the params pre-filter is
+      // not: metadata merges rather than replaces, so two updates that are
+      // each comfortably inside the cap can leave a record outside it. Only a
+      // measurement taken after the merge can see that.
+      final enId = (await etu.createEnrollments(n: 1)).$1.first;
+      final chunk = EnrollVerbHandler.maxEnrollmentRecordBytes ~/ 2;
+
+      final first = await sendUpdate(
+          enId,
+          EnrollParams()
+            ..enrollmentId = enId
+            ..metadata = {'first': 'x' * chunk});
+      expect(first.isError, false,
+          reason: 'the first half must be accepted, or the second is not '
+              'testing the merge');
+
+      await expectLater(
+        sendUpdate(
+            enId,
+            EnrollParams()
+              ..enrollmentId = enId
+              ..metadata = {'second': 'x' * chunk}),
+        throwsA(isA<IllegalArgumentException>().having((e) => e.message,
+            'message', contains('enrollment record is'))),
+      );
+    });
+
+    test('an update naming ONLY apskLegacy is accepted', () async {
+      // The "names nothing to change" guard lists the fields an update may
+      // reach; a field added to the operation and not to that list is refused
+      // by a check written before it existed, which is how this one was caught.
+      final enId = (await etu.createEnrollments(n: 1)).$1.first;
+      const bare = 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A';
+      final r = await sendUpdate(
+          enId, EnrollParams()..enrollmentId = enId..apskLegacy = bare);
+      expect(r.isError, false);
+      expect((await enMgr.getEnrollmentById(enId)).apskLegacy, bare);
     });
   });
 }

--- a/packages/at_secondary_server/test/enrollment_test_utils.dart
+++ b/packages/at_secondary_server/test/enrollment_test_utils.dart
@@ -51,14 +51,19 @@ class ETU {
     return r.data!;
   }
 
-  /// [apsk] is the client-composed signing-key value; leaving it null is the
-  /// ordinary case and means no `_apsk` is published for this enrollment.
+  /// [apsk] is the client-composed signing-key value and [apskLegacy] the bare
+  /// RSA string a plain-legacy enrollment publishes instead. Leaving both null
+  /// is the ordinary case and means no `_apsk` is published for this
+  /// enrollment. Sending both is what a client is refused for, so the pair is
+  /// exposed here rather than made exclusive — a test has to be able to send
+  /// the refused combination.
   Future<String> createPendingEnrollment(
       {required String appName,
       required String deviceName,
       required Map<String, String> namespaces,
       required Duration? apkamKeysExpiryDuration,
-      Map<String, dynamic>? apsk}) async {
+      Map<String, dynamic>? apsk,
+      String? apskLegacy}) async {
     final EnrollParams ep = EnrollParams()
       ..appName = appName
       ..deviceName = deviceName
@@ -68,6 +73,7 @@ class ETU {
       ..namespaces = namespaces
       ..apkamKeysExpiryDuration = apkamKeysExpiryDuration
       ..apsk = apsk
+      ..apskLegacy = apskLegacy
       ..otp = await getOtp();
 
     final String enrollmentRequest = 'enroll:request:'
@@ -163,13 +169,15 @@ class ETU {
     expect(m['enrollmentId'], enIdToDelete);
   }
 
-  Future<String> createPrimaryEnrollment({Map<String, dynamic>? apsk}) async {
+  Future<String> createPrimaryEnrollment(
+      {Map<String, dynamic>? apsk, String? apskLegacy}) async {
     EnrollParams ep = EnrollParams()
       ..appName = 'primary'
       ..deviceName = 'primary'
       ..apkamPublicKey = 'apkam public key'
       ..encryptedAPKAMSymmetricKey = 'encrypted apkam aes key'
       ..apsk = apsk
+      ..apskLegacy = apskLegacy
       ..namespaces = {'*': 'rw'};
     String enrollmentRequest = 'enroll:request:'
         '${jsonEncode(ep.toJson())}';

--- a/tests/at_functional_test/test/apkam_self_enrollment_test.dart
+++ b/tests/at_functional_test/test/apkam_self_enrollment_test.dart
@@ -91,7 +91,8 @@ void main() {
       String? deviceName,
       int? apkamKeysExpiryInMillis,
       String? signingAlgo,
-      Map<String, dynamic>? apsk}) async {
+      Map<String, dynamic>? apsk,
+      String? apskLegacy}) async {
     OutboundConnectionFactory parent = await newConnection();
     expect(
         (await parent.authenticateConnection(
@@ -104,8 +105,13 @@ void main() {
         : ',"apkamKeysExpiryInMillis":$apkamKeysExpiryInMillis';
     String algo = signingAlgo == null ? '' : ',"signingAlgo":"$signingAlgo"';
     String apskField = apsk == null ? '' : ',"apsk":${jsonEncode(apsk)}';
+    // JSON-encoded HERE because this is the request envelope, which is JSON.
+    // What the server must not do is encode it again when it publishes the
+    // value; the tests below assert exactly that.
+    String apskLegacyField =
+        apskLegacy == null ? '' : ',"apskLegacy":${jsonEncode(apskLegacy)}';
     return (await parent.sendRequestToServer(
-            'enroll:request:{"appName":"${appName ?? 'child-${Uuid().v4().hashCode}'}","deviceName":"${deviceName ?? 'device-${Uuid().v4().hashCode}'}","namespaces":${jsonEncode(namespaces)},"apkamPublicKey":"$apkamPublicKey"$expiry$algo$apskField}'))
+            'enroll:request:{"appName":"${appName ?? 'child-${Uuid().v4().hashCode}'}","deviceName":"${deviceName ?? 'device-${Uuid().v4().hashCode}'}","namespaces":${jsonEncode(namespaces)},"apkamPublicKey":"$apkamPublicKey"$expiry$algo$apskField$apskLegacyField}'))
         .trim();
   }
 
@@ -116,14 +122,16 @@ void main() {
       String? deviceName,
       int? apkamKeysExpiryInMillis,
       String? signingAlgo,
-      Map<String, dynamic>? apsk}) async {
+      Map<String, dynamic>? apsk,
+      String? apskLegacy}) async {
     String response = await selfEnroll(parentId,
         namespaces: namespaces,
         appName: appName,
         deviceName: deviceName,
         apkamKeysExpiryInMillis: apkamKeysExpiryInMillis,
         signingAlgo: signingAlgo,
-        apsk: apsk);
+        apsk: apsk,
+        apskLegacy: apskLegacy);
     Map decoded = jsonDecode(response.replaceFirst('data:', ''));
     expect(decoded['status'], 'approved',
         reason: 'a self-enrollment is auto-approved with no human step');
@@ -506,6 +514,53 @@ void main() {
           await apskValue(owner, childId),
           contains('key not found : public:_apsk.$childId.a.__e$atSign '
               'does not exist in keystore'));
+    });
+
+    test('apskLegacy is published as the BARE string a deployed consumer reads',
+        () async {
+      // This is the arm only the wire can settle. Every deployed `_apsk`
+      // consumer base64-decodes what it fetches as an RSA key, so what has to
+      // be true is a property of the BYTES a verifier resolves, not of the
+      // enrollment record: no quotes, no escaping, nothing the server added.
+      const bare =
+          'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAfunctionaltestkey';
+
+      OutboundConnectionFactory owner = await ownerConnection();
+      String parentId =
+          await createApprovedEnrollment(owner, namespaces: {'wavi': 'rw'});
+      String childId = await selfEnrollId(parentId,
+          namespaces: {'wavi': 'r'}, apskLegacy: bare);
+
+      final resolved = await apskValue(owner, childId);
+      expect(resolved, bare);
+      expect(resolved, isNot(jsonEncode(bare)),
+          reason: 'a quoted string is not what a bare-RSA parser reads, and '
+              'a jsonDecode-based assertion would pass on both');
+    });
+
+    test('a request carrying BOTH apsk and apskLegacy is refused', () async {
+      // One record publishes one value, so this is a client error rather than
+      // a precedence question — and it is refused at the verb, which is the
+      // only place the client finds out.
+      OutboundConnectionFactory owner = await ownerConnection();
+      String parentId =
+          await createApprovedEnrollment(owner, namespaces: {'wavi': 'rw'});
+
+      final response = await selfEnroll(parentId,
+          namespaces: {'wavi': 'r'},
+          apsk: {
+            'v': 1,
+            'keys': [
+              {'kid': 'k', 'use': 'sign', 'alg': 'mldsa65', 'pub': 'cA=='}
+            ]
+          },
+          apskLegacy: 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A');
+
+      expect(response, startsWith('error:'));
+      expect(response, contains('mutually exclusive'),
+          reason: 'matched on the message: several unrelated refusals on this '
+              'path are also errors, so a startsWith check alone would go '
+              'green on the wrong one');
     });
   });
 

--- a/tests/at_functional_test/test/enroll_update_test.dart
+++ b/tests/at_functional_test/test/enroll_update_test.dart
@@ -246,5 +246,119 @@ void main() {
           await owner.sendRequestToServer('llookup:public:_apsk.$enId.a.__e$atSign');
       expect(jsonDecode(published.replaceFirst('data:', '').trim()), apsk);
     });
+
+    test('an update carrying apskLegacy republishes the BARE form', () async {
+      // The move an enrollment makes going the other way. Asserted on the
+      // resolved bytes because that is what a deployed consumer
+      // base64-decodes: a JSON-encoded string would fail its parse, and a
+      // jsonDecode-based assertion would pass on either.
+      const bare =
+          'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAupdatedbarekey';
+
+      final owner = await ownerConnection();
+      final enId =
+          await createApprovedEnrollment(owner, namespaces: {'buzz': 'rw'});
+
+      final self = await newConnection();
+      expect(
+          (await self.authenticateConnection(
+                  authType: AuthType.apkam, enrollmentId: enId))
+              .trim(),
+          'data:success');
+      final response = await self.sendRequestToServer(
+          'enroll:update:{"enrollmentId":"$enId","apskLegacy":${jsonEncode(bare)}}');
+      expect(jsonDecode(response.replaceFirst('data:', ''))['status'],
+          'approved');
+
+      final resolved = (await owner
+              .sendRequestToServer('llookup:public:_apsk.$enId.a.__e$atSign'))
+          .trim()
+          .replaceFirst('data:', '');
+      expect(resolved, bare);
+      expect(resolved, isNot(jsonEncode(bare)));
+    });
+
+    test('switching shapes republishes AND clears the shape it left', () async {
+      // enroll:update is the operation that moves an enrollment across, so it
+      // is the one that can leave a record holding both. Both halves are
+      // observable: the bytes a verifier resolves, and the record enroll:list
+      // returns.
+      const bare = 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAswitchedkey';
+      final array = {
+        'v': 1,
+        'keys': [
+          {'kid': 'k', 'use': 'sign', 'alg': 'mldsa65', 'pub': 'c3dpdGNo'}
+        ]
+      };
+
+      final owner = await ownerConnection();
+      final enId =
+          await createApprovedEnrollment(owner, namespaces: {'buzz': 'rw'});
+
+      final self = await newConnection();
+      expect(
+          (await self.authenticateConnection(
+                  authType: AuthType.apkam, enrollmentId: enId))
+              .trim(),
+          'data:success');
+
+      Future<String> resolved() async => (await owner
+              .sendRequestToServer('llookup:public:_apsk.$enId.a.__e$atSign'))
+          .trim()
+          .replaceFirst('data:', '');
+
+      Future<Map> record() async {
+        final listed = jsonDecode(
+            (await owner.sendRequestToServer('enroll:list'))
+                .replaceFirst('data:', '')) as Map;
+        return listed.entries
+            .firstWhere((e) => (e.key as String).startsWith('$enId.'))
+            .value as Map;
+      }
+
+      // bare, then array, then back — each direction has to clear the other,
+      // and a one-way test would pass on a handler that only clears one of them.
+      await self.sendRequestToServer(
+          'enroll:update:{"enrollmentId":"$enId","apskLegacy":${jsonEncode(bare)}}');
+      expect(await resolved(), bare);
+      expect((await record())['apskLegacy'], bare);
+
+      await self.sendRequestToServer(
+          'enroll:update:{"enrollmentId":"$enId","apsk":${jsonEncode(array)}}');
+      expect(jsonDecode(await resolved()), array);
+      final afterArray = await record();
+      expect(afterArray['apsk'], array);
+      expect(afterArray.containsKey('apskLegacy'), false,
+          reason: 'the shape it left must not linger on the record');
+
+      await self.sendRequestToServer(
+          'enroll:update:{"enrollmentId":"$enId","apskLegacy":${jsonEncode(bare)}}');
+      expect(await resolved(), bare);
+      final afterBare = await record();
+      expect(afterBare['apskLegacy'], bare);
+      expect(afterBare.containsKey('apsk'), false);
+    });
+
+    test('an update carrying BOTH shapes is refused', () async {
+      final owner = await ownerConnection();
+      final enId =
+          await createApprovedEnrollment(owner, namespaces: {'buzz': 'rw'});
+
+      final self = await newConnection();
+      expect(
+          (await self.authenticateConnection(
+                  authType: AuthType.apkam, enrollmentId: enId))
+              .trim(),
+          'data:success');
+
+      final response = await self.sendRequestToServer(
+          'enroll:update:{"enrollmentId":"$enId","apsk":{"v":1,"keys":[]},'
+          '"apskLegacy":"MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A"}');
+      expect(response.trim(), startsWith('error:'));
+      expect(response, contains('mutually exclusive'),
+          reason: 'matched on the message: enroll:update has other refusals '
+              'that are also errors, so a startsWith check alone could go '
+              'green on the wrong one');
+    });
   });
 }

--- a/tests/at_functional_test/test/enroll_verb_test.dart
+++ b/tests/at_functional_test/test/enroll_verb_test.dart
@@ -535,6 +535,151 @@ void main() {
     });
   });
 
+  group('The published _apsk is the client\'s own, in the shape it sent', () {
+    // Observable surface, so exercised over the wire rather than only in the
+    // handler's unit tests. Two things are observable and neither is visible
+    // to a unit test: the BYTES a verifier resolves at
+    // `public:_apsk.<id>.a.__e@<atSign>`, and what an operator sees on the
+    // enrollment record through `enroll:list`.
+    //
+    // This is also the enroll:approve branch specifically — the self-enrollment
+    // tests cover the auto-approve one, which publishes from a different call
+    // site with a different value in hand.
+
+    /// CRAM-authenticates [firstAtSignConnection] and gives it an approved
+    /// enrollment, which is what carries `__manage` and therefore the
+    /// authority to approve the enrollments under test.
+    ///
+    /// Called once per test, not from [enrolThroughApproval]: CRAM is a
+    /// once-per-connection step, and a test that enrols twice must not try to
+    /// re-run it.
+    Future<void> becomeApprover() async {
+      await firstAtSignConnection.authenticateConnection(
+          authType: AuthType.cram);
+      expect(
+          jsonDecode((await firstAtSignConnection.sendRequestToServer(
+                  'enroll:request:{"appName":"apsk-approver","deviceName":"device-${Uuid().v4().hashCode}","namespaces":{"wavi":"rw"},"apkamPublicKey":"${at_demos.pkamPublicKeyMap[firstAtSign]!}"}\n'))
+              .replaceAll('data:', ''))['status'],
+          'approved');
+    }
+
+    /// Runs the standard OTP -> pending -> approve flow with [apskField]
+    /// spliced into the `enroll:request` JSON, and returns the enrollment id.
+    /// [becomeApprover] must have run on this connection first.
+    Future<String> enrolThroughApproval(String apskField) async {
+      final otp = (await firstAtSignConnection.sendRequestToServer('otp:get'))
+          .replaceFirst('data:', '')
+          .trim();
+
+      // On its own connection: the enrollment rate limiter is per-connection.
+      final enrolee = await OutboundConnectionFactory()
+          .initiateConnectionWithListener(
+              firstAtSign, firstAtSignHost, firstAtSignPort);
+      final requested = jsonDecode((await enrolee.sendRequestToServer(
+              'enroll:request:{"appName":"apsk-app","deviceName":"device-${Uuid().v4().hashCode}","namespaces":{"wavi":"rw"},"otp":"$otp","apkamPublicKey":"${at_demos.apkamPublicKeyMap[firstAtSign]!}","encryptedAPKAMSymmetricKey":"${apkamEncryptedKeysMap['encryptedAPKAMSymmetricKey']}"$apskField}\n'))
+          .replaceAll('data:', ''));
+      expect(requested['status'], 'pending');
+      final enrollmentId = requested['enrollmentId'];
+      await enrolee.close();
+
+      // Nothing is published while the enrollment is only pending — the
+      // approval is what puts the key in place.
+      expect(
+          await firstAtSignConnection.sendRequestToServer(
+              'llookup:public:_apsk.$enrollmentId.a.__e$firstAtSign'),
+          contains('key not found'));
+
+      expect(
+          jsonDecode((await firstAtSignConnection.sendRequestToServer(
+                  'enroll:approve:{"enrollmentId":"$enrollmentId","encryptedDefaultEncryptionPrivateKey":"${apkamEncryptedKeysMap['encryptedDefaultEncPrivateKey']}","encryptedDefaultSelfEncryptionKey":"${apkamEncryptedKeysMap['encryptedSelfEncKey']}"}'))
+              .replaceAll('data:', ''))['status'],
+          'approved');
+
+      return enrollmentId;
+    }
+
+    /// What a verifier resolves — the raw stored value, `data:` stripped and
+    /// nothing decoded.
+    Future<String> resolveApsk(String enrollmentId) async =>
+        (await firstAtSignConnection.sendRequestToServer(
+                'llookup:public:_apsk.$enrollmentId.a.__e$firstAtSign'))
+            .trim()
+            .replaceFirst('data:', '');
+
+    test('the array form is published on approval, JSON-encoded and intact',
+        () async {
+      // Carries a field the atServer has no code for, on purpose: the value is
+      // opaque, so what a verifier resolves must be what the enrollee composed
+      // and nothing the server could have derived from the record.
+      final composed = {
+        'v': 1,
+        'keys': [
+          {'kid': 'k', 'use': 'sign', 'alg': 'mldsa65', 'pub': 'bWxkc2E='}
+        ],
+        'extraFieldTheServerMustNotDrop': ['a', 'b'],
+      };
+
+      await becomeApprover();
+      final enrollmentId =
+          await enrolThroughApproval(',"apsk":${jsonEncode(composed)}');
+      expect(jsonDecode(await resolveApsk(enrollmentId)), composed);
+    });
+
+    test('the bare form is published on approval VERBATIM, not JSON-encoded',
+        () async {
+      // The property that matters is about the bytes, not the record: every
+      // deployed _apsk consumer base64-decodes what it fetches as an RSA key,
+      // and a quoted string is not what that parser reads. A
+      // jsonDecode-based assertion would pass on both spellings, so this one
+      // compares raw and rejects the encoded form explicitly.
+      const bare =
+          'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAapprovepathkey';
+
+      await becomeApprover();
+      final enrollmentId =
+          await enrolThroughApproval(',"apskLegacy":${jsonEncode(bare)}');
+      final resolved = await resolveApsk(enrollmentId);
+      expect(resolved, bare);
+      expect(resolved, isNot(jsonEncode(bare)));
+    });
+
+    test('enroll:list shows which shape an enrollment carries, and only that '
+        'one', () async {
+      // enroll:list returns the whole enrollment record, so the shape is
+      // operator-visible. The "only that one" half is what stops a record
+      // holding both, where the published value would depend on a precedence
+      // rule nobody stated.
+      final array = {
+        'v': 1,
+        'keys': [
+          {'kid': 'k', 'use': 'sign', 'alg': 'mldsa65', 'pub': 'YXJyYXk='}
+        ]
+      };
+      const bare = 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAlistedkey';
+
+      await becomeApprover();
+      final arrayId = await enrolThroughApproval(',"apsk":${jsonEncode(array)}');
+      final bareId =
+          await enrolThroughApproval(',"apskLegacy":${jsonEncode(bare)}');
+
+      final listed = jsonDecode(
+          (await firstAtSignConnection.sendRequestToServer('enroll:list'))
+              .replaceFirst('data:', '')) as Map;
+
+      Map recordFor(String id) => listed.entries
+          .firstWhere((e) => (e.key as String).startsWith('$id.'))
+          .value as Map;
+
+      final arrayRecord = recordFor(arrayId);
+      expect(arrayRecord['apsk'], array);
+      expect(arrayRecord.containsKey('apskLegacy'), false);
+
+      final bareRecord = recordFor(bareId);
+      expect(bareRecord['apskLegacy'], bare);
+      expect(bareRecord.containsKey('apsk'), false);
+    });
+  });
+
   group('A group of tests related to APKAM revoke operation', () {
     test(
         'A test to verify enrollment revoke operation on own connection results in error',


### PR DESCRIPTION
**- What I did**

- Honour `EnrollParams.apskLegacy` (at_commons 5.15.0): stored on the record, published **verbatim** rather than JSON-encoded. A request carrying both it and `apsk` is refused; `enroll:update` moves between the shapes and clears the one it left.
- Replaced the per-field 20KB `apsk` cap with one **500KB bound on the whole record**. `metadata` carries the key package and was uncapped, so the old bound sat on the one field nobody would use to make a record big.
- Fixed a race in the EnrollmentManager cache (`16dd457f`)
- Version 3.16.1.

**- How I did it**

See commit & diffs.

**- How to verify it**

Tests pass. PR includes a bunch of new unit & functional tests.

**- Description for the changelog**

`EnrollParams.apskLegacy` is published verbatim as the enrollment's `_apsk`; a request carrying both `_apsk` shapes is refused; one 500KB limit now covers the whole enrollment record; and a race in the enrollment-manager cache is fixed.