### PR TITLE
feat(at_secondary_server): exempt the first enrollment from the retrofit cap

### DIFF
--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,4 +1,15 @@
 # 3.16.2
+- feat(at_secondary_server): the atSign's FIRST enrollment is no longer given
+an expiry clock when a retrofit supersedes it.
+  - A retrofit (APKAM self-enrollment) caps the parent it supersedes. The first
+   enrollment - the CRAM-path root that approves every later enrollment, and
+   the one credential the server cannot re-issue - is now exempt, so retiring
+   it stays the owner's explicit act via `enroll:revoke`.
+  - Identified by all three of: root grants (`*` and `__manage`, both `rw`), no
+   expiry on its record, and no other existing enrollment created before it.
+  - Driven by `preserveFirstEnrollmentOnRetrofit` (config.yaml `enrollment:`
+   section, or the env var of the same name), default `true`. Set it false for
+   the previous behaviour.
 - fix(at_secondary_server): an expired immutable record no longer blocks 
 creation of a new one until the delete-expired-keys sweep has run.
   - An update that finds an expired record now deletes it before proceeding,

--- a/packages/at_secondary_server/config/config.yaml
+++ b/packages/at_secondary_server/config/config.yaml
@@ -215,3 +215,11 @@ enrollment:
   # If the duration between the last received invalid OTP and the current date-time
   # exceeds the delayIntervalThreshold, trigger a reset to the default value.
   delayIntervalThreshold: 55
+  # Whether this atSign's FIRST enrollment is exempt from the expiry clock a
+  # retrofit (APKAM self-enrollment) starts on the enrollment it supersedes.
+  # The first enrollment is minted on the CRAM path at onboarding, is the
+  # atSign's root, and approves every later enrollment - so when true it keeps
+  # its absence of expiry and retiring it stays the owner's explicit act via
+  # 'enroll:revoke'. Set false to have it age out like any other parent.
+  # Default: true
+  preserveFirstEnrollmentOnRetrofit: true

--- a/packages/at_secondary_server/lib/src/server/at_secondary_config.dart
+++ b/packages/at_secondary_server/lib/src/server/at_secondary_config.dart
@@ -762,6 +762,38 @@ class AtSecondaryConfig {
         720;
   }
 
+  static final bool _preserveFirstEnrollmentOnRetrofit = true;
+
+  /// Whether the atSign's FIRST enrollment is exempt from the retrofit cap
+  /// that [apkamSelfEnrollmentGraceHours] applies to every other parent.
+  ///
+  /// A retrofit normally starts an expiry clock on the enrollment it
+  /// supersedes. The first enrollment is the one credential that cannot be
+  /// re-issued by this server: it is minted on the CRAM path at onboarding,
+  /// is the atSign's root (`*` and `__manage`, both `rw`), and every later
+  /// enrollment is approved BY it. Letting a retrofit start its clock means
+  /// an atSign whose owner never noticed can be left with no root credential
+  /// at all once the grace elapses, and no enrollment able to approve a new
+  /// one.
+  ///
+  /// So when this is true the superseded first enrollment keeps its absence
+  /// of expiry, and retiring it stays an explicit act: the owner revokes it.
+  /// Exempting it is a deliberate choice to prefer a recoverable atSign over
+  /// an automatically retired credential — set this false to have the first
+  /// enrollment age out like any other.
+  static bool get preserveFirstEnrollmentOnRetrofit {
+    var result = _getBoolEnvVar('preserveFirstEnrollmentOnRetrofit');
+    if (result != null) {
+      return result;
+    }
+    try {
+      return getConfigFromYaml(
+          ['enrollment', 'preserveFirstEnrollmentOnRetrofit']);
+    } on ElementNotFoundException {
+      return _preserveFirstEnrollmentOnRetrofit;
+    }
+  }
+
   static final int _enrollmentResponseDelayIntervalInSeconds = 55;
 
   static int? _maxEnrollRequestsAllowed;

--- a/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
@@ -11,6 +11,7 @@ import 'package:at_secondary/src/notification/notification_manager_impl.dart';
 import 'package:at_secondary/src/server/at_secondary_config.dart';
 import 'package:at_secondary/src/server/at_secondary_impl.dart';
 import 'package:at_secondary/src/utils/apkam_signature_verifier.dart';
+import 'package:at_secondary/src/utils/secondary_util.dart';
 import 'package:at_server_spec/at_server_spec.dart';
 import 'package:at_server_spec/at_verb_spec.dart';
 import 'package:meta/meta.dart';
@@ -488,7 +489,20 @@ class EnrollVerbHandler extends AbstractVerbHandler {
       // sibling retrofit: the legacy credential retires one grace period
       // after the LAST clone upgrades, never past the expiry its own
       // posture already imposes.
-      await _capEnrollmentExpiry(parentEnrollmentId, parent);
+      //
+      // The atSign's FIRST enrollment is exempt (see
+      // AtSecondaryConfig.preserveFirstEnrollmentOnRetrofit): it is the one
+      // credential this server cannot re-issue, so retiring it stays the
+      // owner's explicit act via revoke.
+      if (AtSecondaryConfig.preserveFirstEnrollmentOnRetrofit &&
+          await _isFirstEnrollment(parentEnrollmentId, parent)) {
+        logger.info(
+            'Enrollment $parentEnrollmentId is this atSign\'s first '
+            'enrollment - retrofitted by $newEnrollmentId but NOT capped. It '
+            'keeps authenticating until the owner revokes it');
+      } else {
+        await _capEnrollmentExpiry(parentEnrollmentId, parent);
+      }
       return;
     }
 
@@ -537,6 +551,94 @@ class EnrollVerbHandler extends AbstractVerbHandler {
             'parent enrollment\'s grants — a self-enrollment can hold at '
             'most what its parent holds');
       }
+    }
+  }
+
+  /// Whether [enrollmentId] is this atSign's FIRST enrollment — the root
+  /// credential minted on the CRAM path at onboarding, which a retrofit must
+  /// leave unexpiring when
+  /// [AtSecondaryConfig.preserveFirstEnrollmentOnRetrofit] is set.
+  ///
+  /// All three of the properties that identify it are required, and each is
+  /// read from the authority that owns it rather than inferred:
+  ///
+  /// 1. **Fully privileged** — [AbstractVerbHandler.isRootEnrollment], the
+  ///    same test the rest of the server uses for a root enrollment: `rw` on
+  ///    both `*` and `__manage`. Holding `*` alone does not qualify.
+  /// 2. **No expiration** — asked of the RECORD (`expiresAt`), not of the
+  ///    posture that wrote it. A parent already capped by an earlier retrofit
+  ///    carries an expiry, so it fails here and stays capped: this exemption
+  ///    can only ever preserve an absence of expiry, never restore one that
+  ///    has already been spent.
+  /// 3. **No other enrollment that currently exists was created before it** —
+  ///    see [disqualifiesAsFirst], which is where the millisecond tie is
+  ///    decided and why.
+  ///
+  /// An absent record or an absent `createdAt` answers false: those leave the
+  /// claim unestablished, and capping is the safe direction when nothing can
+  /// be established.
+  Future<bool> _isFirstEnrollment(
+      String enrollmentId, EnrollDataStoreValue enrollment) async {
+    if (!AbstractVerbHandler.isRootEnrollment(enrollment)) return false;
+
+    final key = enMgr.buildEnrollmentKey(enrollmentId);
+    final AtData? atData = await _getOrNull(key);
+    if (atData == null) return false;
+    // An expiry already written - by this enrollment's own posture or by a
+    // previous retrofit's cap - is not an absence to preserve.
+    if (atData.metaData?.expiresAt != null) return false;
+    final createdAt = atData.metaData?.createdAt;
+    if (createdAt == null) return false;
+
+    for (final otherKey in await enMgr.getAllEnrollmentKeys()) {
+      if (otherKey == key) continue;
+      final other = await _getOrNull(otherKey);
+      if (other == null) continue;
+      // An expired record is gone: a reader is already told so, and the
+      // delete-expired sweep has simply not reached it yet. It must not
+      // decide whether this enrollment was the first.
+      if (!SecondaryUtil.isActiveKey(other)) continue;
+      if (disqualifiesAsFirst(createdAt, other.metaData?.createdAt)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /// Whether an enrollment created at [otherCreatedAt] rules out the
+  /// enrollment created at [candidateCreatedAt] being this atSign's first.
+  ///
+  /// Only a STRICTLY earlier sibling does. The same millisecond does not:
+  /// `createdAt` is millisecond-precision, and the retrofit writes its child
+  /// record before the exemption is decided, so the first enrollment ties
+  /// with its own child whenever the two land in one millisecond. Under a
+  /// strict "earlier than everything" reading the atSign's root would lose
+  /// its protection for no reason but clock granularity — the exact harm the
+  /// exemption exists to prevent, where allowing the tie costs at most one
+  /// same-millisecond sibling also keeping its absence of expiry.
+  ///
+  /// A null [otherCreatedAt] disqualifies: a sibling whose creation time
+  /// cannot be read cannot be ruled out as older, and capping is the safe
+  /// direction when nothing can be established.
+  ///
+  /// Exposed because the keystore gives a caller no way to construct the tie:
+  /// AtMetadataBuilder stamps `createdAt` itself and retains the existing
+  /// record's value on update, so no sequence of puts can produce two records
+  /// sharing a millisecond on demand.
+  @visibleForTesting
+  static bool disqualifiesAsFirst(
+      DateTime candidateCreatedAt, DateTime? otherCreatedAt) {
+    if (otherCreatedAt == null) return true;
+    return otherCreatedAt.toUtc().isBefore(candidateCreatedAt.toUtc());
+  }
+
+  /// [keyStore.get] for a key that may legitimately be absent, which it
+  /// signals by throwing rather than by returning null.
+  Future<AtData?> _getOrNull(String key) async {
+    try {
+      return await keyStore.get(key);
+    } on KeyNotFoundException {
+      return null;
     }
   }
 

--- a/packages/at_secondary_server/test/apkam_self_enrollment_test.dart
+++ b/packages/at_secondary_server/test/apkam_self_enrollment_test.dart
@@ -6,12 +6,15 @@ import 'package:at_chops/at_chops.dart'
     show AtChopsUtil, HashingAlgoType, MlDsa65PureDartAlgo, PkamSigningAlgo;
 import 'package:at_commons/at_commons.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_secondary/src/verb/handler/enroll_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/pkam_verb_handler.dart';
 import 'package:at_secondary/src/enroll/enroll_datastore_value.dart';
 import 'package:at_secondary/src/server/at_secondary_config.dart';
 import 'package:at_secondary/src/utils/handler_util.dart';
+import 'package:at_secondary/src/conf/config_util.dart';
 import 'package:at_server_spec/at_server_spec.dart';
 import 'package:test/test.dart';
+import 'package:yaml/yaml.dart';
 
 import 'enrollment_test_utils.dart';
 import 'test_utils.dart';
@@ -127,9 +130,13 @@ void main() {
     final graceMillis =
         Duration(hours: AtSecondaryConfig.apkamSelfEnrollmentGraceHours)
             .inMilliseconds;
-    expect(parentData?.metaData?.ttl, isNotNull,
+    // expiresAt rather than ttl: an uncapped enrollment record already
+    // carries ttl 0 - the keystore's "never expires" - so `ttl isNotNull`
+    // holds whether or not the cap was applied.
+    expect(parentData?.metaData?.expiresAt, isNotNull,
         reason: 'the cap is real: the parent record now carries an expiry');
-    expect(parentData!.metaData!.ttl!, lessThanOrEqualTo(graceMillis + 60000),
+    expect(parentData!.metaData!.ttl!, greaterThan(0));
+    expect(parentData.metaData!.ttl!, lessThanOrEqualTo(graceMillis + 60000),
         reason: 'and it is min(now + grace, existing expiry), not unbounded');
   });
 
@@ -623,5 +630,201 @@ void main() {
         throwsA(isA<UnAuthorizedException>()),
         reason: 'a pending enrollment cannot vouch for anything — only an '
             'approved parent is an authority');
+  });
+
+  /// The atSign's FIRST enrollment - the CRAM-path root every later
+  /// enrollment is approved by - is the one credential this server cannot
+  /// re-issue. AtSecondaryConfig.preserveFirstEnrollmentOnRetrofit exempts it
+  /// from the cap so that retiring it stays the owner's explicit act.
+  group('preserveFirstEnrollmentOnRetrofit', () {
+    /// Points the config at [preserve], leaving the rest of the yaml alone.
+    void setPreserve(bool preserve) {
+      AtSecondaryConfig.configYamlMap = YamlMap.wrap({
+        'enrollment': {'preserveFirstEnrollmentOnRetrofit': preserve}
+      });
+      expect(AtSecondaryConfig.preserveFirstEnrollmentOnRetrofit, preserve,
+          reason: 'the arms of every differential below differ only in this '
+              'value, so it has to have actually taken');
+    }
+
+    tearDown(() {
+      AtSecondaryConfig.configYamlMap = ConfigUtil.getYaml();
+    });
+
+    Future<AtData?> parentRecord(String enId) async =>
+        keyValueStore.get(enMgr.buildEnrollmentKey(enId));
+
+    test('defaults to true', () {
+      AtSecondaryConfig.configYamlMap = YamlMap.wrap({});
+      expect(AtSecondaryConfig.preserveFirstEnrollmentOnRetrofit, true,
+          reason: 'an atSign whose owner never noticed the retrofit must not '
+              'be left with no root credential at all');
+    });
+
+    test('the first enrollment is NOT capped when it is retrofitted',
+        () async {
+      setPreserve(true);
+      final firstId = etu.primaryEnId;
+      final before = await parentRecord(firstId);
+      expect(before?.metaData?.expiresAt, isNull,
+          reason: 'the premise: the CRAM-path root is written with no expiry. '
+              'If it already carried one there would be no absence to '
+              'preserve and this test would prove nothing');
+
+      final r = await selfEnroll(
+          parentEnrollmentId: firstId,
+          namespaces: {'*': 'rw', '__manage': 'rw'});
+      expect(r.isError, false, reason: '${r.errorMessage}');
+      final childId = jsonDecode(r.data!)['enrollmentId'] as String;
+
+      // Control: the retrofit really happened. Without this, a refused
+      // self-enrollment would leave the parent uncapped for the wrong reason
+      // and look exactly like the behaviour under test.
+      final child = await enMgr.getEnrollmentById(childId);
+      expect(child.parentEnrollmentId, firstId,
+          reason: 'the child records this parent, so the parent WAS the one '
+              'retrofitted');
+
+      final after = await parentRecord(firstId);
+      expect(after?.metaData?.expiresAt, isNull,
+          reason: 'the first enrollment keeps its absence of expiry — the '
+              'owner revokes it, the server does not retire it');
+      expect(after?.metaData?.ttl == null || after?.metaData?.ttl == 0, true,
+          reason: 'no clock was started: ttl is absent, or 0 which is the '
+              'keystore\'s "never expires"');
+      expect((await enMgr.getEnrollmentById(firstId)).approval?.state,
+          EnrollmentStatus.approved.name);
+    });
+
+    test('...and IS capped when the config is false', () async {
+      setPreserve(false);
+      final firstId = etu.primaryEnId;
+
+      final r = await selfEnroll(
+          parentEnrollmentId: firstId,
+          namespaces: {'*': 'rw', '__manage': 'rw'});
+      expect(r.isError, false, reason: '${r.errorMessage}');
+
+      final after = await parentRecord(firstId);
+      // expiresAt, not ttl: an uncapped enrollment record carries ttl 0, the
+      // keystore's "never expires", so `ttl isNotNull` would pass without any
+      // cap having been applied and this differential would prove nothing.
+      expect(after?.metaData?.expiresAt, isNotNull,
+          reason: 'the config is what drives the exemption: with it off the '
+              'first enrollment ages out like any other parent');
+      expect(after!.metaData!.ttl!, greaterThan(0));
+      expect(
+          after.metaData!.ttl!,
+          lessThanOrEqualTo(
+              Duration(hours: AtSecondaryConfig.apkamSelfEnrollmentGraceHours)
+                      .inMilliseconds +
+                  60000),
+          reason: 'and it is the ordinary min(now + grace, existing expiry)');
+    });
+
+    test('a LATER fully-privileged enrollment is still capped', () async {
+      setPreserve(true);
+      // Root grants, but not the first enrollment: created after the primary.
+      final laterRootId = await etu.createPendingEnrollment(
+          appName: 'later_root',
+          deviceName: 'later_root_device',
+          namespaces: {'*': 'rw', '__manage': 'rw'},
+          apkamKeysExpiryDuration: null);
+      await etu.approveEnrollment(etu.primaryEnId, laterRootId);
+      final later = await enMgr.getEnrollmentById(laterRootId);
+      expect(later.namespaces, {'*': 'rw', '__manage': 'rw'},
+          reason: 'the premise: this enrollment is fully privileged, so the '
+              'only property it lacks is being FIRST');
+      expect((await parentRecord(laterRootId))?.metaData?.expiresAt, isNull,
+          reason: 'and it has no expiry either — so createdAt is the only '
+              'thing left that can decide this test');
+
+      final r = await selfEnroll(
+          parentEnrollmentId: laterRootId,
+          namespaces: {'*': 'rw', '__manage': 'rw'},
+          appName: 'later_child',
+          deviceName: 'later_child_device');
+      expect(r.isError, false, reason: '${r.errorMessage}');
+
+      final laterAfter = await parentRecord(laterRootId);
+      expect(laterAfter?.metaData?.expiresAt, isNotNull,
+          reason: 'privileges alone do not earn the exemption — being the '
+              'atSign\'s first enrollment does');
+      expect(laterAfter!.metaData!.ttl!, greaterThan(0),
+          reason: 'a real clock, not the ttl 0 an uncapped record carries');
+      expect((await parentRecord(etu.primaryEnId))?.metaData?.expiresAt, isNull,
+          reason: 'and the actual first enrollment, which was not the parent '
+              'here, is untouched');
+    });
+
+    group('disqualifiesAsFirst - the millisecond tie', () {
+      // The keystore gives no way to build this case: AtMetadataBuilder
+      // stamps createdAt itself and retains the existing value on update, so
+      // no sequence of puts produces two records sharing a millisecond on
+      // demand. The rule is therefore pinned directly.
+      final t = DateTime.utc(2026, 8, 18, 12, 0, 0, 500);
+
+      test('a strictly earlier sibling disqualifies', () {
+        expect(
+            EnrollVerbHandler.disqualifiesAsFirst(
+                t, t.subtract(Duration(milliseconds: 1))),
+            isTrue);
+      });
+
+      test('the same millisecond does NOT disqualify', () {
+        expect(EnrollVerbHandler.disqualifiesAsFirst(t, t), isFalse,
+            reason: 'the retrofit writes its child before the exemption is '
+                'decided, so the first enrollment ties with its own child '
+                'whenever both land in one millisecond — clock granularity '
+                'must not cost the atSign its root credential');
+      });
+
+      test('a later sibling does not disqualify', () {
+        expect(
+            EnrollVerbHandler.disqualifiesAsFirst(
+                t, t.add(Duration(milliseconds: 1))),
+            isFalse);
+      });
+
+      test('an unreadable creation time disqualifies', () {
+        expect(EnrollVerbHandler.disqualifiesAsFirst(t, null), isTrue,
+            reason: 'a sibling that cannot be dated cannot be ruled out as '
+                'older, and capping is the safe direction');
+      });
+
+      test('the comparison is timezone-independent', () {
+        expect(
+            EnrollVerbHandler.disqualifiesAsFirst(
+                t.toLocal(), t.toLocal().subtract(Duration(milliseconds: 1))),
+            isTrue,
+            reason: 'records can carry either, and a wrong answer here would '
+                'depend on where the server runs');
+      });
+    });
+
+    test('an already-capped first enrollment is not un-capped', () async {
+      // Spend the absence of expiry with the exemption off...
+      setPreserve(false);
+      final firstId = etu.primaryEnId;
+      await selfEnroll(
+          parentEnrollmentId: firstId,
+          namespaces: {'*': 'rw', '__manage': 'rw'});
+      final capped = await parentRecord(firstId);
+      expect(capped?.metaData?.expiresAt, isNotNull,
+          reason: 'the premise: this retrofit started the clock');
+
+      // ...then retrofit again with it on. The exemption preserves an absence
+      // of expiry; it must not restore one that has already been spent.
+      setPreserve(true);
+      await selfEnroll(
+          parentEnrollmentId: firstId,
+          namespaces: {'*': 'rw', '__manage': 'rw'},
+          appName: 'second_child',
+          deviceName: 'second_child_device');
+
+      expect((await parentRecord(firstId))?.metaData?.expiresAt, isNotNull,
+          reason: 'a credential already retiring must not be made permanent '
+              'again by a later retrofit');
+    });
   });
 }

--- a/tests/at_functional_test/test/enroll_verb_test.dart
+++ b/tests/at_functional_test/test/enroll_verb_test.dart
@@ -1083,15 +1083,36 @@ void main() {
   });
 
   group('A group of test related to Rate limiting enrollment requests', () {
-    String otp = '';
+    /// One OTP. Each is stored under its own key, so several can be
+    /// outstanding at once - which is what lets these tests fetch every OTP
+    /// they need BEFORE the rate-limit window opens, instead of spending a
+    /// round trip inside the window they are measuring.
+    Future<String> freshOtp(OutboundConnectionFactory conn) async =>
+        (await conn.sendRequestToServer('otp:get'))
+            .replaceAll('data:', '')
+            .trim();
+
+    /// An enroll request with a unique (appName, deviceName) and the given
+    /// OTP. Only the OTP varies between the requests these tests send.
+    String enrollRequestFor(String otp) =>
+        'enroll:request:{"appName":"wavi","deviceName":"pixel-${Uuid().v4().hashCode}","namespaces":{"wavi":"rw"},"otp":"$otp","apkamPublicKey":"${apkamPublicKeyMap[firstAtSign]!}","encryptedAPKAMSymmetricKey" : "${apkamEncryptedKeysMap['encryptedAPKAMSymmetricKey']}"}';
+
     setUp(() async {
       await firstAtSignConnection.authenticateConnection(
           authType: AuthType.cram);
       String configResponse = await firstAtSignConnection
           .sendRequestToServer('config:set:maxRequestsPerTimeFrame=1');
       expect(configResponse.trim(), 'data:ok');
+      // 2000ms, not 100ms. Every test below has to fit its two enroll
+      // requests inside this window, and at 100ms the window was smaller than
+      // the round trips the tests themselves make - so on a loaded runner the
+      // first request aged out before the second arrived and the refusal
+      // under test never came. Measured against a dual-mode VE, the in-window
+      // work is ~25ms, so this is roughly an 80x margin. The limiter is a
+      // sliding window over request timestamps, so widening it changes only
+      // the room the test has, not what is being tested.
       configResponse = await firstAtSignConnection
-          .sendRequestToServer('config:set:timeFrameInMillis=100');
+          .sendRequestToServer('config:set:timeFrameInMillis=2000');
       expect(configResponse.trim(), 'data:ok');
     });
 
@@ -1101,10 +1122,12 @@ void main() {
       OutboundConnectionFactory unAuthenticatedConnection =
           await OutboundConnectionFactory().initiateConnectionWithListener(
               firstAtSign, firstAtSignHost, firstAtSignPort);
-      otp = await firstAtSignConnection.sendRequestToServer('otp:get');
-      otp = otp.replaceAll('data:', '').trim();
-      var enrollRequest =
-          'enroll:request:{"appName":"wavi","deviceName":"pixel-${Uuid().v4().hashCode}","namespaces":{"wavi":"rw"},"otp":"$otp","apkamPublicKey":"${apkamPublicKeyMap[firstAtSign]!}","encryptedAPKAMSymmetricKey" : "${apkamEncryptedKeysMap['encryptedAPKAMSymmetricKey']}"}';
+      // Both OTPs are fetched BEFORE the first request, so no otp:get round
+      // trip sits inside the window the test is measuring. Each OTP is stored
+      // under its own key, so two can be outstanding at once.
+      String otp1 = await freshOtp(firstAtSignConnection);
+      String otp2 = await freshOtp(firstAtSignConnection);
+      var enrollRequest = enrollRequestFor(otp1);
       String enrollmentResponse =
           await unAuthenticatedConnection.sendRequestToServer(enrollRequest);
       Map enrollmentResponseMap =
@@ -1112,10 +1135,8 @@ void main() {
       expect(enrollmentResponseMap['status'], 'pending');
       expect(enrollmentResponseMap['enrollmentId'], isNotNull);
 
-      otp = await firstAtSignConnection.sendRequestToServer('otp:get');
-      otp = otp.replaceAll('data:', '').trim();
-      enrollRequest =
-          'enroll:request:{"appName":"wavi","deviceName":"pixel-${Uuid().v4().hashCode}","namespaces":{"wavi":"rw"},"otp":"$otp","apkamPublicKey":"${apkamPublicKeyMap[firstAtSign]!}","encryptedAPKAMSymmetricKey" : "${apkamEncryptedKeysMap['encryptedAPKAMSymmetricKey']}"}\n';
+      // Immediately, with nothing in between.
+      enrollRequest = '${enrollRequestFor(otp2)}\n';
       enrollmentResponse =
           (await unAuthenticatedConnection.sendRequestToServer(enrollRequest))
               .replaceAll('error:', '');
@@ -1131,10 +1152,10 @@ void main() {
           await OutboundConnectionFactory().initiateConnectionWithListener(
               firstAtSign, firstAtSignHost, firstAtSignPort);
 
-      otp = await firstAtSignConnection.sendRequestToServer('otp:get');
-      otp = otp.replaceAll('data:', '').trim();
-      String enrollRequest =
-          'enroll:request:{"appName":"wavi","deviceName":"pixel-${Uuid().v4().hashCode}","namespaces":{"wavi":"rw"},"otp":"$otp","apkamPublicKey":"${apkamPublicKeyMap[firstAtSign]!}","encryptedAPKAMSymmetricKey" : "${apkamEncryptedKeysMap['encryptedAPKAMSymmetricKey']}"}';
+      // Pre-fetched, so the window contains only the two enroll requests.
+      String otp1 = await freshOtp(firstAtSignConnection);
+      String otp2 = await freshOtp(firstAtSignConnection);
+      String enrollRequest = enrollRequestFor(otp1);
       String enrollmentResponse =
           (await unAuthenticatedConnection.sendRequestToServer(enrollRequest))
               .replaceAll('data:', '');
@@ -1143,10 +1164,7 @@ void main() {
       expect(enrollmentResponseMap['status'], 'pending');
       expect(enrollmentResponseMap['enrollmentId'], isNotNull);
 
-      otp = await firstAtSignConnection.sendRequestToServer('otp:get');
-      otp = otp.replaceAll('data:', '').trim();
-      enrollRequest =
-          'enroll:request:{"appName":"wavi","deviceName":"pixel-${Uuid().v4().hashCode}","namespaces":{"wavi":"rw"},"otp":"$otp","apkamPublicKey":"${apkamPublicKeyMap[firstAtSign]!}","encryptedAPKAMSymmetricKey" : "${apkamEncryptedKeysMap['encryptedAPKAMSymmetricKey']}"}';
+      enrollRequest = enrollRequestFor(otp2);
       enrollmentResponse =
           (await unAuthenticatedConnection.sendRequestToServer(enrollRequest))
               .replaceAll('error:', '');
@@ -1154,7 +1172,11 @@ void main() {
           enrollmentResponse.contains(
               'Enrollment requests have exceeded the limit within the specified time frame'),
           true);
-      await Future.delayed(Duration(milliseconds: 110));
+      // Past the window, so the first request has aged out of it. Must exceed
+      // the 2000ms configured in setUp; the refused request above spent no
+      // OTP, because the limit is checked before the OTP is validated, so the
+      // same request can simply be retried.
+      await Future.delayed(Duration(milliseconds: 2200));
       enrollmentResponse =
           (await unAuthenticatedConnection.sendRequestToServer(enrollRequest))
               .replaceAll('data:', '');
@@ -1168,10 +1190,20 @@ void main() {
           await OutboundConnectionFactory().initiateConnectionWithListener(
               firstAtSign, firstAtSignHost, firstAtSignPort);
 
-      otp = await firstAtSignConnection.sendRequestToServer('otp:get');
-      otp = otp.replaceAll('data:', '').trim();
-      var enrollRequest =
-          'enroll:request:{"appName":"wavi","deviceName":"pixel-${Uuid().v4().hashCode}","namespaces":{"wavi":"rw"},"otp":"$otp","apkamPublicKey":"${apkamPublicKeyMap[firstAtSign]!}","encryptedAPKAMSymmetricKey" : "${apkamEncryptedKeysMap['encryptedAPKAMSymmetricKey']}"}';
+      // All three OTPs and the second connection are prepared BEFORE the
+      // window opens. The third request has to land INSIDE the window for
+      // this test to mean anything: if it arrives after the window has rolled
+      // over it is accepted because the limit expired, not because limits are
+      // per connection, and the test passes without testing anything.
+      String otp1 = await freshOtp(firstAtSignConnection);
+      String otp2 = await freshOtp(firstAtSignConnection);
+      String otp3 = await freshOtp(firstAtSignConnection);
+      OutboundConnectionFactory secondUnAuthenticatedConnection2 =
+          await OutboundConnectionFactory().initiateConnectionWithListener(
+              firstAtSign, firstAtSignHost, firstAtSignPort);
+
+      final windowOpened = Stopwatch()..start();
+      var enrollRequest = enrollRequestFor(otp1);
       String enrollmentResponse =
           (await unAuthenticatedConnection.sendRequestToServer(enrollRequest))
               .replaceAll('data:', '');
@@ -1180,10 +1212,7 @@ void main() {
       expect(enrollmentResponseMap['status'], 'pending');
       expect(enrollmentResponseMap['enrollmentId'], isNotNull);
 
-      otp = await firstAtSignConnection.sendRequestToServer('otp:get');
-      otp = otp.replaceAll('data:', '').trim();
-      enrollRequest =
-          'enroll:request:{"appName":"wavi","deviceName":"pixel-${Uuid().v4().hashCode}","namespaces":{"wavi":"rw"},"otp":"$otp","apkamPublicKey":"${apkamPublicKeyMap[firstAtSign]!}","encryptedAPKAMSymmetricKey" : "${apkamEncryptedKeysMap['encryptedAPKAMSymmetricKey']}"}';
+      enrollRequest = enrollRequestFor(otp2);
       enrollmentResponse =
           (await unAuthenticatedConnection.sendRequestToServer(enrollRequest))
               .replaceAll('error:', '');
@@ -1191,20 +1220,20 @@ void main() {
           enrollmentResponse.contains(
               'Enrollment requests have exceeded the limit within the specified time frame'),
           true);
-      OutboundConnectionFactory secondUnAuthenticatedConnection2 =
-          await OutboundConnectionFactory().initiateConnectionWithListener(
-              firstAtSign, firstAtSignHost, firstAtSignPort);
 
-      otp = await firstAtSignConnection.sendRequestToServer('otp:get');
-      otp = otp.replaceAll('data:', '').trim();
-      enrollRequest =
-          'enroll:request:{"appName":"wavi","deviceName":"pixel-${Uuid().v4().hashCode}","namespaces":{"wavi":"rw"},"otp":"$otp","apkamPublicKey":"${apkamPublicKeyMap[firstAtSign]!}","encryptedAPKAMSymmetricKey" : "${apkamEncryptedKeysMap['encryptedAPKAMSymmetricKey']}"}';
+      enrollRequest = enrollRequestFor(otp3);
       enrollmentResponse = await secondUnAuthenticatedConnection2
           .sendRequestToServer(enrollRequest);
+      windowOpened.stop();
       enrollmentResponseMap =
           jsonDecode(enrollmentResponse.replaceAll('data:', ''));
       expect(enrollmentResponseMap['status'], 'pending');
       expect(enrollmentResponseMap['enrollmentId'], isNotNull);
+      expect(windowOpened.elapsedMilliseconds, lessThan(2000),
+          reason: 'the acceptance above only demonstrates per-connection '
+              'limits if it happened while the first connection was still '
+              'rate limited. If this run took longer than the window, the '
+              'third request was accepted because the window rolled over');
     });
 
     tearDown(() async {

--- a/tests/at_functional_test/test/update_verb_test.dart
+++ b/tests/at_functional_test/test/update_verb_test.dart
@@ -363,7 +363,21 @@ void main() async {
     await Future.delayed(Duration(seconds: 3));
     response = await firstAtSignConnection.sendRequestToServer(
         'llookup:$firstAtSign:offer-$uniqueId$firstAtSign');
-    expect(response, contains('data:null'));
+    // Past its ttl the record is gone to a reader — but WHICH of the two
+    // "gone" answers comes back is a race with the expiry sweep, not a
+    // property of expiry. While the record is still in the keystore llookup
+    // finds it, sees it is inactive, and returns data:null; once the sweep has
+    // removed it, keyStore.get throws and llookup answers key-not-found.
+    // Asserting only the first spelling made this test fail whenever the sweep
+    // landed in the gap. Assert the property instead, and still refuse any
+    // OTHER answer.
+    expect(response, isNot(contains(value)),
+        reason: 'the value must not be served once its ttl has elapsed');
+    expect(
+        response,
+        anyOf(contains('data:null'), contains('does not exist in keystore')),
+        reason: 'and it is gone in one of those two ways, not by some other '
+            'error');
   });
 
   test('update-llookup for ttb ', () async {
@@ -420,7 +434,21 @@ void main() async {
     await Future.delayed(Duration(seconds: 4));
     response = await firstAtSignConnection.sendRequestToServer(
         'llookup:$firstAtSign:login-code-$uniqueId$firstAtSign');
-    expect(response, contains('data:null'));
+    // Past its ttl the record is gone to a reader — but WHICH of the two
+    // "gone" answers comes back is a race with the expiry sweep, not a
+    // property of expiry. While the record is still in the keystore llookup
+    // finds it, sees it is inactive, and returns data:null; once the sweep has
+    // removed it, keyStore.get throws and llookup answers key-not-found.
+    // Asserting only the first spelling made this test fail whenever the sweep
+    // landed in the gap. Assert the property instead, and still refuse any
+    // OTHER answer.
+    expect(response, isNot(contains(value)),
+        reason: 'the value must not be served once its ttl has elapsed');
+    expect(
+        response,
+        anyOf(contains('data:null'), contains('does not exist in keystore')),
+        reason: 'and it is gone in one of those two ways, not by some other '
+            'error');
   });
 
   tearDownAll(() async {


### PR DESCRIPTION
**- What I did**

- A retrofit no longer starts an expiry clock on the enrollment it supersedes when that is the atSign's **first** enrollment — the CRAM-path root that approves every later enrollment, and the one credential the server cannot re-issue. Retiring it stays the owner's explicit act via `enroll:revoke`.
- Identified by all three of: root grants (`*` and `__manage`, both `rw`), no expiry on the record, and no other existing enrollment created before it.
- New config `preserveFirstEnrollmentOnRetrofit` — `config.yaml`'s `enrollment:` section or the env var of the same name — defaulting to `true`.
- Fixed two pre-existing races in the functional pack that make `functional_dual_verify` fail intermittently (not caused by this change; see below).

**- How I did it**

See commit & diffs.

Three things worth a look:

- **Ties on `createdAt`.** The rule is "no other enrollment is *strictly* earlier", not "earlier than every other". `createdAt` is millisecond-precision and the retrofit writes its child record before the exemption is decided, so the first enrollment ties with its own child whenever both land in one millisecond. The keystore cannot be made to produce that tie (`AtMetadataBuilder` stamps `createdAt` and retains the existing value on update), so the decision is a `@visibleForTesting` function pinned directly.
- **Rate-limit race.** All three enrollment rate-limiting tests set a 100 ms window and then spent an `otp:get` round trip inside it, between the request that fills the limit and the request whose refusal they assert. Measured on a dual-mode VE, same span, both arms: 25 ms of in-window work against a 100 ms window — a 4× margin. Now the OTPs are pre-fetched (13 ms) and the window is 2000 ms (~154×). `rate limit is per connection` also gained an assertion that its third request really did land inside the window — otherwise it passes when the window rolls over, which tests nothing.
- **ttl race.** Two tests asserted `data:null` after a ttl elapsed. That is one of two correct answers: `data:null` while the record is still present, `key not found` once the expiry sweep has removed it. They now assert the property (the value is not served) and still refuse any third answer.
- **If the first enrollment is ever *deleted* rather than revoked**, the next-oldest root, unexpiring enrollment inherits the exemption.

**- How to verify it**

Tests pass — unit suite (968, 5/5 runs), and the full functional pack 221/221 in **dual** mode, the configuration `functional_dual_verify` runs. Plus 4 mutations each confirmed red on the assertion naming them.