### PR TITLE
feat: implement the at_commons 5.10.0 protocol enhancements

### DIFF
--- a/packages/at_persistence_secondary_server/CHANGELOG.md
+++ b/packages/at_persistence_secondary_server/CHANGELOG.md
@@ -18,6 +18,18 @@
   `createdAt`/`updatedAt`/`expiresAt`/`availableAt` faithfully instead of
   rederiving, and an asserted `expiresAt`/`availableAt` suppresses the
   ttl/ttb derivation for that write only. `remove` accepts `deletedAt`.
+  `AtMetadataBuilder` also derives the inverse on request
+  (`AtAssertedTimestamps.deriveTtl`/`deriveTtb`, set by callers whose own
+  request supplied the absolute without its relative): an asserted
+  `expiresAt` stores the ttl it implies (measured from the stored
+  updatedAt — from the asserted availableAt when that lies ahead of it),
+  and an asserted `availableAt` stores the implied ttb, in each case
+  replacing whatever retained or coerced relative the write's metadata
+  carries; a non-positive implied value clears the relative instead. A
+  ttl-only write on a record whose birth is pinned by an asserted
+  availableAt expires at exactly now + ttl — the metadata's ttb is folded
+  into the expiry derivation only when the same write re-derives the birth
+  window too.
   Assertions travel as an explicit argument rather than through nullable
   `AtMetaData` fields, so internal callers that recycle stored metadata keep
   today's server-derived stamping. NOTE for the next release: these are new

--- a/packages/at_persistence_secondary_server/CHANGELOG.md
+++ b/packages/at_persistence_secondary_server/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 5.2.1
+## 5.3.0
 
 - fix: the dual-write mirror purges the secondary's commit entry when the
   primary holds none for a just-written key. A skipCommit put/create/putMeta
@@ -40,6 +40,9 @@
   which utf7-decodes its argument — a second decode that mangled keys
   containing utf7 escape sequences. Commit-log calls now take the prepared
   key on every path.
+
+## 5.2.1
+
 - feat: `AtCommitLog.iterate` accepts `skipDeletesUntil`/`latestCommitId`,
   pushing sync's delete-skip into the query. Previously sync fetched every
   commit entry from `fromCommitId` and discarded below-watermark DELETE entries

--- a/packages/at_persistence_secondary_server/CHANGELOG.md
+++ b/packages/at_persistence_secondary_server/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## 5.2.1
 
+- fix: the dual-write mirror purges the secondary's commit entry when the
+  primary holds none for a just-written key. A skipCommit put/create/putMeta
+  purges the primary's entry while the key lives on, so "no entry to replay"
+  no longer implies "never committed" — without the purge the secondary kept
+  a stale entry that would resurface in sync after a backend switch (caught
+  by runDualCompare.sh: 79 vs 80 commit entries).
 - fix: the Hive commit-log `iterate` skips an entry whose `commitId` is
   still null — `add` stores the entry and stamps its `commitId` in two
   awaited steps, so a concurrent iterator (sync running while another write

--- a/packages/at_persistence_secondary_server/CHANGELOG.md
+++ b/packages/at_persistence_secondary_server/CHANGELOG.md
@@ -1,5 +1,32 @@
 ## 5.2.1
 
+- feat: keystore write paths accept caller-asserted timestamps
+  (`AtAssertedTimestamps`): `put`/`create`/`putMeta` store an asserted
+  `createdAt`/`updatedAt`/`expiresAt`/`availableAt` faithfully instead of
+  rederiving, and an asserted `expiresAt`/`availableAt` suppresses the
+  ttl/ttb derivation for that write only. `remove` accepts `deletedAt`.
+  Assertions travel as an explicit argument rather than through nullable
+  `AtMetaData` fields, so internal callers that recycle stored metadata keep
+  today's server-derived stamping. NOTE for the next release: these are new
+  named parameters on the `AtKeyValueStore` interface methods — breaking for
+  external implementers of the interface (none known besides test mocks,
+  which tolerate it), fine for callers.
+- feat: `AtCommitLog.commit` accepts an `opTime` (caller-asserted operation
+  time — a delete's `deletedAt`, an update's asserted `updatedAt`), recorded
+  on the commit entry; and `AtCommitLog.removeEntryFor` removes a key's
+  commit entry on both backends (previously reachable only through
+  backend-specific escape hatches).
+- feat: `put`/`create`/`putMeta` with `skipCommit: true` now purge the key's
+  existing commit entry as well as writing none, matching `remove`'s
+  established skipCommit behaviour; `putMeta` gains `skipCommit`.
+- fix: the Hive expiry cache tracks keys by their stored
+  `expiresAt`/`availableAt` rather than by ttl/ttb presence, so a record
+  whose only expiry signal is an asserted `expiresAt` is swept and stops
+  being served at its expiry instead of living forever.
+- fix: Hive `remove`/`removeMany` passed the raw key to the commit log,
+  which utf7-decodes its argument — a second decode that mangled keys
+  containing utf7 escape sequences. Commit-log calls now take the prepared
+  key on every path.
 - feat: `AtCommitLog.iterate` accepts `skipDeletesUntil`/`latestCommitId`,
   pushing sync's delete-skip into the query. Previously sync fetched every
   commit entry from `fromCommitId` and discarded below-watermark DELETE entries

--- a/packages/at_persistence_secondary_server/CHANGELOG.md
+++ b/packages/at_persistence_secondary_server/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## 5.2.1
 
+- fix: the Hive commit-log `iterate` skips an entry whose `commitId` is
+  still null — `add` stores the entry and stamps its `commitId` in two
+  awaited steps, so a concurrent iterator (sync running while another write
+  commits) could observe the half-written entry and crash dereferencing the
+  id. Skipping is safe: the entry is fully visible on the next iteration,
+  and commit-id sequences are gap-tolerant by design. SQLite is unaffected
+  (the row and its id are written in one transaction).
 - feat: keystore write paths accept caller-asserted timestamps
   (`AtAssertedTimestamps`): `put`/`create`/`putMeta` store an asserted
   `createdAt`/`updatedAt`/`expiresAt`/`availableAt` faithfully instead of

--- a/packages/at_persistence_secondary_server/lib/src/dual/dual_write_persistence.dart
+++ b/packages/at_persistence_secondary_server/lib/src/dual/dual_write_persistence.dart
@@ -178,6 +178,12 @@ class _DualWriteKeyStore
     final entry = _primary.commitLog?.getLatestCommitEntry(key);
     if (entry != null) {
       await _secondary.commitLog?.replay(entry);
+    } else {
+      // No entry in primary. Not only the never-committed case: a
+      // skipCommit put/create/putMeta PURGES the key's entry while the
+      // key itself lives on, so the secondary may hold a stale entry
+      // that must be purged too — "same commit entry, or same absence".
+      await _secondary.commitLog?.removeEntryFor(key);
     }
   }
 

--- a/packages/at_persistence_secondary_server/lib/src/dual/dual_write_persistence.dart
+++ b/packages/at_persistence_secondary_server/lib/src/dual/dual_write_persistence.dart
@@ -182,16 +182,21 @@ class _DualWriteKeyStore
   }
 
   @override
-  Future<int?> put(String key, AtData value, {bool skipCommit = false}) async {
-    final id = await _primary.put(key, value, skipCommit: skipCommit);
+  Future<int?> put(String key, AtData value,
+      {bool skipCommit = false,
+      AtAssertedTimestamps? assertedTimestamps}) async {
+    final id = await _primary.put(key, value,
+        skipCommit: skipCommit, assertedTimestamps: assertedTimestamps);
     await _mirror(key);
     return id;
   }
 
   @override
   Future<int?> create(String key, AtData value,
-      {bool skipCommit = false}) async {
-    final id = await _primary.create(key, value, skipCommit: skipCommit);
+      {bool skipCommit = false,
+      AtAssertedTimestamps? assertedTimestamps}) async {
+    final id = await _primary.create(key, value,
+        skipCommit: skipCommit, assertedTimestamps: assertedTimestamps);
     await _mirror(key);
     return id;
   }
@@ -204,8 +209,11 @@ class _DualWriteKeyStore
   }
 
   @override
-  Future<int?> putMeta(String key, AtMetaData? metadata) async {
-    final id = await _primary.putMeta(key, metadata);
+  Future<int?> putMeta(String key, AtMetaData? metadata,
+      {bool skipCommit = false,
+      AtAssertedTimestamps? assertedTimestamps}) async {
+    final id = await _primary.putMeta(key, metadata,
+        skipCommit: skipCommit, assertedTimestamps: assertedTimestamps);
     await _mirror(key);
     return id;
   }
@@ -217,8 +225,10 @@ class _DualWriteKeyStore
   }
 
   @override
-  Future<int?> remove(String key, {bool skipCommit = false}) async {
-    final id = await _primary.remove(key, skipCommit: skipCommit);
+  Future<int?> remove(String key,
+      {bool skipCommit = false, DateTime? deletedAt}) async {
+    final id = await _primary.remove(key,
+        skipCommit: skipCommit, deletedAt: deletedAt);
     await _mirror(key);
     return id;
   }

--- a/packages/at_persistence_secondary_server/lib/src/impl/hive/hive_at_commit_log.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/hive/hive_at_commit_log.dart
@@ -29,7 +29,8 @@ class HiveAtCommitLog extends AtCommitLog {
   /// throws [DataStoreException] if there is an exception writing to hive box
   @override
   @server
-  Future<int?> commit(String key, CommitOp operation) async {
+  Future<int?> commit(String key, CommitOp operation,
+      {DateTime? opTime}) async {
     // If key starts with "public:__", it is a public hidden key which gets synced
     // between cloud and local secondary. So increment commitId.
     // If key starts with "public:_" it is a public hidden key but does not get synced.
@@ -43,8 +44,8 @@ class HiveAtCommitLog extends AtCommitLog {
     }
     int result;
     key = Utf7.decode(key);
-    var entry = CommitEntry(
-        key, operation, DateTime.now().toUtcMillisecondsPrecision());
+    var entry = CommitEntry(key, operation,
+        (opTime ?? DateTime.now()).toUtcMillisecondsPrecision());
     try {
       result = await _commitLogKeyStore.add(entry);
     } on Exception catch (e) {
@@ -121,6 +122,20 @@ class HiveAtCommitLog extends AtCommitLog {
   @server
   CommitEntry? getLatestCommitEntry(String key) {
     return _commitLogKeyStore.getLatestCommitEntry(key);
+  }
+
+  /// [key] is utf7-decoded first, matching [commit]'s treatment, so
+  /// callers pass the same (encoded) form to both. Routes through
+  /// [HiveCommitLogKeyStore.remove], which also evicts the entry
+  /// from the in-memory cache map.
+  @override
+  @server
+  Future<void> removeEntryFor(String key) async {
+    key = Utf7.decode(key);
+    final CommitEntry? entry = _commitLogKeyStore.getLatestCommitEntry(key);
+    if (entry?.commitId != null) {
+      await _commitLogKeyStore.remove(entry!.commitId!);
+    }
   }
 
   /// Closes the [HiveServerCommitLogKeyStore] instance.

--- a/packages/at_persistence_secondary_server/lib/src/impl/hive/hive_at_keyvalue_store.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/hive/hive_at_keyvalue_store.dart
@@ -283,7 +283,9 @@ class HiveAtKeyValueStore
   /// hive does not support directly storing emoji characters, therefore keys
   /// are encoded in [HiveKeyStoreHelper.prepareKey] using utf7 before storing.
   @override
-  Future<int?> put(String key, AtData value, {bool skipCommit = false}) async {
+  Future<int?> put(String key, AtData value,
+      {bool skipCommit = false,
+      AtAssertedTimestamps? assertedTimestamps}) async {
     key = key.toLowerCase();
     final atKey = AtKey.getKeyType(key, enforceNameSpace: false);
     if (atKey == KeyType.invalidKey) {
@@ -298,24 +300,33 @@ class HiveAtKeyValueStore
       // If does not exist, create a new key,
       // else update existing key.
       if (!await exists(key)) {
-        result = await create(key, value, skipCommit: skipCommit);
+        result = await create(key, value,
+            skipCommit: skipCommit, assertedTimestamps: assertedTimestamps);
       } else {
         AtData? existingData = await get(key);
         String hive_key = HiveKeyStoreHelper.prepareKey(key);
         var hive_value = HiveKeyStoreHelper.prepareDataForKeystoreOperation(
             value,
             existingAtData: existingData!,
-            atSign: atSign);
+            atSign: atSign,
+            asserted: assertedTimestamps);
         logger.finest('hive key:$hive_key');
         logger.finest('hive value:$hive_value');
         await getBox().put(hive_key, hive_value);
         _updateMetadataCache(key, hive_value.metaData);
         if (skipCommit) {
+          // A skipCommit write leaves no trace in the commit log: as
+          // well as writing no entry, purge the key's previous entry —
+          // sync would otherwise keep serving a stale entry for a
+          // record whose latest change was deliberately uncommitted.
+          // (No-op on a commit-log-free keystore.)
+          await _commitLog?.removeEntryFor(hive_key);
           result = -1;
         } else {
           // `_commitLog` is null on a commit-log-free keystore — the
           // write still succeeds, it just produces no sequence number.
-          result = await _commitLog?.commit(hive_key, commitOp);
+          result = await _commitLog?.commit(hive_key, commitOp,
+              opTime: assertedTimestamps?.updatedAt);
         }
         _changesController.add(KeyUpdated(key));
       }
@@ -337,7 +348,8 @@ class HiveAtKeyValueStore
   @override
   @server
   Future<int?> create(String key, AtData value,
-      {bool skipCommit = false}) async {
+      {bool skipCommit = false,
+      AtAssertedTimestamps? assertedTimestamps}) async {
     key = key.toLowerCase();
     final atKey = AtKey.getKeyType(key, enforceNameSpace: false);
     if (atKey == KeyType.invalidKey) {
@@ -351,6 +363,7 @@ class HiveAtKeyValueStore
     var hive_data = HiveKeyStoreHelper.prepareDataForKeystoreOperation(
       value,
       atSign: atSign,
+      asserted: assertedTimestamps,
     );
     // Default commitOp to Update.
     commitOp = CommitOp.UPDATE;
@@ -384,11 +397,15 @@ class HiveAtKeyValueStore
       _updateMetadataCache(key, hive_data.metaData);
       _changesController.add(KeyAdded(key));
       if (skipCommit) {
+        // Purge any previous entry for this key, matching put/remove's
+        // skipCommit behaviour. (No-op on a commit-log-free keystore.)
+        await _commitLog?.removeEntryFor(hive_key);
         return -1;
       } else {
         // `_commitLog` is null on a commit-log-free keystore — the
         // write still succeeds, it just produces no sequence number.
-        return await _commitLog?.commit(hive_key, commitOp);
+        return await _commitLog?.commit(hive_key, commitOp,
+            opTime: assertedTimestamps?.updatedAt);
       }
     } on Exception catch (exception) {
       logger.severe('HiveAtKeyValueStore create exception: $exception');
@@ -430,7 +447,8 @@ class HiveAtKeyValueStore
 
   /// Returns an integer if the key to be deleted is present in keystore or cache.
   @override
-  Future<int?> remove(String key, {bool skipCommit = false}) async {
+  Future<int?> remove(String key,
+      {bool skipCommit = false, DateTime? deletedAt}) async {
     key = key.toLowerCase();
 
     for (final hook in preRemoveHooks) {
@@ -439,26 +457,27 @@ class HiveAtKeyValueStore
 
     int? retVal;
     try {
-      await getBox().delete(HiveKeyStoreHelper.prepareKey(key));
+      // The prepared (utf7-encoded) form is the one every commit-log call
+      // takes — commit() and removeEntryFor() both decode internally.
+      // Passing the raw key here would get decoded a second time, which
+      // mangles keys containing utf7 escape sequences.
+      String hiveKey = HiveKeyStoreHelper.prepareKey(key);
+      await getBox().delete(hiveKey);
       // On deleting the key, remove it from the expiryKeyCache.
       _expiryKeysCache.remove(key);
       final commitLog = _commitLog;
       if (skipCommit) {
-        // When skipping commits, remove any existing commit entries for this
+        // When skipping commits, remove any existing commit entry for this
         // key from commitLog. This is critical for synchronization - during
         // sync, other commit entries for this key might be considered valid
         // if we don't remove them. (No-op on a commit-log-free keystore.)
-        if (commitLog != null) {
-          CommitEntry? commitEntry = commitLog.getLatestCommitEntry(key);
-          if (commitEntry != null) {
-            await commitLog.commitLogKeyStore.remove(commitEntry.commitId!);
-          }
-        }
+        await commitLog?.removeEntryFor(hiveKey);
         retVal = -1;
       } else {
         // `commitLog` is null on a commit-log-free keystore — the
         // delete still succeeds, it just produces no sequence number.
-        retVal = await commitLog?.commit(key, CommitOp.DELETE);
+        retVal = await commitLog?.commit(hiveKey, CommitOp.DELETE,
+            opTime: deletedAt);
       }
       _changesController.add(KeyRemoved(key));
     } on Exception catch (exception) {
@@ -684,7 +703,9 @@ class HiveAtKeyValueStore
   }
 
   @override
-  Future<int?> putMeta(String key, AtMetaData? metadata) async {
+  Future<int?> putMeta(String key, AtMetaData? metadata,
+      {bool skipCommit = false,
+      AtAssertedTimestamps? assertedTimestamps}) async {
     key = key.toLowerCase();
     try {
       String hive_key = HiveKeyStoreHelper.prepareKey(key);
@@ -698,14 +719,24 @@ class HiveAtKeyValueStore
       newData.metaData = AtMetadataBuilder(
               newAtMetaData: metadata!,
               existingMetaData: existingData?.metaData,
-              atSign: atSign)
+              atSign: atSign,
+              asserted: assertedTimestamps)
           .build();
 
       await getBox().put(hive_key, newData);
       _updateMetadataCache(key, newData.metaData);
-      // `_commitLog` is null on a commit-log-free keystore — the write
-      // still succeeds, it just produces no sequence number.
-      var result = await _commitLog?.commit(hive_key, CommitOp.UPDATE_META);
+      int? result;
+      if (skipCommit) {
+        // Purge any previous entry for this key, matching put/remove's
+        // skipCommit behaviour. (No-op on a commit-log-free keystore.)
+        await _commitLog?.removeEntryFor(hive_key);
+        result = -1;
+      } else {
+        // `_commitLog` is null on a commit-log-free keystore — the write
+        // still succeeds, it just produces no sequence number.
+        result = await _commitLog?.commit(hive_key, CommitOp.UPDATE_META,
+            opTime: assertedTimestamps?.updatedAt);
+      }
       _changesController
           .add(existingData == null ? KeyAdded(key) : KeyUpdated(key));
       return result;
@@ -758,20 +789,19 @@ class HiveAtKeyValueStore
       await box.deleteAll(preparedToDelete);
 
       // 4. Per-key cache + commit-log bookkeeping. The commit-log
-      //    steps are no-ops on a commit-log-free keystore.
+      //    steps are no-ops on a commit-log-free keystore. Commit-log
+      //    calls take the prepared (utf7-encoded) form, as in remove().
       final commitLog = _commitLog;
       for (final lowered in present) {
         _expiryKeysCache.remove(lowered);
         if (commitLog == null) continue;
+        final hiveKey = HiveKeyStoreHelper.prepareKey(lowered);
         if (skipCommit) {
-          // Match remove(): purge any existing commit entries for this
-          // key, otherwise sync may consider them valid post-delete.
-          CommitEntry? commitEntry = commitLog.getLatestCommitEntry(lowered);
-          if (commitEntry != null) {
-            await commitLog.commitLogKeyStore.remove(commitEntry.commitId!);
-          }
+          // Match remove(): purge any existing commit entry for this
+          // key, otherwise sync may consider it valid post-delete.
+          await commitLog.removeEntryFor(hiveKey);
         } else {
-          await commitLog.commit(lowered, CommitOp.DELETE);
+          await commitLog.commit(hiveKey, CommitOp.DELETE);
         }
       }
     } on Exception catch (exception) {
@@ -1058,7 +1088,7 @@ class HiveAtKeyValueStore
   /// If key is active, returns "true", else returns "false"
   bool _isKeyAvailable(key, {DateTime? now}) {
     // If _expiryKeyCache does not contain the key, then it implies
-    // that key does not have TTL or TTB set.
+    // that the key has neither an expiresAt nor an availableAt.
     // So, the key never expires; return true.
     if (!_expiryKeysCache.containsKey(key)) {
       return true;
@@ -1070,24 +1100,19 @@ class HiveAtKeyValueStore
   /// Adds an entry where key is AtKey and value is Map containing the "expiresAt"
   /// and "availableAt" into the [_expiryKeysCache] map.
   ///
-  /// Adds only the keys whose TTL or TTB is set in the metadata; otherwise ignored.
+  /// Keyed on the FINAL stored `expiresAt`/`availableAt` values rather than
+  /// on ttl/ttb presence: by the time this runs, the metadata builder has
+  /// already derived those fields from ttl/ttb where applicable, and a
+  /// caller-asserted `expiresAt`/`availableAt` can be set with no ttl/ttb at
+  /// all — a key gated on ttl presence would never be swept and would be
+  /// served past its expiry. A key with neither field is active forever and
+  /// is removed from the cache (covers ttl/ttb unset AND ttl:0/ttb:0, which
+  /// the builder maps to null).
   void _updateMetadataCache(String key, AtMetaData? atMetaData) {
-    // If the metadata of a key does not have TTL or TTB set, then the key is active forever.
-    // Do not add it to _expiryKeyCache.
     if (atMetaData == null ||
-        (atMetaData.ttb == null && atMetaData.ttl == null)) {
-      // On an existing key, if TTL or TTB is unset, then TTL/TTB value will be null.
-      // Therefore, the new metadata will not be updated in the _expiryKeyCache.
-      // To prevent the stale metadata being returned from getMeta, remove the entry from
-      // _expiryKeyCache
-      _expiryKeysCache.remove(key);
-      return;
-    }
-    // Setting TTL/TTB to 0 (Zero) implies to unset the metadata.
-    // Therefore, the key will be active forever. Hence remove the existing key
-    // (if any)from expiryKeyCache
-    if ((atMetaData.ttl == null && atMetaData.ttb == 0) ||
-        (atMetaData.ttb == null && atMetaData.ttl == 0)) {
+        (atMetaData.expiresAt == null && atMetaData.availableAt == null)) {
+      // To prevent stale expiry state being consulted for this key,
+      // remove any existing entry from _expiryKeysCache.
       _expiryKeysCache.remove(key);
       return;
     }

--- a/packages/at_persistence_secondary_server/lib/src/impl/hive/hive_at_keyvalue_store.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/hive/hive_at_keyvalue_store.dart
@@ -1106,8 +1106,10 @@ class HiveAtKeyValueStore
   /// caller-asserted `expiresAt`/`availableAt` can be set with no ttl/ttb at
   /// all — a key gated on ttl presence would never be swept and would be
   /// served past its expiry. A key with neither field is active forever and
-  /// is removed from the cache (covers ttl/ttb unset AND ttl:0/ttb:0, which
-  /// the builder maps to null).
+  /// is removed from the cache. ttl:0 lands in that removal branch (the
+  /// builder maps it to a null expiresAt); ttb:0 does NOT — the builder
+  /// derives availableAt = the write instant, so a ttb:0 key stays cached
+  /// with an already-past birth time, which every reader treats as "born".
   void _updateMetadataCache(String key, AtMetaData? atMetaData) {
     if (atMetaData == null ||
         (atMetaData.expiresAt == null && atMetaData.availableAt == null)) {

--- a/packages/at_persistence_secondary_server/lib/src/impl/hive/hive_commit_log_keystore.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/hive/hive_commit_log_keystore.dart
@@ -205,6 +205,13 @@ class HiveCommitLogKeyStore with HiveBase<CommitEntry?> {
     for (final key in getBox().keys) {
       if (fromCommitId != null && (key as int) < fromCommitId) continue;
       final entry = await getValue(key) as CommitEntry;
+      // A null commitId is an entry [add] is mid-way through writing: the
+      // box.add has landed (entry visible) but the follow-up put that
+      // stamps the commitId has not. Skip it — consumers dereference
+      // commitId, and a client simply picks the entry up on its next
+      // iteration. (Legacy at-rest nulls are repaired at init by
+      // [repairNullCommitIDs], so mid-write is the only live source.)
+      if (entry.commitId == null) continue;
       // Sync's delete-skip: drop below-watermark DELETE entries, keeping
       // only the latest so the client can still advance its watermark.
       if (skipDeletesUntil != null &&

--- a/packages/at_persistence_secondary_server/lib/src/impl/hive/hive_keystore_helper.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/hive/hive_keystore_helper.dart
@@ -1,3 +1,4 @@
+import 'package:at_persistence_secondary_server/src/spec/keystore/at_asserted_timestamps.dart';
 import 'package:at_persistence_secondary_server/src/spec/keystore/at_data.dart';
 import 'package:at_persistence_secondary_server/src/spec/keystore/at_metadata_builder.dart';
 import 'package:at_utf7/at_utf7.dart';
@@ -18,15 +19,19 @@ class HiveKeyStoreHelper {
 
   /// Builds the [AtData] that should land in the keystore for an
   /// `update`-style operation, merging the new payload with any
-  /// existing metadata.
+  /// existing metadata. [asserted] carries caller-asserted
+  /// timestamps for the builder (see [AtAssertedTimestamps]).
   static AtData prepareDataForKeystoreOperation(AtData newAtData,
-      {AtData? existingAtData, required String atSign}) {
+      {AtData? existingAtData,
+      required String atSign,
+      AtAssertedTimestamps? asserted}) {
     var atData = AtData();
     atData.data = newAtData.data;
     atData.metaData = AtMetadataBuilder(
       atSign: atSign,
       newAtMetaData: newAtData.metaData,
       existingMetaData: existingAtData?.metaData,
+      asserted: asserted,
     ).build();
     return atData;
   }

--- a/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_at_commit_log.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_at_commit_log.dart
@@ -28,7 +28,10 @@ class SqliteAtCommitLog extends AtCommitLog {
   /// allocated commit id, or `-1` for an elided key. Re-entrant via
   /// [SqliteDatabase.runInTransaction]: joins the caller's transaction
   /// when there is one, else opens its own.
-  int? commitSync(String atKey, CommitOp operation) {
+  ///
+  /// [opTime] as on [AtCommitLog.commit]: caller-asserted operation
+  /// time when supplied, else now.
+  int? commitSync(String atKey, CommitOp operation, {DateTime? opTime}) {
     if (_isElided(atKey)) return -1;
     return _db.runInTransaction(() {
       _db.raw.execute(
@@ -48,7 +51,9 @@ class SqliteAtCommitLog extends AtCommitLog {
           atKey,
           commitId,
           operation.name,
-          DateTime.now().toUtcMillisecondsPrecision().millisecondsSinceEpoch,
+          (opTime ?? DateTime.now())
+              .toUtcMillisecondsPrecision()
+              .millisecondsSinceEpoch,
         ],
       );
       return commitId;
@@ -63,8 +68,12 @@ class SqliteAtCommitLog extends AtCommitLog {
   }
 
   @override
-  Future<int?> commit(String key, CommitOp operation) async =>
-      commitSync(key, operation);
+  Future<int?> commit(String key, CommitOp operation,
+          {DateTime? opTime}) async =>
+      commitSync(key, operation, opTime: opTime);
+
+  @override
+  Future<void> removeEntryFor(String key) async => purgeSync(key);
 
   @override
   Future<void> replay(CommitEntry entry) async {

--- a/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_at_keyvalue_store.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_at_keyvalue_store.dart
@@ -73,10 +73,13 @@ class SqliteAtKeyValueStore
   }
 
   @override
-  Future<int?> put(String key, AtData value, {bool skipCommit = false}) async {
+  Future<int?> put(String key, AtData value,
+      {bool skipCommit = false,
+      AtAssertedTimestamps? assertedTimestamps}) async {
     final k = _validateAndNormalize(key);
     if (!_existsSync(k)) {
-      return create(key, value, skipCommit: skipCommit);
+      return create(key, value,
+          skipCommit: skipCommit, assertedTimestamps: assertedTimestamps);
     }
     final existing = _getSync(k);
     final toStore = AtData()
@@ -85,10 +88,19 @@ class SqliteAtKeyValueStore
         atSign: atSign,
         newAtMetaData: value.metaData,
         existingMetaData: existing?.metaData,
+        asserted: assertedTimestamps,
       ).build();
     final result = _db.runInTransaction(() {
       _upsertAtData(k, toStore);
-      return skipCommit ? -1 : _commitOrNull(k, CommitOp.UPDATE_ALL);
+      if (skipCommit) {
+        // A skipCommit write leaves no trace in the commit log: purge
+        // the key's previous entry as well as writing none, matching
+        // remove()'s behaviour.
+        _sqliteCommitLog?.purgeSync(k);
+        return -1;
+      }
+      return _commitOrNull(k, CommitOp.UPDATE_ALL,
+          opTime: assertedTimestamps?.updatedAt);
     });
     _changes.add(KeyUpdated(k));
     return result;
@@ -96,18 +108,27 @@ class SqliteAtKeyValueStore
 
   @override
   Future<int?> create(String key, AtData value,
-      {bool skipCommit = false}) async {
+      {bool skipCommit = false,
+      AtAssertedTimestamps? assertedTimestamps}) async {
     final k = _validateAndNormalize(key);
     _checkMaxLength(k);
     final toStore = AtData()
       ..data = value.data
-      ..metaData =
-          AtMetadataBuilder(atSign: atSign, newAtMetaData: value.metaData)
-              .build();
+      ..metaData = AtMetadataBuilder(
+              atSign: atSign,
+              newAtMetaData: value.metaData,
+              asserted: assertedTimestamps)
+          .build();
     final commitOp = _commitOpForNewWrite(value.metaData);
     final result = _db.runInTransaction(() {
       _upsertAtData(k, toStore);
-      return skipCommit ? -1 : _commitOrNull(k, commitOp);
+      if (skipCommit) {
+        // Purge any previous entry for this key, matching put/remove's
+        // skipCommit behaviour.
+        _sqliteCommitLog?.purgeSync(k);
+        return -1;
+      }
+      return _commitOrNull(k, commitOp, opTime: assertedTimestamps?.updatedAt);
     });
     _changes.add(KeyAdded(k));
     return result;
@@ -133,7 +154,9 @@ class SqliteAtKeyValueStore
   }
 
   @override
-  Future<int?> putMeta(String key, AtMetaData? metadata) async {
+  Future<int?> putMeta(String key, AtMetaData? metadata,
+      {bool skipCommit = false,
+      AtAssertedTimestamps? assertedTimestamps}) async {
     final k = _validateAndNormalize(key);
     final existing = _existsSync(k) ? _getSync(k)! : AtData();
     final toStore = AtData()
@@ -142,10 +165,18 @@ class SqliteAtKeyValueStore
         atSign: atSign,
         newAtMetaData: metadata,
         existingMetaData: existing.metaData,
+        asserted: assertedTimestamps,
       ).build();
     final result = _db.runInTransaction(() {
       _upsertAtData(k, toStore);
-      return _commitOrNull(k, CommitOp.UPDATE_META);
+      if (skipCommit) {
+        // Purge any previous entry for this key, matching put/remove's
+        // skipCommit behaviour.
+        _sqliteCommitLog?.purgeSync(k);
+        return -1;
+      }
+      return _commitOrNull(k, CommitOp.UPDATE_META,
+          opTime: assertedTimestamps?.updatedAt);
     });
     _changes.add(KeyUpdated(k));
     return result;
@@ -170,7 +201,8 @@ class SqliteAtKeyValueStore
   }
 
   @override
-  Future<int?> remove(String key, {bool skipCommit = false}) async {
+  Future<int?> remove(String key,
+      {bool skipCommit = false, DateTime? deletedAt}) async {
     final lowered = key.toLowerCase();
     for (final hook in preRemoveHooks) {
       await hook(lowered, skipCommit: skipCommit);
@@ -182,7 +214,7 @@ class SqliteAtKeyValueStore
         _sqliteCommitLog?.purgeSync(k);
         return -1;
       }
-      return _commitOrNull(k, CommitOp.DELETE);
+      return _commitOrNull(k, CommitOp.DELETE, opTime: deletedAt);
     });
     _changes.add(KeyRemoved(k));
     for (final hook in postRemoveHooks) {
@@ -558,8 +590,8 @@ class SqliteAtKeyValueStore
     );
   }
 
-  int? _commitOrNull(String atkey, CommitOp op) =>
-      _sqliteCommitLog?.commitSync(atkey, op);
+  int? _commitOrNull(String atkey, CommitOp op, {DateTime? opTime}) =>
+      _sqliteCommitLog?.commitSync(atkey, op, opTime: opTime);
 
   AtData _atDataFromRow(Row row, String atkey) => AtData()
     ..data = row['value'] as String?

--- a/packages/at_persistence_secondary_server/lib/src/spec/commitlog/at_commit_log.dart
+++ b/packages/at_persistence_secondary_server/lib/src/spec/commitlog/at_commit_log.dart
@@ -13,7 +13,25 @@ abstract class AtCommitLog implements Compactable {
   /// Append a new entry for [key] / [operation]. Returns the
   /// assigned `commitId`, or `-1` for keys that bypass the commit
   /// log (`private:`, `privatekey:`, `public:_`, `local:`, ...).
-  Future<int?> commit(String key, CommitOp operation);
+  ///
+  /// [opTime] is the operation time recorded on the entry: pass a
+  /// caller-asserted time (a delete's `deletedAt`, an update's
+  /// asserted `updatedAt`) when the protocol supplied one; when
+  /// null, now. Truncated to millisecond precision. Informational —
+  /// entry ordering is by `commitId`, never by `opTime`.
+  Future<int?> commit(String key, CommitOp operation, {DateTime? opTime});
+
+  /// Remove the commit entry for [key], if one exists. The log
+  /// holds at most one entry per atKey, so at most one entry is
+  /// removed; removing none is not an error. Used by the
+  /// skipCommit write paths: a write that must leave no commit
+  /// entry also scrubs the key's previous entry, otherwise sync
+  /// would keep serving a stale entry for a record whose latest
+  /// change was deliberately uncommitted.
+  ///
+  /// [key] takes the same form that [commit] accepts on the same
+  /// backend.
+  Future<void> removeEntryFor(String key);
 
   /// Replay [entry] under its existing `commitId` WITHOUT firing
   /// change-event listeners. Used by the persistence migrator to

--- a/packages/at_persistence_secondary_server/lib/src/spec/keystore/at_asserted_timestamps.dart
+++ b/packages/at_persistence_secondary_server/lib/src/spec/keystore/at_asserted_timestamps.dart
@@ -1,0 +1,51 @@
+import 'package:at_persistence_secondary_server/src/utils/date_time_extensions.dart';
+
+/// Caller-asserted timestamps for a keystore write.
+///
+/// The Atsign Protocol lets a caller transmit `createdAt` / `updatedAt` /
+/// `expiresAt` / `availableAt` with a write (the `:cAt:` / `:uAt:` / `:eAt:` /
+/// `:aAt:` metadata fragments), to be stored faithfully rather than rederived
+/// on the receiving side. Those assertions travel as this explicit argument —
+/// never smuggled through the nullable timestamp fields on `AtMetaData` —
+/// because the metadata builder cannot otherwise tell "the caller asserts
+/// this value" from "this value was copied out of the stored record":
+/// internal read-modify-write callers routinely pass metadata objects whose
+/// timestamp fields came from the store, and those writes must keep their
+/// server-derived stamping.
+///
+/// Precedence in `AtMetadataBuilder`: an asserted value wins; an absent one
+/// leaves the builder's behaviour unchanged. In particular an asserted
+/// `expiresAt`/`availableAt` suppresses the ttl/ttb derivation for that
+/// write only — a later write without an assertion derives as usual.
+///
+/// Values are truncated to millisecond precision on construction, matching
+/// the precision the keystore can hold (Hive stores [DateTime]s to
+/// milliseconds).
+class AtAssertedTimestamps {
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
+  final DateTime? expiresAt;
+  final DateTime? availableAt;
+
+  AtAssertedTimestamps(
+      {DateTime? createdAt,
+      DateTime? updatedAt,
+      DateTime? expiresAt,
+      DateTime? availableAt})
+      : createdAt = createdAt?.toUtcMillisecondsPrecision(),
+        updatedAt = updatedAt?.toUtcMillisecondsPrecision(),
+        expiresAt = expiresAt?.toUtcMillisecondsPrecision(),
+        availableAt = availableAt?.toUtcMillisecondsPrecision();
+
+  /// `true` when no field is asserted.
+  bool get isEmpty =>
+      createdAt == null &&
+      updatedAt == null &&
+      expiresAt == null &&
+      availableAt == null;
+
+  @override
+  String toString() =>
+      'AtAssertedTimestamps{createdAt: $createdAt, updatedAt: $updatedAt,'
+      ' expiresAt: $expiresAt, availableAt: $availableAt}';
+}

--- a/packages/at_persistence_secondary_server/lib/src/spec/keystore/at_asserted_timestamps.dart
+++ b/packages/at_persistence_secondary_server/lib/src/spec/keystore/at_asserted_timestamps.dart
@@ -14,9 +14,23 @@ import 'package:at_persistence_secondary_server/src/utils/date_time_extensions.d
 /// server-derived stamping.
 ///
 /// Precedence in `AtMetadataBuilder`: an asserted value wins; an absent one
-/// leaves the builder's behaviour unchanged. In particular an asserted
+/// leaves the builder's behaviour unchanged. An asserted
 /// `expiresAt`/`availableAt` suppresses the ttl/ttb derivation for that
-/// write only — a later write without an assertion derives as usual.
+/// write. A later write that supplies a ttl/ttb without an assertion
+/// derives from now as usual; a caller that wants a write to leave an
+/// expiry axis untouched asserts the record's stored absolute back (that
+/// is how the update verbs keep expiry-silent writes from moving expiry).
+///
+/// [deriveTtl] / [deriveTtb] carry the caller's per-axis derivation
+/// intent: `deriveTtl: true` means "this write supplies [expiresAt] and no
+/// ttl of its own — store the ttl the absolute implies, replacing whatever
+/// ttl the metadata handed to the write may carry (a retained or coerced
+/// value, not the caller's)". Only the caller can make that call: by the
+/// time metadata reaches the builder, a caller-supplied ttl and one merged
+/// in from the stored record (or coerced from an absent field, as commons
+/// `Metadata.fromJson` and the notify wire layer do — both turn an absent
+/// ttl/ttb into 0) are indistinguishable. The flags default to false, so a
+/// plain assertion never overwrites a relative it did not ask about.
 ///
 /// Values are truncated to millisecond precision on construction, matching
 /// the precision the keystore can hold (Hive stores [DateTime]s to
@@ -27,11 +41,22 @@ class AtAssertedTimestamps {
   final DateTime? expiresAt;
   final DateTime? availableAt;
 
+  /// Derive and store the ttl implied by [expiresAt], replacing any ttl on
+  /// the write's metadata. Meaningful only when [expiresAt] is non-null.
+  final bool deriveTtl;
+
+  /// Derive and store the ttb implied by [availableAt], replacing any ttb
+  /// on the write's metadata. Meaningful only when [availableAt] is
+  /// non-null.
+  final bool deriveTtb;
+
   AtAssertedTimestamps(
       {DateTime? createdAt,
       DateTime? updatedAt,
       DateTime? expiresAt,
-      DateTime? availableAt})
+      DateTime? availableAt,
+      this.deriveTtl = false,
+      this.deriveTtb = false})
       : createdAt = createdAt?.toUtcMillisecondsPrecision(),
         updatedAt = updatedAt?.toUtcMillisecondsPrecision(),
         expiresAt = expiresAt?.toUtcMillisecondsPrecision(),
@@ -47,5 +72,6 @@ class AtAssertedTimestamps {
   @override
   String toString() =>
       'AtAssertedTimestamps{createdAt: $createdAt, updatedAt: $updatedAt,'
-      ' expiresAt: $expiresAt, availableAt: $availableAt}';
+      ' expiresAt: $expiresAt, availableAt: $availableAt,'
+      ' deriveTtl: $deriveTtl, deriveTtb: $deriveTtb}';
 }

--- a/packages/at_persistence_secondary_server/lib/src/spec/keystore/at_keyvalue_store.dart
+++ b/packages/at_persistence_secondary_server/lib/src/spec/keystore/at_keyvalue_store.dart
@@ -84,10 +84,49 @@ abstract interface class AtKeyValueStore<K, V, T>
     int? limit,
   });
 
+  /// Associates [value] with [key]. Overrides [KeyValueStore.put]
+  /// with the atKey-aware extras:
+  ///
+  ///   * [skipCommit] — as well as writing no commit entry, the
+  ///     key's existing commit entry (if any) is purged, so the
+  ///     commit log carries no trace of the key's history. Sync
+  ///     would otherwise keep serving a stale entry for a record
+  ///     whose latest change was deliberately uncommitted.
+  ///   * [assertedTimestamps] — caller-asserted timestamps stored
+  ///     faithfully instead of being rederived; see
+  ///     [AtAssertedTimestamps] for the precedence rules. An
+  ///     asserted `updatedAt` is also recorded as the commit
+  ///     entry's `opTime`.
+  @override
+  Future<int?> put(K key, V value,
+      {bool skipCommit = false, AtAssertedTimestamps? assertedTimestamps});
+
+  /// Creates [key] with [value]. Overrides [KeyValueStore.create]
+  /// with the same [skipCommit]-purges and [assertedTimestamps]
+  /// extras as [put].
+  @override
+  Future<int?> create(K key, V value,
+      {bool skipCommit = false, AtAssertedTimestamps? assertedTimestamps});
+
+  /// Removes the mapping for [key] if present. Overrides
+  /// [KeyValueStore.remove]:
+  ///
+  ///   * [skipCommit] — as for [put]: no DELETE entry is written
+  ///     AND the key's existing commit entry is purged.
+  ///   * [deletedAt] — caller-asserted deletion time, recorded as
+  ///     the DELETE commit entry's `opTime` (truncated to
+  ///     millisecond precision). Ignored when [skipCommit] is true
+  ///     — there is no entry to stamp.
+  @override
+  Future<int?> remove(K key, {bool skipCommit = false, DateTime? deletedAt});
+
   /// Updates the metadata for [key] without touching its value.
   /// Returns the commit-log sequence number assigned to this
   /// write, or `null` if no sequence number was produced.
-  Future<int?> putMeta(K key, T metadata);
+  ///
+  /// [skipCommit] and [assertedTimestamps] behave as on [put].
+  Future<int?> putMeta(K key, T metadata,
+      {bool skipCommit = false, AtAssertedTimestamps? assertedTimestamps});
 
   /// Writes [value] and [metadata] for [key] atomically. Returns
   /// the commit-log sequence number assigned to this write, or

--- a/packages/at_persistence_secondary_server/lib/src/spec/keystore/at_metadata_builder.dart
+++ b/packages/at_persistence_secondary_server/lib/src/spec/keystore/at_metadata_builder.dart
@@ -13,25 +13,47 @@ class AtMetadataBuilder {
 
   static final AtSignLogger logger = AtSignLogger('AtMetadataBuilder');
 
-  /// Requires an AtMetaData
+  /// Requires an AtMetaData.
+  ///
+  /// [asserted] carries caller-asserted timestamps (see
+  /// [AtAssertedTimestamps]). An asserted value is stored faithfully:
+  ///
+  ///   * `createdAt`: asserted value wins — on creation and on update of an
+  ///     existing record alike (the protocol treats a transmitted createdAt
+  ///     as the record's true creation time, e.g. when a record moves
+  ///     between atServers). Absent an assertion, a new record is stamped
+  ///     now and an existing record keeps its stored value.
+  ///   * `updatedAt`: asserted value wins; else stamped now.
+  ///   * `expiresAt` / `availableAt`: an asserted value wins AT THIS WRITE,
+  ///     suppressing the ttl/ttb derivation that would otherwise recompute
+  ///     it from now — that derivation is exactly what a faithful transfer
+  ///     must avoid, since it would restart the expiry clock on arrival.
+  ///     A later write without an assertion derives from ttl/ttb as usual.
   AtMetadataBuilder({
     required String atSign,
     required AtMetaData? newAtMetaData,
     AtMetaData? existingMetaData,
+    AtAssertedTimestamps? asserted,
   }) {
     atMetaData = newAtMetaData ?? existingMetaData ?? AtMetaData();
     // createdAt indicates the date and time of the key created.
     // For a new key, the currentDateTime is set and remains unchanged
-    // on an update event.
-    (existingMetaData?.createdAt == null)
-        ? atMetaData.createdAt = currentUtcTimeToMillisecondPrecision
-        : atMetaData.createdAt = existingMetaData?.createdAt;
+    // on an update event — unless the caller asserts a createdAt.
+    if (asserted?.createdAt != null) {
+      atMetaData.createdAt = asserted!.createdAt;
+    } else {
+      (existingMetaData?.createdAt == null)
+          ? atMetaData.createdAt = currentUtcTimeToMillisecondPrecision
+          : atMetaData.createdAt = existingMetaData?.createdAt;
+    }
     atMetaData.createdBy ??= atSign;
     atMetaData.updatedBy = atSign;
     // updatedAt indicates the date and time of the key updated.
     // For a new key, the updatedAt is same as createdAt and on key
-    // update, set the updatedAt to the currentDateTime.
-    atMetaData.updatedAt = currentUtcTimeToMillisecondPrecision;
+    // update, set the updatedAt to the currentDateTime — unless the
+    // caller asserts an updatedAt.
+    atMetaData.updatedAt =
+        asserted?.updatedAt ?? currentUtcTimeToMillisecondPrecision;
     atMetaData.status = 'active';
     // The version indicates the number of updates a key has received.
     // Version is set to 0 for a new key and for each update the key receives,
@@ -69,12 +91,17 @@ class AtMetadataBuilder {
       atMetaData.immutable = true;
     }
 
-    // set expiresAt based on the ttl
-    if (atMetaData.ttl != null && atMetaData.ttl! >= 0) {
+    // set expiresAt based on the ttl — an asserted expiresAt wins over
+    // the derivation at this write (ttl itself is still stored)
+    if (asserted?.expiresAt != null) {
+      atMetaData.expiresAt = asserted!.expiresAt;
+    } else if (atMetaData.ttl != null && atMetaData.ttl! >= 0) {
       setTTL(atMetaData.ttl, ttb: atMetaData.ttb);
     }
-    // set availableAt based on the ttb
-    if (atMetaData.ttb != null && atMetaData.ttb! >= 0) {
+    // set availableAt based on the ttb — same assertion-wins rule
+    if (asserted?.availableAt != null) {
+      atMetaData.availableAt = asserted!.availableAt;
+    } else if (atMetaData.ttb != null && atMetaData.ttb! >= 0) {
       setTTB(atMetaData.ttb);
     }
     // Set refreshAt based on the TTR

--- a/packages/at_persistence_secondary_server/lib/src/spec/keystore/at_metadata_builder.dart
+++ b/packages/at_persistence_secondary_server/lib/src/spec/keystore/at_metadata_builder.dart
@@ -28,7 +28,19 @@ class AtMetadataBuilder {
   ///     suppressing the ttl/ttb derivation that would otherwise recompute
   ///     it from now — that derivation is exactly what a faithful transfer
   ///     must avoid, since it would restart the expiry clock on arrival.
-  ///     A later write without an assertion derives from ttl/ttb as usual.
+  ///     A later write that supplies a ttl/ttb without an assertion
+  ///     derives from now as usual. A caller that wants a write to leave
+  ///     an expiry axis untouched carries the record's stored absolute
+  ///     forward as an assertion — that is how the update verbs keep a
+  ///     write that says nothing about expiry from restarting the expiry
+  ///     clock.
+  ///
+  /// The inverse derivation also holds, on the caller's request: when
+  /// [asserted] carries `deriveTtl`/`deriveTtb` (set by callers whose own
+  /// request supplied the absolute without its relative), the ttl/ttb the
+  /// asserted absolute implies is derived and stored, replacing whatever
+  /// retained or coerced relative the write's metadata carries. See the
+  /// derivation block in the constructor body for the formulas.
   AtMetadataBuilder({
     required String atSign,
     required AtMetaData? newAtMetaData,
@@ -92,11 +104,21 @@ class AtMetadataBuilder {
     }
 
     // set expiresAt based on the ttl — an asserted expiresAt wins over
-    // the derivation at this write (ttl itself is still stored)
+    // the derivation at this write (the write's ttl, if any, is still
+    // stored unless the caller asked for a derivation below)
     if (asserted?.expiresAt != null) {
       atMetaData.expiresAt = asserted!.expiresAt;
     } else if (atMetaData.ttl != null && atMetaData.ttl! >= 0) {
-      setTTL(atMetaData.ttl, ttb: atMetaData.ttb);
+      // The ttb offset (forward: expiresAt = now + ttb + ttl, a record
+      // lives ttl ms from when it becomes available) applies only when
+      // this same write is re-deriving the birth window too. When an
+      // asserted availableAt pins the birth (a caller assertion, or the
+      // update verbs' expiry-silent carry), folding the metadata's ttb in
+      // would stretch the lifetime by a birth delay that is not
+      // restarting: a ttl-only write on a born record must expire at
+      // now + ttl exactly.
+      setTTL(atMetaData.ttl,
+          ttb: asserted?.availableAt == null ? atMetaData.ttb : null);
     }
     // set availableAt based on the ttb — same assertion-wins rule
     if (asserted?.availableAt != null) {
@@ -104,6 +126,46 @@ class AtMetadataBuilder {
     } else if (atMetaData.ttb != null && atMetaData.ttb! >= 0) {
       setTTB(atMetaData.ttb);
     }
+
+    // A record stored with an asserted absolute also carries the relative
+    // it implies — when the caller ASKED for that, via deriveTtb/deriveTtl
+    // (set when the caller's own request supplied the absolute without the
+    // relative; only the caller can tell, because a caller-supplied ttl
+    // and one retained from the stored record or coerced from an absent
+    // field are indistinguishable here). The derivation happens once, at
+    // this write; reads return the stored values verbatim and never
+    // recompute. It REPLACES whatever ttl/ttb the write's metadata
+    // carries — that value is retained or coerced, not the caller's. The
+    // formulas invert setTTB/setTTL's forward derivations, computed from
+    // the ASSERTED absolutes only (never from an availableAt that
+    // setTTB(0) manufactured from this server's clock three lines up):
+    // ttb spans updatedAt→availableAt, and ttl spans birth→expiresAt,
+    // where birth is the asserted availableAt when that lies ahead of
+    // updatedAt. Measuring from the stored updatedAt rather than this
+    // server's clock makes the result reproducible: a faithful transfer
+    // asserting uAt derives the same ttl on every server. A non-positive
+    // result clears the relative instead (null, never 0 — ttl 0 would
+    // mean "never expires"): the record is simply already available /
+    // already expired, and a retained relative would contradict the
+    // asserted absolute.
+    if (asserted != null) {
+      final updatedAt = atMetaData.updatedAt!;
+      if (asserted.deriveTtb && asserted.availableAt != null) {
+        final ttb =
+            asserted.availableAt!.difference(updatedAt).inMilliseconds;
+        atMetaData.ttb = ttb > 0 ? ttb : null;
+      }
+      if (asserted.deriveTtl && asserted.expiresAt != null) {
+        final assertedAvailableAt = asserted.availableAt;
+        final birth = (assertedAvailableAt != null &&
+                assertedAvailableAt.isAfter(updatedAt))
+            ? assertedAvailableAt
+            : updatedAt;
+        final ttl = asserted.expiresAt!.difference(birth).inMilliseconds;
+        atMetaData.ttl = ttl > 0 ? ttl : null;
+      }
+    }
+
     // Set refreshAt based on the TTR
     if (atMetaData.ttr != null && atMetaData.ttr! > 0 || atMetaData.ttr == -1) {
       setTTR(atMetaData.ttr);

--- a/packages/at_persistence_secondary_server/lib/src/spec/keystore/at_metadata_builder.dart
+++ b/packages/at_persistence_secondary_server/lib/src/spec/keystore/at_metadata_builder.dart
@@ -67,7 +67,7 @@ class AtMetadataBuilder {
     // to do.
     //
     // No update or update:meta arrives here with an immutable record. Both
-    // share AbstractUpdateVerbHandler.preProcessAndNotify, which refuses one
+    // share AbstractUpdateVerbHandler.preProcess, which refuses one
     // outright ('Immutable records may not be updated'). That stays true for an
     // EXPIRED immutable record, but for the opposite reason: such a record is
     // deleted before the write, so this builder is handed existingMetaData ==

--- a/packages/at_persistence_secondary_server/lib/src/spec/spec.dart
+++ b/packages/at_persistence_secondary_server/lib/src/spec/spec.dart
@@ -21,6 +21,7 @@ export 'keystore/keystore_stats.dart';
 export 'keystore/keystore_txn.dart';
 export 'keystore/order_by_key.dart';
 export 'keystore/predicate.dart';
+export 'keystore/at_asserted_timestamps.dart';
 export 'keystore/at_keyvalue_store.dart';
 export 'keystore/at_data.dart';
 export 'keystore/at_meta_data.dart';

--- a/packages/at_persistence_secondary_server/pubspec.yaml
+++ b/packages/at_persistence_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_persistence_secondary_server
 description: A Dart library with the implementation classes for the persistence layer of the secondary server.
-version: 5.2.1
+version: 5.3.0
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://docs.atsign.com/
 

--- a/packages/at_persistence_secondary_server/test/asserted_timestamps_test.dart
+++ b/packages/at_persistence_secondary_server/test/asserted_timestamps_test.dart
@@ -1,0 +1,253 @@
+import 'dart:io';
+
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_persistence_secondary_server/hive.dart';
+import 'package:at_persistence_secondary_server/sqlite.dart';
+import 'package:test/test.dart';
+
+/// Caller-asserted timestamps ([AtAssertedTimestamps]) through the metadata
+/// builder and both keystore backends: an asserted value is stored
+/// faithfully; an absent one leaves every derivation exactly as it was.
+void main() {
+  final cAt = DateTime.utc(2020, 1, 2, 3, 4, 5, 678);
+  final uAt = DateTime.utc(2021, 2, 3, 4, 5, 6, 789);
+  final aAt = DateTime.utc(2022, 3, 4, 5, 6, 7, 890);
+
+  group('AtMetadataBuilder with asserted timestamps', () {
+    test('asserted createdAt wins over an existing record\'s createdAt', () {
+      final existing = AtMetaData()..createdAt = DateTime.utc(2019, 6, 1);
+      final built = AtMetadataBuilder(
+        atSign: '@alice',
+        newAtMetaData: AtMetaData(),
+        existingMetaData: existing,
+        asserted: AtAssertedTimestamps(createdAt: cAt),
+      ).build();
+      expect(built.createdAt, cAt,
+          reason: 'an explicit cAt assertion overwrites stored createdAt');
+    });
+
+    test('without an assertion, existing createdAt is preserved', () {
+      final existing = AtMetaData()..createdAt = DateTime.utc(2019, 6, 1);
+      final built = AtMetadataBuilder(
+        atSign: '@alice',
+        newAtMetaData: AtMetaData(),
+        existingMetaData: existing,
+      ).build();
+      expect(built.createdAt, DateTime.utc(2019, 6, 1));
+    });
+
+    test('asserted updatedAt wins; absent means stamped now', () {
+      final before = DateTime.now().toUtcMillisecondsPrecision();
+      final asserted = AtMetadataBuilder(
+        atSign: '@alice',
+        newAtMetaData: AtMetaData(),
+        asserted: AtAssertedTimestamps(updatedAt: uAt),
+      ).build();
+      expect(asserted.updatedAt, uAt);
+
+      final stamped = AtMetadataBuilder(
+        atSign: '@alice',
+        newAtMetaData: AtMetaData(),
+      ).build();
+      final after = DateTime.now().toUtcMillisecondsPrecision();
+      expect(stamped.updatedAt!.isBefore(before), isFalse);
+      expect(stamped.updatedAt!.isAfter(after), isFalse);
+    });
+
+    test('asserted expiresAt suppresses the ttl derivation at this write', () {
+      final eAt = DateTime.utc(2030, 1, 1);
+      final built = AtMetadataBuilder(
+        atSign: '@alice',
+        newAtMetaData: AtMetaData()..ttl = 60000,
+        asserted: AtAssertedTimestamps(expiresAt: eAt),
+      ).build();
+      expect(built.expiresAt, eAt,
+          reason: 'derivation from ttl would restart the expiry clock, which '
+              'is exactly what a faithful transfer must avoid');
+      expect(built.ttl, 60000, reason: 'ttl itself is still stored');
+    });
+
+    test('asserted expiresAt survives ttl:0 (which otherwise clears expiry)',
+        () {
+      final eAt = DateTime.utc(2030, 1, 1);
+      final built = AtMetadataBuilder(
+        atSign: '@alice',
+        newAtMetaData: AtMetaData()..ttl = 0,
+        asserted: AtAssertedTimestamps(expiresAt: eAt),
+      ).build();
+      expect(built.expiresAt, eAt);
+
+      final cleared = AtMetadataBuilder(
+        atSign: '@alice',
+        newAtMetaData: AtMetaData()..ttl = 0,
+      ).build();
+      expect(cleared.expiresAt, isNull,
+          reason: 'without an assertion ttl:0 still clears expiry');
+    });
+
+    test('asserted availableAt suppresses the ttb derivation at this write',
+        () {
+      final built = AtMetadataBuilder(
+        atSign: '@alice',
+        newAtMetaData: AtMetaData()..ttb = 60000,
+        asserted: AtAssertedTimestamps(availableAt: aAt),
+      ).build();
+      expect(built.availableAt, aAt);
+      expect(built.ttb, 60000);
+    });
+
+    test('assertions are truncated to millisecond precision', () {
+      final micros = DateTime.utc(2020, 1, 2, 3, 4, 5, 678, 901);
+      final t = AtAssertedTimestamps(
+          createdAt: micros,
+          updatedAt: micros,
+          expiresAt: micros,
+          availableAt: micros);
+      final expected = DateTime.utc(2020, 1, 2, 3, 4, 5, 678);
+      expect(t.createdAt, expected);
+      expect(t.updatedAt, expected);
+      expect(t.expiresAt, expected);
+      expect(t.availableAt, expected);
+    });
+  });
+
+  for (final backend in ['hive', 'sqlite']) {
+    group('$backend keystore with asserted timestamps', () {
+      late Directory tempDir;
+      late AtPersistenceFactory factory;
+      late AtKeyValueStore<String, AtData, AtMetaData?> keyStore;
+
+      setUp(() async {
+        tempDir = await Directory.systemTemp.createTemp('asserted_ts_');
+        final AtPersistenceBundle bundle;
+        if (backend == 'hive') {
+          factory = HiveAtPersistenceFactory();
+          bundle = await factory.initialize(
+            '@alice',
+            HivePersistenceConfig.serverDefaults(
+              storagePath: '${tempDir.path}/hive',
+              commitLogPath: '${tempDir.path}/commitLog',
+              accessLogPath: '${tempDir.path}/accessLog',
+              notificationStoragePath: '${tempDir.path}/notification',
+            ),
+          );
+        } else {
+          factory = SqliteAtPersistenceFactory();
+          bundle = await factory.initialize(
+            '@alice',
+            SqlitePersistenceConfig.serverDefaults(
+                storagePath: '${tempDir.path}/sqlite'),
+          );
+        }
+        keyStore = bundle.keyValueStore;
+      });
+
+      tearDown(() async {
+        await factory.close();
+        if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+      });
+
+      test('put stores asserted createdAt/updatedAt faithfully', () async {
+        await keyStore.put('phone.wavi@alice', AtData()..data = 'v1',
+            assertedTimestamps:
+                AtAssertedTimestamps(createdAt: cAt, updatedAt: uAt));
+        final meta = await keyStore.getMeta('phone.wavi@alice');
+        expect(meta!.createdAt, cAt);
+        expect(meta.updatedAt, uAt);
+      });
+
+      test('asserted createdAt overwrites an existing record\'s createdAt',
+          () async {
+        await keyStore.put('phone.wavi@alice', AtData()..data = 'v1');
+        final original = (await keyStore.getMeta('phone.wavi@alice'))!;
+        expect(original.createdAt, isNot(cAt));
+
+        await keyStore.put('phone.wavi@alice', AtData()..data = 'v2',
+            assertedTimestamps: AtAssertedTimestamps(createdAt: cAt));
+        final meta = (await keyStore.getMeta('phone.wavi@alice'))!;
+        expect(meta.createdAt, cAt);
+      });
+
+      test('without assertions an update keeps createdAt and re-stamps '
+          'updatedAt', () async {
+        await keyStore.put('phone.wavi@alice', AtData()..data = 'v1',
+            assertedTimestamps:
+                AtAssertedTimestamps(createdAt: cAt, updatedAt: uAt));
+        final before = DateTime.now().toUtcMillisecondsPrecision();
+        await keyStore.put('phone.wavi@alice', AtData()..data = 'v2');
+        final meta = (await keyStore.getMeta('phone.wavi@alice'))!;
+        expect(meta.createdAt, cAt,
+            reason: 'createdAt is preserved from the existing record');
+        expect(meta.updatedAt!.isBefore(before), isFalse,
+            reason: 'updatedAt is re-stamped when not asserted');
+      });
+
+      test('asserted expiresAt beats ttl derivation; a later ttl write '
+          're-derives', () async {
+        final eAt = DateTime.now()
+            .add(Duration(days: 30))
+            .toUtcMillisecondsPrecision();
+        await keyStore.put(
+            'phone.wavi@alice', AtData()..data = 'v1'..metaData = (AtMetaData()..ttl = 86400000),
+            assertedTimestamps: AtAssertedTimestamps(expiresAt: eAt));
+        var meta = (await keyStore.getMeta('phone.wavi@alice'))!;
+        expect(meta.expiresAt, eAt);
+        expect(meta.ttl, 86400000);
+
+        // A later write that supplies ttl WITHOUT an assertion derives
+        // from now as always.
+        final before = DateTime.now().toUtcMillisecondsPrecision();
+        await keyStore.put('phone.wavi@alice',
+            AtData()..data = 'v2'..metaData = (AtMetaData()..ttl = 86400000));
+        meta = (await keyStore.getMeta('phone.wavi@alice'))!;
+        expect(meta.expiresAt, isNot(eAt));
+        expect(meta.expiresAt!.isAfter(before), isTrue);
+      });
+
+      test('a record with asserted expiresAt and no ttl actually expires',
+          () async {
+        final eAt = DateTime.now().add(Duration(milliseconds: 150));
+        await keyStore.put('otp.wavi@alice', AtData()..data = 'v1',
+            assertedTimestamps: AtAssertedTimestamps(expiresAt: eAt));
+        expect(await keyStore.exists('otp.wavi@alice'), isTrue);
+        expect(await keyStore.nextExpiresAt(), isNotNull,
+            reason: 'the expiry machinery must see an asserted expiresAt '
+                'even though no ttl is set — otherwise the key is immortal');
+
+        await Future.delayed(Duration(milliseconds: 300));
+        final expired = await (await keyStore.getExpiredKeys()).toList();
+        expect(expired, contains('otp.wavi@alice'),
+            reason: 'the expiry sweep must include a key whose only expiry '
+                'signal is an asserted expiresAt');
+        await keyStore.deleteExpiredKeys();
+        expect(await keyStore.exists('otp.wavi@alice'), isFalse);
+      });
+
+      test('asserted availableAt is stored faithfully', () async {
+        await keyStore.put('phone.wavi@alice', AtData()..data = 'v1',
+            assertedTimestamps: AtAssertedTimestamps(availableAt: aAt));
+        final meta = (await keyStore.getMeta('phone.wavi@alice'))!;
+        expect(meta.availableAt, aAt);
+      });
+
+      test('putMeta stores asserted timestamps faithfully', () async {
+        await keyStore.put('phone.wavi@alice', AtData()..data = 'v1');
+        await keyStore.putMeta('phone.wavi@alice', AtMetaData(),
+            assertedTimestamps:
+                AtAssertedTimestamps(createdAt: cAt, updatedAt: uAt));
+        final meta = (await keyStore.getMeta('phone.wavi@alice'))!;
+        expect(meta.createdAt, cAt);
+        expect(meta.updatedAt, uAt);
+      });
+
+      test('create stores asserted timestamps faithfully', () async {
+        await keyStore.create('phone.wavi@alice', AtData()..data = 'v1',
+            assertedTimestamps:
+                AtAssertedTimestamps(createdAt: cAt, updatedAt: uAt));
+        final meta = (await keyStore.getMeta('phone.wavi@alice'))!;
+        expect(meta.createdAt, cAt);
+        expect(meta.updatedAt, uAt);
+      });
+    });
+  }
+}

--- a/packages/at_persistence_secondary_server/test/asserted_timestamps_test.dart
+++ b/packages/at_persistence_secondary_server/test/asserted_timestamps_test.dart
@@ -76,6 +76,20 @@ void main() {
         asserted: AtAssertedTimestamps(expiresAt: eAt),
       ).build();
       expect(built.expiresAt, eAt);
+      expect(built.ttl, 0,
+          reason: 'without deriveTtl the builder must not touch the '
+              'metadata\'s ttl — deciding that a 0 means "unsupplied" is '
+              'the request layer\'s call, made via the deriveTtl flag');
+
+      final derived = AtMetadataBuilder(
+        atSign: '@alice',
+        newAtMetaData: AtMetaData()..ttl = 0,
+        asserted: AtAssertedTimestamps(expiresAt: eAt, deriveTtl: true),
+      ).build();
+      expect(derived.ttl, eAt.difference(derived.updatedAt!).inMilliseconds,
+          reason: 'with deriveTtl (set by the request layer when the json '
+              'path\'s coerced ttl:0 accompanies an asserted expiry) the '
+              'implied ttl replaces the 0');
 
       final cleared = AtMetadataBuilder(
         atSign: '@alice',
@@ -94,6 +108,119 @@ void main() {
       ).build();
       expect(built.availableAt, aAt);
       expect(built.ttb, 60000);
+    });
+
+    test('an asserted expiresAt with deriveTtl derives and stores the ttl '
+        'it implies', () {
+      final eAt = DateTime.utc(2030, 1, 1);
+      final built = AtMetadataBuilder(
+        atSign: '@alice',
+        newAtMetaData: AtMetaData(),
+        asserted: AtAssertedTimestamps(
+            updatedAt: uAt, expiresAt: eAt, deriveTtl: true),
+      ).build();
+      expect(built.expiresAt, eAt);
+      expect(built.ttl, eAt.difference(uAt).inMilliseconds,
+          reason: 'a record with an absolute expiry also carries the ttl it '
+              'implies — measured from the stored updatedAt, so every server '
+              'derives the same value from the same assertions');
+    });
+
+    test('deriveTtl replaces a ttl the write\'s metadata carries', () {
+      // The metadata's ttl may be a stale value the verb layer retained
+      // from the stored record; the caller set deriveTtl because its own
+      // request supplied no ttl, and the derivation must win.
+      final eAt = DateTime.utc(2030, 1, 1);
+      final built = AtMetadataBuilder(
+        atSign: '@alice',
+        newAtMetaData: AtMetaData()..ttl = 86400000,
+        asserted: AtAssertedTimestamps(
+            updatedAt: uAt, expiresAt: eAt, deriveTtl: true),
+      ).build();
+      expect(built.ttl, eAt.difference(uAt).inMilliseconds,
+          reason: 'a stale retained ttl stored beside a fresh asserted '
+              'expiresAt would contradict it, and any consumer re-deriving '
+              'expiry from that ttl would restart the expiry clock');
+    });
+
+    test('an asserted availableAt with deriveTtb derives and stores the ttb '
+        'it implies', () {
+      final built = AtMetadataBuilder(
+        atSign: '@alice',
+        newAtMetaData: AtMetaData(),
+        asserted: AtAssertedTimestamps(
+            updatedAt: uAt, availableAt: aAt, deriveTtb: true),
+      ).build();
+      expect(built.availableAt, aAt);
+      expect(built.ttb, aAt.difference(uAt).inMilliseconds);
+    });
+
+    test('with availableAt and expiresAt both asserted, ttl spans '
+        'birth-to-expiry', () {
+      final eAt = DateTime.utc(2030, 1, 1);
+      final built = AtMetadataBuilder(
+        atSign: '@alice',
+        newAtMetaData: AtMetaData(),
+        asserted: AtAssertedTimestamps(
+            updatedAt: uAt,
+            availableAt: aAt,
+            expiresAt: eAt,
+            deriveTtl: true,
+            deriveTtb: true),
+      ).build();
+      expect(built.ttb, aAt.difference(uAt).inMilliseconds);
+      expect(built.ttl, eAt.difference(aAt).inMilliseconds,
+          reason: 'forward, expiresAt = now + ttb + ttl — a record lives '
+              'ttl ms from when it becomes available — so the inverse '
+              'measures ttl from availableAt');
+    });
+
+    test('the derivation ignores an availableAt that setTTB(0) manufactured',
+        () {
+      // A coerced ttb:0 (how "no ttb" arrives from update:json and from
+      // the notify wire layer) makes setTTB stamp availableAt to this
+      // server's clock. That manufactured availableAt is NOT an asserted
+      // birth: it must neither become the base of the ttl derivation
+      // (which would store expiresAt - arrival-time instead of the
+      // reproducible expiresAt - updatedAt) nor spawn a fabricated ttb.
+      final eAt = DateTime.utc(2030, 1, 1);
+      final built = AtMetadataBuilder(
+        atSign: '@alice',
+        newAtMetaData: AtMetaData()..ttb = 0,
+        asserted: AtAssertedTimestamps(
+            updatedAt: uAt, expiresAt: eAt, deriveTtl: true),
+      ).build();
+      expect(built.ttl, eAt.difference(uAt).inMilliseconds,
+          reason: 'the ttl derivation must measure from the asserted '
+              'updatedAt, not from the availableAt setTTB(0) stamped from '
+              'this server\'s clock');
+      expect(built.ttb, 0,
+          reason: 'no aAt was asserted and deriveTtb was not requested, so '
+              'the ttb must stay exactly as the metadata carried it — a '
+              'positive ttb here would be fabricated from transfer latency');
+    });
+
+    test('a non-positive derived ttl/ttb clears the relative', () {
+      // updatedAt asserted at-or-after the absolutes — e.g. a transfer
+      // from a server whose clock runs ahead. The absolutes are stored
+      // faithfully; the implied relatives are non-positive, and a ttl of 0
+      // would mean "never expires", so the relatives are cleared to null
+      // (a retained value would contradict the asserted absolute).
+      final past = DateTime.utc(2019, 1, 1);
+      final built = AtMetadataBuilder(
+        atSign: '@alice',
+        newAtMetaData: AtMetaData()..ttl = 86400000,
+        asserted: AtAssertedTimestamps(
+            updatedAt: uAt,
+            availableAt: past,
+            expiresAt: past,
+            deriveTtl: true,
+            deriveTtb: true),
+      ).build();
+      expect(built.expiresAt, past);
+      expect(built.availableAt, past);
+      expect(built.ttl, isNull);
+      expect(built.ttb, isNull);
     });
 
     test('assertions are truncated to millisecond precision', () {
@@ -204,11 +331,35 @@ void main() {
         expect(meta.expiresAt!.isAfter(before), isTrue);
       });
 
+      test('put with asserted expiresAt and deriveTtl stores the derived ttl',
+          () async {
+        final eAt = DateTime.utc(2030, 1, 1);
+        await keyStore.put('phone.wavi@alice', AtData()..data = 'v1',
+            assertedTimestamps: AtAssertedTimestamps(
+                updatedAt: uAt, expiresAt: eAt, deriveTtl: true));
+        final meta = (await keyStore.getMeta('phone.wavi@alice'))!;
+        expect(meta.expiresAt, eAt);
+        expect(meta.ttl, eAt.difference(uAt).inMilliseconds);
+      });
+
       test('a record with asserted expiresAt and no ttl actually expires',
           () async {
+        // The only reachable expiresAt-without-ttl state: the implied ttl
+        // is non-positive (updatedAt asserted at-or-after expiresAt — a
+        // transfer from a clock that runs ahead), so the derivation clears
+        // it. The expiry machinery must still see such a record —
+        // otherwise it is immortal.
         final eAt = DateTime.now().add(Duration(milliseconds: 150));
         await keyStore.put('otp.wavi@alice', AtData()..data = 'v1',
-            assertedTimestamps: AtAssertedTimestamps(expiresAt: eAt));
+            assertedTimestamps: AtAssertedTimestamps(
+                updatedAt: DateTime.now().add(Duration(seconds: 10)),
+                expiresAt: eAt,
+                deriveTtl: true));
+        final meta = (await keyStore.getMeta('otp.wavi@alice'))!;
+        expect(meta.ttl, isNull,
+            reason: 'this test exists to cover the expiresAt-without-ttl '
+                'state; if a ttl were derived here, the expiry cache could '
+                'be seeing the ttl rather than the asserted expiresAt');
         expect(await keyStore.exists('otp.wavi@alice'), isTrue);
         expect(await keyStore.nextExpiresAt(), isNotNull,
             reason: 'the expiry machinery must see an asserted expiresAt '

--- a/packages/at_persistence_secondary_server/test/commit_log_nc_primitives_test.dart
+++ b/packages/at_persistence_secondary_server/test/commit_log_nc_primitives_test.dart
@@ -1,0 +1,200 @@
+import 'dart:io';
+
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_persistence_secondary_server/hive.dart';
+import 'package:at_persistence_secondary_server/sqlite.dart';
+import 'package:test/test.dart';
+
+/// The commit-log primitives behind the protocol's `:nc` (no-commit) flag and
+/// `:dAt`/`:uAt` operation times:
+///
+///   * every write path with `skipCommit: true` (put / create / putMeta /
+///     remove / removeMany) writes no commit entry AND purges the key's
+///     existing entry — [AtCommitLog.removeEntryFor];
+///   * `commit(..., opTime:)` records a caller-asserted operation time on the
+///     entry, threaded from `remove(deletedAt:)` and from an asserted
+///     `updatedAt` on the update paths.
+///
+/// Runs identically against both backends, except where a pinned divergence
+/// says otherwise.
+void main() {
+  for (final backend in ['hive', 'sqlite']) {
+    group('$backend skipCommit purge + opTime', () {
+      late Directory tempDir;
+      late AtPersistenceFactory factory;
+      late AtKeyValueStore<String, AtData, AtMetaData?> keyStore;
+      late AtCommitLog commitLog;
+
+      setUp(() async {
+        tempDir = await Directory.systemTemp.createTemp('nc_primitives_');
+        final AtPersistenceBundle bundle;
+        if (backend == 'hive') {
+          factory = HiveAtPersistenceFactory();
+          bundle = await factory.initialize(
+            '@alice',
+            HivePersistenceConfig.serverDefaults(
+              storagePath: '${tempDir.path}/hive',
+              commitLogPath: '${tempDir.path}/commitLog',
+              accessLogPath: '${tempDir.path}/accessLog',
+              notificationStoragePath: '${tempDir.path}/notification',
+            ),
+          );
+        } else {
+          factory = SqliteAtPersistenceFactory();
+          bundle = await factory.initialize(
+            '@alice',
+            SqlitePersistenceConfig.serverDefaults(
+                storagePath: '${tempDir.path}/sqlite'),
+          );
+        }
+        keyStore = bundle.keyValueStore;
+        commitLog = keyStore.commitLog!;
+      });
+
+      tearDown(() async {
+        await factory.close();
+        if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+      });
+
+      test('put with skipCommit purges the existing commit entry and '
+          'returns -1', () async {
+        await keyStore.put('phone.wavi@alice', AtData()..data = 'v1');
+        expect(commitLog.getLatestCommitEntry('phone.wavi@alice'), isNotNull);
+
+        final result = await keyStore.put(
+            'phone.wavi@alice', AtData()..data = 'v2',
+            skipCommit: true);
+        expect(result, -1);
+        expect(commitLog.getLatestCommitEntry('phone.wavi@alice'), isNull,
+            reason: 'a no-commit write scrubs the key\'s previous entry — '
+                'sync must not serve a stale entry for a record whose '
+                'latest change was deliberately uncommitted');
+        expect((await keyStore.get('phone.wavi@alice'))!.data, 'v2',
+            reason: 'the write itself still happens');
+      });
+
+      test('create with skipCommit purges the DELETE entry left by an '
+          'earlier remove', () async {
+        await keyStore.put('phone.wavi@alice', AtData()..data = 'v1');
+        await keyStore.remove('phone.wavi@alice');
+        expect(commitLog.getLatestCommitEntry('phone.wavi@alice')!.operation,
+            CommitOp.DELETE);
+
+        final result = await keyStore.create(
+            'phone.wavi@alice', AtData()..data = 'v2',
+            skipCommit: true);
+        expect(result, -1);
+        expect(commitLog.getLatestCommitEntry('phone.wavi@alice'), isNull);
+      });
+
+      test('putMeta with skipCommit purges and returns -1', () async {
+        await keyStore.put('phone.wavi@alice', AtData()..data = 'v1');
+        expect(commitLog.getLatestCommitEntry('phone.wavi@alice'), isNotNull);
+
+        final result = await keyStore.putMeta(
+            'phone.wavi@alice', AtMetaData()..ttl = 60000,
+            skipCommit: true);
+        expect(result, -1);
+        expect(commitLog.getLatestCommitEntry('phone.wavi@alice'), isNull);
+        expect((await keyStore.getMeta('phone.wavi@alice'))!.ttl, 60000,
+            reason: 'the metadata write itself still happens');
+      });
+
+      test('remove with skipCommit purges even when the key is already gone',
+          () async {
+        // The cruft case: a commit entry for a key that no longer exists.
+        await keyStore.put('phone.wavi@alice', AtData()..data = 'v1');
+        await keyStore.remove('phone.wavi@alice');
+        expect(commitLog.getLatestCommitEntry('phone.wavi@alice'), isNotNull,
+            reason: 'a normal delete leaves a DELETE entry (the cruft)');
+
+        final result =
+            await keyStore.remove('phone.wavi@alice', skipCommit: true);
+        expect(result, -1);
+        expect(commitLog.getLatestCommitEntry('phone.wavi@alice'), isNull,
+            reason: 'no-commit delete of an already-deleted key must still '
+                'purge the entry — that is the whole point of commit-log '
+                'cruft management');
+      });
+
+      test('removeMany with skipCommit purges every key\'s entry', () async {
+        await keyStore.put('a.wavi@alice', AtData()..data = '1');
+        await keyStore.put('b.wavi@alice', AtData()..data = '2');
+        await keyStore.put('c.wavi@alice', AtData()..data = '3');
+
+        await keyStore.removeMany(['a.wavi@alice', 'b.wavi@alice'],
+            skipCommit: true);
+        expect(commitLog.getLatestCommitEntry('a.wavi@alice'), isNull);
+        expect(commitLog.getLatestCommitEntry('b.wavi@alice'), isNull);
+        expect(commitLog.getLatestCommitEntry('c.wavi@alice'), isNotNull,
+            reason: 'an untouched key keeps its entry');
+      });
+
+      test('removeEntryFor removes at most one entry and tolerates absence',
+          () async {
+        await keyStore.put('phone.wavi@alice', AtData()..data = 'v1');
+        await keyStore.put('other.wavi@alice', AtData()..data = 'v2');
+        final countBefore = commitLog.entriesCount();
+
+        await commitLog.removeEntryFor('phone.wavi@alice');
+        expect(commitLog.getLatestCommitEntry('phone.wavi@alice'), isNull);
+        expect(commitLog.getLatestCommitEntry('other.wavi@alice'), isNotNull);
+        expect(commitLog.entriesCount(), countBefore - 1);
+
+        // Removing a nonexistent entry is not an error.
+        await commitLog.removeEntryFor('phone.wavi@alice');
+        expect(commitLog.entriesCount(), countBefore - 1);
+      });
+
+      test('lastCommittedSequenceNumber after purging the newest entry: '
+          'pinned per-backend divergence', () async {
+        final id1 = await keyStore.put('a.wavi@alice', AtData()..data = '1');
+        final id2 = await keyStore.put('b.wavi@alice', AtData()..data = '2');
+        expect(id2! > id1!, isTrue);
+        expect(commitLog.lastCommittedSequenceNumber(), id2);
+
+        await commitLog.removeEntryFor('b.wavi@alice');
+        if (backend == 'hive') {
+          expect(commitLog.lastCommittedSequenceNumber(), id2,
+              reason: 'Hive\'s latestCommitId is monotonic and never '
+                  'decremented on purge — a phantom id pointing at a purged '
+                  'entry is tolerated by sync (gaps are routine) and a '
+                  'client syncing from it simply receives nothing');
+        } else {
+          expect(commitLog.lastCommittedSequenceNumber(), id1,
+              reason: 'SQLite answers MAX(commit_id) from the table, so '
+                  'purging the newest entry lowers the reported ceiling');
+        }
+      });
+
+      test('remove(deletedAt:) records the asserted time as the DELETE '
+          'entry\'s opTime', () async {
+        final dAt = DateTime.utc(2023, 5, 5, 11, 59, 44, 123);
+        await keyStore.put('phone.wavi@alice', AtData()..data = 'v1');
+        await keyStore.remove('phone.wavi@alice', deletedAt: dAt);
+        final entry = commitLog.getLatestCommitEntry('phone.wavi@alice')!;
+        expect(entry.operation, CommitOp.DELETE);
+        expect(entry.opTime, dAt);
+      });
+
+      test('put with asserted updatedAt records it as the entry\'s opTime',
+          () async {
+        final uAt = DateTime.utc(2023, 6, 6, 10, 30, 0, 500);
+        await keyStore.put('phone.wavi@alice', AtData()..data = 'v1',
+            assertedTimestamps: AtAssertedTimestamps(updatedAt: uAt));
+        final entry = commitLog.getLatestCommitEntry('phone.wavi@alice')!;
+        expect(entry.opTime, uAt);
+      });
+
+      test('without an asserted time, opTime is stamped now', () async {
+        final before = DateTime.now().toUtcMillisecondsPrecision();
+        await keyStore.put('phone.wavi@alice', AtData()..data = 'v1');
+        final after = DateTime.now().toUtcMillisecondsPrecision();
+        final opTime =
+            commitLog.getLatestCommitEntry('phone.wavi@alice')!.opTime!;
+        expect(opTime.isBefore(before), isFalse);
+        expect(opTime.isAfter(after), isFalse);
+      });
+    });
+  }
+}

--- a/packages/at_persistence_secondary_server/test/dual_write_test.dart
+++ b/packages/at_persistence_secondary_server/test/dual_write_test.dart
@@ -64,6 +64,29 @@ void main() {
     await ks.create('bye.wavi$atSign', d('later'));
     await ks.remove('bye.wavi$atSign');
 
+    // Caller-asserted timestamps and opTimes must mirror byte-exactly.
+    await ks.create('faithful.wavi$atSign', d('x'),
+        assertedTimestamps: AtAssertedTimestamps(
+            createdAt: DateTime.utc(2020, 1, 2, 3, 4, 5, 678),
+            updatedAt: DateTime.utc(2021, 2, 3, 4, 5, 6, 789),
+            expiresAt: DateTime.utc(2030, 1, 1)));
+    await ks.create('dat.wavi$atSign', d('y'));
+    await ks.remove('dat.wavi$atSign',
+        deletedAt: DateTime.utc(2023, 5, 5, 11, 59, 44, 123));
+
+    // A skipCommit write purges the key's commit entry while the key lives
+    // on (the update:nc shape); the mirror must purge the secondary's stale
+    // entry too — "same commit entry, or same absence".
+    await ks.create('quiet.wavi$atSign', d('v1'));
+    await ks.put('quiet.wavi$atSign', d('v2'), skipCommit: true);
+    expect(
+        bundle.secondary.keyValueStore.commitLog!
+            .getLatestCommitEntry('quiet.wavi$atSign'),
+        isNull,
+        reason: 'a skipCommit write purged the primary\'s commit entry; a '
+            'stale secondary entry would resurface in sync after a '
+            'backend switch');
+
     // Expired TTL key swept via deleteExpiredKeys.
     await ks.restore(
         'exp.wavi$atSign',

--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -14,6 +14,18 @@
   - `delete:dAt` — recorded as the DELETE commit entry's opTime. Works with
     `:nc` for commit-log cruft management: a `delete:nc` of a key that no
     longer exists still purges the key's leftover entry.
+- feat: server-to-server faithfulness for the four timestamps (#2678):
+  outbound notifications emit `:cAt`/`:uAt`/`:eAt`/`:aAt` from the
+  notification's metadata (for auto-notifications, the STORED record's
+  values); a delete auto-notification carries its deletion time as `:uAt`
+  and deliberately nothing else (deployed receivers default an absent
+  isEncrypted to true for non-public keys). The receiving side stores
+  cached keys with the transmitted origin timestamps — on first cache and
+  on every refresh — and records a transmitted deletion time as the cached
+  key's DELETE commit entry opTime. The lookup-driven cache does the same
+  for data keys; `cached:public:publickey@` keeps its own createdAt
+  semantics (it records when THIS server learned of a changed key — the
+  signal PK-change handling is built on).
 - fix: the update/update:meta auto-notification is queued AFTER the
   keystore write, carrying the metadata that was actually stored — the old
   order transmitted pre-merge values (e.g. a freshly-fabricated createdAt

--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -25,22 +25,39 @@
   degrade to a plain remote scan.
 - feat: server-to-server faithfulness for the four timestamps (#2678):
   outbound notifications emit `:cAt`/`:uAt`/`:eAt`/`:aAt` from the
-  notification's metadata (for auto-notifications, the STORED record's
-  values); a delete auto-notification carries its deletion time as `:uAt`
-  and deliberately nothing else (deployed receivers default an absent
-  isEncrypted to true for non-public keys). The receiving side stores
-  cached keys with the transmitted origin timestamps — on first cache and
-  on every refresh — and records a transmitted deletion time as the cached
-  key's DELETE commit entry opTime. The lookup-driven cache does the same
-  for data keys; `cached:public:publickey@` keeps its own createdAt
-  semantics (it records when THIS server learned of a changed key — the
-  signal PK-change handling is built on).
+  notification's metadata — for update auto-notifications, the STORED
+  record's values, so every update auto-notification now carries `:cAt`
+  and `:uAt` on the wire. NOTE: an atServer built with at_commons older
+  than 5.10.0 (before 2026-05-12; releases ≤ c3.12.0 built before then)
+  rejects that shape outright — its notify grammar has no timestamp
+  groups — so auto-notifications from an upgraded sender to such a server
+  fail and retry until they expire; the receiver must upgrade. A delete
+  auto-notification attaches metadata ONLY when the client asserted
+  `:dAt` (emitted as `:uAt`); an ordinary delete's wire shape is
+  byte-identical to before, and client-issued `notify:delete` /
+  `notify:all:delete` metadata still goes on the wire exactly as it
+  always has. The receiving side stores cached keys with the transmitted
+  origin timestamps — on first cache and on every refresh — and records a
+  transmitted deletion time as the cached key's DELETE commit entry
+  opTime. The lookup-driven cache does the same for data keys;
+  `cached:public:publickey@` keeps its own createdAt semantics (it
+  records when THIS server learned of a changed key — the signal
+  PK-change handling is built on).
 - fix: the update/update:meta auto-notification is queued AFTER the
   keystore write, carrying the metadata that was actually stored — the old
   order transmitted pre-merge values (e.g. a freshly-fabricated createdAt
   for an existing record) and queued a notification even when the write
-  then failed. A notify-queueing failure after a successful write is logged
-  at warning and does not fail the client's request.
+  then failed. If the record was deleted concurrently before the
+  read-back, the update notification is skipped (at warning) rather than
+  queued after the delete's own notification, which could have
+  resurrected the receiver's cached copy; a transient read-back failure
+  falls back to the written metadata instead. A notify-queueing failure
+  after a successful write is logged at warning and does not fail the
+  client's request.
+- fix: the per-key update mutex is keyed on the lowercased record name.
+  The keystore canonicalizes keys to lowercase, so two case-variants of
+  one update command name the same stored record; keyed on the original
+  case they took different mutexes and raced.
 - fix(at_secondary_server): a closed `NotificationManager` now stops its
 delivery retries.
   - `PerAtSignNotifSender.send()` retries until delivery succeeds or the

--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -4,10 +4,27 @@
   - `:cAt`/`:uAt`/`:eAt`/`:aAt` — caller-asserted
     createdAt/updatedAt/expiresAt/availableAt are stored faithfully instead
     of rederived. An asserted cAt wins on create and update alike; an
-    asserted eAt/aAt suppresses the ttl/ttb derivation for that write only
-    (later writes without an assertion derive as before). Values are
-    truncated to millisecond precision. An asserted updatedAt is also
-    recorded as the commit entry's opTime.
+    asserted eAt/aAt suppresses the ttl/ttb derivation for that write.
+    Values are truncated to millisecond precision. An asserted updatedAt
+    is also recorded as the commit entry's opTime.
+  - a request that supplies an absolute without its relative gets the
+    relative derived and stored: an `:eAt` with no ttl derives the ttl
+    (measured from the stored updatedAt — from the asserted availableAt
+    when that lies ahead — so every server derives the same value from the
+    same assertions), and an `:aAt` with no ttb derives the ttb, in each
+    case replacing any relative retained from the stored record. A
+    supplied 0 counts as unsupplied (the update:json path and the notify
+    receiver coerce an absent ttl/ttb to 0); a non-positive implied value
+    clears the relative instead.
+  - once set, expiresAt/availableAt move only when a request speaks about
+    that axis: an asserted `:eAt`/`:aAt` stores faithfully, an explicit
+    ttl/ttb re-derives from now (a ttl-only write on a record whose birth
+    is pinned expires at exactly now + ttl — the record's retained ttb is
+    no longer folded in), ttl:0 clears the expiry, and ttb:0 re-stamps
+    availableAt to now. A write that says nothing about expiry no longer
+    restarts the expiry clock from the record's retained ttl (and no
+    longer re-opens a ttb record's not-yet-born window) — the update verbs
+    carry the stored absolutes forward as assertions.
   - `:nc` (no-commit) — the operation runs as usual (auto-notification
     included) but writes no commit entry AND purges the key's existing
     entry; the response is `data:-1`.

--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -14,6 +14,15 @@
   - `delete:dAt` — recorded as the DELETE commit entry's opTime. Works with
     `:nc` for commit-log cruft management: a `delete:nc` of a key that no
     longer exists still purges the key's leftover entry.
+- feat: `scan:cl` — scan the commit log instead of the keystore (#2678),
+  so a client can inspect its entries and `delete:nc` the cruft. Returns a
+  JSON array in ascending commitId order of
+  `{"atKey", "operation" (the CommitOp symbol sync uses), "commitId",
+  "opTime" (ISO 8601 UTC)}`; DELETE entries included. Authenticated
+  connections only; the same regex / hidden-key / enrollment-namespace
+  filters as a keystore scan apply. `scan:cl:@other` is refused loudly —
+  the outbound scan proxy cannot forward `:cl`, so it would silently
+  degrade to a plain remote scan.
 - feat: server-to-server faithfulness for the four timestamps (#2678):
   outbound notifications emit `:cAt`/`:uAt`/`:eAt`/`:aAt` from the
   notification's metadata (for auto-notifications, the STORED record's

--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 3.16.2
+# 3.16.3
 - feat: implement the at_commons 5.10.0 protocol enhancements on the
   update/update:meta/update:json/delete surface (#2678):
   - `:cAt`/`:uAt`/`:eAt`/`:aAt` — caller-asserted
@@ -58,6 +58,8 @@
   The keystore canonicalizes keys to lowercase, so two case-variants of
   one update command name the same stored record; keyed on the original
   case they took different mutexes and raced.
+
+# 3.16.2
 - fix(at_secondary_server): a closed `NotificationManager` now stops its
 delivery retries.
   - `PerAtSignNotifSender.send()` retries until delivery succeeds or the

--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,4 +1,25 @@
 # 3.16.2
+- feat: implement the at_commons 5.10.0 protocol enhancements on the
+  update/update:meta/update:json/delete surface (#2678):
+  - `:cAt`/`:uAt`/`:eAt`/`:aAt` — caller-asserted
+    createdAt/updatedAt/expiresAt/availableAt are stored faithfully instead
+    of rederived. An asserted cAt wins on create and update alike; an
+    asserted eAt/aAt suppresses the ttl/ttb derivation for that write only
+    (later writes without an assertion derive as before). Values are
+    truncated to millisecond precision. An asserted updatedAt is also
+    recorded as the commit entry's opTime.
+  - `:nc` (no-commit) — the operation runs as usual (auto-notification
+    included) but writes no commit entry AND purges the key's existing
+    entry; the response is `data:-1`.
+  - `delete:dAt` — recorded as the DELETE commit entry's opTime. Works with
+    `:nc` for commit-log cruft management: a `delete:nc` of a key that no
+    longer exists still purges the key's leftover entry.
+- fix: the update/update:meta auto-notification is queued AFTER the
+  keystore write, carrying the metadata that was actually stored — the old
+  order transmitted pre-merge values (e.g. a freshly-fabricated createdAt
+  for an existing record) and queued a notification even when the write
+  then failed. A notify-queueing failure after a successful write is logged
+  at warning and does not fail the client's request.
 - fix(at_secondary_server): a closed `NotificationManager` now stops its
 delivery retries.
   - `PerAtSignNotifSender.send()` retries until delivery succeeds or the

--- a/packages/at_secondary_server/lib/src/caching/cache_manager.dart
+++ b/packages/at_secondary_server/lib/src/caching/cache_manager.dart
@@ -523,11 +523,18 @@ class AtCacheManager {
             metadata.availableAt == null)) {
       return null;
     }
+    // Derive the relative a remote absolute implies when the remote record
+    // carries none (an older origin that never derived one) — 0 included,
+    // since a 0 beside an absolute is a coercion artefact, not a value.
     return AtAssertedTimestamps(
         createdAt: metadata.createdAt,
         updatedAt: metadata.updatedAt,
         expiresAt: metadata.expiresAt,
-        availableAt: metadata.availableAt);
+        availableAt: metadata.availableAt,
+        deriveTtl: metadata.expiresAt != null &&
+            (metadata.ttl == null || metadata.ttl == 0),
+        deriveTtb: metadata.availableAt != null &&
+            (metadata.ttb == null || metadata.ttb == 0));
   }
 
   /// Does the remote lookup - returns the Atsign Protocol string which it receives

--- a/packages/at_secondary_server/lib/src/caching/cache_manager.dart
+++ b/packages/at_secondary_server/lib/src/caching/cache_manager.dart
@@ -309,7 +309,8 @@ class AtCacheManager {
     }
 
     if (!cachedKeyName.startsWith('cached:public:publickey@')) {
-      await keyStore.put(cachedKeyName, atData);
+      await keyStore.put(cachedKeyName, atData,
+          assertedTimestamps: _assertedFromRemote(atData.metaData));
       if (existingAtData == null) {
         return CacheUpdateResult(
           newEntry: true,
@@ -501,6 +502,32 @@ class AtCacheManager {
     await keyStore.remove(cachedKeyName);
     atData.metaData!.ttr = -1;
     await keyStore.put(cachedKeyName, atData);
+  }
+
+  /// The origin's timestamps as carried on remotely-looked-up [metadata],
+  /// asserted into the cached copy's write so the cache holds the origin's
+  /// createdAt/updatedAt/expiresAt/availableAt rather than values rederived
+  /// on this server's clock at cache time. Null when the remote record
+  /// carries none (the builder then stamps as it always has).
+  ///
+  /// Deliberately NOT used for `cached:public:publickey@` writes
+  /// ([putCachedPublicKey]): that flow re-creates the cached entry on a
+  /// public-key change precisely so its createdAt records when THIS server
+  /// learned of the new key — the signal the PK-change handling is built
+  /// on — and asserting the origin's createdAt would erase it.
+  AtAssertedTimestamps? _assertedFromRemote(AtMetaData? metadata) {
+    if (metadata == null ||
+        (metadata.createdAt == null &&
+            metadata.updatedAt == null &&
+            metadata.expiresAt == null &&
+            metadata.availableAt == null)) {
+      return null;
+    }
+    return AtAssertedTimestamps(
+        createdAt: metadata.createdAt,
+        updatedAt: metadata.updatedAt,
+        expiresAt: metadata.expiresAt,
+        availableAt: metadata.availableAt);
   }
 
   /// Does the remote lookup - returns the Atsign Protocol string which it receives

--- a/packages/at_secondary_server/lib/src/constants/wire_param_names.dart
+++ b/packages/at_secondary_server/lib/src/constants/wire_param_names.dart
@@ -1,0 +1,23 @@
+/// Named-group names from at_commons `VerbSyntax` that have no
+/// `AtConstants` entry. Each string must match its regex group name
+/// exactly — the name is the only link between the grammar and the
+/// handler that reads the parsed param.
+class WireParams {
+  // Don't instantiate.
+  WireParams._();
+
+  /// `:nc` on update / update:meta / update:json / delete.
+  static const String noCommit = 'noCommit';
+
+  /// `:dAt:<ISO 8601 UTC>` on delete.
+  static const String deletedAt = 'deletedAt';
+
+  /// `:eAt:<ISO 8601 UTC>` in the metadata fragment.
+  static const String expiresAt = 'expiresAt';
+
+  /// `:aAt:<ISO 8601 UTC>` in the metadata fragment.
+  static const String availableAt = 'availableAt';
+
+  /// `:cl` on scan.
+  static const String commitLog = 'commitLog';
+}

--- a/packages/at_secondary_server/lib/src/notification/notification_manager_impl.dart
+++ b/packages/at_secondary_server/lib/src/notification/notification_manager_impl.dart
@@ -256,19 +256,15 @@ class NotificationManager {
       commandBody = '$commandBody:${atNotification.atValue}';
     }
     var atMetaData = atNotification.atMetadata;
-    if (atMetaData != null && atNotification.opType == OperationType.delete) {
-      // A delete notification's metadata exists only to carry the deletion
-      // time as :uAt:. Emit nothing else: the receiver treats an ABSENT
-      // isEncrypted as true for non-public keys, and delete notifications
-      // have never carried a metadata fragment, so emitting the usual
-      // unconditional isEncrypted:false here would silently flip that
-      // default on every deployed receiver.
-      if (atMetaData.updatedAt != null) {
-        commandBody = 'uAt:'
-            '${VerbUtil.formatIso8601Micros(atMetaData.updatedAt!)}'
-            ':$commandBody';
-      }
-    } else if (atMetaData != null) {
+    if (atMetaData != null) {
+      // One emission block for every notification that carries metadata —
+      // client-issued delete notifications carry it too (isEncrypted at
+      // minimum, ttr:ccd etc. when supplied) and their wire shape must not
+      // change. The AUTO-delete stays metadata-free unless the client
+      // asserted :dAt (DeleteVerbHandler._notify attaches metadata only
+      // then), so an ordinary delete's wire shape is exactly what it
+      // always was.
+      //
       // appMetadata is the LAST group in VerbSyntax.metadataFragment;
       // since this body is built back-to-front, it is prepended first.
       if (atNotification.atMetadata!.appMetadata != null) {

--- a/packages/at_secondary_server/lib/src/notification/notification_manager_impl.dart
+++ b/packages/at_secondary_server/lib/src/notification/notification_manager_impl.dart
@@ -256,7 +256,19 @@ class NotificationManager {
       commandBody = '$commandBody:${atNotification.atValue}';
     }
     var atMetaData = atNotification.atMetadata;
-    if (atMetaData != null) {
+    if (atMetaData != null && atNotification.opType == OperationType.delete) {
+      // A delete notification's metadata exists only to carry the deletion
+      // time as :uAt:. Emit nothing else: the receiver treats an ABSENT
+      // isEncrypted as true for non-public keys, and delete notifications
+      // have never carried a metadata fragment, so emitting the usual
+      // unconditional isEncrypted:false here would silently flip that
+      // default on every deployed receiver.
+      if (atMetaData.updatedAt != null) {
+        commandBody = 'uAt:'
+            '${VerbUtil.formatIso8601Micros(atMetaData.updatedAt!)}'
+            ':$commandBody';
+      }
+    } else if (atMetaData != null) {
       // appMetadata is the LAST group in VerbSyntax.metadataFragment;
       // since this body is built back-to-front, it is prepended first.
       if (atNotification.atMetadata!.appMetadata != null) {
@@ -302,6 +314,31 @@ class NotificationManager {
       String? isEncryptedStr =
           (atNotification.atMetadata!.isEncrypted ?? false) ? 'true' : 'false';
       commandBody = '${AtConstants.isEncrypted}:$isEncryptedStr:$commandBody';
+
+      // The four timestamp groups sit between ccd and dataSignature in
+      // VerbSyntax.metadataFragment, so in this back-to-front build they
+      // are prepended (in reverse order) between the isEncrypted prepend
+      // above and the ttr:ccd prepend below.
+      if (atMetaData.availableAt != null) {
+        commandBody = 'aAt:'
+            '${VerbUtil.formatIso8601Micros(atMetaData.availableAt!)}'
+            ':$commandBody';
+      }
+      if (atMetaData.expiresAt != null) {
+        commandBody = 'eAt:'
+            '${VerbUtil.formatIso8601Micros(atMetaData.expiresAt!)}'
+            ':$commandBody';
+      }
+      if (atMetaData.updatedAt != null) {
+        commandBody = 'uAt:'
+            '${VerbUtil.formatIso8601Micros(atMetaData.updatedAt!)}'
+            ':$commandBody';
+      }
+      if (atMetaData.createdAt != null) {
+        commandBody = 'cAt:'
+            '${VerbUtil.formatIso8601Micros(atMetaData.createdAt!)}'
+            ':$commandBody';
+      }
 
       if (atMetaData.ttr != null) {
         commandBody =

--- a/packages/at_secondary_server/lib/src/verb/handler/abstract_update_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/abstract_update_verb_handler.dart
@@ -198,18 +198,41 @@ abstract class AbstractUpdateVerbHandler extends ChangeVerbHandler {
   /// exactly what was stored (client-asserted timestamps included).
   ///
   /// The caller still holds the per-key mutex, but delete and the TTL sweep
-  /// take no mutex — if the record vanished in that window, fall back to the
-  /// metadata that was written rather than dropping the notification.
+  /// take no mutex, so the record can vanish between the write and the
+  /// read-back. The two outcomes are deliberately different:
   ///
-  /// A notify failure is logged at warning and NOT rethrown: the write
-  /// happened, and the client's response must report it faithfully.
+  ///   * read-back returns NULL — the record was concurrently deleted, and
+  ///     the deleter has queued (or is queueing) its own delete
+  ///     notification. Queueing this update notification anyway could land
+  ///     it AFTER the delete notification and resurrect the receiver's
+  ///     cached key, so it is skipped, at warning.
+  ///   * read-back THROWS — a transient store error; the record is
+  ///     presumed present, so the notification is queued from the metadata
+  ///     that was written rather than being dropped.
+  ///
+  /// A notify-queueing failure is logged at warning and NOT rethrown: the
+  /// write happened, and the client's response must report it faithfully.
   Future<void> notifyAfterStore(
       HashMap<String, String?> verbParams,
       UpdateParams updateParams,
       UpdatePreProcessResult result) async {
+    AtMetaData? stored;
+    var readBackFailed = false;
     try {
-      AtMetaData? stored = await keyStore.getMeta(result.atKey);
-      stored ??= result.atData.metaData;
+      stored = await keyStore.getMeta(result.atKey);
+    } catch (e) {
+      readBackFailed = true;
+      logger.warning('metadata read-back for ${result.atKey} failed ($e);'
+          ' queueing the auto-notification from the written metadata');
+    }
+    if (stored == null && !readBackFailed) {
+      logger.warning('auto-notification for ${result.atKey} skipped: the'
+          ' record was deleted concurrently, and queueing an update'
+          ' notification now could overtake the delete notification');
+      return;
+    }
+    stored ??= result.atData.metaData;
+    try {
       await notify(
           updateParams.sharedBy,
           updateParams.sharedWith,

--- a/packages/at_secondary_server/lib/src/verb/handler/abstract_update_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/abstract_update_verb_handler.dart
@@ -5,6 +5,7 @@ import 'dart:convert';
 import 'package:at_commons/at_commons.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:at_secondary/src/connection/inbound/inbound_connection_metadata.dart';
+import 'package:at_secondary/src/constants/wire_param_names.dart';
 import 'package:at_secondary/src/notification/notification_manager_impl.dart';
 import 'package:at_secondary/src/server/at_secondary_config.dart';
 import 'package:at_secondary/src/utils/handler_util.dart' as hu;
@@ -77,7 +78,12 @@ abstract class AbstractUpdateVerbHandler extends ChangeVerbHandler {
   ///   has a null value
   ///   - Iterate through the verb params again; if there is a metadata param
   ///   supplied with a value of 'null' then set the AtMetaData field to null
-  Future<UpdatePreProcessResult> preProcessAndNotify(
+  ///
+  /// The auto-notification is NOT queued here — the handler queues it via
+  /// [notifyAfterStore] once the keystore write has succeeded, so the
+  /// notification carries the metadata that was actually stored and a failed
+  /// write queues nothing.
+  Future<UpdatePreProcessResult> preProcess(
       Response response,
       HashMap<String, String?> verbParams,
       UpdateParams updateParams,
@@ -86,7 +92,6 @@ abstract class AbstractUpdateVerbHandler extends ChangeVerbHandler {
     await super.processVerb(response, verbParams, atConnection);
 
     // Get the key and update the value
-    final sharedWith = updateParams.sharedWith;
     final sharedBy = updateParams.sharedBy;
     final value = updateParams.value;
     final atData = AtData();
@@ -185,15 +190,56 @@ abstract class AbstractUpdateVerbHandler extends ChangeVerbHandler {
       existingAtMetaData,
     );
 
-    await notify(
-        sharedBy,
-        sharedWith,
-        verbParams[AtConstants.atKey],
-        value,
-        SecondaryUtil.getNotificationPriority(verbParams[AtConstants.priority]),
-        atData.metaData!);
-
     return UpdatePreProcessResult(atKey, atData);
+  }
+
+  /// Queues the auto-notification for a write that has already succeeded,
+  /// reading the metadata back from the store so the notification carries
+  /// exactly what was stored (client-asserted timestamps included).
+  ///
+  /// The caller still holds the per-key mutex, but delete and the TTL sweep
+  /// take no mutex — if the record vanished in that window, fall back to the
+  /// metadata that was written rather than dropping the notification.
+  ///
+  /// A notify failure is logged at warning and NOT rethrown: the write
+  /// happened, and the client's response must report it faithfully.
+  Future<void> notifyAfterStore(
+      HashMap<String, String?> verbParams,
+      UpdateParams updateParams,
+      UpdatePreProcessResult result) async {
+    try {
+      AtMetaData? stored = await keyStore.getMeta(result.atKey);
+      stored ??= result.atData.metaData;
+      await notify(
+          updateParams.sharedBy,
+          updateParams.sharedWith,
+          verbParams[AtConstants.atKey],
+          updateParams.value,
+          SecondaryUtil.getNotificationPriority(
+              verbParams[AtConstants.priority]),
+          stored!);
+    } catch (e) {
+      logger.warning('auto-notification for ${result.atKey} was not queued'
+          ' ($e); the write itself succeeded');
+    }
+  }
+
+  /// The caller-asserted timestamps carried by [metadata]'s
+  /// createdAt/updatedAt/expiresAt/availableAt fields (parsed off the wire
+  /// by [getUpdateParams] or, for `update:json`, by commons
+  /// `Metadata.fromJson`), or null when none were supplied.
+  AtAssertedTimestamps? assertedTimestampsOf(Metadata metadata) {
+    if (metadata.createdAt == null &&
+        metadata.updatedAt == null &&
+        metadata.expiresAt == null &&
+        metadata.availableAt == null) {
+      return null;
+    }
+    return AtAssertedTimestamps(
+        createdAt: metadata.createdAt,
+        updatedAt: metadata.updatedAt,
+        expiresAt: metadata.expiresAt,
+        availableAt: metadata.availableAt);
   }
 
   UpdateParams getUpdateParams(HashMap<String, String?> verbParams) {
@@ -227,6 +273,21 @@ abstract class AbstractUpdateVerbHandler extends ChangeVerbHandler {
     if (verbParams[AtConstants.ccd] != null) {
       metadata.ccd =
           AtMetadataUtil.getBoolVerbParams(verbParams[AtConstants.ccd]);
+    }
+    // Caller-asserted timestamps (:cAt/:uAt/:eAt/:aAt) — the verb grammar
+    // pins these to ISO 8601 UTC, so DateTime.parse cannot see a local time.
+    if (verbParams[AtConstants.createdAt] != null) {
+      metadata.createdAt = DateTime.parse(verbParams[AtConstants.createdAt]!);
+    }
+    if (verbParams[AtConstants.updatedAt] != null) {
+      metadata.updatedAt = DateTime.parse(verbParams[AtConstants.updatedAt]!);
+    }
+    if (verbParams[WireParams.expiresAt] != null) {
+      metadata.expiresAt = DateTime.parse(verbParams[WireParams.expiresAt]!);
+    }
+    if (verbParams[WireParams.availableAt] != null) {
+      metadata.availableAt =
+          DateTime.parse(verbParams[WireParams.availableAt]!);
     }
     metadata.dataSignature = verbParams[AtConstants.publicDataSignature];
     if (verbParams[AtConstants.isBinary] != null) {

--- a/packages/at_secondary_server/lib/src/verb/handler/abstract_update_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/abstract_update_verb_handler.dart
@@ -190,7 +190,14 @@ abstract class AbstractUpdateVerbHandler extends ChangeVerbHandler {
       existingAtMetaData,
     );
 
-    return UpdatePreProcessResult(atKey, atData);
+    // Computed here, where existingAtMetaData reflects the expired-record
+    // drop above — an expired record must not have its old expiry carried
+    // forward into the record replacing it.
+    return UpdatePreProcessResult(
+        atKey,
+        atData,
+        effectiveAssertedTimestamps(updateParams.metadata!,
+            existingAtMetaData));
   }
 
   /// Queues the auto-notification for a write that has already succeeded,
@@ -247,22 +254,64 @@ abstract class AbstractUpdateVerbHandler extends ChangeVerbHandler {
     }
   }
 
-  /// The caller-asserted timestamps carried by [metadata]'s
-  /// createdAt/updatedAt/expiresAt/availableAt fields (parsed off the wire
-  /// by [getUpdateParams] or, for `update:json`, by commons
-  /// `Metadata.fromJson`), or null when none were supplied.
-  AtAssertedTimestamps? assertedTimestampsOf(Metadata metadata) {
+  /// The timestamps this write must store faithfully: the request's own
+  /// assertions ([metadata]'s createdAt/updatedAt/expiresAt/availableAt,
+  /// parsed off the wire by [getUpdateParams] or, for `update:json`, by
+  /// commons `Metadata.fromJson`) — plus, when the request says nothing at
+  /// all about an expiry axis, the [existing] record's absolute for that
+  /// axis, carried forward as an assertion so this write cannot move it.
+  ///
+  /// Without the carry, the retain-from-existing merge re-feeds the stored
+  /// ttl/ttb into the metadata builder, which re-derives the absolute from
+  /// now — so a write that never mentioned expiry would restart the expiry
+  /// clock (and re-open a ttb record's not-yet-born window). Once set, an
+  /// absolute moves only when a request speaks about its axis: a new
+  /// assertion stores faithfully, a fresh ttl/ttb re-derives from now,
+  /// ttl:0 clears the expiry, and ttb:0 re-stamps availableAt to now
+  /// (immediate availability — the birth axis has no cleared state).
+  ///
+  /// A request that asserts an absolute WITHOUT supplying its relative
+  /// (an eAt with no ttl, an aAt with no ttb) additionally asks the store
+  /// to derive the relative the absolute implies — deriveTtl/deriveTtb on
+  /// the returned assertions — replacing any ttl/ttb the retain-merge or
+  /// the json coercion may have put on the write's metadata. That decision
+  /// belongs here because only the request layer can tell a caller-
+  /// supplied relative from a retained or coerced one.
+  ///
+  /// "Says nothing" is judged per axis on the request's own metadata,
+  /// where absent means null. On the update:json path commons
+  /// `Metadata.fromJson` coerces an absent ttl/ttb to 0, which is
+  /// indistinguishable from an explicit 0 and therefore counts as the
+  /// request speaking (ttl:0 clears expiry, as it always has) — except
+  /// alongside an asserted absolute, where a 0 contradicts the absolute
+  /// and counts as unsupplied, so the derivation wins on both encodings.
+  ///
+  /// Returns null when there is nothing to assert.
+  AtAssertedTimestamps? effectiveAssertedTimestamps(
+      Metadata metadata, AtMetaData? existing) {
+    final expiryCarry = (metadata.expiresAt == null && metadata.ttl == null)
+        ? existing?.expiresAt
+        : null;
+    final birthCarry = (metadata.availableAt == null && metadata.ttb == null)
+        ? existing?.availableAt
+        : null;
     if (metadata.createdAt == null &&
         metadata.updatedAt == null &&
         metadata.expiresAt == null &&
-        metadata.availableAt == null) {
+        metadata.availableAt == null &&
+        expiryCarry == null &&
+        birthCarry == null) {
       return null;
     }
     return AtAssertedTimestamps(
         createdAt: metadata.createdAt,
         updatedAt: metadata.updatedAt,
-        expiresAt: metadata.expiresAt,
-        availableAt: metadata.availableAt);
+        expiresAt: metadata.expiresAt ?? expiryCarry,
+        availableAt: metadata.availableAt ?? birthCarry,
+        deriveTtl: metadata.expiresAt != null &&
+            (metadata.ttl == null || metadata.ttl == 0),
+        deriveTtb: metadata.availableAt != null &&
+            (metadata.ttb == null || metadata.ttb == 0));
   }
 
   UpdateParams getUpdateParams(HashMap<String, String?> verbParams) {
@@ -516,7 +565,12 @@ class UpdatePreProcessResult {
   String atKey;
   AtData atData;
 
-  UpdatePreProcessResult(this.atKey, this.atData);
+  /// What the store must keep faithfully for this write — the request's
+  /// own timestamp assertions plus the silent-write expiry carry. See
+  /// [AbstractUpdateVerbHandler.effectiveAssertedTimestamps].
+  AtAssertedTimestamps? assertedTimestamps;
+
+  UpdatePreProcessResult(this.atKey, this.atData, this.assertedTimestamps);
 }
 
 /// Mutable holder for the per-key update mutex and its waiter count, so that

--- a/packages/at_secondary_server/lib/src/verb/handler/delete_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/delete_verb_handler.dart
@@ -63,6 +63,16 @@ class DeleteVerbHandler extends ChangeVerbHandler {
     if (verbParams[AtConstants.atSign] != null) {
       atSign = AtUtils.fixAtSign(verbParams[AtConstants.atSign]!);
     }
+    // :dAt — the caller-asserted deletion time. Recorded as the DELETE
+    // commit entry's opTime, and carried to the sharedWith atServer on the
+    // auto-notification (as :uAt: — the notify grammar has no dAt group)
+    // so the receiver's cached-key delete records the origin deletion
+    // time. With :nc there is no commit entry, so it has nothing to stamp
+    // locally. The verb grammar pins the value to ISO 8601 UTC.
+    DateTime? deletedAt;
+    if (verbParams[WireParams.deletedAt] != null) {
+      deletedAt = DateTime.parse(verbParams[WireParams.deletedAt]!);
+    }
     var deleteKey = verbParams[AtConstants.atKey];
     // If key is cram secret do not append atsign.
     if (verbParams[AtConstants.atKey] != AtConstants.atCramSecret) {
@@ -126,16 +136,6 @@ class DeleteVerbHandler extends ChangeVerbHandler {
           }
         }
       }
-      // The :nc flag maps to skipCommit: write no DELETE commit entry AND
-      // purge the key's existing entry (the response is then -1). Works for
-      // a key that is already gone — remove() tolerates a missing key and
-      // still purges, which is the commit-log cruft-management case. The
-      // :dAt timestamp is recorded as the DELETE entry's opTime; with :nc
-      // there is no entry, so it has nothing to stamp.
-      DateTime? deletedAt;
-      if (verbParams[WireParams.deletedAt] != null) {
-        deletedAt = DateTime.parse(verbParams[WireParams.deletedAt]!);
-      }
       var result = await keyStore.remove(deleteKey,
           skipCommit: verbParams[WireParams.noCommit] != null,
           deletedAt: deletedAt);
@@ -167,7 +167,8 @@ class DeleteVerbHandler extends ChangeVerbHandler {
               atSign,
               key,
               SecondaryUtil.getNotificationPriority(
-                  verbParams[AtConstants.priority]));
+                  verbParams[AtConstants.priority]),
+              deletedAt: deletedAt);
         } catch (exception) {
           logger.severe(
               'Exception while sending notification ${exception.toString()}');
@@ -179,18 +180,26 @@ class DeleteVerbHandler extends ChangeVerbHandler {
     }
   }
 
-  Future<void> _notify(forAtSign, atSign, key, priority) async {
+  Future<void> _notify(forAtSign, atSign, key, priority,
+      {DateTime? deletedAt}) async {
     if (forAtSign == null) {
       return;
     }
     key = '$forAtSign:$key$atSign';
+    // The deletion time travels as the metadata's updatedAt and is emitted
+    // on the wire as :uAt: (the notify grammar has no dAt group — a
+    // deletion is the record's last update). The emitter special-cases
+    // delete notifications to emit ONLY that fragment.
     var atNotification = (AtNotificationBuilder()
           ..type = NotificationType.sent
           ..fromAtSign = atSign
           ..toAtSign = forAtSign
           ..notification = key
           ..priority = priority
-          ..opType = OperationType.delete)
+          ..opType = OperationType.delete
+          ..atMetaData = (AtMetaData()
+            ..updatedAt =
+                (deletedAt ?? DateTime.now()).toUtcMillisecondsPrecision()))
         .build();
     await notificationManager.notify(atNotification);
   }

--- a/packages/at_secondary_server/lib/src/verb/handler/delete_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/delete_verb_handler.dart
@@ -186,10 +186,12 @@ class DeleteVerbHandler extends ChangeVerbHandler {
       return;
     }
     key = '$forAtSign:$key$atSign';
-    // The deletion time travels as the metadata's updatedAt and is emitted
+    // A client-asserted :dAt travels as the metadata's updatedAt, emitted
     // on the wire as :uAt: (the notify grammar has no dAt group — a
-    // deletion is the record's last update). The emitter special-cases
-    // delete notifications to emit ONLY that fragment.
+    // deletion is the record's last update). Without an assertion, no
+    // metadata is attached at all, keeping an ordinary delete
+    // notification's wire shape exactly what it always was — a receiver
+    // built before the timestamp syntax existed still parses it.
     var atNotification = (AtNotificationBuilder()
           ..type = NotificationType.sent
           ..fromAtSign = atSign
@@ -197,9 +199,10 @@ class DeleteVerbHandler extends ChangeVerbHandler {
           ..notification = key
           ..priority = priority
           ..opType = OperationType.delete
-          ..atMetaData = (AtMetaData()
-            ..updatedAt =
-                (deletedAt ?? DateTime.now()).toUtcMillisecondsPrecision()))
+          ..atMetaData = deletedAt == null
+              ? null
+              : (AtMetaData()
+                ..updatedAt = deletedAt.toUtcMillisecondsPrecision()))
         .build();
     await notificationManager.notify(atNotification);
   }

--- a/packages/at_secondary_server/lib/src/verb/handler/delete_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/delete_verb_handler.dart
@@ -3,6 +3,7 @@ import 'dart:collection';
 import 'package:at_commons/at_commons.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:at_secondary/src/connection/inbound/inbound_connection_metadata.dart';
+import 'package:at_secondary/src/constants/wire_param_names.dart';
 import 'package:at_secondary/src/notification/notification_manager_impl.dart';
 import 'package:at_secondary/src/server/at_secondary_config.dart';
 import 'package:at_secondary/src/server/at_secondary_impl.dart';
@@ -125,7 +126,19 @@ class DeleteVerbHandler extends ChangeVerbHandler {
           }
         }
       }
-      var result = await keyStore.remove(deleteKey);
+      // The :nc flag maps to skipCommit: write no DELETE commit entry AND
+      // purge the key's existing entry (the response is then -1). Works for
+      // a key that is already gone — remove() tolerates a missing key and
+      // still purges, which is the commit-log cruft-management case. The
+      // :dAt timestamp is recorded as the DELETE entry's opTime; with :nc
+      // there is no entry, so it has nothing to stamp.
+      DateTime? deletedAt;
+      if (verbParams[WireParams.deletedAt] != null) {
+        deletedAt = DateTime.parse(verbParams[WireParams.deletedAt]!);
+      }
+      var result = await keyStore.remove(deleteKey,
+          skipCommit: verbParams[WireParams.noCommit] != null,
+          deletedAt: deletedAt);
       response.data = result?.toString();
       logger.finer('delete success. delete key: $deleteKey');
     } on KeyNotFoundException {

--- a/packages/at_secondary_server/lib/src/verb/handler/notify_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/notify_verb_handler.dart
@@ -226,6 +226,14 @@ class NotifyVerbHandler extends AbstractVerbHandler {
 
   /// The sender-asserted timestamps carried by this notification's
   /// :cAt/:uAt/:eAt/:aAt params, or null when none were transmitted.
+  ///
+  /// The derive flags are judged on the WIRE params, before this handler's
+  /// metadata assembly coerces an absent ttl/ttb to 0: a notification that
+  /// transmits an absolute without its relative asks the store to derive
+  /// the relative the absolute implies, replacing that coerced 0. Without
+  /// the flags, the coerced ttb:0 would make setTTB stamp availableAt to
+  /// arrival time on the cached copy, and any derivation reading the
+  /// merged metadata would treat the coercion as the sender's value.
   AtAssertedTimestamps? _assertedTimestampsFromParams(
       HashMap<String, String?> verbParams) {
     DateTime? parse(String? v) => v == null ? null : DateTime.parse(v);
@@ -243,7 +251,10 @@ class NotifyVerbHandler extends AbstractVerbHandler {
         createdAt: createdAt,
         updatedAt: updatedAt,
         expiresAt: expiresAt,
-        availableAt: availableAt);
+        availableAt: availableAt,
+        deriveTtl: expiresAt != null && verbParams[AtConstants.ttl] == null,
+        deriveTtb:
+            availableAt != null && verbParams[AtConstants.ttb] == null);
   }
 
   Future<void> _handleAuthenticatedConnection(

--- a/packages/at_secondary_server/lib/src/verb/handler/notify_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/notify_verb_handler.dart
@@ -3,6 +3,7 @@ import 'dart:collection';
 import 'package:at_commons/at_commons.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:at_secondary/src/connection/inbound/inbound_connection_metadata.dart';
+import 'package:at_secondary/src/constants/wire_param_names.dart';
 import 'package:at_secondary/src/notification/notification_manager_impl.dart';
 import 'package:at_secondary/src/server/at_secondary_config.dart';
 import 'package:at_secondary/src/server/at_secondary_impl.dart';
@@ -167,11 +168,19 @@ class NotifyVerbHandler extends AbstractVerbHandler {
       throw InvalidAtKeyException(
           'notification key length ${cachedNotificationKey.length} is greater than $_maxKeyLength chars');
     }
+    // Sender-asserted timestamps travel to the keystore explicitly, so the
+    // cached key is stored with the origin's values. Passed on EVERY write
+    // that transmits them — a refresh of an existing cached key included —
+    // because direct keystore writes have no retain-merge to carry a
+    // previously-asserted expiry forward.
+    final asserted = _assertedTimestampsFromParams(verbParams);
+
     // If operationType is delete, remove the cached key only
     // when cascade delete is set to true
     int? cachedKeyCommitId;
     if (operationType == OperationType.delete) {
-      cachedKeyCommitId = await _removeCachedKey(cachedNotificationKey);
+      cachedKeyCommitId = await _removeCachedKey(cachedNotificationKey,
+          deletedAt: atNotificationBuilder.atMetaData?.updatedAt);
       //write the latest commit id to the StatsNotificationService
       _writeStats(cachedKeyCommitId, operationType.name);
       response.data = 'data:success';
@@ -193,7 +202,7 @@ class NotifyVerbHandler extends AbstractVerbHandler {
               existingMetaData: atMetadata)
           .build();
       cachedKeyCommitId = await _storeCachedKey(cachedNotificationKey, metadata,
-          atValue: atNotificationBuilder.atValue);
+          atValue: atNotificationBuilder.atValue, assertedTimestamps: asserted);
       //write the latest commit id to the StatsNotificationService
       _writeStats(cachedKeyCommitId, operationType.name);
       response.data = 'data:success';
@@ -203,8 +212,9 @@ class NotifyVerbHandler extends AbstractVerbHandler {
     // cached key metadata.
     else if (isKeyPresent) {
       var atMetaData = atNotificationBuilder.atMetaData;
-      cachedKeyCommitId =
-          await _updateMetadata(cachedNotificationKey, atMetaData);
+      cachedKeyCommitId = await _updateMetadata(
+          cachedNotificationKey, atMetaData,
+          assertedTimestamps: asserted);
       //write the latest commit id to the StatsNotificationService
       _writeStats(cachedKeyCommitId, operationType.name);
       response.data = 'data:success';
@@ -212,6 +222,28 @@ class NotifyVerbHandler extends AbstractVerbHandler {
     }
     response.data = 'data:success';
     return;
+  }
+
+  /// The sender-asserted timestamps carried by this notification's
+  /// :cAt/:uAt/:eAt/:aAt params, or null when none were transmitted.
+  AtAssertedTimestamps? _assertedTimestampsFromParams(
+      HashMap<String, String?> verbParams) {
+    DateTime? parse(String? v) => v == null ? null : DateTime.parse(v);
+    final createdAt = parse(verbParams[AtConstants.createdAt]);
+    final updatedAt = parse(verbParams[AtConstants.updatedAt]);
+    final expiresAt = parse(verbParams[WireParams.expiresAt]);
+    final availableAt = parse(verbParams[WireParams.availableAt]);
+    if (createdAt == null &&
+        updatedAt == null &&
+        expiresAt == null &&
+        availableAt == null) {
+      return null;
+    }
+    return AtAssertedTimestamps(
+        createdAt: createdAt,
+        updatedAt: updatedAt,
+        expiresAt: expiresAt,
+        availableAt: availableAt);
   }
 
   Future<void> _handleAuthenticatedConnection(
@@ -255,31 +287,36 @@ class NotifyVerbHandler extends AbstractVerbHandler {
   /// AtMetadata metadata of the key.
   /// atValue value of the key to cache.
   Future<int?> _storeCachedKey(String cachedKey, AtMetaData? atMetaData,
-      {String? atValue}) async {
+      {String? atValue, AtAssertedTimestamps? assertedTimestamps}) async {
     var atData = AtData();
     atData.data = atValue;
     atData.metaData = atMetaData;
     if (logger.isLoggable('info')) {
       logger.info('Cached $cachedKey :  $atMetaData');
     }
-    return await keyStore.put(cachedKey, atData);
+    return await keyStore.put(cachedKey, atData,
+        assertedTimestamps: assertedTimestamps);
   }
 
-  Future<int?> _updateMetadata(String cachedKey, AtMetaData? atMetaData) async {
+  Future<int?> _updateMetadata(String cachedKey, AtMetaData? atMetaData,
+      {AtAssertedTimestamps? assertedTimestamps}) async {
     if (logger.isLoggable('info')) {
       logger.info('Updating the metadata of $cachedKey');
     }
-    return await keyStore.putMeta(cachedKey, atMetaData);
+    return await keyStore.putMeta(cachedKey, atMetaData,
+        assertedTimestamps: assertedTimestamps);
   }
 
-  ///Removes the cached key from the keystore.
-  Future<int?> _removeCachedKey(String cachedKey) async {
+  ///Removes the cached key from the keystore. [deletedAt] is the origin's
+  ///deletion time (transmitted as the delete notification's :uAt:),
+  ///recorded as the DELETE commit entry's opTime.
+  Future<int?> _removeCachedKey(String cachedKey, {DateTime? deletedAt}) async {
     var metadata = await keyStore.getMeta(cachedKey);
     if (metadata != null && metadata.isCascade == true) {
       if (logger.isLoggable('info')) {
         logger.info('Removed cached key $cachedKey');
       }
-      return await keyStore.remove(cachedKey);
+      return await keyStore.remove(cachedKey, deletedAt: deletedAt);
     } else {
       return null;
     }
@@ -408,6 +445,23 @@ class NotifyVerbHandler extends AbstractVerbHandler {
     if (verbParams[AtConstants.immutable] != null) {
       atMetadata.immutable =
           SecondaryUtil.getBoolFromString(verbParams[AtConstants.immutable]);
+    }
+    // Sender-asserted timestamps (:cAt/:uAt/:eAt/:aAt) — carried on the
+    // notification so a cached key on this side can be stored with the
+    // ORIGIN's values rather than rederiving them on this server's clock.
+    // The grammar pins them to ISO 8601 UTC.
+    if (verbParams[AtConstants.createdAt] != null) {
+      atMetadata.createdAt = DateTime.parse(verbParams[AtConstants.createdAt]!);
+    }
+    if (verbParams[AtConstants.updatedAt] != null) {
+      atMetadata.updatedAt = DateTime.parse(verbParams[AtConstants.updatedAt]!);
+    }
+    if (verbParams[WireParams.expiresAt] != null) {
+      atMetadata.expiresAt = DateTime.parse(verbParams[WireParams.expiresAt]!);
+    }
+    if (verbParams[WireParams.availableAt] != null) {
+      atMetadata.availableAt =
+          DateTime.parse(verbParams[WireParams.availableAt]!);
     }
     // Arrives base64(JSON)-encoded on the wire; decodeAppMetadata also
     // maps an absent param (or the literal 'null') to null.

--- a/packages/at_secondary_server/lib/src/verb/handler/scan_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/scan_verb_handler.dart
@@ -2,8 +2,10 @@ import 'dart:collection';
 import 'dart:convert';
 
 import 'package:at_commons/at_commons.dart';
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:at_secondary/src/caching/cache_manager.dart';
 import 'package:at_secondary/src/connection/inbound/inbound_connection_metadata.dart';
+import 'package:at_secondary/src/constants/wire_param_names.dart';
 import 'package:at_secondary/src/connection/outbound/outbound_client.dart';
 import 'package:at_secondary/src/connection/outbound/outbound_client_manager.dart';
 import 'package:at_secondary/src/server/at_secondary_impl.dart';
@@ -62,6 +64,25 @@ class ScanVerbHandler extends AbstractVerbHandler {
 
     try {
       var currentAtSign = AtSecondaryServerImpl.getInstance().currentAtSign;
+      if (verbParams[WireParams.commitLog] != null) {
+        // scan:cl — scan the commit log instead of the keystore, so a
+        // client can inspect (and then delete:nc) its entries.
+        if (!atConnectionMetadata.isAuthenticated) {
+          throw UnAuthenticatedException(
+              'scan:cl requires an authenticated connection');
+        }
+        if ((forAtSign != null && forAtSign.isNotEmpty) &&
+            forAtSign != currentAtSign) {
+          // The outbound scan proxy cannot forward :cl, so a remote
+          // commit-log scan would silently degrade to a plain remote
+          // scan — refuse loudly instead.
+          throw InvalidRequestException(
+              'scan:cl can only scan this atSign\'s own commit log');
+        }
+        response.data = jsonEncode(await getCommitLogEntries(
+            atConnectionMetadata, scanRegex, showHiddenKeys, currentAtSign));
+        return;
+      }
       // If forAtSign is set, fetch keys that are sharedBy the "forAtSign" to the currentAtSign
       // If currentAtSign is @alice and forAtSign is @bob, fetch all the keys that @bob has
       // created for @alice.
@@ -156,6 +177,64 @@ class ScanVerbHandler extends AbstractVerbHandler {
       }
       return localKeysList;
     }
+  }
+
+  /// The commit-log entries visible to this connection, as the JSON-ready
+  /// maps `scan:cl` returns, in ascending commitId order:
+  /// `{"atKey", "operation" (the CommitOp symbol sync also uses),
+  /// "commitId", "opTime" (ISO 8601 UTC)}`.
+  ///
+  /// The same filters as a keystore scan apply: [scanRegex] against the
+  /// atKey, the hidden-key rules ([_isPrivateKeyForAtSign] with
+  /// [showHiddenKeys]), and — for an APKAM connection — the enrollment
+  /// namespace filter ([_filterKeysBasedOnEnrollmentId]). DELETE entries
+  /// are included: an entry for a key that no longer exists is exactly
+  /// what commit-log cruft management is looking for.
+  @visibleForTesting
+  Future<List<Map<String, Object?>>> getCommitLogEntries(
+      InboundConnectionMetadata atConnectionMetadata,
+      String? scanRegex,
+      bool showHiddenKeys,
+      String currentAtSign) async {
+    final commitLog = keyStore.commitLog;
+    if (commitLog == null) {
+      return [];
+    }
+    final regex = scanRegex == null ? null : RegExp(scanRegex);
+    // The commit log holds at most one entry per atKey, so entries can be
+    // keyed by atKey and scan's own enrollment filter reused verbatim.
+    final byKey = <String, CommitEntry>{};
+    await for (final entry in commitLog.iterate()) {
+      final atKey = entry.atKey;
+      if (atKey == null || entry.commitId == null) {
+        continue;
+      }
+      if (_isPrivateKeyForAtSign(atKey, showHiddenKeys)) {
+        continue;
+      }
+      if (regex != null && !regex.hasMatch(atKey)) {
+        continue;
+      }
+      byKey[atKey] = entry;
+    }
+    List<String> visibleKeys = byKey.keys.toList();
+    if (atConnectionMetadata.enrollmentId != null &&
+        atConnectionMetadata.enrollmentId!.isNotEmpty) {
+      visibleKeys = await _filterKeysBasedOnEnrollmentId(
+          atConnectionMetadata, visibleKeys, currentAtSign);
+    }
+    final entries = visibleKeys.map((key) => byKey[key]!).toList()
+      ..sort((a, b) => a.commitId!.compareTo(b.commitId!));
+    return entries
+        .map((entry) => <String, Object?>{
+              'atKey': entry.atKey,
+              'operation': entry.operation.name,
+              'commitId': entry.commitId,
+              'opTime': entry.opTime == null
+                  ? null
+                  : VerbUtil.formatIso8601Micros(entry.opTime!),
+            })
+        .toList();
   }
 
   /// Checks if a key starts with `public:_`, `private:`, `privatekey:`.

--- a/packages/at_secondary_server/lib/src/verb/handler/update_meta_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/update_meta_verb_handler.dart
@@ -1,6 +1,7 @@
 import 'dart:collection';
 
 import 'package:at_commons/at_commons.dart';
+import 'package:at_secondary/src/constants/wire_param_names.dart';
 import 'package:at_secondary/src/verb/handler/abstract_update_verb_handler.dart';
 import 'package:at_server_spec/at_server_spec.dart';
 
@@ -39,19 +40,30 @@ class UpdateMetaVerbHandler extends AbstractUpdateVerbHandler {
       }
       await mutexRef.mutex.acquire();
 
-      var updatePreProcessResult = await super.preProcessAndNotify(
+      var updatePreProcessResult = await super.preProcess(
         response,
         verbParams,
         updateParams,
         atConnection,
       );
 
-      // update the key in data store
+      // update the key in data store. The :nc flag maps to skipCommit
+      // (write no commit entry AND purge the key's existing one, so the
+      // response is -1); asserted timestamps are stored faithfully.
       logger.finer(
           'calling keyValueStore.putMeta(${updatePreProcessResult.atKey}, ${updatePreProcessResult.atData.metaData!}');
-      var result = await keyStore.putMeta(updatePreProcessResult.atKey,
-          updatePreProcessResult.atData.metaData!);
+      var result = await keyStore.putMeta(
+        updatePreProcessResult.atKey,
+        updatePreProcessResult.atData.metaData!,
+        skipCommit: verbParams[WireParams.noCommit] != null,
+        assertedTimestamps: assertedTimestampsOf(updateParams.metadata!),
+      );
       response.data = result?.toString();
+
+      // Queue the auto-notification from the STORED record, after the
+      // write — see notifyAfterStore.
+      await super.notifyAfterStore(verbParams, updateParams,
+          updatePreProcessResult);
     } finally {
       mutexRef.mutex.release();
       mutexRef.waiters--;

--- a/packages/at_secondary_server/lib/src/verb/handler/update_meta_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/update_meta_verb_handler.dart
@@ -28,7 +28,10 @@ class UpdateMetaVerbHandler extends AbstractUpdateVerbHandler {
       InboundConnection atConnection) async {
     UpdateParams updateParams = getUpdateParams(verbParams);
 
-    String dataStoreKey = getDataStoreKey(updateParams);
+    // Lowercased: the keystore canonicalizes keys to lowercase, so two
+    // case-variants of one command name the same stored record and must
+    // contend for the same mutex.
+    String dataStoreKey = getDataStoreKey(updateParams).toLowerCase();
 
     final mutexRef = updateMutexes.putIfAbsent(dataStoreKey, MutexRef.new);
 

--- a/packages/at_secondary_server/lib/src/verb/handler/update_meta_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/update_meta_verb_handler.dart
@@ -52,14 +52,15 @@ class UpdateMetaVerbHandler extends AbstractUpdateVerbHandler {
 
       // update the key in data store. The :nc flag maps to skipCommit
       // (write no commit entry AND purge the key's existing one, so the
-      // response is -1); asserted timestamps are stored faithfully.
+      // response is -1); asserted timestamps — the request's own plus the
+      // silent-write expiry carry — are stored faithfully.
       logger.finer(
           'calling keyValueStore.putMeta(${updatePreProcessResult.atKey}, ${updatePreProcessResult.atData.metaData!}');
       var result = await keyStore.putMeta(
         updatePreProcessResult.atKey,
         updatePreProcessResult.atData.metaData!,
         skipCommit: verbParams[WireParams.noCommit] != null,
-        assertedTimestamps: assertedTimestampsOf(updateParams.metadata!),
+        assertedTimestamps: updatePreProcessResult.assertedTimestamps,
       );
       response.data = result?.toString();
 

--- a/packages/at_secondary_server/lib/src/verb/handler/update_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/update_verb_handler.dart
@@ -1,6 +1,7 @@
 import 'dart:collection';
 
 import 'package:at_commons/at_commons.dart';
+import 'package:at_secondary/src/constants/wire_param_names.dart';
 import 'package:at_secondary/src/verb/handler/abstract_update_verb_handler.dart';
 import 'package:at_server_spec/at_server_spec.dart';
 import 'package:at_server_spec/at_verb_spec.dart';
@@ -52,19 +53,28 @@ class UpdateVerbHandler extends AbstractUpdateVerbHandler {
       }
       await mutexRef.mutex.acquire();
 
-      var updatePreProcessResult = await super.preProcessAndNotify(
+      var updatePreProcessResult = await super.preProcess(
         response,
         verbParams,
         updateParams,
         atConnection,
       );
 
-      // update the key in data store
+      // update the key in data store. The :nc flag maps to skipCommit
+      // (write no commit entry AND purge the key's existing one, so the
+      // response is -1); asserted timestamps are stored faithfully.
       var result = await keyStore.put(
         updatePreProcessResult.atKey,
         updatePreProcessResult.atData,
+        skipCommit: verbParams[WireParams.noCommit] != null,
+        assertedTimestamps: assertedTimestampsOf(updateParams.metadata!),
       );
       response.data = result?.toString();
+
+      // Queue the auto-notification from the STORED record, after the
+      // write — see notifyAfterStore.
+      await super.notifyAfterStore(verbParams, updateParams,
+          updatePreProcessResult);
     } finally {
       mutexRef.mutex.release();
       mutexRef.waiters--;

--- a/packages/at_secondary_server/lib/src/verb/handler/update_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/update_verb_handler.dart
@@ -41,7 +41,10 @@ class UpdateVerbHandler extends AbstractUpdateVerbHandler {
       InboundConnection atConnection) async {
     UpdateParams updateParams = getUpdateParams(verbParams);
 
-    String dataStoreKey = getDataStoreKey(updateParams);
+    // Lowercased: the keystore canonicalizes keys to lowercase, so two
+    // case-variants of one command name the same stored record and must
+    // contend for the same mutex.
+    String dataStoreKey = getDataStoreKey(updateParams).toLowerCase();
 
     final mutexRef = updateMutexes.putIfAbsent(dataStoreKey, MutexRef.new);
 

--- a/packages/at_secondary_server/lib/src/verb/handler/update_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/update_verb_handler.dart
@@ -65,12 +65,13 @@ class UpdateVerbHandler extends AbstractUpdateVerbHandler {
 
       // update the key in data store. The :nc flag maps to skipCommit
       // (write no commit entry AND purge the key's existing one, so the
-      // response is -1); asserted timestamps are stored faithfully.
+      // response is -1); asserted timestamps — the request's own plus the
+      // silent-write expiry carry — are stored faithfully.
       var result = await keyStore.put(
         updatePreProcessResult.atKey,
         updatePreProcessResult.atData,
         skipCommit: verbParams[WireParams.noCommit] != null,
-        assertedTimestamps: assertedTimestampsOf(updateParams.metadata!),
+        assertedTimestamps: updatePreProcessResult.assertedTimestamps,
       );
       response.data = result?.toString();
 

--- a/packages/at_secondary_server/pubspec.lock
+++ b/packages/at_secondary_server/pubspec.lock
@@ -87,14 +87,14 @@ packages:
       path: "../at_persistence_secondary_server"
       relative: true
     source: path
-    version: "5.2.1"
+    version: "5.3.0"
   at_server_spec:
     dependency: "direct main"
     description:
       path: "../at_server_spec"
       relative: true
     source: path
-    version: "5.2.0"
+    version: "5.2.1"
   at_utf7:
     dependency: transitive
     description:

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_secondary
 description: Implementation of secondary server.
-version: 3.16.2
+version: 3.16.3
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://www.example.com
 publish_to: none

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   at_chops: ^3.5.0
   at_lookup: ^3.6.0
   at_server_spec: ^5.1.0
-  at_persistence_secondary_server: ^5.2.1
+  at_persistence_secondary_server: ^5.3.0
   intl: ^0.20.3
   json_annotation: ^4.12.0
   version: ^3.0.2

--- a/packages/at_secondary_server/test/notification_manager_test.dart
+++ b/packages/at_secondary_server/test/notification_manager_test.dart
@@ -325,6 +325,11 @@ void main() async {
           matches(RegExp('id:1234:update:messageType:key:notifier:system'
               ':ttln:\\d{5}'
               ':ttr:1:ccd:true'
+              // fromCommonsMetadata's builder pass stamps
+              // createdAt/updatedAt, and the emitter transmits whatever
+              // timestamps the notification's metadata carries.
+              ':cAt:\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{6}Z'
+              ':uAt:\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{6}Z'
               ':isEncrypted:false'
               ':sharedKeyEnc:abc:pubKeyCS:123'
               ':pubKeyHash:someHash:hashingAlgo:someAlgo'

--- a/packages/at_secondary_server/test/notify_timestamps_test.dart
+++ b/packages/at_secondary_server/test/notify_timestamps_test.dart
@@ -118,8 +118,12 @@ void main() {
               ':@bob:phone.wavi$alice\$')));
     });
 
-    test('delete notification carries :uAt: and NOTHING else — no '
-        'isEncrypted (wire-shape pin)', () {
+    test('a dAt-asserted delete notification carries :uAt: through the '
+        'ordinary metadata block (wire-shape pin)', () {
+      // DeleteVerbHandler attaches metadata (updatedAt only) exactly when
+      // the client asserted :dAt, so this shape appears only for the new
+      // feature — and goes through the same emission block as every other
+      // metadata-bearing notification.
       final n = (AtNotificationBuilder()
             ..id = 'del-pin-1'
             ..fromAtSign = alice
@@ -137,16 +141,62 @@ void main() {
           matches(RegExp(r'^id:del-pin-1:delete:messageType:key'
               r':notifier:system:ttln:\d+'
               ':uAt:$uAtWire'
+              ':isEncrypted:false'
               ':@bob:phone.wavi$alice\$')));
-      expect(body, isNot(contains('isEncrypted')),
-          reason: 'delete notifications have never carried a metadata '
-              'fragment; deployed receivers default an ABSENT isEncrypted '
-              'to true for non-public keys, so emitting isEncrypted:false '
-              'here would silently flip that default');
 
       final HashMap<String, String?> reParsed =
           getVerbParam(Notify().syntax(), 'notify:$body');
       expect(reParsed[AtConstants.updatedAt], uAtWire);
+    });
+
+    test('an ordinary (no-dAt) delete notification keeps its historical '
+        'metadata-free wire shape (wire-shape pin)', () {
+      // No metadata attached — the shape a receiver built before the
+      // timestamp syntax existed still parses.
+      final n = (AtNotificationBuilder()
+            ..id = 'del-pin-2'
+            ..fromAtSign = alice
+            ..toAtSign = '@bob'
+            ..notification = '@bob:phone.wavi$alice'
+            ..type = NotificationType.sent
+            ..opType = OperationType.delete
+            ..ttl = 60000)
+          .build();
+      final body = notificationManager.prepareNotifyCommandBody(n);
+      expect(
+          body,
+          matches(RegExp(r'^id:del-pin-2:delete:messageType:key'
+              r':notifier:system:ttln:\d+'
+              ':@bob:phone.wavi$alice\$')));
+    });
+
+    test('a client-issued delete notification\'s metadata still goes on '
+        'the wire (regression pin)', () {
+      // notify:delete from a client carries metadata (isEncrypted always,
+      // ttr:ccd when supplied); a delete-op special case in the emitter
+      // must not swallow it — the receiver defaults an ABSENT isEncrypted
+      // by key shape, flipping an explicit value.
+      final n = (AtNotificationBuilder()
+            ..id = 'del-pin-3'
+            ..fromAtSign = alice
+            ..toAtSign = '@bob'
+            ..notification = '@bob:phone.wavi$alice'
+            ..type = NotificationType.sent
+            ..opType = OperationType.delete
+            ..ttl = 60000
+            ..atMetaData = (AtMetaData()
+              ..ttr = 2000
+              ..isCascade = true
+              ..isEncrypted = false))
+          .build();
+      final body = notificationManager.prepareNotifyCommandBody(n);
+      expect(
+          body,
+          matches(RegExp(r'^id:del-pin-3:delete:messageType:key'
+              r':notifier:system:ttln:\d+'
+              r':ttr:2000:ccd:true'
+              ':isEncrypted:false'
+              ':@bob:phone.wavi$alice\$')));
     });
   });
 
@@ -161,8 +211,12 @@ void main() {
 
     test('a ttr notification with cAt/uAt/eAt stores the cached key with '
         'the origin values; a refresh updates them', () async {
+      // ttl accompanies eAt so the assertion is proven to BEAT the ttl
+      // derivation on the receive path (without ttl the value would pass
+      // through whether or not the assertion mechanism ran).
       await notifyHandler.process(
-          'notify:id:rcv-1:update:messageType:key:ttr:100000:ccd:true'
+          'notify:id:rcv-1:update:messageType:key'
+          ':ttl:600000:ttr:100000:ccd:true'
           ':cAt:$cAtWire:uAt:$uAtWire:eAt:$eAtWire'
           ':$alice:phone.wavi$bob:hello',
           inboundConnection);

--- a/packages/at_secondary_server/test/notify_timestamps_test.dart
+++ b/packages/at_secondary_server/test/notify_timestamps_test.dart
@@ -256,6 +256,41 @@ void main() {
       expect(cached.metaData!.updatedAt!.isBefore(before), isFalse);
     });
 
+    test('a notification transmitting uAt but no ttb does not fabricate a '
+        'ttb on the cached key', () async {
+      // The receive path coerces an absent ttb to 0 before the keystore
+      // write, and setTTB(0) stamps availableAt to arrival time. A
+      // derivation that trusted the merged metadata would then store
+      // ttb = arrival - origin uAt: milliseconds on a fast link, days if
+      // this server was offline and the notification was retried — a
+      // birth window the origin record does not have.
+      await notifyHandler.process(
+          'notify:id:rcv-nofab:update:messageType:key:ttr:100000'
+          ':uAt:$uAtWire'
+          ':$alice:phone.wavi$bob:hello',
+          inboundConnection);
+      final cached = await keyValueStore.get('cached:$alice:phone.wavi$bob');
+      expect(cached!.metaData!.ttb ?? 0, 0,
+          reason: 'no ttb was transmitted, so none may be fabricated from '
+              'transfer latency');
+    });
+
+    test('a notification with eAt and no ttl derives ttl = eAt - uAt on '
+        'the cached key, not eAt - arrival time', () async {
+      await notifyHandler.process(
+          'notify:id:rcv-derive:update:messageType:key:ttr:100000'
+          ':uAt:$uAtWire:eAt:$eAtWire'
+          ':$alice:phone.wavi$bob:hello',
+          inboundConnection);
+      final cached = await keyValueStore.get('cached:$alice:phone.wavi$bob');
+      expect(cached!.metaData!.expiresAt, eAt);
+      expect(cached.metaData!.ttl, eAt.difference(uAt).inMilliseconds,
+          reason: 'the derivation must measure from the transmitted '
+              'updatedAt so every server derives the same ttl from the '
+              'same notification — measuring from arrival time would '
+              'erode the ttl by the transfer latency at every hop');
+    });
+
     test('a delete notification\'s :uAt: becomes the cached key\'s DELETE '
         'commit entry opTime (ccd case)', () async {
       await notifyHandler.process(

--- a/packages/at_secondary_server/test/notify_timestamps_test.dart
+++ b/packages/at_secondary_server/test/notify_timestamps_test.dart
@@ -1,0 +1,267 @@
+// The notify half of the at_commons 5.10.0 protocol enhancements:
+// server-to-server transmission of cAt/uAt/eAt/aAt.
+//
+//   * the outbound notify command body emits the four timestamps between
+//     ccd and isEncrypted (wire-shape pins, raw literals)
+//   * a delete notification carries its deletion time as :uAt: and NOTHING
+//     else — in particular no isEncrypted, whose absence deployed receivers
+//     default to true for non-public keys
+//   * the receiving side stores cached keys with the ORIGIN's timestamps,
+//     on first cache and on refresh, and records a transmitted deletion
+//     time as the cached key's DELETE commit entry opTime
+//   * the lookup-driven cache (AtCacheManager) stores the origin's
+//     timestamps on the cached copy
+//
+// Isolation: per-test, via verbTestsSetUp/verbTestsTearDown.
+
+import 'dart:collection';
+
+import 'package:at_commons/at_commons.dart';
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_secondary/src/utils/handler_util.dart';
+import 'package:at_secondary/src/utils/secondary_util.dart';
+import 'package:at_secondary/src/verb/handler/lookup_verb_handler.dart';
+import 'package:at_secondary/src/verb/handler/notify_verb_handler.dart';
+import 'package:at_server_spec/at_verb_spec.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+import 'test_utils.dart';
+
+void main() {
+  // Millisecond-precision instants (what the store holds) and their exact
+  // wire spellings (formatIso8601Micros pads to six fractional digits).
+  final cAt = DateTime.utc(2020, 1, 2, 3, 4, 5, 678);
+  const cAtWire = '2020-01-02T03:04:05.678000Z';
+  final uAt = DateTime.utc(2021, 2, 3, 4, 5, 6, 789);
+  const uAtWire = '2021-02-03T04:05:06.789000Z';
+  final eAt = DateTime.utc(2030, 1, 1);
+  const eAtWire = '2030-01-01T00:00:00.000000Z';
+  final aAt = DateTime.utc(2022, 3, 4, 5, 6, 7, 890);
+  const aAtWire = '2022-03-04T05:06:07.890000Z';
+
+  verbTestsSetUpLogging();
+
+  setUpAll(() async {
+    await verbTestsSetUpAll();
+  });
+
+  setUp(() async {
+    await verbTestsSetUp();
+  });
+
+  tearDown(() async {
+    await verbTestsTearDown();
+  });
+
+  group('outbound notify command body', () {
+    test('update notification emits cAt/uAt/eAt/aAt between ccd and '
+        'isEncrypted (wire-shape pin)', () {
+      final n = (AtNotificationBuilder()
+            ..id = 'ts-pin-1'
+            ..fromAtSign = alice
+            ..toAtSign = '@bob'
+            ..notification = '@bob:phone.wavi$alice'
+            ..type = NotificationType.sent
+            ..opType = OperationType.update
+            ..ttl = 60000
+            ..atValue = 'hello'
+            ..atMetaData = (AtMetaData()
+              ..ttr = 10
+              ..isCascade = false
+              ..isEncrypted = true
+              ..createdAt = cAt
+              ..updatedAt = uAt
+              ..expiresAt = eAt
+              ..availableAt = aAt))
+          .build();
+
+      final body = notificationManager.prepareNotifyCommandBody(n);
+      // Wire-shape pin: this is the contract every deployed receiver's
+      // regex must accept — the fragment order is frozen by
+      // VerbSyntax.metadataFragment (timestamps sit between ccd and
+      // isEncrypted). Only ttln's value is clock-dependent.
+      expect(
+          body,
+          matches(RegExp(r'^id:ts-pin-1:update:messageType:key'
+              r':notifier:system:ttln:\d+'
+              r':ttr:10:ccd:false'
+              ':cAt:$cAtWire:uAt:$uAtWire:eAt:$eAtWire:aAt:$aAtWire'
+              ':isEncrypted:true'
+              ':@bob:phone.wavi$alice:hello\$')));
+
+      // And the receiving grammar accepts it verbatim.
+      final HashMap<String, String?> reParsed =
+          getVerbParam(Notify().syntax(), 'notify:$body');
+      expect(reParsed[AtConstants.createdAt], cAtWire);
+      expect(reParsed[AtConstants.updatedAt], uAtWire);
+      expect(reParsed['expiresAt'], eAtWire);
+      expect(reParsed['availableAt'], aAtWire);
+    });
+
+    test('a metadata-less notification emits no timestamp fragments '
+        '(unchanged wire shape)', () {
+      final n = (AtNotificationBuilder()
+            ..id = 'ts-pin-2'
+            ..fromAtSign = alice
+            ..toAtSign = '@bob'
+            ..notification = '@bob:phone.wavi$alice'
+            ..type = NotificationType.sent
+            ..opType = OperationType.update
+            ..ttl = 60000)
+          .build();
+      final body = notificationManager.prepareNotifyCommandBody(n);
+      expect(
+          body,
+          matches(RegExp(r'^id:ts-pin-2:update:messageType:key'
+              r':notifier:system:ttln:\d+'
+              ':@bob:phone.wavi$alice\$')));
+    });
+
+    test('delete notification carries :uAt: and NOTHING else — no '
+        'isEncrypted (wire-shape pin)', () {
+      final n = (AtNotificationBuilder()
+            ..id = 'del-pin-1'
+            ..fromAtSign = alice
+            ..toAtSign = '@bob'
+            ..notification = '@bob:phone.wavi$alice'
+            ..type = NotificationType.sent
+            ..opType = OperationType.delete
+            ..ttl = 60000
+            ..atMetaData = (AtMetaData()..updatedAt = uAt))
+          .build();
+
+      final body = notificationManager.prepareNotifyCommandBody(n);
+      expect(
+          body,
+          matches(RegExp(r'^id:del-pin-1:delete:messageType:key'
+              r':notifier:system:ttln:\d+'
+              ':uAt:$uAtWire'
+              ':@bob:phone.wavi$alice\$')));
+      expect(body, isNot(contains('isEncrypted')),
+          reason: 'delete notifications have never carried a metadata '
+              'fragment; deployed receivers default an ABSENT isEncrypted '
+              'to true for non-public keys, so emitting isEncrypted:false '
+              'here would silently flip that default');
+
+      final HashMap<String, String?> reParsed =
+          getVerbParam(Notify().syntax(), 'notify:$body');
+      expect(reParsed[AtConstants.updatedAt], uAtWire);
+    });
+  });
+
+  group('receiving side: cached keys carry the origin\'s timestamps', () {
+    late NotifyVerbHandler notifyHandler;
+
+    setUp(() {
+      notifyHandler = NotifyVerbHandler(keyValueStore, notificationManager);
+      inboundConnection.metadata.isPolAuthenticated = true;
+      inboundConnection.metadata.fromAtSign = bob;
+    });
+
+    test('a ttr notification with cAt/uAt/eAt stores the cached key with '
+        'the origin values; a refresh updates them', () async {
+      await notifyHandler.process(
+          'notify:id:rcv-1:update:messageType:key:ttr:100000:ccd:true'
+          ':cAt:$cAtWire:uAt:$uAtWire:eAt:$eAtWire'
+          ':$alice:phone.wavi$bob:hello',
+          inboundConnection);
+
+      var cached = await keyValueStore.get('cached:$alice:phone.wavi$bob');
+      expect(cached!.metaData!.createdAt, cAt,
+          reason: 'the cached copy must carry the ORIGIN\'s createdAt, not '
+              'one stamped on this server\'s clock at cache time');
+      expect(cached.metaData!.updatedAt, uAt);
+      expect(cached.metaData!.expiresAt, eAt,
+          reason: 'an origin absolute expiry must not be rederived');
+
+      // A refresh notification transmits newer values; the cached copy
+      // adopts them (direct keystore writes have no retain-merge, so the
+      // receiver re-passes what each notification transmits).
+      final uAt2 = DateTime.utc(2021, 6, 1, 12);
+      const uAt2Wire = '2021-06-01T12:00:00.000000Z';
+      await notifyHandler.process(
+          'notify:id:rcv-2:update:messageType:key:ttr:100000:ccd:true'
+          ':cAt:$cAtWire:uAt:$uAt2Wire'
+          ':$alice:phone.wavi$bob:hello2',
+          inboundConnection);
+      cached = await keyValueStore.get('cached:$alice:phone.wavi$bob');
+      expect(cached!.metaData!.updatedAt, uAt2);
+      expect(cached.metaData!.createdAt, cAt);
+    });
+
+    test('a ttr notification without timestamps stamps them on this '
+        'server\'s clock (unchanged behaviour)', () async {
+      final before = DateTime.now().toUtcMillisecondsPrecision();
+      await notifyHandler.process(
+          'notify:id:rcv-3:update:messageType:key:ttr:100000'
+          ':$alice:phone.wavi$bob:hello',
+          inboundConnection);
+      final cached = await keyValueStore.get('cached:$alice:phone.wavi$bob');
+      expect(cached!.metaData!.createdAt!.isBefore(before), isFalse);
+      expect(cached.metaData!.updatedAt!.isBefore(before), isFalse);
+    });
+
+    test('a delete notification\'s :uAt: becomes the cached key\'s DELETE '
+        'commit entry opTime (ccd case)', () async {
+      await notifyHandler.process(
+          'notify:id:rcv-4:update:messageType:key:ttr:100000:ccd:true'
+          ':$alice:phone.wavi$bob:hello',
+          inboundConnection);
+      expect(await keyValueStore.exists('cached:$alice:phone.wavi$bob'),
+          isTrue);
+
+      await notifyHandler.process(
+          'notify:id:rcv-5:delete:messageType:key'
+          ':uAt:$uAtWire'
+          ':$alice:phone.wavi$bob',
+          inboundConnection);
+
+      expect(await keyValueStore.exists('cached:$alice:phone.wavi$bob'),
+          isFalse,
+          reason: 'the cached key was stored with isCascade, so the delete '
+              'notification removes it');
+      final entry =
+          atCommitLog.getLatestCommitEntry('cached:$alice:phone.wavi$bob')!;
+      expect(entry.operation, CommitOp.DELETE);
+      expect(entry.opTime, uAt,
+          reason: 'the DELETE entry records the origin deletion time');
+    });
+  });
+
+  group('lookup-driven cache (AtCacheManager)', () {
+    test('the cached copy of a remotely-looked-up key carries the origin\'s '
+        'timestamps', () async {
+      inboundConnection.metadata.isAuthenticated = true;
+      const keyName = 'some_key.some_namespace@bob';
+
+      final AtData bobData = createRandomAtData(bob);
+      bobData.metaData!.ttr = 10;
+      bobData.metaData!.ttb = null;
+      bobData.metaData!.ttl = null;
+      bobData.metaData!.createdAt = cAt;
+      bobData.metaData!.updatedAt = uAt;
+      bobData.metaData!.expiresAt = eAt;
+      final String bobDataAsJsonWithKey = SecondaryUtil.prepareResponseData(
+          'all', bobData,
+          key: '$alice:$keyName')!;
+
+      when(() => mockOutboundConnection.write('lookup:all:$keyName\n'))
+          .thenAnswer((Invocation invocation) async {
+        socketOnDataFn("data:$bobDataAsJsonWithKey\n$alice@".codeUnits);
+      });
+
+      final lookupHandler = LookupVerbHandler(
+          keyValueStore, mockOutboundClientManager, cacheManager, enMgr,
+          accessLog: atAccessLog);
+      await lookupHandler.process('lookup:all:$keyName', inboundConnection);
+
+      final cached = await keyValueStore.get('cached:$alice:$keyName');
+      expect(cached!.metaData!.createdAt, cAt,
+          reason: 'the cache must hold the origin\'s createdAt, not a '
+              'cache-time stamp');
+      expect(cached.metaData!.updatedAt, uAt);
+      expect(cached.metaData!.expiresAt, eAt);
+    });
+  });
+}

--- a/packages/at_secondary_server/test/protocol_timestamps_nc_verb_test.dart
+++ b/packages/at_secondary_server/test/protocol_timestamps_nc_verb_test.dart
@@ -100,6 +100,12 @@ void main() {
       expect(meta.updatedAt, uAtStored);
       expect(meta.expiresAt, eAtStored);
       expect(meta.availableAt, aAtStored);
+      expect(meta.ttb, aAtStored.difference(uAtStored).inMilliseconds,
+          reason: 'no ttb was supplied, so the one the absolutes imply is '
+              'derived and stored');
+      expect(meta.ttl, eAtStored.difference(aAtStored).inMilliseconds,
+          reason: 'no ttl was supplied; the record lives ttl ms from when '
+              'it becomes available, so ttl spans availableAt→expiresAt');
     });
 
     test('asserted cAt on an EXISTING key overwrites stored createdAt',
@@ -186,6 +192,67 @@ void main() {
       final meta = await llookupAllAtMetaData('@bob:phone.wavi$alice');
       expect(meta.expiresAt, eAtStored);
       expect(meta.availableAt, aAtStored);
+      expect(meta.ttl, eAtStored.difference(meta.updatedAt!).inMilliseconds,
+          reason: 'the coerced ttl:0 counts as unsupplied, so the implied '
+              'ttl is derived — from updatedAt, because this availableAt '
+              'lies in the past');
+      expect(meta.ttb, isNull,
+          reason: 'the implied ttb is negative (availableAt is in the '
+              'past), so the derivation clears the coerced 0 — a stored '
+              'ttb:0 would read as "born at the write" beside an '
+              'availableAt that says otherwise');
+    });
+
+    test('update with eAt and no ttl derives and stores the implied ttl',
+        () async {
+      await updateHandler.process(
+          'update:uAt:$uAtWire:eAt:$eAtWire:@bob:phone.wavi$alice v1',
+          inboundConnection);
+      final meta = await llookupAllAtMetaData('@bob:phone.wavi$alice');
+      expect(meta.expiresAt, eAtStored);
+      expect(meta.ttl, eAtStored.difference(uAtStored).inMilliseconds,
+          reason: 'a record with an absolute expiry also carries the ttl '
+              'it implies — measured from the stored updatedAt, so every '
+              'server derives the same value from the same assertions');
+    });
+
+    test('update with aAt and no ttb derives and stores the implied ttb',
+        () async {
+      await updateHandler.process(
+          'update:uAt:$uAtWire:aAt:$aAtWire:@bob:phone.wavi$alice v1',
+          inboundConnection);
+      final meta = await llookupAllAtMetaData('@bob:phone.wavi$alice');
+      expect(meta.availableAt, aAtStored);
+      expect(meta.ttb, aAtStored.difference(uAtStored).inMilliseconds);
+    });
+
+    test('eAt on an existing ttl-record derives the implied ttl, replacing '
+        'the stale one', () async {
+      await updateHandler.process(
+          'update:ttl:86400000:@bob:phone.wavi$alice v1', inboundConnection);
+      await updateHandler.process(
+          'update:eAt:$eAtWire:@bob:phone.wavi$alice v2', inboundConnection);
+      final meta = await llookupAllAtMetaData('@bob:phone.wavi$alice');
+      expect(meta.expiresAt, eAtStored);
+      expect(meta.ttl, eAtStored.difference(meta.updatedAt!).inMilliseconds,
+          reason: 'the request supplied the absolute without a ttl, so the '
+              'implied ttl replaces the record\'s stale one — keeping the '
+              'retained 86400000 beside a 2030 expiry would contradict it, '
+              'and the same request sent as update:json would derive, so '
+              'the two encodings must agree');
+    });
+
+    test('aAt on an existing ttb-record derives the implied ttb, replacing '
+        'the stale one', () async {
+      await updateHandler.process(
+          'update:ttb:86400000:@bob:phone.wavi$alice v1', inboundConnection);
+      await updateHandler.process(
+          'update:uAt:$uAtWire:aAt:$aAtWire:@bob:phone.wavi$alice v2',
+          inboundConnection);
+      final meta = await llookupAllAtMetaData('@bob:phone.wavi$alice');
+      expect(meta.availableAt, aAtStored);
+      expect(meta.ttb, aAtStored.difference(uAtStored).inMilliseconds,
+          reason: 'mirror of the eAt/ttl rule on the birth axis');
     });
 
     test('update:json with createdAt/updatedAt stores them faithfully',
@@ -221,6 +288,153 @@ void main() {
               'update:cAt:2020-01-02T03:04:05.678901:@bob:phone.wavi$alice v',
               inboundConnection),
           throwsA(isA<InvalidSyntaxException>()));
+    });
+  });
+
+  group('once set, an absolute moves only when a request speaks about it',
+      () {
+    test('a write that says nothing about expiry does not move expiresAt',
+        () async {
+      await updateHandler.process(
+          'update:ttl:86400000:@bob:phone.wavi$alice v1', inboundConnection);
+      final before = await llookupAllAtMetaData('@bob:phone.wavi$alice');
+      expect(before.expiresAt, isNotNull,
+          reason: 'guards the comparison below — null == null would pass '
+              'without the axis ever having been populated');
+      // Far enough apart that a re-derivation from now would visibly move
+      // the millisecond-precision expiresAt.
+      await Future.delayed(Duration(milliseconds: 50));
+      await updateHandler.process(
+          'update:@bob:phone.wavi$alice v2', inboundConnection);
+      final after = await llookupAllAtMetaData('@bob:phone.wavi$alice');
+      expect(after.expiresAt, before.expiresAt,
+          reason: 'once set, expiresAt moves only when a request speaks '
+              'about expiry: an eAt assertion, a fresh ttl, or ttl:0 — '
+              'a value update must not restart the expiry clock');
+      expect(after.ttl, 86400000);
+      expect(after.updatedAt!.isAfter(before.updatedAt!), isTrue,
+          reason: 'proves the second write actually happened — the '
+              'unchanged expiresAt must not be because the write was lost');
+    });
+
+    test('update:meta that says nothing about expiry does not move '
+        'expiresAt', () async {
+      await updateHandler.process(
+          'update:ttl:86400000:@bob:phone.wavi$alice v1', inboundConnection);
+      final before = await llookupAllAtMetaData('@bob:phone.wavi$alice');
+      expect(before.expiresAt, isNotNull);
+      await Future.delayed(Duration(milliseconds: 50));
+      await updateMetaHandler.process(
+          'update:meta:@bob:phone.wavi$alice:isBinary:true',
+          inboundConnection);
+      final after = await llookupAllAtMetaData('@bob:phone.wavi$alice');
+      expect(after.expiresAt, before.expiresAt);
+      expect(after.isBinary, true,
+          reason: 'proves the metadata write actually happened');
+    });
+
+    test('a ttl-only write leaves a pinned birth axis alone and expires at '
+        'exactly now + ttl', () async {
+      await updateHandler.process(
+          'update:ttb:100:@bob:phone.wavi$alice v1', inboundConnection);
+      // Wait out the birth window so llookup can see the record at all.
+      await Future.delayed(Duration(milliseconds: 150));
+      final before = await llookupAllAtMetaData('@bob:phone.wavi$alice');
+      expect(before.availableAt, isNotNull);
+
+      await updateHandler.process(
+          'update:ttl:60000:@bob:phone.wavi$alice v2', inboundConnection);
+      final after = await llookupAllAtMetaData('@bob:phone.wavi$alice');
+      expect(after.availableAt, before.availableAt,
+          reason: 'the request said nothing about the birth axis');
+      expect(after.ttb, before.ttb,
+          reason: 'the silent axis keeps its relative too');
+      expect(after.expiresAt!.difference(after.updatedAt!).inMilliseconds,
+          60000,
+          reason: 'a ttl-only write on a born record must expire at '
+              'exactly now + ttl — folding the record\'s retained ttb in '
+              'would stretch the lifetime by a birth delay that is not '
+              'restarting');
+    });
+
+    test('a ttb-only write leaves a pinned expiry axis alone and is born at '
+        'exactly now + ttb', () async {
+      await updateHandler.process(
+          'update:ttl:86400000:@bob:phone.wavi$alice v1', inboundConnection);
+      final before = await llookupAllAtMetaData('@bob:phone.wavi$alice');
+      expect(before.expiresAt, isNotNull);
+      await Future.delayed(Duration(milliseconds: 50));
+
+      await updateHandler.process(
+          'update:ttb:100:@bob:phone.wavi$alice v2', inboundConnection);
+      // Wait out the new birth window before looking.
+      await Future.delayed(Duration(milliseconds: 150));
+      final after = await llookupAllAtMetaData('@bob:phone.wavi$alice');
+      expect(after.expiresAt, before.expiresAt,
+          reason: 'the request said nothing about the expiry axis');
+      expect(after.ttl, before.ttl);
+      expect(after.availableAt!.difference(after.updatedAt!).inMilliseconds,
+          100,
+          reason: 'the explicit ttb re-derives availableAt = now + ttb');
+    });
+
+    test('an expiry-silent update:json clears expiry (the json encoding '
+        'cannot say nothing about expiry)', () async {
+      // commons Metadata.fromJson coerces an absent ttl to 0, and a 0
+      // with no asserted expiry is indistinguishable from an explicit
+      // clear — so the no-slide carry is unreachable via update:json.
+      // This pins that documented limitation.
+      await updateHandler.process(
+          'update:ttl:86400000:@bob:phone.wavi$alice v1', inboundConnection);
+      final before = await llookupAllAtMetaData('@bob:phone.wavi$alice');
+      expect(before.expiresAt, isNotNull);
+
+      final json = jsonEncode({
+        'atKey': 'phone.wavi',
+        'value': 'v2',
+        'sharedBy': alice,
+        'sharedWith': '@bob',
+        'metadata': Metadata().toJson(),
+      });
+      await updateHandler.process('update:json:$json', inboundConnection);
+      final after = await llookupAllAtMetaData('@bob:phone.wavi$alice');
+      expect(after.expiresAt, isNull,
+          reason: 'the coerced ttl:0 counts as the request speaking, and '
+              'ttl:0 clears — an update:json client that wants to keep a '
+              'record\'s expiry must send its metadata back');
+    });
+
+    test('a write that says nothing about availability does not move '
+        'availableAt (no re-opened not-yet-born window)', () async {
+      await updateHandler.process(
+          'update:ttb:100:@bob:phone.wavi$alice v1', inboundConnection);
+      // Wait out the birth window so llookup can see the record at all.
+      await Future.delayed(Duration(milliseconds: 150));
+      final before = await llookupAllAtMetaData('@bob:phone.wavi$alice');
+      expect(before.availableAt, isNotNull,
+          reason: 'guards the comparison below — null == null would pass '
+              'without the axis ever having been populated');
+      await Future.delayed(Duration(milliseconds: 50));
+      await updateHandler.process(
+          'update:@bob:phone.wavi$alice v2', inboundConnection);
+      final after = await llookupAllAtMetaData('@bob:phone.wavi$alice');
+      expect(after.availableAt, before.availableAt,
+          reason: 'a value update must not re-derive availableAt = '
+              'now + ttb, which would make the record unavailable again '
+              'for ttb ms after every write');
+      expect(after.updatedAt!.isAfter(before.updatedAt!), isTrue);
+    });
+
+    test('ttl:0 still clears expiry on a record whose expiresAt is set',
+        () async {
+      await updateHandler.process(
+          'update:ttl:86400000:@bob:phone.wavi$alice v1', inboundConnection);
+      await updateHandler.process(
+          'update:ttl:0:@bob:phone.wavi$alice v2', inboundConnection);
+      final meta = await llookupAllAtMetaData('@bob:phone.wavi$alice');
+      expect(meta.expiresAt, isNull,
+          reason: 'clearing is not deriving: an explicit ttl:0 still '
+              'removes the expiry');
     });
   });
 
@@ -392,7 +606,8 @@ void main() {
             '$bob:ghost.wavi$alice',
             AtData()
               ..data = 'v1'
-              ..metaData = AtMetaData());
+              ..metaData = AtMetaData(),
+            null);
         final before = (await (await notifStore.getKeys()).toList()).length;
         await updateHandler.notifyAfterStore(
             verbParams, updateParams, result);

--- a/packages/at_secondary_server/test/protocol_timestamps_nc_verb_test.dart
+++ b/packages/at_secondary_server/test/protocol_timestamps_nc_verb_test.dart
@@ -1,0 +1,405 @@
+// The update/update:meta/update:json/delete halves of the at_commons 5.10.0
+// protocol enhancements, at the verb layer:
+//
+//   * :cAt/:uAt/:eAt/:aAt — caller-asserted timestamps stored faithfully
+//     (wire fragment -> verb regex -> AtAssertedTimestamps -> keystore ->
+//     llookup:all)
+//   * :nc — perform the operation, write no commit entry, purge the key's
+//     existing entry, respond data:-1; autoNotify unaffected
+//   * delete:dAt — recorded as the DELETE commit entry's opTime
+//   * the auto-notification carries the STORED metadata (queued after the
+//     write)
+//
+// Isolation: per-test, via verbTestsSetUp/verbTestsTearDown (same as
+// update_verb_test.dart).
+
+import 'dart:collection';
+import 'dart:convert';
+
+import 'package:at_commons/at_commons.dart';
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_secondary/src/verb/handler/abstract_update_verb_handler.dart';
+import 'package:at_secondary/src/verb/handler/delete_verb_handler.dart';
+import 'package:at_secondary/src/verb/handler/local_lookup_verb_handler.dart';
+import 'package:at_secondary/src/verb/handler/sync_progressive_verb_handler.dart';
+import 'package:at_secondary/src/verb/handler/update_meta_verb_handler.dart';
+import 'package:at_secondary/src/verb/handler/update_verb_handler.dart';
+import 'package:test/test.dart';
+
+import 'test_utils.dart';
+
+void main() {
+  // Wire form carries microseconds; the store holds milliseconds.
+  const cAtWire = '2020-01-02T03:04:05.678901Z';
+  final cAtStored = DateTime.utc(2020, 1, 2, 3, 4, 5, 678);
+  const uAtWire = '2021-02-03T04:05:06.789012Z';
+  final uAtStored = DateTime.utc(2021, 2, 3, 4, 5, 6, 789);
+  const eAtWire = '2030-01-01T00:00:00.000000Z';
+  final eAtStored = DateTime.utc(2030, 1, 1);
+  const aAtWire = '2022-03-04T05:06:07.890123Z';
+  final aAtStored = DateTime.utc(2022, 3, 4, 5, 6, 7, 890);
+
+  verbTestsSetUpLogging();
+
+  setUpAll(() async {
+    await verbTestsSetUpAll();
+  });
+
+  late UpdateVerbHandler updateHandler;
+  late UpdateMetaVerbHandler updateMetaHandler;
+  late DeleteVerbHandler deleteHandler;
+  late LocalLookupVerbHandler llookupHandler;
+
+  setUp(() async {
+    await verbTestsSetUp();
+    updateHandler = UpdateVerbHandler(
+        keyValueStore, statsNotificationService, notificationManager, alice);
+    updateMetaHandler = UpdateMetaVerbHandler(
+        keyValueStore, statsNotificationService, notificationManager, alice);
+    deleteHandler = DeleteVerbHandler(
+        keyValueStore, statsNotificationService, notificationManager);
+    llookupHandler = LocalLookupVerbHandler(keyValueStore, enMgr);
+    inboundConnection.metadata.isAuthenticated = true;
+  });
+
+  tearDown(() async {
+    await verbTestsTearDown();
+  });
+
+  Future<AtMetaData> llookupAllAtMetaData(String fullKeyName) async {
+    await llookupHandler.process('llookup:all:$fullKeyName', inboundConnection);
+    final mapSentToClient = decodeResponse(inboundConnection.lastWrittenData!);
+    return AtMetaData.fromJson(mapSentToClient['metaData']);
+  }
+
+  int lastResponseAsInt() => int.parse(
+      inboundConnection.lastWrittenData!.split('\n')[0].replaceAll('data:', ''));
+
+  Future<List<dynamic>> syncFromMinusOne() async {
+    final syncHandler =
+        SyncProgressiveVerbHandler(keyValueStore, commitLog: atCommitLog);
+    final response = Response();
+    final verbParams = HashMap<String, String?>();
+    verbParams[AtConstants.fromCommitSequence] = '-1';
+    await syncHandler.processVerb(response, verbParams, inboundConnection);
+    return jsonDecode(response.data!);
+  }
+
+  group('asserted timestamps via update', () {
+    test('update with cAt/uAt/eAt/aAt stores them faithfully (ms-truncated)',
+        () async {
+      await updateHandler.process(
+          'update:cAt:$cAtWire:uAt:$uAtWire:eAt:$eAtWire:aAt:$aAtWire'
+          ':@bob:phone.wavi$alice hello',
+          inboundConnection);
+
+      final meta = await llookupAllAtMetaData('@bob:phone.wavi$alice');
+      expect(meta.createdAt, cAtStored);
+      expect(meta.updatedAt, uAtStored);
+      expect(meta.expiresAt, eAtStored);
+      expect(meta.availableAt, aAtStored);
+    });
+
+    test('asserted cAt on an EXISTING key overwrites stored createdAt',
+        () async {
+      await updateHandler.process(
+          'update:@bob:phone.wavi$alice hello', inboundConnection);
+      final original = await llookupAllAtMetaData('@bob:phone.wavi$alice');
+      expect(original.createdAt, isNot(cAtStored));
+
+      await updateHandler.process(
+          'update:cAt:$cAtWire:@bob:phone.wavi$alice hello2',
+          inboundConnection);
+      final meta = await llookupAllAtMetaData('@bob:phone.wavi$alice');
+      expect(meta.createdAt, cAtStored,
+          reason: 'an explicit cAt assertion wins on update as on create');
+    });
+
+    test('without assertions, behaviour is unchanged: createdAt preserved, '
+        'updatedAt re-stamped', () async {
+      await updateHandler.process(
+          'update:cAt:$cAtWire:uAt:$uAtWire:@bob:phone.wavi$alice v1',
+          inboundConnection);
+      final before = DateTime.now().toUtcMillisecondsPrecision();
+      await updateHandler.process(
+          'update:@bob:phone.wavi$alice v2', inboundConnection);
+
+      final meta = await llookupAllAtMetaData('@bob:phone.wavi$alice');
+      expect(meta.createdAt, cAtStored);
+      expect(meta.updatedAt!.isBefore(before), isFalse,
+          reason: 'updatedAt is server-stamped when no uAt is asserted');
+    });
+
+    test('asserted eAt wins over ttl derivation at that write; a later '
+        'ttl-bearing write re-derives', () async {
+      await updateHandler.process(
+          'update:ttl:86400000:eAt:$eAtWire:@bob:phone.wavi$alice v1',
+          inboundConnection);
+      var meta = await llookupAllAtMetaData('@bob:phone.wavi$alice');
+      expect(meta.expiresAt, eAtStored,
+          reason: 'the transmitted absolute expiry must not be re-derived '
+              'from now+ttl on arrival');
+      expect(meta.ttl, 86400000);
+
+      final before = DateTime.now().toUtcMillisecondsPrecision();
+      await updateHandler.process(
+          'update:ttl:86400000:@bob:phone.wavi$alice v2', inboundConnection);
+      meta = await llookupAllAtMetaData('@bob:phone.wavi$alice');
+      expect(meta.expiresAt, isNot(eAtStored));
+      expect(meta.expiresAt!.isAfter(before), isTrue,
+          reason: 'without an eAt assertion, ttl re-derives from now');
+    });
+
+    test('update:meta with uAt/eAt stores them faithfully', () async {
+      await updateHandler.process(
+          'update:@bob:phone.wavi$alice v1', inboundConnection);
+      await updateMetaHandler.process(
+          'update:meta:@bob:phone.wavi$alice:uAt:$uAtWire:eAt:$eAtWire',
+          inboundConnection);
+
+      final meta = await llookupAllAtMetaData('@bob:phone.wavi$alice');
+      expect(meta.updatedAt, uAtStored);
+      expect(meta.expiresAt, eAtStored);
+    });
+
+    test('update:json with eAt and NO ttl: the asserted expiry survives the '
+        'json path\'s ttl-to-0 coercion', () async {
+      // Metadata.fromJson coerces an absent ttl to 0, and ttl:0 normally
+      // CLEARS expiresAt — the assertion must beat that derivation. The
+      // metadata map is built through commons Metadata.toJson, the shape
+      // every real client emits.
+      final metadataJson = (Metadata()
+            ..expiresAt = DateTime.parse(eAtWire)
+            ..availableAt = DateTime.parse(aAtWire))
+          .toJson();
+      final json = jsonEncode({
+        'atKey': 'phone.wavi',
+        'value': 'json-value',
+        'sharedBy': alice,
+        'sharedWith': '@bob',
+        'metadata': metadataJson,
+      });
+      await updateHandler.process('update:json:$json', inboundConnection);
+
+      final meta = await llookupAllAtMetaData('@bob:phone.wavi$alice');
+      expect(meta.expiresAt, eAtStored);
+      expect(meta.availableAt, aAtStored);
+    });
+
+    test('update:json with createdAt/updatedAt stores them faithfully',
+        () async {
+      final metadataJson = (Metadata()
+            ..createdAt = DateTime.parse(cAtWire)
+            ..updatedAt = DateTime.parse(uAtWire))
+          .toJson();
+      final json = jsonEncode({
+        'atKey': 'phone.wavi',
+        'value': 'json-value',
+        'sharedBy': alice,
+        'sharedWith': '@bob',
+        'metadata': metadataJson,
+      });
+      await updateHandler.process('update:json:$json', inboundConnection);
+
+      final meta = await llookupAllAtMetaData('@bob:phone.wavi$alice');
+      expect(meta.createdAt, cAtStored);
+      expect(meta.updatedAt, uAtStored);
+    });
+
+    test('update with uAt records it as the commit entry\'s opTime', () async {
+      await updateHandler.process(
+          'update:uAt:$uAtWire:@bob:phone.wavi$alice v1', inboundConnection);
+      final entry = atCommitLog.getLatestCommitEntry('@bob:phone.wavi$alice')!;
+      expect(entry.opTime, uAtStored);
+    });
+
+    test('a non-UTC timestamp does not match the grammar', () async {
+      await expectLater(
+          updateHandler.process(
+              'update:cAt:2020-01-02T03:04:05.678901:@bob:phone.wavi$alice v',
+              inboundConnection),
+          throwsA(isA<InvalidSyntaxException>()));
+    });
+  });
+
+  group(':nc on update / update:meta / update:json', () {
+    test('update:nc responds data:-1, stores the value, purges the commit '
+        'entry', () async {
+      await updateHandler.process(
+          'update:@bob:phone.wavi$alice v1', inboundConnection);
+      expect(
+          atCommitLog.getLatestCommitEntry('@bob:phone.wavi$alice'), isNotNull);
+
+      await updateHandler.process(
+          'update:nc:@bob:phone.wavi$alice v2', inboundConnection);
+      expect(lastResponseAsInt(), -1);
+      expect(atCommitLog.getLatestCommitEntry('@bob:phone.wavi$alice'), isNull,
+          reason: 'a no-commit update scrubs the key\'s previous entry');
+
+      await llookupHandler.process(
+          'llookup:@bob:phone.wavi$alice', inboundConnection);
+      expect(inboundConnection.lastWrittenData, startsWith('data:v2'),
+          reason: 'the write itself still happens');
+    });
+
+    test('after update:nc, sync no longer returns an entry for the key',
+        () async {
+      await updateHandler.process(
+          'update:@bob:phone.wavi$alice v1', inboundConnection);
+      var syncEntries = await syncFromMinusOne();
+      expect(syncEntries.where((e) => e['atKey'] == '@bob:phone.wavi$alice'),
+          isNotEmpty);
+
+      await updateHandler.process(
+          'update:nc:@bob:phone.wavi$alice v2', inboundConnection);
+      syncEntries = await syncFromMinusOne();
+      expect(syncEntries.where((e) => e['atKey'] == '@bob:phone.wavi$alice'),
+          isEmpty);
+    });
+
+    test('update:meta:nc responds data:-1 and purges', () async {
+      await updateHandler.process(
+          'update:@bob:phone.wavi$alice v1', inboundConnection);
+      await updateMetaHandler.process(
+          'update:meta:nc:@bob:phone.wavi$alice:ttl:60000', inboundConnection);
+      expect(lastResponseAsInt(), -1);
+      expect(atCommitLog.getLatestCommitEntry('@bob:phone.wavi$alice'), isNull);
+
+      final meta = await llookupAllAtMetaData('@bob:phone.wavi$alice');
+      expect(meta.ttl, 60000, reason: 'the metadata write itself happened');
+    });
+
+    test('update:nc:json responds data:-1 and purges', () async {
+      await updateHandler.process(
+          'update:@bob:phone.wavi$alice v1', inboundConnection);
+      final json = jsonEncode({
+        'atKey': 'phone.wavi',
+        'value': 'v2',
+        'sharedBy': alice,
+        'sharedWith': '@bob',
+        'metadata': Metadata().toJson(),
+      });
+      await updateHandler.process('update:nc:json:$json', inboundConnection);
+      expect(lastResponseAsInt(), -1);
+      expect(atCommitLog.getLatestCommitEntry('@bob:phone.wavi$alice'), isNull);
+    });
+
+    test('update:nc still autoNotifies the sharedWith atSign', () async {
+      AbstractUpdateVerbHandler.setAutoNotify(true);
+      try {
+        await updateHandler.process(
+            'update:nc:$bob:nc-notified.wavi$alice hi', inboundConnection);
+
+        AtNotification? generated;
+        for (final id in await (await notifStore.getKeys()).toList()) {
+          final n = await notifStore.get(id);
+          if (n != null && n.notification!.contains('nc-notified.wavi')) {
+            generated = n;
+            break;
+          }
+        }
+        expect(generated, isNotNull,
+            reason: ':nc changes commit-log behaviour ONLY — the operation, '
+                'including its auto-notification, runs as usual');
+      } finally {
+        AbstractUpdateVerbHandler.setAutoNotify(false);
+      }
+    });
+  });
+
+  group('delete:dAt and delete:nc', () {
+    test('delete:dAt records the asserted time as the DELETE entry\'s opTime',
+        () async {
+      await updateHandler.process(
+          'update:@bob:phone.wavi$alice v1', inboundConnection);
+      await deleteHandler.process(
+          'delete:dAt:$uAtWire:@bob:phone.wavi$alice', inboundConnection);
+
+      final entry = atCommitLog.getLatestCommitEntry('@bob:phone.wavi$alice')!;
+      expect(entry.operation, CommitOp.DELETE);
+      expect(entry.opTime, uAtStored);
+    });
+
+    test('delete:nc responds data:-1 and purges; the cruft case (key already '
+        'gone) purges too', () async {
+      await updateHandler.process(
+          'update:@bob:phone.wavi$alice v1', inboundConnection);
+      await deleteHandler.process(
+          'delete:@bob:phone.wavi$alice', inboundConnection);
+      expect(atCommitLog.getLatestCommitEntry('@bob:phone.wavi$alice')!
+          .operation, CommitOp.DELETE,
+          reason: 'a normal delete leaves the DELETE entry — the cruft');
+
+      // The key no longer exists; delete:nc must still purge its entry.
+      await deleteHandler.process(
+          'delete:nc:@bob:phone.wavi$alice', inboundConnection);
+      expect(lastResponseAsInt(), -1);
+      expect(atCommitLog.getLatestCommitEntry('@bob:phone.wavi$alice'), isNull);
+    });
+
+    test('delete:dAt:nc parses; dAt is moot (no entry to stamp)', () async {
+      await updateHandler.process(
+          'update:@bob:phone.wavi$alice v1', inboundConnection);
+      await deleteHandler.process(
+          'delete:dAt:$uAtWire:nc:@bob:phone.wavi$alice', inboundConnection);
+      expect(lastResponseAsInt(), -1);
+      expect(atCommitLog.getLatestCommitEntry('@bob:phone.wavi$alice'), isNull);
+    });
+
+    test('delete:nc still autoNotifies the sharedWith atSign', () async {
+      AbstractUpdateVerbHandler.setAutoNotify(true);
+      try {
+        await updateHandler.process(
+            'update:$bob:nc-deleted.wavi$alice hi', inboundConnection);
+        await deleteHandler.process(
+            'delete:nc:$bob:nc-deleted.wavi$alice', inboundConnection);
+
+        AtNotification? deleteNotification;
+        for (final id in await (await notifStore.getKeys()).toList()) {
+          final n = await notifStore.get(id);
+          if (n != null &&
+              n.notification!.contains('nc-deleted.wavi') &&
+              n.opType == OperationType.delete) {
+            deleteNotification = n;
+            break;
+          }
+        }
+        expect(deleteNotification, isNotNull,
+            reason: ':nc changes commit-log behaviour ONLY');
+      } finally {
+        AbstractUpdateVerbHandler.setAutoNotify(false);
+      }
+    });
+  });
+
+  group('the auto-notification carries the STORED metadata', () {
+    test('updating an existing key notifies with the stored (old) createdAt, '
+        'not a freshly-fabricated one', () async {
+      AbstractUpdateVerbHandler.setAutoNotify(true);
+      try {
+        await updateHandler.process(
+            'update:cAt:$cAtWire:$bob:stored-meta.wavi$alice v1',
+            inboundConnection);
+        await updateHandler.process(
+            'update:$bob:stored-meta.wavi$alice v2', inboundConnection);
+
+        final notifications = <AtNotification>[];
+        for (final id in await (await notifStore.getKeys()).toList()) {
+          final n = await notifStore.get(id);
+          if (n != null && n.notification!.contains('stored-meta.wavi')) {
+            notifications.add(n);
+          }
+        }
+        expect(notifications, isNotEmpty);
+        for (final n in notifications) {
+          expect(n.atMetadata?.createdAt, cAtStored,
+              reason: 'the notification must carry what the store holds — '
+                  'a pre-store fabricated createdAt would transmit a wrong '
+                  'value to the other atServer');
+        }
+      } finally {
+        AbstractUpdateVerbHandler.setAutoNotify(false);
+      }
+    });
+  });
+}

--- a/packages/at_secondary_server/test/protocol_timestamps_nc_verb_test.dart
+++ b/packages/at_secondary_server/test/protocol_timestamps_nc_verb_test.dart
@@ -18,12 +18,14 @@ import 'dart:convert';
 
 import 'package:at_commons/at_commons.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_secondary/src/utils/handler_util.dart';
 import 'package:at_secondary/src/verb/handler/abstract_update_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/delete_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/local_lookup_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/sync_progressive_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/update_meta_verb_handler.dart';
 import 'package:at_secondary/src/verb/handler/update_verb_handler.dart';
+import 'package:at_server_spec/at_verb_spec.dart';
 import 'package:test/test.dart';
 
 import 'test_utils.dart';
@@ -373,6 +375,36 @@ void main() {
   });
 
   group('the auto-notification carries the STORED metadata', () {
+    test('the auto-notification is SKIPPED when the record vanished before '
+        'the read-back', () async {
+      // Delete takes no per-key mutex, so a record can vanish between the
+      // put and notifyAfterStore's read-back. Queueing the update
+      // notification then could overtake the delete's own notification and
+      // resurrect the receiver's cached copy — so it must be skipped.
+      AbstractUpdateVerbHandler.setAutoNotify(true);
+      try {
+        final command = 'update:$bob:ghost.wavi$alice v1';
+        final verbParams = getVerbParam(Update().syntax(), command);
+        final updateParams = updateHandler.getUpdateParams(verbParams);
+        // The record does NOT exist (never written): the read-back
+        // returns null exactly as it would after a concurrent delete.
+        final result = UpdatePreProcessResult(
+            '$bob:ghost.wavi$alice',
+            AtData()
+              ..data = 'v1'
+              ..metaData = AtMetaData());
+        final before = (await (await notifStore.getKeys()).toList()).length;
+        await updateHandler.notifyAfterStore(
+            verbParams, updateParams, result);
+        final after = (await (await notifStore.getKeys()).toList()).length;
+        expect(after, before,
+            reason: 'no notification may be queued for a record the '
+                'read-back found deleted');
+      } finally {
+        AbstractUpdateVerbHandler.setAutoNotify(false);
+      }
+    });
+
     test('updating an existing key notifies with the stored (old) createdAt, '
         'not a freshly-fabricated one', () async {
       AbstractUpdateVerbHandler.setAutoNotify(true);

--- a/packages/at_secondary_server/test/remove_malformed_keys_test.dart
+++ b/packages/at_secondary_server/test/remove_malformed_keys_test.dart
@@ -16,7 +16,8 @@ class MockAtKeyValueStore extends Mock
   }
 
   @override
-  Future<int?> remove(String key, {bool skipCommit = false}) async {
+  Future<int?> remove(String key,
+      {bool skipCommit = false, DateTime? deletedAt}) async {
     dummyKeyStore.remove(key);
     return 1;
   }

--- a/packages/at_secondary_server/test/scan_commit_log_test.dart
+++ b/packages/at_secondary_server/test/scan_commit_log_test.dart
@@ -1,0 +1,222 @@
+// scan:cl — the commit-log scan from the at_commons 5.10.0 protocol
+// enhancements: an authenticated client lists commit-log entries (to judge
+// cruft, then delete:nc it), filtered exactly as a keystore scan is —
+// regex, hidden-key rules, enrollment namespaces.
+//
+// Isolation: per-test, via verbTestsSetUp/verbTestsTearDown.
+
+import 'dart:convert';
+
+import 'package:at_commons/at_commons.dart';
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_secondary/src/verb/handler/delete_verb_handler.dart';
+import 'package:at_secondary/src/verb/handler/scan_verb_handler.dart';
+import 'package:at_secondary/src/verb/handler/update_verb_handler.dart';
+import 'package:test/test.dart';
+
+import 'test_utils.dart';
+
+void main() {
+  verbTestsSetUpLogging();
+
+  setUpAll(() async {
+    await verbTestsSetUpAll();
+  });
+
+  late ScanVerbHandler scanHandler;
+  late UpdateVerbHandler updateHandler;
+  late DeleteVerbHandler deleteHandler;
+
+  setUp(() async {
+    await verbTestsSetUp();
+    scanHandler =
+        ScanVerbHandler(keyValueStore, mockOutboundClientManager, cacheManager);
+    updateHandler = UpdateVerbHandler(
+        keyValueStore, statsNotificationService, notificationManager, alice);
+    deleteHandler = DeleteVerbHandler(
+        keyValueStore, statsNotificationService, notificationManager);
+    inboundConnection.metadata.isAuthenticated = true;
+  });
+
+  tearDown(() async {
+    await verbTestsTearDown();
+  });
+
+  Future<List> scanCl([String suffix = '']) async {
+    await scanHandler.process('scan:cl$suffix', inboundConnection);
+    final data = inboundConnection.lastWrittenData!
+        .split('\n')[0]
+        .replaceAll('data:', '');
+    return jsonDecode(data) as List;
+  }
+
+  group('scan:cl basics', () {
+    test('returns entries in ascending commitId order with the pinned '
+        'shape', () async {
+      await updateHandler.process(
+          'update:phone.wavi$alice 12345', inboundConnection);
+      await updateHandler.process(
+          'update:email.wavi$alice a@b.c', inboundConnection);
+
+      final entries = await scanCl();
+      expect(entries.length, 2);
+      final first = entries[0] as Map;
+      final second = entries[1] as Map;
+      // Shape pin: this is a new client-facing wire contract.
+      expect(first.keys.toSet(), {'atKey', 'operation', 'commitId', 'opTime'});
+      expect(first['atKey'], 'phone.wavi$alice');
+      expect(first['operation'], '*',
+          reason: 'a handler-driven update commits as UPDATE_ALL — the '
+              'same symbol vocabulary sync emits');
+      expect(first['commitId'], isA<int>());
+      expect(
+          first['opTime'],
+          matches(RegExp(
+              r'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}Z$')),
+          reason: 'opTime uses the same ISO 8601 UTC vocabulary as the '
+              'wire timestamps');
+      expect(second['atKey'], 'email.wavi$alice');
+      expect((second['commitId'] as int) > (first['commitId'] as int), isTrue,
+          reason: 'entries are ordered by ascending commitId');
+    });
+
+    test('a DELETE entry appears, carrying the asserted dAt as its opTime',
+        () async {
+      await updateHandler.process(
+          'update:phone.wavi$alice 12345', inboundConnection);
+      await deleteHandler.process(
+          'delete:dAt:2023-05-05T11:59:44.123000Z:phone.wavi$alice',
+          inboundConnection);
+
+      final entries = await scanCl();
+      final deleteEntry = entries
+          .cast<Map>()
+          .firstWhere((e) => e['atKey'] == 'phone.wavi$alice');
+      expect(deleteEntry['operation'], '-',
+          reason: 'a DELETE entry for a key that no longer exists is '
+              'exactly what cruft management is looking for');
+      expect(deleteEntry['opTime'], '2023-05-05T11:59:44.123000Z');
+    });
+
+    test('after update:nc, the key\'s entry is gone from scan:cl', () async {
+      await updateHandler.process(
+          'update:phone.wavi$alice 12345', inboundConnection);
+      expect((await scanCl()).cast<Map>()
+          .where((e) => e['atKey'] == 'phone.wavi$alice'), isNotEmpty);
+
+      await updateHandler.process(
+          'update:nc:phone.wavi$alice 6789', inboundConnection);
+      expect((await scanCl()).cast<Map>()
+          .where((e) => e['atKey'] == 'phone.wavi$alice'), isEmpty);
+    });
+
+    test('regex filters entries by atKey', () async {
+      await updateHandler.process(
+          'update:phone.wavi$alice 12345', inboundConnection);
+      await updateHandler.process(
+          'update:mobile.buzz$alice 999', inboundConnection);
+
+      final entries = await scanCl(' .wavi');
+      expect(entries.cast<Map>().map((e) => e['atKey']),
+          contains('phone.wavi$alice'));
+      expect(entries.cast<Map>().map((e) => e['atKey']),
+          isNot(contains('mobile.buzz$alice')));
+    });
+
+    test('hidden keys are excluded unless showhidden:true', () async {
+      // public:__ keys ARE synced, so they have commit entries.
+      await keyValueStore.put(
+          'public:__hidden.wavi$alice', AtData()..data = 'h');
+      await updateHandler.process(
+          'update:phone.wavi$alice 12345', inboundConnection);
+
+      var keys =
+          (await scanCl()).cast<Map>().map((e) => e['atKey']).toList();
+      expect(keys, isNot(contains('public:__hidden.wavi$alice')));
+
+      keys = (await scanCl(':showhidden:true'))
+          .cast<Map>()
+          .map((e) => e['atKey'])
+          .toList();
+      expect(keys, contains('public:__hidden.wavi$alice'));
+    });
+  });
+
+  group('scan:cl refusals', () {
+    test('unauthenticated connection is refused', () async {
+      inboundConnection.metadata.isAuthenticated = false;
+      await expectLater(
+          scanHandler.process('scan:cl', inboundConnection),
+          throwsA(isA<UnAuthenticatedException>()));
+    });
+
+    test('scan:cl for another atSign is refused loudly', () async {
+      // The outbound scan proxy cannot forward :cl — silently degrading
+      // to a plain remote scan would return keystore keys labelled as
+      // commit-log entries.
+      await expectLater(
+          scanHandler.process('scan:cl:@bob', inboundConnection),
+          throwsA(isA<InvalidRequestException>()));
+    });
+  });
+
+  group('scan:cl APKAM enrollment filtering', () {
+    test('an enrollment sees only entries in its authorized namespaces',
+        () async {
+      await updateHandler.process(
+          'update:firstname.wavi$alice alice', inboundConnection);
+      await updateHandler.process(
+          'update:mobile.buzz$alice +1 434', inboundConnection);
+      await updateHandler.process(
+          'update:public:city.wavi$alice tokyo', inboundConnection);
+
+      final enrollmentId =
+          await createAndPersistAnEnrollment('wavi', 'pixel', {'wavi': 'r'});
+      inboundConnection.metadata.sessionID = 'dummy_session';
+      inboundConnection.metadata.enrollmentId = enrollmentId;
+
+      final keys =
+          (await scanCl()).cast<Map>().map((e) => e['atKey']).toList();
+      expect(keys, contains('firstname.wavi$alice'));
+      expect(keys, contains('public:city.wavi$alice'),
+          reason: 'public keys stay visible to any enrollment');
+      expect(keys, isNot(contains('mobile.buzz$alice')),
+          reason: 'entries outside the enrolled namespaces are filtered');
+    });
+
+    test('a *:rw enrollment sees all namespaces but not enrollment keys',
+        () async {
+      await updateHandler.process(
+          'update:firstname.wavi$alice alice', inboundConnection);
+      await updateHandler.process(
+          'update:mobile.buzz$alice +1 434', inboundConnection);
+      // An enrollment record committed to the log (unlike the harness's
+      // skipCommit-written ones) must still be invisible to '*'.
+      await keyValueStore.put('deadbeef.new.enrollments.__manage$alice',
+          AtData()..data = '{"appName":"x"}');
+
+      final enrollmentId =
+          await createAndPersistAnEnrollment('wavi', 'pixel', {'*': 'rw'});
+      inboundConnection.metadata.sessionID = 'dummy_session';
+      inboundConnection.metadata.enrollmentId = enrollmentId;
+
+      final keys =
+          (await scanCl()).cast<Map>().map((e) => e['atKey']).toList();
+      expect(keys, contains('firstname.wavi$alice'));
+      expect(keys, contains('mobile.buzz$alice'));
+      expect(keys, isNot(contains('deadbeef.new.enrollments.__manage$alice')));
+    });
+
+    test('an enrollment with no namespaces sees nothing', () async {
+      await updateHandler.process(
+          'update:firstname.wavi$alice alice', inboundConnection);
+
+      final enrollmentId = await createAndPersistAnEnrollment(
+          'wavi', 'pixel', <String, String>{});
+      inboundConnection.metadata.sessionID = 'dummy_session';
+      inboundConnection.metadata.enrollmentId = enrollmentId;
+
+      expect(await scanCl(), isEmpty);
+    });
+  });
+}

--- a/packages/at_server_spec/CHANGELOG.md
+++ b/packages/at_server_spec/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## 5.2.0
+- docs: the Scan/Update/UpdateMeta/Delete verb dartdocs describe the
+  at_commons 5.10.0 wire options: `scan:cl`, `:nc`, `delete:dAt` and the
+  `:cAt`/`:uAt`/`:eAt`/`:aAt` timestamp fragments.
 - chore: dependency bump — `at_commons` to `^5.12.0`
 
 ## 5.1.0

--- a/packages/at_server_spec/CHANGELOG.md
+++ b/packages/at_server_spec/CHANGELOG.md
@@ -1,7 +1,9 @@
-## 5.2.0
+## 5.2.1
 - docs: the Scan/Update/UpdateMeta/Delete verb dartdocs describe the
   at_commons 5.10.0 wire options: `scan:cl`, `:nc`, `delete:dAt` and the
   `:cAt`/`:uAt`/`:eAt`/`:aAt` timestamp fragments.
+
+## 5.2.0
 - chore: dependency bump — `at_commons` to `^5.12.0`
 
 ## 5.1.0

--- a/packages/at_server_spec/lib/src/verb/delete.dart
+++ b/packages/at_server_spec/lib/src/verb/delete.dart
@@ -9,6 +9,17 @@ import 'package:at_commons/at_commons.dart';
 /// /// Syntax : delete:<key to be deleted>
 /// e.g.
 /// @alice@delete:public:phone@alice - delete alice's public phone number
+/// dAt:
+/// Caller-asserted deletion time (ISO 8601 UTC), recorded as the DELETE
+/// commit log entry's operation time and carried to the sharedWith
+/// atServer's cached-key delete —
+/// delete:dAt:2026-05-05T11:59:44.123456Z:@bob:phone@alice
+/// nc (no-commit):
+/// Performs the delete as usual (auto-notification included) but writes no
+/// commit log entry AND removes the key's existing entry; the response is
+/// data:-1. Works for a key that is already gone, which is how a client
+/// removes stale commit log entries found via scan:cl —
+/// delete:nc:@bob:phone@alice
 class Delete extends Verb {
   @override
   String name() => 'delete';

--- a/packages/at_server_spec/lib/src/verb/scan.dart
+++ b/packages/at_server_spec/lib/src/verb/scan.dart
@@ -7,6 +7,13 @@ import 'package:at_commons/at_commons.dart';
 ///
 /// Syntax: scan
 /// To get the keys matches with the regex - scan:<regex>
+/// To scan the commit log instead of the keystore - scan:cl (authenticated
+/// connections only). Returns a JSON array, ascending by commitId, of
+/// {"atKey", "operation", "commitId", "opTime"}: operation is the commit
+/// operation symbol (+ # * -), opTime an ISO 8601 UTC timestamp. DELETE
+/// entries are included, so a client can find entries for keys that no
+/// longer exist and remove them with delete:nc. The same regex, hidden-key
+/// and enrollment-namespace filters as a keystore scan apply.
 class Scan extends Verb {
   @override
   String name() => 'scan';

--- a/packages/at_server_spec/lib/src/verb/update.dart
+++ b/packages/at_server_spec/lib/src/verb/update.dart
@@ -26,8 +26,15 @@ import 'package:at_commons/at_commons.dart';
 /// cAt / uAt / eAt / aAt:
 ///   Caller-asserted createdAt / updatedAt / expiresAt / availableAt, as
 ///   ISO 8601 UTC timestamps, stored faithfully instead of being rederived
-///   on the server — an asserted cAt wins on create and update alike, and an
-///   asserted eAt/aAt suppresses the ttl/ttb derivation for that write only.
+///   on the server. An asserted cAt wins on create and update alike. An
+///   asserted eAt/aAt wins over the ttl/ttb derivation at that write, and
+///   when no ttl/ttb accompanies it the relative the absolute implies is
+///   derived and stored alongside (replacing any relative the record
+///   already carried). Once set, expiresAt/availableAt move only when a
+///   request speaks about that axis: a new assertion (stored faithfully),
+///   a fresh ttl/ttb (rederives from now), ttl:0 (clears the expiry), or
+///   ttb:0 (re-stamps availableAt to now) — a write that says nothing
+///   about expiry leaves it untouched.
 ///   Example: update:cAt:2026-05-05T11:59:44.123456Z:phone@alice +1 123
 /// nc (no-commit):
 ///   Performs the update as usual (auto-notification included) but writes no

--- a/packages/at_server_spec/lib/src/verb/update.dart
+++ b/packages/at_server_spec/lib/src/verb/update.dart
@@ -23,6 +23,16 @@ import 'package:at_commons/at_commons.dart';
 ///   Creates a cached key at the receiver side.
 ///   Accepts a time duration in milli seconds which is a positive integer value to refresh the cached key or -1 to cache for forever.
 ///   Example: update:ttr:-1:@alice:city@bob california.
+/// cAt / uAt / eAt / aAt:
+///   Caller-asserted createdAt / updatedAt / expiresAt / availableAt, as
+///   ISO 8601 UTC timestamps, stored faithfully instead of being rederived
+///   on the server — an asserted cAt wins on create and update alike, and an
+///   asserted eAt/aAt suppresses the ttl/ttb derivation for that write only.
+///   Example: update:cAt:2026-05-05T11:59:44.123456Z:phone@alice +1 123
+/// nc (no-commit):
+///   Performs the update as usual (auto-notification included) but writes no
+///   commit log entry AND removes the key's existing entry; the response is
+///   data:-1. Example: update:nc:phone@alice +1 123
 class Update extends Verb {
   @override
   String name() => 'update';

--- a/packages/at_server_spec/lib/src/verb/update_meta.dart
+++ b/packages/at_server_spec/lib/src/verb/update_meta.dart
@@ -17,6 +17,14 @@ import 'package:at_commons/at_commons.dart';
 /// Creates a cached key at the receiver side.
 /// Accepts a time duration in milli seconds which is a positive integer value to refresh the cached key or -1 to cache for forever.
 /// update:meta:@alice:location@bob:ttr:60000 - updates the existing ttb value to 60000 for the location
+/// cAt / uAt / eAt / aAt:
+/// Caller-asserted createdAt / updatedAt / expiresAt / availableAt, as
+/// ISO 8601 UTC timestamps, stored faithfully instead of being rederived —
+/// update:meta:@alice:location@bob:uAt:2026-05-05T11:59:44.123456Z
+/// nc (no-commit):
+/// Performs the metadata update as usual but writes no commit log entry AND
+/// removes the key's existing entry; the response is data:-1 —
+/// update:meta:nc:@alice:location@bob:ttl:60000
 class UpdateMeta extends Verb {
   @override
   Verb dependsOn() => Cram();

--- a/packages/at_server_spec/lib/src/verb/update_meta.dart
+++ b/packages/at_server_spec/lib/src/verb/update_meta.dart
@@ -19,7 +19,11 @@ import 'package:at_commons/at_commons.dart';
 /// update:meta:@alice:location@bob:ttr:60000 - updates the existing ttb value to 60000 for the location
 /// cAt / uAt / eAt / aAt:
 /// Caller-asserted createdAt / updatedAt / expiresAt / availableAt, as
-/// ISO 8601 UTC timestamps, stored faithfully instead of being rederived —
+/// ISO 8601 UTC timestamps, stored faithfully instead of being rederived.
+/// An asserted eAt/aAt with no accompanying ttl/ttb also stores the
+/// relative it implies. Once set, expiresAt/availableAt move only when a
+/// request speaks about that axis (an assertion, a fresh ttl/ttb, ttl:0
+/// to clear the expiry, or ttb:0 to re-stamp availableAt to now) —
 /// update:meta:@alice:location@bob:uAt:2026-05-05T11:59:44.123456Z
 /// nc (no-commit):
 /// Performs the metadata update as usual but writes no commit log entry AND

--- a/packages/at_server_spec/pubspec.yaml
+++ b/packages/at_server_spec/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_server_spec
 description: A Dart library containing abstract classes that defines what implementations of the root and secondary servers are responsible for.
-version: 5.2.0
+version: 5.2.1
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://docs.atsign.com
 documentation: https://docs.atsign.com/atplatform/secondaryserver

--- a/tests/at_end2end_test/test/protocol_timestamps_e2e_test.dart
+++ b/tests/at_end2end_test/test/protocol_timestamps_e2e_test.dart
@@ -1,0 +1,172 @@
+// Cross-atServer coverage for the at_commons 5.10.0 protocol enhancements
+// (#2678): the four timestamps survive the hop between two real atServers.
+//
+//   * a notification carrying cAt/uAt/eAt stores the RECEIVER's cached key
+//     with the origin's values — on first cache and on refresh
+//   * a delete:dAt propagates: the receiver's cached-key DELETE commit
+//     entry records the origin deletion time (visible via scan:cl)
+//
+// Both tests self-skip when either atServer predates the capability: every
+// deployed server PARSES the syntax (it rolled out ahead of this), so the
+// probe must test behaviour, not grammar — scan:cl returns a list of maps
+// on a capable server and falls through to a plain scan (a list of
+// strings) on one that ignores the :cl flag.
+
+import 'dart:convert';
+
+import 'package:test/test.dart';
+
+import 'e2e_test_utils.dart' as e2e;
+import 'notify_verb_test.dart' as notification;
+
+void main() {
+  late String atSign_1;
+  late e2e.SimpleOutboundConnection sh1;
+
+  late String atSign_2;
+  late e2e.SimpleOutboundConnection sh2;
+
+  int lastValue = DateTime.now().millisecondsSinceEpoch;
+
+  const cAtWire = '2020-01-02T03:04:05.678000Z';
+  const cAtJson = '2020-01-02 03:04:05.678Z';
+  const uAtWire = '2021-02-03T04:05:06.789000Z';
+  const uAtJson = '2021-02-03 04:05:06.789Z';
+  const uAt2Wire = '2021-06-01T12:00:00.000000Z';
+  const uAt2Json = '2021-06-01 12:00:00.000Z';
+  const dAtWire = '2023-05-05T11:59:44.123000Z';
+
+  /// Whether the atServer behind [sh] implements scan:cl (the probe for the
+  /// whole 5.10.0 feature set: it lands in the same release). Seeds a key
+  /// first so the response is never an empty list, which would be
+  /// indistinguishable between the two behaviours.
+  Future<bool> supportsProtocolEnhancements(
+      e2e.SimpleOutboundConnection sh, String atSign) async {
+    await sh.writeCommand('update:capprobe-$lastValue.e2e$atSign probe');
+    await sh.read();
+    await sh.writeCommand('scan:cl capprobe-$lastValue');
+    final response = await sh.read();
+    if (!response.startsWith('data:')) {
+      return false;
+    }
+    final decoded = jsonDecode(response.replaceAll('data:', ''));
+    return decoded is List && decoded.isNotEmpty && decoded.first is Map;
+  }
+
+  late bool bothSidesCapable;
+
+  setUpAll(() async {
+    List<String> atSigns = e2e.knownAtSigns();
+    atSign_1 = atSigns[0];
+    sh1 = await e2e.getSocketHandler(atSign_1);
+    atSign_2 = atSigns[1];
+    sh2 = await e2e.getSocketHandler(atSign_2);
+    bothSidesCapable = await supportsProtocolEnhancements(sh1, atSign_1) &&
+        await supportsProtocolEnhancements(sh2, atSign_2);
+    if (!bothSidesCapable) {
+      print('An atServer in this pairing predates the 5.10.0 protocol '
+          'enhancements; the tests in this file will self-skip.');
+    }
+  });
+
+  tearDownAll(() {
+    sh1.close();
+    sh2.close();
+  });
+
+  setUp(() async {
+    sh1.clear();
+    sh2.clear();
+  });
+
+  test('a notification carrying cAt/uAt stores the cached key with the '
+      'origin values; a refresh updates them', () async {
+    if (!bothSidesCapable) {
+      return;
+    }
+    var key = 'tskey-$lastValue';
+    var value = 'ts-value-$lastValue';
+
+    await sh1.writeCommand('notify:update:ttl:600000:ttr:-1'
+        ':cAt:$cAtWire:uAt:$uAtWire'
+        ':$atSign_2:$key$atSign_1:$value');
+    String response = await sh1.read();
+    assert(
+        (!response.contains('Invalid syntax')) && (!response.contains('null')));
+    String notificationId = response.replaceAll('data:', '');
+    await notification.getNotifyStatus(sh1, notificationId,
+        returnWhenStatusIn: ['delivered'], timeOutMillis: 60000);
+    await Future.delayed(Duration(seconds: 2));
+
+    await sh2.writeCommand('llookup:all:cached:$atSign_2:$key$atSign_1');
+    response = await sh2.read();
+    Map metaData = jsonDecode(response.replaceAll('data:', ''))['metaData'];
+    expect(metaData['createdAt'], cAtJson,
+        reason: 'the cached copy must carry the ORIGIN\'s createdAt, not '
+            'one stamped on the receiving server\'s clock');
+    expect(metaData['updatedAt'], uAtJson);
+
+    // Refresh with a newer uAt; the cached copy adopts it.
+    await sh1.writeCommand('notify:update:ttl:600000:ttr:-1'
+        ':cAt:$cAtWire:uAt:$uAt2Wire'
+        ':$atSign_2:$key$atSign_1:$value-2');
+    response = await sh1.read();
+    notificationId = response.replaceAll('data:', '');
+    await notification.getNotifyStatus(sh1, notificationId,
+        returnWhenStatusIn: ['delivered'], timeOutMillis: 60000);
+    await Future.delayed(Duration(seconds: 2));
+
+    await sh2.writeCommand('llookup:all:cached:$atSign_2:$key$atSign_1');
+    response = await sh2.read();
+    metaData = jsonDecode(response.replaceAll('data:', ''))['metaData'];
+    expect(metaData['updatedAt'], uAt2Json,
+        reason: 'a refresh notification transmits the origin\'s newer '
+            'updatedAt and the cached copy adopts it');
+    expect(metaData['createdAt'], cAtJson);
+  }, timeout: Timeout(Duration(seconds: 120)));
+
+  test('delete:dAt propagates: the receiver\'s cached-key DELETE entry '
+      'records the origin deletion time', () async {
+    if (!bothSidesCapable) {
+      return;
+    }
+    var key = 'delkey-$lastValue';
+    var value = 'del-value-$lastValue';
+
+    // Cache the key on atSign_2 with cascade delete, via autoNotify.
+    await sh1
+        .writeCommand('update:ttr:100000:ccd:true:$atSign_2:$key$atSign_1 $value');
+    String response = await sh1.read();
+    assert(
+        (!response.contains('Invalid syntax')) && (!response.contains('null')));
+    await Future.delayed(Duration(seconds: 3));
+
+    await sh2.writeCommand('llookup:cached:$atSign_2:$key$atSign_1');
+    response = await sh2.read();
+    expect(response, contains('data:$value'),
+        reason: 'the cached key must exist before the delete propagates');
+
+    // Delete with an asserted deletion time.
+    await sh1.writeCommand('delete:dAt:$dAtWire:$atSign_2:$key$atSign_1');
+    response = await sh1.read();
+    assert(
+        (!response.contains('Invalid syntax')) && (!response.contains('null')));
+    await Future.delayed(Duration(seconds: 3));
+
+    await sh2.writeCommand('llookup:cached:$atSign_2:$key$atSign_1');
+    response = await sh2.read();
+    expect(response, contains('does not exist in keystore'),
+        reason: 'ccd:true means the cascade delete removes the cached copy');
+
+    // The receiver's DELETE commit entry carries the origin deletion time.
+    await sh2.writeCommand('scan:cl $key');
+    response = await sh2.read();
+    final List entries = jsonDecode(response.replaceAll('data:', ''));
+    final Map entry = entries.cast<Map>().firstWhere(
+        (e) => e['atKey'] == 'cached:$atSign_2:$key$atSign_1');
+    expect(entry['operation'], '-');
+    expect(entry['opTime'], dAtWire,
+        reason: 'the delete auto-notification carries dAt as :uAt: and the '
+            'receiver records it as the DELETE entry\'s opTime');
+  }, timeout: Timeout(Duration(seconds: 120)));
+}

--- a/tests/at_end2end_test/test/protocol_timestamps_e2e_test.dart
+++ b/tests/at_end2end_test/test/protocol_timestamps_e2e_test.dart
@@ -35,6 +35,8 @@ void main() {
   const uAt2Wire = '2021-06-01T12:00:00.000000Z';
   const uAt2Json = '2021-06-01 12:00:00.000Z';
   const dAtWire = '2023-05-05T11:59:44.123000Z';
+  const eAtWire = '2030-01-01T00:00:00.000000Z';
+  const eAtJson = '2030-01-01 00:00:00.000Z';
 
   /// Sends [command] on [sh] every 500ms until [done] accepts the response
   /// or [timeoutMillis] elapses; returns the last response either way, so a
@@ -198,5 +200,99 @@ void main() {
     expect(entry['opTime'], dAtWire,
         reason: 'the delete auto-notification carries dAt as :uAt: and the '
             'receiver records it as the DELETE entry\'s opTime');
+  }, timeout: Timeout(Duration(seconds: 180)));
+
+  test('autoNotify transmits the STORED timestamps: a plain update with cAt '
+      'yields a cached key carrying that cAt on the receiver', () async {
+    if (!bothSidesCapable) {
+      markTestSkipped('an atServer in this pairing predates the 5.10.0 '
+          'protocol enhancements');
+      return;
+    }
+    var key = 'ankey-$lastValue';
+    var value = 'an-value-$lastValue';
+
+    // No explicit notify: the plain update's auto-notification must read the
+    // STORED record (asserted cAt included) and transmit it.
+    await sh1.writeCommand(
+        'update:ttr:100000:cAt:$cAtWire:$atSign_2:$key$atSign_1 $value');
+    String response = await sh1.read();
+    assert(
+        (!response.contains('Invalid syntax')) && (!response.contains('null')));
+
+    response = await pollUntil(
+        sh2,
+        'llookup:all:cached:$atSign_2:$key$atSign_1',
+        (r) => r.startsWith('data:'));
+    final Map metaData =
+        jsonDecode(response.replaceAll('data:', ''))['metaData'];
+    expect(metaData['createdAt'], cAtJson,
+        reason: 'the auto-notification is queued after the write, from the '
+            'stored metadata — a pre-store fabricated createdAt would '
+            'arrive here instead of the asserted one');
+  }, timeout: Timeout(Duration(seconds: 180)));
+
+  test('an origin absolute expiry survives the hop: eAt alongside ttl is '
+      'not rederived on the receiver', () async {
+    if (!bothSidesCapable) {
+      markTestSkipped('an atServer in this pairing predates the 5.10.0 '
+          'protocol enhancements');
+      return;
+    }
+    var key = 'eatkey-$lastValue';
+    var value = 'eat-value-$lastValue';
+
+    // ttl accompanies eAt: a receiver that rederived would store
+    // now+ttl, not the transmitted absolute instant.
+    await sh1.writeCommand('notify:update:ttl:600000:ttr:-1'
+        ':eAt:$eAtWire'
+        ':$atSign_2:$key$atSign_1:$value');
+    String response = await sh1.read();
+    assert(
+        (!response.contains('Invalid syntax')) && (!response.contains('null')));
+    String notificationId = response.replaceAll('data:', '');
+    await notification.getNotifyStatus(sh1, notificationId,
+        returnWhenStatusIn: ['delivered'], timeOutMillis: 60000);
+
+    response = await pollUntil(
+        sh2,
+        'llookup:all:cached:$atSign_2:$key$atSign_1',
+        (r) => r.startsWith('data:'));
+    final Map metaData =
+        jsonDecode(response.replaceAll('data:', ''))['metaData'];
+    expect(metaData['expiresAt'], eAtJson,
+        reason: 'the cached copy must hold the origin\'s absolute expiry, '
+            'not one rederived from now+ttl at cache time');
+    expect(metaData['ttl'], 600000);
+  }, timeout: Timeout(Duration(seconds: 180)));
+
+  test('update:nc still auto-notifies: the receiver caches the key although '
+      'the sender wrote no commit entry', () async {
+    if (!bothSidesCapable) {
+      markTestSkipped('an atServer in this pairing predates the 5.10.0 '
+          'protocol enhancements');
+      return;
+    }
+    var key = 'nckey-$lastValue';
+    var value = 'nc-value-$lastValue';
+
+    await sh1.writeCommand(
+        'update:nc:ttr:100000:$atSign_2:$key$atSign_1 $value');
+    String response = await sh1.read();
+    expect(response.trim(), 'data:-1',
+        reason: 'the no-commit write returns -1 on the sender');
+
+    // :nc changes commit-log behaviour ONLY — the auto-notification still
+    // crosses to the other atServer and caches the key there.
+    response = await pollUntil(sh2, 'llookup:cached:$atSign_2:$key$atSign_1',
+        (r) => r.contains('data:$value'));
+    expect(response, contains('data:$value'));
+
+    // And the sender's own commit log holds nothing for the key.
+    await sh1.writeCommand('scan:cl $key');
+    response = await sh1.read();
+    final List entries = jsonDecode(response.replaceAll('data:', ''));
+    expect(entries, isEmpty,
+        reason: 'the sender wrote no commit entry for the :nc update');
   }, timeout: Timeout(Duration(seconds: 180)));
 }

--- a/tests/at_end2end_test/test/protocol_timestamps_e2e_test.dart
+++ b/tests/at_end2end_test/test/protocol_timestamps_e2e_test.dart
@@ -6,11 +6,11 @@
 //   * a delete:dAt propagates: the receiver's cached-key DELETE commit
 //     entry records the origin deletion time (visible via scan:cl)
 //
-// Both tests self-skip when either atServer predates the capability: every
-// deployed server PARSES the syntax (it rolled out ahead of this), so the
-// probe must test behaviour, not grammar — scan:cl returns a list of maps
-// on a capable server and falls through to a plain scan (a list of
-// strings) on one that ignores the :cl flag.
+// Both tests skip (visibly, via markTestSkipped) when either atServer
+// predates the capability: every deployed server PARSES the syntax (it
+// rolled out ahead of this), so the probe must test behaviour, not grammar —
+// scan:cl returns a list of maps on a capable server and falls through to a
+// plain scan (a list of strings) on one that ignores the :cl flag.
 
 import 'dart:convert';
 
@@ -36,14 +36,38 @@ void main() {
   const uAt2Json = '2021-06-01 12:00:00.000Z';
   const dAtWire = '2023-05-05T11:59:44.123000Z';
 
+  /// Sends [command] on [sh] every 500ms until [done] accepts the response
+  /// or [timeoutMillis] elapses; returns the last response either way, so a
+  /// timeout surfaces as a normal assertion failure on real observed state.
+  Future<String> pollUntil(e2e.SimpleOutboundConnection sh, String command,
+      bool Function(String response) done,
+      {int timeoutMillis = 30000}) async {
+    final deadline = DateTime.now().add(Duration(milliseconds: timeoutMillis));
+    String response = '';
+    while (DateTime.now().isBefore(deadline)) {
+      await sh.writeCommand(command);
+      response = await sh.read();
+      if (done(response)) {
+        return response;
+      }
+      await Future.delayed(Duration(milliseconds: 500));
+    }
+    return response;
+  }
+
   /// Whether the atServer behind [sh] implements scan:cl (the probe for the
   /// whole 5.10.0 feature set: it lands in the same release). Seeds a key
   /// first so the response is never an empty list, which would be
-  /// indistinguishable between the two behaviours.
+  /// indistinguishable between the two behaviours. A failed seed is a rig
+  /// failure and throws — it must not read as 'predates the feature'.
   Future<bool> supportsProtocolEnhancements(
       e2e.SimpleOutboundConnection sh, String atSign) async {
     await sh.writeCommand('update:capprobe-$lastValue.e2e$atSign probe');
-    await sh.read();
+    final seedResponse = await sh.read();
+    if (!RegExp(r'^data:-?\d+$').hasMatch(seedResponse.trim())) {
+      throw StateError('capability-probe seed update on $atSign failed:'
+          ' $seedResponse');
+    }
     await sh.writeCommand('scan:cl capprobe-$lastValue');
     final response = await sh.read();
     if (!response.startsWith('data:')) {
@@ -63,10 +87,6 @@ void main() {
     sh2 = await e2e.getSocketHandler(atSign_2);
     bothSidesCapable = await supportsProtocolEnhancements(sh1, atSign_1) &&
         await supportsProtocolEnhancements(sh2, atSign_2);
-    if (!bothSidesCapable) {
-      print('An atServer in this pairing predates the 5.10.0 protocol '
-          'enhancements; the tests in this file will self-skip.');
-    }
   });
 
   tearDownAll(() {
@@ -82,6 +102,8 @@ void main() {
   test('a notification carrying cAt/uAt stores the cached key with the '
       'origin values; a refresh updates them', () async {
     if (!bothSidesCapable) {
+      markTestSkipped('an atServer in this pairing predates the 5.10.0 '
+          'protocol enhancements');
       return;
     }
     var key = 'tskey-$lastValue';
@@ -96,10 +118,12 @@ void main() {
     String notificationId = response.replaceAll('data:', '');
     await notification.getNotifyStatus(sh1, notificationId,
         returnWhenStatusIn: ['delivered'], timeOutMillis: 60000);
-    await Future.delayed(Duration(seconds: 2));
 
-    await sh2.writeCommand('llookup:all:cached:$atSign_2:$key$atSign_1');
-    response = await sh2.read();
+    // Delivery confirms the wire hop; poll for receive-side processing.
+    response = await pollUntil(
+        sh2,
+        'llookup:all:cached:$atSign_2:$key$atSign_1',
+        (r) => r.startsWith('data:'));
     Map metaData = jsonDecode(response.replaceAll('data:', ''))['metaData'];
     expect(metaData['createdAt'], cAtJson,
         reason: 'the cached copy must carry the ORIGIN\'s createdAt, not '
@@ -114,35 +138,41 @@ void main() {
     notificationId = response.replaceAll('data:', '');
     await notification.getNotifyStatus(sh1, notificationId,
         returnWhenStatusIn: ['delivered'], timeOutMillis: 60000);
-    await Future.delayed(Duration(seconds: 2));
 
-    await sh2.writeCommand('llookup:all:cached:$atSign_2:$key$atSign_1');
-    response = await sh2.read();
+    response = await pollUntil(
+        sh2,
+        'llookup:all:cached:$atSign_2:$key$atSign_1',
+        (r) =>
+            r.startsWith('data:') &&
+            jsonDecode(r.replaceAll('data:', ''))['metaData']['updatedAt'] ==
+                uAt2Json);
     metaData = jsonDecode(response.replaceAll('data:', ''))['metaData'];
     expect(metaData['updatedAt'], uAt2Json,
         reason: 'a refresh notification transmits the origin\'s newer '
             'updatedAt and the cached copy adopts it');
     expect(metaData['createdAt'], cAtJson);
-  }, timeout: Timeout(Duration(seconds: 120)));
+  }, timeout: Timeout(Duration(seconds: 180)));
 
   test('delete:dAt propagates: the receiver\'s cached-key DELETE entry '
       'records the origin deletion time', () async {
     if (!bothSidesCapable) {
+      markTestSkipped('an atServer in this pairing predates the 5.10.0 '
+          'protocol enhancements');
       return;
     }
     var key = 'delkey-$lastValue';
     var value = 'del-value-$lastValue';
 
     // Cache the key on atSign_2 with cascade delete, via autoNotify.
-    await sh1
-        .writeCommand('update:ttr:100000:ccd:true:$atSign_2:$key$atSign_1 $value');
+    await sh1.writeCommand(
+        'update:ttr:100000:ccd:true:$atSign_2:$key$atSign_1 $value');
     String response = await sh1.read();
     assert(
         (!response.contains('Invalid syntax')) && (!response.contains('null')));
-    await Future.delayed(Duration(seconds: 3));
 
-    await sh2.writeCommand('llookup:cached:$atSign_2:$key$atSign_1');
-    response = await sh2.read();
+    // autoNotify returns no notification id, so poll for the cached copy.
+    response = await pollUntil(sh2, 'llookup:cached:$atSign_2:$key$atSign_1',
+        (r) => r.contains('data:$value'));
     expect(response, contains('data:$value'),
         reason: 'the cached key must exist before the delete propagates');
 
@@ -151,10 +181,9 @@ void main() {
     response = await sh1.read();
     assert(
         (!response.contains('Invalid syntax')) && (!response.contains('null')));
-    await Future.delayed(Duration(seconds: 3));
 
-    await sh2.writeCommand('llookup:cached:$atSign_2:$key$atSign_1');
-    response = await sh2.read();
+    response = await pollUntil(sh2, 'llookup:cached:$atSign_2:$key$atSign_1',
+        (r) => r.contains('does not exist in keystore'));
     expect(response, contains('does not exist in keystore'),
         reason: 'ccd:true means the cascade delete removes the cached copy');
 
@@ -162,11 +191,12 @@ void main() {
     await sh2.writeCommand('scan:cl $key');
     response = await sh2.read();
     final List entries = jsonDecode(response.replaceAll('data:', ''));
-    final Map entry = entries.cast<Map>().firstWhere(
-        (e) => e['atKey'] == 'cached:$atSign_2:$key$atSign_1');
+    final Map entry = entries
+        .cast<Map>()
+        .firstWhere((e) => e['atKey'] == 'cached:$atSign_2:$key$atSign_1');
     expect(entry['operation'], '-');
     expect(entry['opTime'], dAtWire,
         reason: 'the delete auto-notification carries dAt as :uAt: and the '
             'receiver records it as the DELETE entry\'s opTime');
-  }, timeout: Timeout(Duration(seconds: 120)));
+  }, timeout: Timeout(Duration(seconds: 180)));
 }

--- a/tests/at_functional_test/runDualCompare.sh
+++ b/tests/at_functional_test/runDualCompare.sh
@@ -4,11 +4,17 @@
 # (Hive primary + SQLite secondary, every write mirrored), then compares each
 # hosted atSign's Hive and SQLite DB sets for byte-identity.
 #
-#   ./runDualCompare.sh [--build]
+#   ./runDualCompare.sh [--build] [BASE_PORT]
 #
 # --build recompiles the root/secondary binaries first; without it, the
 # binaries already staged in ve/contents (e.g. from a prior runLocal.sh) are
 # reused. The VE image is always rebuilt so it picks up libsqlite3.
+#
+# Optional VE base port, as in runLocal.sh: set VIRTUALENV_BASE_PORT (env) or
+# pass it as a positional argument. Shifts the whole VE port range —
+# atDirectory to BASE, atServers to BASE+1.., Redis to BASE+99 — so this run
+# coexists with anything squatting the default 64/443/6379/25000+ ports. The
+# harness reads VIRTUALENV_BASE_PORT too (config_util, the readiness checks).
 #
 # Exit: 0 = pack passed AND every atSign's Hive == SQLite; non-zero otherwise.
 
@@ -17,7 +23,28 @@ cd "$(dirname -- "$0")"; cd ../../; repoDir=$(pwd)
 CONT=at_server_func_cont
 PERSIST_PKG="${repoDir}/packages/at_persistence_secondary_server"
 
-if [[ "${1:-}" == "--build" ]]; then
+BUILD=""
+for arg in "$@"; do
+  case "$arg" in
+    --build) BUILD="--build" ;;
+    *) VIRTUALENV_BASE_PORT="$arg" ;;
+  esac
+done
+VIRTUALENV_BASE_PORT="${VIRTUALENV_BASE_PORT:-}"
+if [[ -n "$VIRTUALENV_BASE_PORT" ]]; then
+  export VIRTUALENV_BASE_PORT
+  export rootServerPort="$VIRTUALENV_BASE_PORT" # install_PKAM_Keys reads this
+  veEnvArgs="-e VIRTUALENV_BASE_PORT=${VIRTUALENV_BASE_PORT}"
+  vePortArgs="-p ${VIRTUALENV_BASE_PORT}-$((VIRTUALENV_BASE_PORT + 99)):${VIRTUALENV_BASE_PORT}-$((VIRTUALENV_BASE_PORT + 99))"
+  veCmd="bash /atsign/entrypoint.sh"
+  echo "Using VE base port ${VIRTUALENV_BASE_PORT} (atServers ${VIRTUALENV_BASE_PORT}+1.., Redis +99)"
+else
+  veEnvArgs=""
+  vePortArgs="-p 6379:6379 -p 25000-25040:25000-25040 -p 64:64 -p 443:443"
+  veCmd=""
+fi
+
+if [[ "$BUILD" == "--build" ]]; then
   echo "== compile root =="
   docker run --rm -v "${repoDir}:/app" -w /app/packages/at_root_server \
     dart:3.11.2 sh -c 'dart pub get && dart compile exe bin/main.dart -o root' || exit 1
@@ -41,8 +68,8 @@ echo "== run container in DUAL mode =="
 docker rm -f $CONT 2>/dev/null
 docker run -d --name $CONT \
   -e testingMode="true" -e httpsEnabled="true" -e persistenceBackend="dual" \
-  -p 6379:6379 -p 25000-25040:25000-25040 -p 64:64 -p 443:443 \
-  at_virtual_env:local || exit 1
+  $veEnvArgs $vePortArgs \
+  at_virtual_env:local $veCmd || exit 1
 
 echo "== readiness + keys =="
 cd "${repoDir}/tests/at_functional_test"

--- a/tests/at_functional_test/test/protocol_enhancements_test.dart
+++ b/tests/at_functional_test/test/protocol_enhancements_test.dart
@@ -167,6 +167,130 @@ void main() {
       expect(response, 'data:v2', reason: 'the write itself still happens');
     });
 
+    test('a key created with update:nc never appears in sync', () async {
+      // A committed sibling provides the sync watermark.
+      String response = await firstAtSignConnection
+          .sendRequestToServer('update:sibling-$uniqueId.wavi$firstAtSign s');
+      expect(response, matches(RegExp(r'^data:\d+$')));
+      final watermark = int.parse(response.replaceAll('data:', ''));
+
+      response = await firstAtSignConnection
+          .sendRequestToServer('update:nc:born-$uniqueId.wavi$firstAtSign v1');
+      expect(response, 'data:-1');
+
+      response = await firstAtSignConnection.sendRequestToServer(
+          'sync:from:${watermark - 1}:limit:50:$uniqueId');
+      expect(response, contains('"sibling-$uniqueId.wavi$firstAtSign"'),
+          reason: 'the committed sibling proves the sync request itself '
+              'sees this test\'s keys');
+      expect(response, isNot(contains('"born-$uniqueId.wavi$firstAtSign"')),
+          reason: 'a key born with :nc has no commit entry to sync');
+
+      response = await firstAtSignConnection
+          .sendRequestToServer('llookup:born-$uniqueId.wavi$firstAtSign');
+      expect(response, 'data:v1');
+    });
+
+    test('update:meta:nc removes the entry from sync', () async {
+      String response = await firstAtSignConnection
+          .sendRequestToServer('update:ncm-$uniqueId.wavi$firstAtSign v1');
+      expect(response, matches(RegExp(r'^data:\d+$')));
+      final commitId = int.parse(response.replaceAll('data:', ''));
+
+      response = await firstAtSignConnection.sendRequestToServer(
+          'sync:from:${commitId - 1}:limit:50:$uniqueId');
+      expect(response, contains('"ncm-$uniqueId.wavi$firstAtSign"'));
+
+      response = await firstAtSignConnection.sendRequestToServer(
+          'update:meta:nc:ncm-$uniqueId.wavi$firstAtSign:ttl:60000');
+      expect(response, 'data:-1');
+
+      response = await firstAtSignConnection.sendRequestToServer(
+          'sync:from:${commitId - 1}:limit:50:$uniqueId');
+      expect(response, isNot(contains('"ncm-$uniqueId.wavi$firstAtSign"')),
+          reason: 'the no-commit metadata write purges the key\'s entry');
+    });
+
+    test('a normal update after :nc re-enters sync with a fresh, higher '
+        'commitId', () async {
+      String response = await firstAtSignConnection
+          .sendRequestToServer('update:again-$uniqueId.wavi$firstAtSign v1');
+      expect(response, matches(RegExp(r'^data:\d+$')));
+      final firstId = int.parse(response.replaceAll('data:', ''));
+
+      response = await firstAtSignConnection
+          .sendRequestToServer('update:nc:again-$uniqueId.wavi$firstAtSign v2');
+      expect(response, 'data:-1');
+
+      response = await firstAtSignConnection
+          .sendRequestToServer('update:again-$uniqueId.wavi$firstAtSign v3');
+      expect(response, matches(RegExp(r'^data:\d+$')));
+      final secondId = int.parse(response.replaceAll('data:', ''));
+      expect(secondId > firstId, isTrue,
+          reason: ':nc is not permanent — a later normal write re-commits '
+              'under a fresh id');
+
+      response = await firstAtSignConnection.sendRequestToServer(
+          'sync:from:${firstId - 1}:limit:50:again-$uniqueId');
+      final List entries = jsonDecode(response.replaceAll('data:', ''));
+      expect(entries.length, 1,
+          reason: 'sync serves exactly the one re-committed entry — the '
+              'purged first entry must not reappear');
+      expect(entries[0]['commitId'], secondId);
+      expect(entries[0]['value'], 'v3');
+    });
+
+    test('delete:nc removes the DELETE tombstone from sync', () async {
+      String response = await firstAtSignConnection
+          .sendRequestToServer('update:tomb-$uniqueId.wavi$firstAtSign v1');
+      expect(response, matches(RegExp(r'^data:\d+$')));
+      final commitId = int.parse(response.replaceAll('data:', ''));
+
+      response = await firstAtSignConnection
+          .sendRequestToServer('delete:tomb-$uniqueId.wavi$firstAtSign');
+      expect(response, matches(RegExp(r'^data:\d+$')));
+
+      response = await firstAtSignConnection.sendRequestToServer(
+          'sync:from:${commitId - 1}:limit:50:tomb-$uniqueId');
+      List entries = jsonDecode(response.replaceAll('data:', ''));
+      expect(entries.length, 1);
+      expect(entries[0]['operation'], '-',
+          reason: 'a normal delete leaves a tombstone that sync serves');
+
+      response = await firstAtSignConnection
+          .sendRequestToServer('delete:nc:tomb-$uniqueId.wavi$firstAtSign');
+      expect(response, 'data:-1');
+
+      response = await firstAtSignConnection.sendRequestToServer(
+          'sync:from:${commitId - 1}:limit:50:tomb-$uniqueId');
+      entries = jsonDecode(response.replaceAll('data:', ''));
+      expect(entries, isEmpty,
+          reason: 'delete:nc of the already-deleted key purges the '
+              'tombstone; sync serves nothing for the key');
+    });
+
+    test('update:nc:json is absent from sync', () async {
+      String response = await firstAtSignConnection
+          .sendRequestToServer('update:sib2-$uniqueId.wavi$firstAtSign s');
+      expect(response, matches(RegExp(r'^data:\d+$')));
+      final watermark = int.parse(response.replaceAll('data:', ''));
+
+      final json = jsonEncode({
+        'atKey': 'jnc-$uniqueId.wavi',
+        'value': 'jv',
+        'sharedBy': firstAtSign,
+        'metadata': Metadata().toJson(),
+      });
+      response = await firstAtSignConnection
+          .sendRequestToServer('update:nc:json:$json');
+      expect(response, 'data:-1');
+
+      response = await firstAtSignConnection.sendRequestToServer(
+          'sync:from:${watermark - 1}:limit:50:$uniqueId');
+      expect(response, contains('"sib2-$uniqueId.wavi$firstAtSign"'));
+      expect(response, isNot(contains('"jnc-$uniqueId.wavi$firstAtSign"')));
+    });
+
     test('update:meta:nc responds data:-1', () async {
       String response = await firstAtSignConnection
           .sendRequestToServer('update:nc2-$uniqueId.wavi$firstAtSign v1');

--- a/tests/at_functional_test/test/protocol_enhancements_test.dart
+++ b/tests/at_functional_test/test/protocol_enhancements_test.dart
@@ -64,7 +64,10 @@ void main() {
       String response = await firstAtSignConnection.sendRequestToServer(
           'update:cAt:$cAtWire:uAt:$uAtWire'
           ':ts1-$uniqueId.wavi$firstAtSign hello');
-      expect(response, matches(RegExp(r'^data:-?\d+$')));
+      expect(response, matches(RegExp(r'^data:\d+$')),
+          reason: 'an asserted-timestamp write is an ordinary COMMITTED '
+              'write — a -1 here would mean it silently skipped its '
+              'commit entry');
 
       response = await firstAtSignConnection
           .sendRequestToServer('llookup:all:ts1-$uniqueId.wavi$firstAtSign');
@@ -77,7 +80,10 @@ void main() {
       String response = await firstAtSignConnection.sendRequestToServer(
           'update:ttl:86400000:eAt:$eAtWire'
           ':ts2-$uniqueId.wavi$firstAtSign hello');
-      expect(response, matches(RegExp(r'^data:-?\d+$')));
+      expect(response, matches(RegExp(r'^data:\d+$')),
+          reason: 'an asserted-timestamp write is an ordinary COMMITTED '
+              'write — a -1 here would mean it silently skipped its '
+              'commit entry');
 
       response = await firstAtSignConnection
           .sendRequestToServer('llookup:all:ts2-$uniqueId.wavi$firstAtSign');
@@ -100,7 +106,10 @@ void main() {
       });
       String response =
           await firstAtSignConnection.sendRequestToServer('update:json:$json');
-      expect(response, matches(RegExp(r'^data:-?\d+$')));
+      expect(response, matches(RegExp(r'^data:\d+$')),
+          reason: 'an asserted-timestamp write is an ordinary COMMITTED '
+              'write — a -1 here would mean it silently skipped its '
+              'commit entry');
 
       response = await firstAtSignConnection
           .sendRequestToServer('llookup:all:ts3-$uniqueId.wavi$firstAtSign');
@@ -113,7 +122,10 @@ void main() {
           DateTime.now().toUtc().add(Duration(seconds: 3)));
       String response = await firstAtSignConnection.sendRequestToServer(
           'update:eAt:$soon:ts4-$uniqueId.wavi$firstAtSign fleeting');
-      expect(response, matches(RegExp(r'^data:-?\d+$')));
+      expect(response, matches(RegExp(r'^data:\d+$')),
+          reason: 'an asserted-timestamp write is an ordinary COMMITTED '
+              'write — a -1 here would mean it silently skipped its '
+              'commit entry');
 
       response =
           await firstAtSignConnection.sendRequestToServer('scan $uniqueId');

--- a/tests/at_functional_test/test/protocol_enhancements_test.dart
+++ b/tests/at_functional_test/test/protocol_enhancements_test.dart
@@ -1,0 +1,265 @@
+// End-to-end coverage (live atServer over the wire) for the at_commons
+// 5.10.0 protocol enhancements (#2678):
+//
+//   * :cAt/:uAt/:eAt/:aAt — caller-asserted timestamps stored faithfully
+//   * :nc — no commit entry, existing entry purged, response data:-1
+//   * delete:dAt — recorded as the DELETE commit entry's opTime
+//   * scan:cl — list commit-log entries
+//
+// Every key is uniqueId-scoped: the virtualenv atSign persists across the
+// whole pack.
+
+import 'dart:convert';
+
+import 'package:at_commons/at_commons.dart';
+import 'package:at_functional_test/conf/config_util.dart';
+import 'package:at_functional_test/connection/outbound_connection_wrapper.dart';
+import 'package:test/test.dart';
+import 'package:uuid/uuid.dart';
+
+void main() {
+  late String uniqueId;
+  OutboundConnectionFactory firstAtSignConnection = OutboundConnectionFactory();
+
+  String firstAtSign =
+      ConfigUtil.getYaml()!['firstAtSignServer']['firstAtSignName'];
+  String firstAtSignHost =
+      ConfigUtil.getYaml()!['firstAtSignServer']['firstAtSignUrl'];
+  int firstAtSignPort =
+      ConfigUtil.getYaml()!['firstAtSignServer']['firstAtSignPort'];
+  String secondAtSign =
+      ConfigUtil.getYaml()!['secondAtSignServer']['secondAtSignName'];
+
+  // Wire timestamps and the exact spellings llookup:all's metaData JSON
+  // uses for them (AtMetaData.toJson emits DateTime.toString()).
+  const cAtWire = '2020-01-02T03:04:05.678000Z';
+  const cAtJson = '2020-01-02 03:04:05.678Z';
+  const uAtWire = '2021-02-03T04:05:06.789000Z';
+  const uAtJson = '2021-02-03 04:05:06.789Z';
+  const eAtWire = '2030-01-01T00:00:00.000000Z';
+  const eAtJson = '2030-01-01 00:00:00.000Z';
+  const dAtWire = '2023-05-05T11:59:44.123000Z';
+
+  Map metaDataOfLlookupAll(String response) =>
+      jsonDecode(response.replaceAll('data:', ''))['metaData'];
+
+  setUpAll(() async {
+    await firstAtSignConnection.initiateConnectionWithListener(
+        firstAtSign, firstAtSignHost, firstAtSignPort);
+    String authResponse = await firstAtSignConnection.authenticateConnection();
+    expect(authResponse, 'data:success',
+        reason: 'Authentication failed when executing test');
+  });
+
+  setUp(() {
+    uniqueId = Uuid().v4();
+  });
+
+  tearDownAll(() async {
+    await firstAtSignConnection.close();
+  });
+
+  group('asserted timestamps', () {
+    test('update with cAt/uAt stores them faithfully', () async {
+      String response = await firstAtSignConnection.sendRequestToServer(
+          'update:cAt:$cAtWire:uAt:$uAtWire'
+          ':ts1-$uniqueId.wavi$firstAtSign hello');
+      expect(response, matches(RegExp(r'^data:-?\d+$')));
+
+      response = await firstAtSignConnection
+          .sendRequestToServer('llookup:all:ts1-$uniqueId.wavi$firstAtSign');
+      final metaData = metaDataOfLlookupAll(response);
+      expect(metaData['createdAt'], cAtJson);
+      expect(metaData['updatedAt'], uAtJson);
+    });
+
+    test('asserted eAt wins over ttl derivation at that write', () async {
+      String response = await firstAtSignConnection.sendRequestToServer(
+          'update:ttl:86400000:eAt:$eAtWire'
+          ':ts2-$uniqueId.wavi$firstAtSign hello');
+      expect(response, matches(RegExp(r'^data:-?\d+$')));
+
+      response = await firstAtSignConnection
+          .sendRequestToServer('llookup:all:ts2-$uniqueId.wavi$firstAtSign');
+      final metaData = metaDataOfLlookupAll(response);
+      expect(metaData['expiresAt'], eAtJson,
+          reason: 'the transmitted absolute expiry must not be rederived '
+              'from now+ttl on arrival');
+      expect(metaData['ttl'], 86400000);
+    });
+
+    test('update:json with eAt and no ttl keeps the asserted expiry',
+        () async {
+      final metadataJson =
+          (Metadata()..expiresAt = DateTime.parse(eAtWire)).toJson();
+      final json = jsonEncode({
+        'atKey': 'ts3-$uniqueId.wavi',
+        'value': 'json-value',
+        'sharedBy': firstAtSign,
+        'metadata': metadataJson,
+      });
+      String response =
+          await firstAtSignConnection.sendRequestToServer('update:json:$json');
+      expect(response, matches(RegExp(r'^data:-?\d+$')));
+
+      response = await firstAtSignConnection
+          .sendRequestToServer('llookup:all:ts3-$uniqueId.wavi$firstAtSign');
+      final metaData = metaDataOfLlookupAll(response);
+      expect(metaData['expiresAt'], eAtJson);
+    });
+
+    test('a key with asserted eAt and no ttl actually expires', () async {
+      final soon = VerbUtil.formatIso8601Micros(
+          DateTime.now().toUtc().add(Duration(seconds: 3)));
+      String response = await firstAtSignConnection.sendRequestToServer(
+          'update:eAt:$soon:ts4-$uniqueId.wavi$firstAtSign fleeting');
+      expect(response, matches(RegExp(r'^data:-?\d+$')));
+
+      response =
+          await firstAtSignConnection.sendRequestToServer('scan $uniqueId');
+      expect(response, contains('"ts4-$uniqueId.wavi$firstAtSign"'));
+
+      await Future.delayed(Duration(seconds: 5));
+      response =
+          await firstAtSignConnection.sendRequestToServer('scan $uniqueId');
+      expect(response, isNot(contains('"ts4-$uniqueId.wavi$firstAtSign"')),
+          reason: 'a key whose only expiry signal is an asserted eAt must '
+              'stop being served at that instant');
+    });
+  });
+
+  group(':nc (no-commit)', () {
+    test('update:nc responds data:-1 and removes the entry from sync',
+        () async {
+      String response = await firstAtSignConnection
+          .sendRequestToServer('update:nc1-$uniqueId.wavi$firstAtSign v1');
+      expect(response, matches(RegExp(r'^data:\d+$')));
+      final commitId = int.parse(response.replaceAll('data:', ''));
+
+      response = await firstAtSignConnection.sendRequestToServer(
+          'sync:from:${commitId - 1}:limit:50:$uniqueId');
+      expect(response, contains('"nc1-$uniqueId.wavi$firstAtSign"'));
+
+      response = await firstAtSignConnection
+          .sendRequestToServer('update:nc:nc1-$uniqueId.wavi$firstAtSign v2');
+      expect(response, 'data:-1');
+
+      response = await firstAtSignConnection.sendRequestToServer(
+          'sync:from:${commitId - 1}:limit:50:$uniqueId');
+      expect(response, isNot(contains('"nc1-$uniqueId.wavi$firstAtSign"')),
+          reason: 'the no-commit write purges the key\'s commit entry, so '
+              'sync must no longer serve one');
+
+      response = await firstAtSignConnection
+          .sendRequestToServer('llookup:nc1-$uniqueId.wavi$firstAtSign');
+      expect(response, 'data:v2', reason: 'the write itself still happens');
+    });
+
+    test('update:meta:nc responds data:-1', () async {
+      String response = await firstAtSignConnection
+          .sendRequestToServer('update:nc2-$uniqueId.wavi$firstAtSign v1');
+      expect(response, matches(RegExp(r'^data:\d+$')));
+
+      response = await firstAtSignConnection.sendRequestToServer(
+          'update:meta:nc:nc2-$uniqueId.wavi$firstAtSign:ttl:60000');
+      expect(response, 'data:-1');
+    });
+
+    test('delete:nc purges the leftover DELETE entry (the cruft case)',
+        () async {
+      String response = await firstAtSignConnection
+          .sendRequestToServer('update:nc3-$uniqueId.wavi$firstAtSign v1');
+      expect(response, matches(RegExp(r'^data:\d+$')));
+      response = await firstAtSignConnection
+          .sendRequestToServer('delete:nc3-$uniqueId.wavi$firstAtSign');
+      expect(response, matches(RegExp(r'^data:\d+$')));
+
+      // The DELETE entry (the cruft) is visible in scan:cl...
+      response =
+          await firstAtSignConnection.sendRequestToServer('scan:cl $uniqueId');
+      List entries = jsonDecode(response.replaceAll('data:', ''));
+      expect(
+          entries.cast<Map>().where((e) =>
+              e['atKey'] == 'nc3-$uniqueId.wavi$firstAtSign' &&
+              e['operation'] == '-'),
+          isNotEmpty);
+
+      // ...delete:nc of the already-gone key purges it.
+      response = await firstAtSignConnection
+          .sendRequestToServer('delete:nc:nc3-$uniqueId.wavi$firstAtSign');
+      expect(response, 'data:-1');
+
+      response =
+          await firstAtSignConnection.sendRequestToServer('scan:cl $uniqueId');
+      entries = jsonDecode(response.replaceAll('data:', ''));
+      expect(
+          entries.cast<Map>().where(
+              (e) => e['atKey'] == 'nc3-$uniqueId.wavi$firstAtSign'),
+          isEmpty);
+    });
+  });
+
+  group('scan:cl and delete:dAt', () {
+    test('scan:cl lists entries with the pinned shape, filtered by regex',
+        () async {
+      String response = await firstAtSignConnection
+          .sendRequestToServer('update:sc1-$uniqueId.wavi$firstAtSign v1');
+      expect(response, matches(RegExp(r'^data:\d+$')));
+      final commitId = int.parse(response.replaceAll('data:', ''));
+
+      response =
+          await firstAtSignConnection.sendRequestToServer('scan:cl $uniqueId');
+      final List entries = jsonDecode(response.replaceAll('data:', ''));
+      expect(entries.length, 1,
+          reason: 'the regex confines the listing to this test\'s key');
+      final Map entry = entries[0];
+      expect(entry.keys.toSet(), {'atKey', 'operation', 'commitId', 'opTime'});
+      expect(entry['atKey'], 'sc1-$uniqueId.wavi$firstAtSign');
+      expect(entry['operation'], '*');
+      expect(entry['commitId'], commitId);
+      expect(entry['opTime'],
+          matches(RegExp(r'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}Z$')));
+    });
+
+    test('delete:dAt is visible as the DELETE entry\'s opTime in scan:cl',
+        () async {
+      String response = await firstAtSignConnection
+          .sendRequestToServer('update:sc2-$uniqueId.wavi$firstAtSign v1');
+      expect(response, matches(RegExp(r'^data:\d+$')));
+      response = await firstAtSignConnection.sendRequestToServer(
+          'delete:dAt:$dAtWire:sc2-$uniqueId.wavi$firstAtSign');
+      expect(response, matches(RegExp(r'^data:\d+$')));
+
+      response =
+          await firstAtSignConnection.sendRequestToServer('scan:cl $uniqueId');
+      final List entries = jsonDecode(response.replaceAll('data:', ''));
+      final Map entry = entries
+          .cast<Map>()
+          .firstWhere((e) => e['atKey'] == 'sc2-$uniqueId.wavi$firstAtSign');
+      expect(entry['operation'], '-');
+      expect(entry['opTime'], dAtWire);
+    });
+
+    test('scan:cl on an unauthenticated connection is refused', () async {
+      final unauthConnection = OutboundConnectionFactory();
+      await unauthConnection.initiateConnectionWithListener(
+          firstAtSign, firstAtSignHost, firstAtSignPort);
+      try {
+        final response =
+            await unauthConnection.sendRequestToServer('scan:cl');
+        expect(response, contains('error'));
+      } finally {
+        await unauthConnection.close();
+      }
+    });
+
+    test('scan:cl for another atSign is refused', () async {
+      final response = await firstAtSignConnection
+          .sendRequestToServer('scan:cl:$secondAtSign');
+      expect(response, contains('error'),
+          reason: 'the outbound scan proxy cannot forward :cl, so a remote '
+              'commit-log scan must be refused rather than silently '
+              'degrading to a plain remote scan');
+    });
+  });
+}

--- a/tests/at_functional_test/test/protocol_enhancements_test.dart
+++ b/tests/at_functional_test/test/protocol_enhancements_test.dart
@@ -118,10 +118,18 @@ void main() {
     });
 
     test('a key with asserted eAt and no ttl actually expires', () async {
+      // uAt is asserted BEYOND the eAt so the implied ttl is non-positive
+      // and none is stored (a clock-skewed transfer) — this is the only
+      // reachable expiresAt-without-ttl state now that an eAt-only write
+      // derives and stores the ttl it implies, and it is the state that
+      // proves the expiry machinery sees the asserted eAt itself.
       final soon = VerbUtil.formatIso8601Micros(
           DateTime.now().toUtc().add(Duration(seconds: 3)));
+      final beyond = VerbUtil.formatIso8601Micros(
+          DateTime.now().toUtc().add(Duration(seconds: 30)));
       String response = await firstAtSignConnection.sendRequestToServer(
-          'update:eAt:$soon:ts4-$uniqueId.wavi$firstAtSign fleeting');
+          'update:uAt:$beyond:eAt:$soon:ts4-$uniqueId.wavi$firstAtSign '
+          'fleeting');
       expect(response, matches(RegExp(r'^data:\d+$')),
           reason: 'an asserted-timestamp write is an ordinary COMMITTED '
               'write — a -1 here would mean it silently skipped its '
@@ -137,6 +145,61 @@ void main() {
       expect(response, isNot(contains('"ts4-$uniqueId.wavi$firstAtSign"')),
           reason: 'a key whose only expiry signal is an asserted eAt must '
               'stop being served at that instant');
+    });
+
+    test('update with eAt and no ttl derives and stores the implied ttl',
+        () async {
+      String response = await firstAtSignConnection.sendRequestToServer(
+          'update:uAt:$uAtWire:eAt:$eAtWire'
+          ':ts5-$uniqueId.wavi$firstAtSign hello');
+      expect(response, matches(RegExp(r'^data:\d+$')));
+
+      response = await firstAtSignConnection
+          .sendRequestToServer('llookup:all:ts5-$uniqueId.wavi$firstAtSign');
+      final metaData = metaDataOfLlookupAll(response);
+      expect(metaData['expiresAt'], eAtJson);
+      expect(
+          metaData['ttl'],
+          DateTime.parse(eAtWire)
+              .difference(DateTime.parse(uAtWire))
+              .inMilliseconds,
+          reason: 'a record with an absolute expiry also carries the ttl '
+              'it implies, measured from the stored updatedAt');
+    });
+
+    test('a write that says nothing about expiry does not move expiresAt',
+        () async {
+      String response = await firstAtSignConnection.sendRequestToServer(
+          'update:ttl:86400000:ts6-$uniqueId.wavi$firstAtSign v1');
+      expect(response, matches(RegExp(r'^data:\d+$')));
+      response = await firstAtSignConnection
+          .sendRequestToServer('llookup:all:ts6-$uniqueId.wavi$firstAtSign');
+      final before = metaDataOfLlookupAll(response);
+      expect(before['expiresAt'], isNotNull,
+          reason: 'guards the comparison below — null == null would pass '
+              'without the axis ever having been populated');
+
+      // Far enough apart that a re-derivation from now would visibly move
+      // the millisecond-precision expiresAt.
+      await Future.delayed(Duration(milliseconds: 50));
+      response = await firstAtSignConnection
+          .sendRequestToServer('update:ts6-$uniqueId.wavi$firstAtSign v2');
+      expect(response, matches(RegExp(r'^data:\d+$')));
+      response = await firstAtSignConnection
+          .sendRequestToServer('llookup:all:ts6-$uniqueId.wavi$firstAtSign');
+      final after = metaDataOfLlookupAll(response);
+
+      expect(after['expiresAt'], before['expiresAt'],
+          reason: 'once set, expiresAt moves only when a request speaks '
+              'about expiry: an eAt assertion, a fresh ttl, or ttl:0 — '
+              'a value update must not restart the expiry clock');
+      expect(after['ttl'], 86400000);
+      expect(
+          DateTime.parse(after['updatedAt'])
+              .isAfter(DateTime.parse(before['updatedAt'])),
+          isTrue,
+          reason: 'proves the second write actually happened — the '
+              'unchanged expiresAt must not be because the write was lost');
     });
   });
 


### PR DESCRIPTION
**- What I did**

- Implemented the at_commons 5.10.0 protocol enhancements (Closes #2678):
  - `:cAt`/`:uAt`/`:eAt`/`:aAt` on update / update:meta / update:json — caller-asserted timestamps stored faithfully instead of rederived; asserted eAt/aAt beats the ttl/ttb derivation
  - expiry-axis consistency rules: an asserted eAt/aAt with no accompanying ttl/ttb derives and stores the relative it implies (replacing a retained one — measured from the stored updatedAt, so every server derives the same value from the same assertions); once set, expiresAt/availableAt move only when a request speaks about that axis (an assertion, a fresh ttl/ttb, or ttl:0 to clear) — a write that says nothing about expiry no longer restarts the expiry clock, and no longer re-opens a ttb record's not-yet-born window
  - `:nc` on update / update:meta / update:json / delete — the operation runs as usual (autoNotify included), writes no commit entry AND purges the key's existing one; response `data:-1`; works for already-deleted keys (commit-log cruft removal)
  - `delete:dAt` — recorded as the DELETE commit entry's opTime, and carried to the sharedWith atServer as `:uAt` on the delete auto-notification
  - `scan:cl` — commit-log listing (`{atKey, operation, commitId, opTime}`, ascending commitId), authenticated only, same regex/hidden/enrollment filters as scan
  - server→server faithfulness: notifications emit the four timestamps (auto-notifications from the STORED record) and receivers store cached keys with the origin's values; auto-notifications are queued after the keystore write, from what was actually stored
- Fixed three latent bugs the work surfaced: a Hive commit-log iterate crash on a mid-write entry, the dual-write mirror keeping a stale secondary commit entry after a skipCommit purge, and the per-key update mutex being keyed case-sensitively
- Note: an atServer built with pre-5.10.0 at_commons (before 2026-05-12) rejects the new notify shape; auto-notifications to such a server fail until it upgrades (deliberate — the syntax rolled out fleet-wide ahead of this, per the at_client_sdk PR 1931 plan)

**- How I did it**

See commit & diffs. Assertions travel as an explicit `AtAssertedTimestamps` argument through the keystore API rather than through nullable `AtMetaData` fields, so internal callers keep today's server-derived stamping. The carrier also holds per-axis `deriveTtl`/`deriveTtb` intents set by the request layer (only it can tell a caller-supplied ttl from a retained or coerced one), and the update verbs carry a stored absolute forward as an assertion when a request says nothing about that axis — that is what keeps expiry-silent writes from moving expiry.

**The easiest way to review is commit by commit** — they build on each other logically: persistence primitives → sync-race fix → update/delete verb surface → notify + cache paths → scan:cl → functional/e2e tests → dual-mirror fix → adversarial-review fixes → verb dartdocs → version bumps (3.16.3 / 5.3.0 / 5.2.1) → sync-driven :nc tests + e2e widening → derived relatives + non-sliding absolutes (its own adversarial review folded in).

**- How to verify it**

Tests pass: unit (both persistence backends), functional (runLocal.sh), dual-persistence compare (runDualCompare.sh, 40/40 atSigns byte-identical), e2e (runLocal.sh). Full CI matrix green on this PR.

Unit tests added (103 as executed — the two persistence files run once per backend):
- 31 : asserted-timestamp precedence + derived relatives (builder rules + both keystore backends, incl. expiry-by-eAt, derive-over-retained, the manufactured-availableAt differential)
- 20 : :nc purge + opTime commit-log primitives (both backends, incl. the already-deleted cruft case)
- 31 : verb-layer round trips (:cAt/:uAt/:eAt/:aAt incl. update:json, :nc, :dAt, stored-metadata notify) + non-sliding absolutes (per-axis no-slide differentials with mechanism-ran guards, exact now+ttl expiry on a pinned birth, json-clears pin)
- 11 : notify wire-shape pins (raw literals) + receive-path cached-key faithfulness (incl. no fabricated ttb, reproducible eAt−uAt derivation)
- 10 : scan:cl shape, ordering, filters, APKAM cases, refusals
-  1 : dual-write scenario extended (asserted stamps + skipCommit purge mirror byte-exactly)

Functional tests added (`protocol_enhancements_test.dart`, 18):
- update with cAt/uAt stores them faithfully
- asserted eAt wins over ttl derivation at that write
- update:json with eAt and no ttl keeps the asserted expiry
- a key with asserted eAt and no ttl actually expires (clock-skew shape: uAt beyond eAt, so no ttl is derived)
- update with eAt and no ttl derives and stores the implied ttl
- a write that says nothing about expiry does not move expiresAt
- update:nc responds data:-1 and removes the entry from sync
- a key created with update:nc never appears in sync
- update:meta:nc removes the entry from sync
- a normal update after :nc re-enters sync with a fresh, higher commitId
- delete:nc removes the DELETE tombstone from sync
- update:nc:json is absent from sync
- update:meta:nc responds data:-1
- delete:nc purges the leftover DELETE entry (the cruft case)
- scan:cl lists entries with the pinned shape, filtered by regex
- delete:dAt is visible as the DELETE entry's opTime in scan:cl
- scan:cl on an unauthenticated connection is refused
- scan:cl for another atSign is refused

e2e tests added (`protocol_timestamps_e2e_test.dart`, 5, two real atServers; markTestSkipped when a server predates the capability):
- a notification carrying cAt/uAt stores the cached key with the origin values; a refresh updates them
- delete:dAt propagates: the receiver's cached-key DELETE entry records the origin deletion time (via scan:cl on the receiver)
- autoNotify transmits the STORED timestamps: a plain update with cAt yields a cached key carrying that cAt on the receiver
- an origin absolute expiry survives the hop: eAt alongside ttl is not rederived on the receiver
- update:nc still auto-notifies: the receiver caches the key although the sender wrote no commit entry

**- Description for the changelog**

Implement the at_commons 5.10.0 protocol enhancements: caller-asserted timestamps (cAt/uAt/eAt/aAt, delete:dAt), the :nc no-commit flag, scan:cl commit-log listing, and faithful server-to-server timestamp transmission. An asserted absolute with no accompanying relative derives and stores the ttl/ttb it implies, and a write that says nothing about expiry no longer moves expiresAt/availableAt.

