### PR TITLE
fix(at_secondary_server): a closed NotificationManager stops its retry loop

### DIFF
--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,4 +1,10 @@
 # 3.16.2
+- fix(at_secondary_server): a closed `NotificationManager` now stops its
+delivery retries.
+  - `PerAtSignNotifSender.send()` retries until delivery succeeds or the
+   atSign leaves the atDirectory, and did not consult `closed` - so every
+   undelivered notification kept retrying past `AtSecondaryServerImpl.stop()`,
+   against a keystore that `stop()` closes immediately afterwards.
 - feat(at_secondary_server): the atSign's FIRST enrollment is no longer given
 an expiry clock when a retrofit supersedes it.
   - A retrofit (APKAM self-enrollment) caps the parent it supersedes. The first

--- a/packages/at_secondary_server/lib/src/notification/notification_manager_impl.dart
+++ b/packages/at_secondary_server/lib/src/notification/notification_manager_impl.dart
@@ -406,6 +406,15 @@ class PerAtSignNotifSender {
     // (2) atSign no longer in directory
     Duration delay = initialDelay;
     while (true) {
+      // Delivery is retried until it succeeds or the atSign leaves the
+      // directory, so a closed manager must break the loop explicitly:
+      // otherwise every undelivered notification keeps retrying past
+      // server shutdown, against a keystore that `stop()` closes right
+      // after us.
+      if (notifMgr.closed) {
+        logger.info('NotificationManager is closed - abandoning ${n.id}');
+        return;
+      }
       try {
         // not much point in sending expired notifications, is there
         if (n.isExpired()) {

--- a/packages/at_secondary_server/test/notification_manager_test.dart
+++ b/packages/at_secondary_server/test/notification_manager_test.dart
@@ -1,4 +1,5 @@
 import 'package:at_commons/at_commons.dart';
+import 'package:at_lookup/at_lookup.dart' as at_lookup;
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:at_secondary/src/connection/outbound/outbound_client.dart'
     show OutboundClient;
@@ -150,6 +151,50 @@ void main() async {
       await nm.close();
       await expectLater(nm.notify(AtNotificationBuilder().build()),
           throwsA(predicate((dynamic e) => e is StateError)));
+    });
+
+    test('send() abandons its retry loop once the manager is closed',
+        () async {
+      final savedInitialDelay = PerAtSignNotifSender.initialDelay;
+      PerAtSignNotifSender.initialDelay = Duration(milliseconds: 5);
+      addTearDown(
+          () => PerAtSignNotifSender.initialDelay = savedInitialDelay);
+
+      var nm = makeMgr();
+      var addressFinder = MockSecondaryAddressFinder();
+      when(() => addressFinder.findSecondary(bob)).thenAnswer(
+          (_) async => at_lookup.SecondaryAddress('bob.example.com', 1234));
+      when(() => nm.notifyConnectionsPool.secondaryAddressFinder)
+          .thenReturn(addressFinder);
+
+      // Delivery never succeeds, so `send()` sits in its retry loop.
+      var attempts = 0;
+      when(() => nm.notifyConnectionsPool.getOutboundClient(bob))
+          .thenAnswer((_) async {
+        attempts++;
+        throw Exception('mock: delivery fails');
+      });
+
+      await nm.notify((AtNotificationBuilder()
+            ..id = 'retry-loop-stops-on-close'
+            ..type = NotificationType.sent
+            ..fromAtSign = alice
+            ..toAtSign = '@bob'
+            ..notification = '@bob:verify_retry_stops$alice')
+          .build());
+
+      await Future.delayed(Duration(milliseconds: 100));
+      expect(attempts, greaterThan(1),
+          reason: 'precondition: the retry loop should be running');
+
+      await nm.close();
+      // Let whichever iteration was already in flight finish.
+      await Future.delayed(Duration(milliseconds: 100));
+      var attemptsAfterClose = attempts;
+
+      await Future.delayed(Duration(milliseconds: 200));
+      expect(attempts, attemptsAfterClose,
+          reason: 'send() kept retrying after the manager was closed');
     });
 
     test('Verify close', () async {

--- a/packages/at_secondary_server/test/test_utils.dart
+++ b/packages/at_secondary_server/test/test_utils.dart
@@ -216,11 +216,32 @@ late NotificationManager notificationManager;
 late MockStatsNotificationService statsNotificationService;
 late EnrollmentManager enMgr;
 
-late Function(dynamic data) socketOnDataFn;
-// ignore: unused_local_variable
-late Function() socketOnDoneFn;
-// ignore: unused_local_variable
-late Function(Exception e, StackTrace st) socketOnErrorFn;
+/// The socket callbacks registered by one *generation* of mocks — i.e.
+/// by one [verbTestsSetUp] call.
+///
+/// Every mock built in a given [verbTestsSetUp] captures that call's
+/// holder, so a connection left behind by an earlier test can only ever
+/// answer into its own (by then unread) holder. Without that, a stray
+/// write — most often a `notify:` still being retried by an earlier
+/// test's [PerAtSignNotifSender] — reaches whichever test is reading
+/// now, and that test fails on a request it never made (issue #2747).
+class MockSocketListener {
+  late Function(dynamic data) onData;
+  late Function() onDone;
+  late Function(Exception e, StackTrace st) onError;
+}
+
+MockSocketListener _currentSocketListener = MockSocketListener();
+
+/// The current generation's socket `onData`. Test files push mock
+/// responses through this; see [MockSocketListener] for why it is a
+/// getter rather than a variable.
+Function(dynamic data) get socketOnDataFn => _currentSocketListener.onData;
+
+Function() get socketOnDoneFn => _currentSocketListener.onDone;
+
+Function(Exception e, StackTrace st) get socketOnErrorFn =>
+    _currentSocketListener.onError;
 
 String storageDir = '${Directory.current.path}/unit_test_storage';
 // Default to bare mocks so handler-construction tests that never run
@@ -286,17 +307,26 @@ verbTestsSetUp() async {
   atServer.accessLog = atAccessLog = bundle.accessLog!;
   keyValueStore = bundle.keyValueStore;
 
-  mockSecondaryAddressFinder = MockSecondaryAddressFinder();
-  when(() => mockSecondaryAddressFinder.findSecondary(bob))
-      .thenAnswer((_) async {
+  // Everything below is built into locals first and only then published
+  // to the top-level `late` variables. Every stub closure captures the
+  // local, so the mocks of one `verbTestsSetUp` call form a
+  // self-consistent generation: work still in flight from an earlier
+  // test keeps talking to the mocks it started with instead of reaching
+  // into whichever test is running now (issue #2747).
+  final socketListener = _currentSocketListener = MockSocketListener();
+
+  final addressFinder = mockSecondaryAddressFinder =
+      MockSecondaryAddressFinder();
+  when(() => addressFinder.findSecondary(bob)).thenAnswer((_) async {
     return at_lookup.SecondaryAddress(bobHost, bobPort);
   });
 
-  mockOutboundConnection = MockOutboundConnection();
-  mockOutboundConnectionFactory = MockOutboundConnectionFactory();
-  when(() => mockOutboundConnectionFactory.createOutboundConnection(
+  final outboundConnection = mockOutboundConnection = MockOutboundConnection();
+  final outboundConnectionFactory =
+      mockOutboundConnectionFactory = MockOutboundConnectionFactory();
+  when(() => outboundConnectionFactory.createOutboundConnection(
       bobHost, bobPort, bob)).thenAnswer((invocation) async {
-    return mockOutboundConnection;
+    return outboundConnection;
   });
 
   inboundConnection = DummyInboundConnection();
@@ -307,24 +337,25 @@ verbTestsSetUp() async {
   // inboundPool.init(5);
   // inboundPool.add(inboundConnection);
 
-  outboundClientWithHandshake = OutboundClient(
+  final clientWithHandshake = outboundClientWithHandshake = OutboundClient(
     inboundConnection,
     bob,
-    mockSecondaryAddressFinder,
+    addressFinder,
     true,
-    mockOutboundConnectionFactory,
+    outboundConnectionFactory,
   )
     ..notifyTimeoutMillis = 100
     ..lookupTimeoutMillis = 100
     ..toHost = bobHost
     ..toPort = bobPort.toString()
     ..productionMode = false;
-  outboundClientWithoutHandshake = OutboundClient(
+  final clientWithoutHandshake =
+      outboundClientWithoutHandshake = OutboundClient(
     inboundConnection,
     bob,
-    mockSecondaryAddressFinder,
+    addressFinder,
     false,
-    mockOutboundConnectionFactory,
+    outboundConnectionFactory,
   )
     ..notifyTimeoutMillis = 100
     ..lookupTimeoutMillis = 100
@@ -332,40 +363,37 @@ verbTestsSetUp() async {
     ..toPort = bobPort.toString()
     ..productionMode = false;
 
-  mockOutboundClientManager = MockOutboundClientManager();
-  when(() => mockOutboundClientManager.getClient(bob, any(),
-      handshakeRequired: true)).thenAnswer((_) async {
-    await outboundClientWithHandshake.connect();
-    return outboundClientWithHandshake;
+  final clientManager = mockOutboundClientManager = MockOutboundClientManager();
+  when(() => clientManager.getClient(bob, any(), handshakeRequired: true))
+      .thenAnswer((_) async {
+    await clientWithHandshake.connect();
+    return clientWithHandshake;
   });
-  when(() => mockOutboundClientManager.getClient(bob, any(),
-      handshakeRequired: false)).thenAnswer((_) async {
-    await outboundClientWithoutHandshake.connect();
-    return outboundClientWithoutHandshake;
+  when(() => clientManager.getClient(bob, any(), handshakeRequired: false))
+      .thenAnswer((_) async {
+    await clientWithoutHandshake.connect();
+    return clientWithoutHandshake;
   });
 
   AtConnectionMetaData outboundConnectionMetadata =
       OutboundConnectionMetadata();
   outboundConnectionMetadata.sessionID = 'mock-session-id';
-  when(() => mockOutboundConnection.metaData)
-      .thenReturn(outboundConnectionMetadata);
-  when(() => mockOutboundConnection.metaData)
+  when(() => outboundConnection.metaData)
       .thenReturn(outboundConnectionMetadata);
 
-  mockSecureSocket = MockSecureSocket();
-  when(() => mockOutboundConnection.underlying)
-      .thenAnswer((_) => mockSecureSocket);
-  when(() => mockOutboundConnection.isInValid()).thenReturn(false);
-  when(() => mockOutboundConnection.close()).thenAnswer((_) async => {});
+  final secureSocket = mockSecureSocket = MockSecureSocket();
+  when(() => outboundConnection.underlying).thenAnswer((_) => secureSocket);
+  when(() => outboundConnection.isInValid()).thenReturn(false);
+  when(() => outboundConnection.close()).thenAnswer((_) async => {});
 
-  when(() => mockSecureSocket.listen(
+  when(() => secureSocket.listen(
         any(),
         onDone: any(named: "onDone"),
         onError: any(named: "onError"),
       )).thenAnswer((Invocation invocation) {
-    socketOnDataFn = invocation.positionalArguments[0];
-    socketOnDoneFn = invocation.namedArguments[#onDone];
-    socketOnErrorFn = invocation.namedArguments[#onError];
+    socketListener.onData = invocation.positionalArguments[0];
+    socketListener.onDone = invocation.namedArguments[#onDone];
+    socketListener.onError = invocation.namedArguments[#onError];
 
     return MockStreamSubscription();
   });
@@ -375,20 +403,18 @@ verbTestsSetUp() async {
   notificationManager = atServer.notificationManager = NotificationManager(
       alice,
       notifStore,
-      NotifyConnectionsPool(
-          mockSecondaryAddressFinder, mockOutboundConnectionFactory));
+      NotifyConnectionsPool(addressFinder, outboundConnectionFactory));
   registerFallbackValue(AtNotificationBuilder().build());
 
   cacheManager = atServer.cacheManager = AtCacheManager(
     alice,
     keyValueStore,
-    mockOutboundClientManager,
+    clientManager,
     notificationManager,
   );
 
   AtSecondaryServerImpl.getInstance().keyValueStore = keyValueStore;
-  AtSecondaryServerImpl.getInstance().outboundClientManager =
-      mockOutboundClientManager;
+  AtSecondaryServerImpl.getInstance().outboundClientManager = clientManager;
   AtSecondaryServerImpl.getInstance().currentAtSign = alice;
   AtSecondaryServerImpl.getInstance().signingKey =
       bobServerSigningKeypair.privateKey.toString();
@@ -406,31 +432,32 @@ verbTestsSetUp() async {
     ..ttr = -1
     ..createdAt = now
     ..updatedAt = now;
-  bobOriginalPublicKeyAsJson = SecondaryUtil.prepareResponseData(
-      'all', bobOriginalPublicKeyAtData,
-      key: 'public:publickey$bob')!;
+  final publicKeyAsJson = bobOriginalPublicKeyAsJson =
+      SecondaryUtil.prepareResponseData('all', bobOriginalPublicKeyAtData,
+          key: 'public:publickey$bob')!;
   bobOriginalPublicKeyAtData =
-      AtData().fromJson(jsonDecode(bobOriginalPublicKeyAsJson));
+      AtData().fromJson(jsonDecode(publicKeyAsJson));
 
-  when(() => mockOutboundConnection.write(any()))
+  when(() => outboundConnection.write(any()))
       .thenAnswer((Invocation invocation) async {
-    socketOnDataFn('error:AT0001-Mock exception : '
+    socketListener.onData('error:AT0001-Mock exception : '
             'No mock response defined for request '
             '[${invocation.positionalArguments[0]}]\n$alice@'
         .codeUnits);
   });
-  when(() => mockOutboundConnection.write('from:$alice\n'))
+  when(() => outboundConnection.write('from:$alice\n'))
       .thenAnswer((Invocation invocation) async {
-    socketOnDataFn("data:proof:mock-session-id$bob:server-challenge-text\n@"
-        .codeUnits); // actual challenge is different, of course, but not important for unit tests
+    socketListener.onData(
+        "data:proof:mock-session-id$bob:server-challenge-text\n@"
+            .codeUnits); // actual challenge is different, of course, but not important for unit tests
   });
-  when(() => mockOutboundConnection.write('pol\n'))
+  when(() => outboundConnection.write('pol\n'))
       .thenAnswer((Invocation invocation) async {
-    socketOnDataFn("$alice@".codeUnits);
+    socketListener.onData("$alice@".codeUnits);
   });
-  when(() => mockOutboundConnection.write('lookup:all:publickey@bob\n'))
+  when(() => outboundConnection.write('lookup:all:publickey@bob\n'))
       .thenAnswer((Invocation invocation) async {
-    socketOnDataFn("data:$bobOriginalPublicKeyAsJson\n$alice@".codeUnits);
+    socketListener.onData("data:$publicKeyAsJson\n$alice@".codeUnits);
   });
 
   statsNotificationService = MockStatsNotificationService();
@@ -439,6 +466,11 @@ verbTestsSetUp() async {
 Future<void> verbTestsTearDown() async {
   keyValueStore.preRemoveHooks.clear();
   keyValueStore.postRemoveHooks.clear();
+  // Undelivered notifications are retried until they succeed, and the
+  // mock outbound connection never lets one succeed. Closing the
+  // manager — as the server's own stop() does — stops those senders
+  // rather than leaving one spinning per test for the rest of the file.
+  await notificationManager.close();
   // factory.close() cascades to commit log, access log, notification
   // keystore and the Hive persistence manager, and clears the legacy
   // singletons' caches.

--- a/packages/at_secondary_server/test/test_utils_generation_isolation_test.dart
+++ b/packages/at_secondary_server/test/test_utils_generation_isolation_test.dart
@@ -1,0 +1,60 @@
+// Guards the isolation property `test_utils.dart`'s mock bundle is
+// supposed to have: each `verbTestsSetUp()` call builds a *generation*
+// of mocks, and nothing left over from an earlier generation may write
+// into the current generation's socket listener.
+//
+// Why it matters (issue #2747): `PerAtSignNotifSender.send()` retries a
+// failed delivery forever, so a notification raised by one test is still
+// being retried while later tests run. Its `notify:id:<fresh-uuid>:…`
+// command can never match a registered mock, so it always lands on the
+// catch-all `write` stub — which answers by pushing an error line into a
+// socket listener. If that listener is the *current* test's, the current
+// test reads an error naming a request it never made.
+
+import 'dart:convert';
+
+import 'package:test/test.dart';
+
+import 'test_utils.dart';
+
+void main() {
+  verbTestsSetUpLogging();
+
+  setUpAll(() async {
+    await verbTestsSetUpAll();
+  });
+
+  test(
+      'a superseded generation of mocks cannot write into the current '
+      'generation\'s socket listener', () async {
+    await verbTestsSetUp();
+    final staleConnection = mockOutboundConnection;
+    final staleReads = <String>[];
+    mockSecureSocket.listen((dynamic d) => staleReads.add(utf8.decode(d)),
+        onDone: () {}, onError: (e, st) {});
+    await verbTestsTearDown();
+
+    await verbTestsSetUp();
+    final currentReads = <String>[];
+    mockSecureSocket.listen((dynamic d) => currentReads.add(utf8.decode(d)),
+        onDone: () {}, onError: (e, st) {});
+
+    // A notification left in flight from the earlier test, writing on
+    // the outbound connection that test's notify pool holds.
+    await staleConnection
+        .write('notify:id:296926cc-0f59-48d3-822f-1bd5e6b571a4:update:'
+            'messageType:key:notifier:SYSTEM:@bob:phone.wavi@alice\n');
+
+    expect(currentReads, isEmpty,
+        reason: 'a write on a superseded outbound connection reached the '
+            'current generation\'s reader');
+
+    // Positive control: the catch-all did fire, and answered on the
+    // stale generation's own listener.
+    expect(staleReads, hasLength(1));
+    expect(staleReads.single, contains('No mock response defined'));
+    expect(staleReads.single, contains('notify:id:'));
+
+    await verbTestsTearDown();
+  });
+}


### PR DESCRIPTION
Fixes #2747

**- What I did**

- `PerAtSignNotifSender.send()`'s retry loop now returns when the `NotificationManager` is closed. It previously retried forever, so `AtSecondaryServerImpl.stop()` closed the manager and then closed persistence while senders kept retrying against a closed keystore.
- That same loop is the engine behind #2747: in the unit tests no notify can ever succeed, so one live sender accumulates per test for the rest of the file.
- `verbTestsSetUp()` now builds a self-consistent *generation* of mocks — every stub closure captures locals instead of the top-level `late` variables, and the socket callbacks live in a per-generation `MockSocketListener`. A leftover connection can only answer into its own, unread, holder rather than into whichever test is reading now.
- `verbTestsTearDown()` closes the notification manager, as the server's own `stop()` does.
- New `test_utils_generation_isolation_test.dart` pins the isolation property; new `notification_manager_test.dart` case pins the close-stops-retries behaviour.

**- How I did it**

See commit & diffs

**- How to verify it**

Tests pass — `at_secondary_server` 970/970 and `at_functional_test` 221/221. Both new tests were confirmed red before their respective fixes: the isolation test fails with the exact error text quoted in #2747.

**- Description for the changelog**

fix(at_secondary_server): a closed `NotificationManager` now stops its delivery retries, instead of retrying past server shutdown against a closed keystore.