### PR TITLE
fix(at_persistence_secondary_server): correct immutable guard comment

### DIFF
--- a/packages/at_persistence_secondary_server/lib/src/spec/keystore/at_metadata_builder.dart
+++ b/packages/at_persistence_secondary_server/lib/src/spec/keystore/at_metadata_builder.dart
@@ -42,13 +42,26 @@ class AtMetadataBuilder {
 
     // Ensure that if there was existing metadata and it had immutable == true
     // then that value is preserved regardless of what the new update is trying
-    // to do
-    // Note: this condition never occurs right now but we will leave it here
-    // for safety's sake
+    // to do.
+    //
+    // No update or update:meta arrives here with an immutable record. Both
+    // share AbstractUpdateVerbHandler.preProcessAndNotify, which refuses one
+    // outright ('Immutable records may not be updated'). That stays true for an
+    // EXPIRED immutable record, but for the opposite reason: such a record is
+    // deleted before the write, so this builder is handed existingMetaData ==
+    // null and inherits nothing from it. The test 'A create over an EXPIRED
+    // record inherits nothing from it', in at_secondary_server's
+    // test/update_verb_test.dart, is what pins that.
+    //
+    // The guard is not dead code: the verb handlers are not the only writers.
+    // The caching, enrollment, otp and config paths call keyStore.put/putMeta
+    // directly, and that refusal is the only immutability check in the tree, so
+    // none of them consults it. This is the backstop for those — which is why
+    // the warning below logs what it was asked to do.
     if (existingMetaData?.immutable == true) {
       if (newAtMetaData?.immutable != true) {
         logger.warning('Existing metadata.immutable is true,'
-            ' but new metadata.immutable is newAtMetaData?.immutable'
+            ' but new metadata.immutable is ${newAtMetaData?.immutable}'
             ' : will preserve immutable == true'
             ' : logging stack trace for reference');
         logger.warning(StackTrace.current);

--- a/packages/at_secondary_server/test/update_verb_test.dart
+++ b/packages/at_secondary_server/test/update_verb_test.dart
@@ -1137,8 +1137,14 @@ void main() {
       inboundConnection.metaData.isAuthenticated = true;
 
       final atKey = AtKey.fromString('expiring_lock.wavi$alice');
+      // ttl long enough that the control below cannot race it. At ttl:1 the
+      // record was already dead by the time the control ran, so the control
+      // failed on any machine slower than the CI runner — it asserts against a
+      // LIVE record and needs one to still exist. The functional twin of this
+      // test uses the same 1000/1500 pair for the same reason.
       await updateHandler.process(
-          'update:ttl:1:immutable:true:$atKey first holder', inboundConnection);
+          'update:ttl:1000:immutable:true:$atKey first holder',
+          inboundConnection);
 
       // Control: while it is alive, the refusal still stands. Without this the
       // test below could pass because immutability stopped working at all
@@ -1150,7 +1156,7 @@ void main() {
           reason: 'a LIVE immutable record must still refuse a second create — '
               'that refusal is the interlock');
 
-      await Future.delayed(Duration(milliseconds: 20));
+      await Future.delayed(Duration(milliseconds: 1500));
 
       // The record has expired, so a reader is already told it is gone. The
       // writer must agree.


### PR DESCRIPTION
**- What I did**

- Corrected the comment above the immutable-preservation branch in `at_metadata_builder.dart`, which claimed "this condition never occurs right now". Since #2751 that holds for two reasons, not one: a LIVE immutable record is refused by the check `update`/`update:meta` share, and an EXPIRED one is deleted before the write, so the builder is handed `existingMetaData == null` and inherits nothing.
- Recorded why the guard is not dead code: the caching, enrollment, otp and config paths call `keyStore.put`/`putMeta` directly, and that refusal is the only immutability check in the tree.
- Fixed a missing interpolation in that branch's warning — it logged the literal text `newAtMetaData?.immutable` instead of the value.
- Fixed a flaky test from #2751: `An EXPIRED immutable record may be created again` created its record with `ttl:1`, so the live-record control raced the expiry — 0/5 locally, green on CI. Now `ttl:1000` + 1500ms, the pair the functional twin already uses.

**- How I did it**

See commit & diffs.

**- How to verify it**

Tests pass. The comment's claim is pinned by `A create over an EXPIRED record inherits nothing from it`; the flaky test goes 0/5 → 5/5.