### PR TITLE
fix(atServer): handle updates of expired records correctly

### DIFF
--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 3.16.2
+- fix(at_secondary_server): an expired immutable record no longer blocks 
+creation of a new one until the delete-expired-keys sweep has run.
+  - An update that finds an expired record now deletes it before proceeding,
+  - so that the cache-metadata validation, the immutability check and the 
+   keystore's own metadata merge all see the same absence.
+
 # 3.16.1
 - feat: honour `EnrollParams.apskLegacy` — the bare RSA `_apsk` string,
   published verbatim rather than JSON-encoded. A request carrying both it and

--- a/packages/at_secondary_server/lib/src/verb/handler/abstract_update_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/abstract_update_verb_handler.dart
@@ -120,6 +120,41 @@ abstract class AbstractUpdateVerbHandler extends ChangeVerbHandler {
     }
 
     var existingAtMetaData = await keyStore.getMeta(atKey);
+
+    // An EXPIRED record is gone — a lookup of it already answers null — so it
+    // must not shape the record that replaces it. Delete it outright rather
+    // than teaching each reader below to look past it: once it is out of the
+    // store, the cache-metadata validation, the immutability check and the
+    // keystore's OWN retain-from-existing merge all see the same absence that
+    // a reader already sees, instead of three places agreeing to pretend.
+    //
+    // Teaching the readers here would not have been enough. The keystore
+    // re-reads the record for itself when it merges metadata
+    // (AtMetadataBuilder), so an expired record would still have supplied
+    // `immutable`, `createdAt` and `version` to the record replacing it — and
+    // a create that asked for neither would be born immutable with an expiry
+    // already in the past.
+    //
+    // Without this the server gave two different answers about whether a
+    // record existed. It refused a create over an expired immutable record,
+    // which made a ttl on such a record meaningless: the ttl expired the value
+    // but the record stayed in the keystore until next expired-keys-cleanup
+    // sweep, so a create-once interlock whose holder died blocked its own
+    // atSign for longer than intended.
+    //
+    // skipCommit because nothing observable changes. Whenever we delete
+    // expired records, we skip commit, because clients with sync'd copies will
+    // also see the expiration and delete their local copy.
+    //
+    // Expiry only, and deliberately NOT SecondaryUtil.isActiveKey, which also
+    // answers false before a record's ttb has elapsed. A not-yet-born record
+    // still exists and must still refuse a second create; only an expired one
+    // has stopped existing.
+    if (existingAtMetaData != null && _hasExpired(existingAtMetaData)) {
+      await keyStore.remove(atKey, skipCommit: true);
+      existingAtMetaData = null;
+    }
+
     var cacheRefreshMetaMap = hu.validateCacheMetadata(existingAtMetaData,
         updateParams.metadata!.ttr, updateParams.metadata!.ccd);
     updateParams.metadata!.ttr = cacheRefreshMetaMap[AtConstants.ttr];
@@ -140,7 +175,8 @@ abstract class AbstractUpdateVerbHandler extends ChangeVerbHandler {
     atData.metaData =
         AtMetaData.fromCommonsMetadata(updateParams.metadata!, atSign);
 
-    // Enforce the immutable feature
+    // Enforce the immutable feature. An expired record has already been
+    // dropped above, so this asks about a record that still exists.
     if (existingAtMetaData?.immutable == true) {
       throw IllegalStateException('Immutable records may not be updated');
     }
@@ -359,6 +395,18 @@ abstract class AbstractUpdateVerbHandler extends ChangeVerbHandler {
     newAtMetadata.appMetadata ??= existing?.appMetadata;
 
     return newAtMetadata;
+  }
+
+  /// Whether [metaData]'s record has passed its ttl.
+  ///
+  /// Compared on epoch milliseconds like [SecondaryUtil.isActiveKey], so the
+  /// two agree about when a record dies even though they are asked different
+  /// questions — that one folds in ttb and this one deliberately does not.
+  static bool _hasExpired(AtMetaData metaData) {
+    final expiresAt = metaData.expiresAt;
+    if (expiresAt == null) return false;
+    return expiresAt.toUtc().millisecondsSinceEpoch <
+        DateTime.now().millisecondsSinceEpoch;
   }
 
   static String? _mergeStringField(String? newValue, String? existingValue) {

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_secondary
 description: Implementation of secondary server.
-version: 3.16.1
+version: 3.16.2
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://www.example.com
 publish_to: none

--- a/packages/at_secondary_server/test/update_verb_test.dart
+++ b/packages/at_secondary_server/test/update_verb_test.dart
@@ -1123,6 +1123,121 @@ void main() {
           throwsA(isA<IllegalStateException>()));
     });
 
+    test('An EXPIRED immutable record may be created again', () async {
+      // A short-ttl immutable record is how several clients of one atSign hold
+      // a create-once interlock between them: the server's refusal of the
+      // second create IS the lock, and the ttl is what releases it if the
+      // holder dies mid-operation.
+      UpdateVerbHandler updateHandler = UpdateVerbHandler(
+        keyValueStore,
+        statsNotificationService,
+        notificationManager,
+        alice,
+      );
+      inboundConnection.metaData.isAuthenticated = true;
+
+      final atKey = AtKey.fromString('expiring_lock.wavi$alice');
+      await updateHandler.process(
+          'update:ttl:1:immutable:true:$atKey first holder', inboundConnection);
+
+      // Control: while it is alive, the refusal still stands. Without this the
+      // test below could pass because immutability stopped working at all
+      // rather than because the record expired.
+      await expectLater(
+          updateHandler.process(
+              'update:immutable:true:$atKey second holder', inboundConnection),
+          throwsA(isA<IllegalStateException>()),
+          reason: 'a LIVE immutable record must still refuse a second create — '
+              'that refusal is the interlock');
+
+      await Future.delayed(Duration(milliseconds: 20));
+
+      // The record has expired, so a reader is already told it is gone. The
+      // writer must agree.
+      expect(SecondaryUtil.isActiveKey(await keyValueStore.get(atKey.toString())),
+          false,
+          reason: 'the premise: this record is expired, so a lookup answers '
+              'null for it. If it is somehow still active the assertion below '
+              'proves nothing about expiry');
+
+      await updateHandler.process(
+          'update:ttl:1000:immutable:true:$atKey second holder',
+          inboundConnection);
+      AtData d = (await keyValueStore.get(atKey.toString()))!;
+      expect(d.data, 'second holder',
+          reason: 'an expired record is gone — a lookup of it answers null — '
+              'so it must not go on refusing a create. Otherwise the server '
+              'gives two different answers about whether the record exists');
+      expect(d.metaData?.immutable, true);
+    });
+
+    test('A create over an EXPIRED record inherits nothing from it', () async {
+      // The other half of treating an expired record as absent. Metadata is
+      // merged from the existing record wherever the new one leaves a field
+      // null — so if a dead record can still be seen here, a plain create over
+      // it silently becomes immutable and is born already expired, because it
+      // inherits both `immutable` and a past `expiresAt`.
+      UpdateVerbHandler updateHandler = UpdateVerbHandler(
+        keyValueStore,
+        statsNotificationService,
+        notificationManager,
+        alice,
+      );
+      inboundConnection.metaData.isAuthenticated = true;
+
+      final atKey = AtKey.fromString('expired_inherits.wavi$alice');
+      await updateHandler.process(
+          'update:ttl:1:immutable:true:$atKey first holder', inboundConnection);
+      await Future.delayed(Duration(milliseconds: 20));
+
+      // A plain create: not immutable, no ttl.
+      await updateHandler.process(
+          'update:$atKey second holder', inboundConnection);
+      AtData d = (await keyValueStore.get(atKey.toString()))!;
+
+      expect(d.data, 'second holder');
+      expect(d.metaData?.immutable, false,
+          reason: 'the dead record was immutable and this create did not ask '
+              'to be — inheriting the flag makes a record permanent that '
+              'nobody declared permanent');
+      expect(d.metaData?.expiresAt, isNull,
+          reason: 'inheriting the dead record\'s expiresAt would give this one '
+              'an expiry already in the past, so it would be born expired');
+    });
+
+    test('A not-yet-born immutable record still refuses a second create',
+        () async {
+      // The other side of the same rule, and the reason the check is expiry
+      // only rather than SecondaryUtil.isActiveKey: a record inside its ttb
+      // has NOT stopped existing, it has not started yet. Treating it as
+      // absent would let a second writer replace a record that is about to
+      // become visible.
+      UpdateVerbHandler updateHandler = UpdateVerbHandler(
+        keyValueStore,
+        statsNotificationService,
+        notificationManager,
+        alice,
+      );
+      inboundConnection.metaData.isAuthenticated = true;
+
+      final atKey = AtKey.fromString('unborn_lock.wavi$alice');
+      await updateHandler.process(
+          'update:ttb:60000:immutable:true:$atKey first holder',
+          inboundConnection);
+
+      expect(SecondaryUtil.isActiveKey(await keyValueStore.get(atKey.toString())),
+          false,
+          reason: 'the premise: isActiveKey answers false here too, which is '
+              'exactly why the immutability check must not use it');
+
+      await expectLater(
+          updateHandler.process(
+              'update:immutable:true:$atKey second holder', inboundConnection),
+          throwsA(isA<IllegalStateException>()),
+          reason: 'not-yet-born is not gone. The record exists and will become '
+              'visible, so a second create must still be refused');
+    });
+
     test('Create records with random metadata and verify correctness',
         () async {
       UpdateVerbHandler updateHandler = UpdateVerbHandler(

--- a/tests/at_functional_test/test/create_update_key_test.dart
+++ b/tests/at_functional_test/test/create_update_key_test.dart
@@ -60,38 +60,56 @@ void main() {
     test(
         'A test to assert of default fields in metadata are populated on update of a key',
         () async {
-      // The test asserts the following on update of a key
-      // 1. The version of the key should be set to 1
-      // 2. The createdAt should be populated with currentDateTime (now),
-      // 3. The updatedAt should be populated with DateTime which is higher than now,
-      // 4. The createdBy should be populated with atSign.
-      // Insert a new key. To ensure the key is always new, append UUID.
-      var keyCreationDateTime = DateTime.now().toUtc();
+      // What updating a key must do to its metadata:
+      // 1. version increments to 1
+      // 2. createdAt is PRESERVED from the create
+      // 3. updatedAt is REGENERATED, so it moves forward
+      // 4. createdBy / updatedBy name the atSign
+      //
+      // Every comparison here is between two values the SERVER produced, one
+      // per update.
       String key = 'newkey-$uniqueId';
-      var response = await firstAtSignConnection
+
+      Future<Map<String, dynamic>> metadataOf(String k) async =>
+          jsonDecode((await firstAtSignConnection
+                      .sendRequestToServer('llookup:all:public:$k$firstAtSign'))
+                  .replaceAll('data:', ''))['metaData']
+              as Map<String, dynamic>;
+
+      await firstAtSignConnection
           .sendRequestToServer('update:public:$key$firstAtSign new-value');
-      var keyUpdateDateTime = DateTime.now().toUtc();
-      response = await firstAtSignConnection
+      final afterCreate = await metadataOf(key);
+
+      var response = await firstAtSignConnection
           .sendRequestToServer('update:public:$key$firstAtSign updated-value');
       assert((!response.contains('Invalid syntax')) &&
           (!response.contains('null')));
-      response = (await firstAtSignConnection
-              .sendRequestToServer('llookup:all:public:$key$firstAtSign'))
-          .replaceAll('data:', '');
-      var atData = jsonDecode(response);
-      expect(atData['metaData']['version'], 1);
+      final afterUpdate = await metadataOf(key);
+
+      expect(afterCreate['version'], 0);
+      expect(afterUpdate['version'], 1);
+
+      // Both present before either is parsed, so a metadata field that stops
+      // being populated at all fails by name rather than as a cast error
+      // several lines later.
+      expect(afterCreate['updatedAt'], isNotNull);
+      expect(afterUpdate['updatedAt'], isNotNull);
+
+      expect(afterUpdate['createdAt'], afterCreate['createdAt'],
+          reason: 'createdAt is fixed when the record is created and preserved '
+              'by every later update');
       expect(
-          DateTime.parse(atData['metaData']['createdAt'])
-                  .millisecondsSinceEpoch >=
-              keyCreationDateTime.millisecondsSinceEpoch,
-          true);
-      expect(
-          DateTime.parse(atData['metaData']['updatedAt'])
-                  .millisecondsSinceEpoch >=
-              keyUpdateDateTime.millisecondsSinceEpoch,
-          true);
-      expect(atData['metaData']['createdBy'], firstAtSign);
-      expect(atData['metaData']['updatedBy'], firstAtSign);
+          DateTime.parse(afterUpdate['updatedAt'])
+              .isAfter(DateTime.parse(afterCreate['updatedAt'])),
+          true,
+          reason: 'updatedAt is regenerated on every update. Retaining it — '
+              'which is what happens if AtMetadataBuilder stops overwriting it '
+              'and the retain-from-existing merge takes over — is the defect '
+              'this guards, and the two updates are separated by a full round '
+              'trip so there is real headroom');
+
+      expect(afterUpdate['createdBy'], firstAtSign);
+      expect(afterUpdate['updatedBy'], firstAtSign);
     });
   });
 

--- a/tests/at_functional_test/test/update_verb_test.dart
+++ b/tests/at_functional_test/test/update_verb_test.dart
@@ -78,6 +78,114 @@ void main() async {
     await updateLookupUpdateDeleteForceDeleteImmutable(atKey);
   });
 
+  /// An immutable record carrying a ttl is a create-once interlock that
+  /// releases itself: the refusal of the second create IS the lock, and the
+  /// ttl is what stops a holder that died mid-operation from blocking its own
+  /// atSign for good. Several clients of one atSign use it to elect exactly
+  /// one of themselves to perform an operation.
+  ///
+  /// That only works if expiry frees the NAME and not merely the value.
+  /// Before this was fixed the two disagreed — `llookup` answered that the
+  /// record was gone while `update` went on refusing to create it — so the
+  /// ttl expired the value but the record remained in the data store
+  /// until the expired-keys cleanup sweep next ran.
+  group('immutable records with a ttl', () {
+    test('an EXPIRED immutable record may be created again', () async {
+      String atKey = 'expiringlock-$uniqueId$firstAtSign';
+
+      var response = await firstAtSignConnection.sendRequestToServer(
+          'update:ttl:1000:immutable:true:$atKey first holder');
+      expect(response, contains(RegExp(r'data:\d+')));
+
+      // Control. Without this, the acceptance below could mean immutability
+      // stopped working altogether rather than that the record expired.
+      response = await firstAtSignConnection.sendRequestToServer(
+          'update:immutable:true:$atKey second holder');
+      expect(response, contains('error:{"errorCode":"AT0032",'),
+          reason: 'while it is LIVE the record must still refuse a second '
+              'create — that refusal is the interlock itself');
+
+      await Future.delayed(Duration(milliseconds: 1500));
+
+      // The reader already says it is gone. Asserted as "does not carry the
+      // value" rather than against a particular error shape, so this pins the
+      // property rather than the spelling of a response.
+      response =
+          await firstAtSignConnection.sendRequestToServer('llookup:$atKey');
+      expect(response, isNot(contains('first holder')),
+          reason: 'the premise: past its ttl the record is gone to a reader. '
+              'If it still reads, the assertion below proves nothing about '
+              'expiry');
+
+      // …and the writer must agree.
+      response = await firstAtSignConnection.sendRequestToServer(
+          'update:ttl:60000:immutable:true:$atKey second holder');
+      expect(response, contains(RegExp(r'data:\d+')),
+          reason: 'an expired record is gone, so it must not go on refusing a '
+              'create. Otherwise a ttl on an immutable record expires the '
+              'value while reserving the name for ever, and a lock whose '
+              'holder crashed blocks its atSign permanently');
+
+      response =
+          await firstAtSignConnection.sendRequestToServer('llookup:$atKey');
+      expect(response, contains('data:second holder'));
+
+      await firstAtSignConnection.sendRequestToServer('delete:force:$atKey');
+    });
+
+    test('a NOT-YET-BORN immutable record still refuses a second create',
+        () async {
+      // The other half of the rule, and the reason the check is expiry only
+      // rather than the server's general is-this-record-active test: a record
+      // inside its ttb has not stopped existing, it has not started yet.
+      // Treating it as absent would let a second writer replace a record that
+      // is about to become visible.
+      String atKey = 'unbornlock-$uniqueId$firstAtSign';
+
+      var response = await firstAtSignConnection.sendRequestToServer(
+          'update:ttb:60000:immutable:true:$atKey first holder');
+      expect(response, contains(RegExp(r'data:\d+')));
+
+      response =
+          await firstAtSignConnection.sendRequestToServer('llookup:$atKey');
+      expect(response, isNot(contains('first holder')),
+          reason: 'the premise: inside its ttb the record does not read either '
+              '— which is exactly why "does not read" cannot be the test for '
+              'whether a create is allowed');
+
+      response = await firstAtSignConnection.sendRequestToServer(
+          'update:immutable:true:$atKey second holder');
+      expect(response, contains('error:{"errorCode":"AT0032",'),
+          reason: 'not-yet-born is not gone. The record exists and will become '
+              'visible, so a second create must still be refused');
+
+      await firstAtSignConnection.sendRequestToServer('delete:force:$atKey');
+    });
+
+    test('an immutable record with NO ttl still refuses a create for ever',
+        () async {
+      // The behaviour that must not change. Everything above narrows when
+      // immutability stops applying; this pins that it still applies at all.
+      String atKey = 'permanentlock-$uniqueId$firstAtSign';
+
+      try {
+        var response = await firstAtSignConnection
+            .sendRequestToServer('update:immutable:true:$atKey first holder');
+        expect(response, contains(RegExp(r'data:\d+')));
+
+        await Future.delayed(Duration(milliseconds: 1500));
+
+        response = await firstAtSignConnection
+            .sendRequestToServer('update:immutable:true:$atKey second holder');
+        expect(response, contains('error:{"errorCode":"AT0032",'),
+            reason: 'with no ttl there is nothing to expire, so the record '
+                'refuses a create for as long as it exists');
+      } finally {
+        await firstAtSignConnection.sendRequestToServer('delete:force:$atKey');
+      }
+    });
+  });
+
   test('update-llookup verb with public key', () async {
     /// UPDATE VERB
     var value = 'Hyderabad$lastValue';


### PR DESCRIPTION
### What I did

When a record has expired, it must be treated exactly as if it does not exist even if it still exists on the keystore. Discovered that it does not while working on some tests in the pq project
- an update that finds an expired record now deletes it (skipCommit) before proceeding
- so that the cache-metadata validation, immutability check, and the keystore's metadata merge all just see an absence.

### How
See commits and diffs

### How to verify
Added some new unit and functional tests, they should all pass
