### PR TITLE
fix(at_secondary_server): cache a ttl/ttb of 0 the origin holds rather than re-deriving it

### DIFF
--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -12,10 +12,15 @@
     (measured from the stored updatedAt — from the asserted availableAt
     when that lies ahead — so every server derives the same value from the
     same assertions), and an `:aAt` with no ttb derives the ttb, in each
-    case replacing any relative retained from the stored record. A
-    supplied 0 counts as unsupplied (the update:json path and the notify
-    receiver coerce an absent ttl/ttb to 0); a non-positive implied value
-    clears the relative instead.
+    case replacing any relative retained from the stored record. A 0
+    counts as unsupplied only where an absent value genuinely arrives as
+    one — the `update:json` path, where commons `Metadata.fromJson` turns
+    an absent ttl/ttb into 0. Where a missing relative is a real null —
+    the notify receiver, which keys on what the wire carried, and the
+    lookup-driven cache, which keys on the origin's own stored value — a
+    `ttb: 0` ("available with no delay") is cached as it stands rather
+    than re-derived. A non-positive implied value clears the relative
+    instead.
   - once set, expiresAt/availableAt move only when a request speaks about
     that axis: an asserted `:eAt`/`:aAt` stores faithfully, an explicit
     ttl/ttb re-derives from now (a ttl-only write on a record whose birth

--- a/packages/at_secondary_server/lib/src/caching/cache_manager.dart
+++ b/packages/at_secondary_server/lib/src/caching/cache_manager.dart
@@ -523,18 +523,25 @@ class AtCacheManager {
             metadata.availableAt == null)) {
       return null;
     }
-    // Derive the relative a remote absolute implies when the remote record
-    // carries none (an older origin that never derived one) — 0 included,
-    // since a 0 beside an absolute is a coercion artefact, not a value.
+    // Derive the relative a remote absolute implies only when the remote
+    // record carries NONE of it. A 0 here is the origin's own value, never
+    // a coercion artefact: this path parses the remote record with
+    // AtMetaData.fromJson, which preserves a null ttl/ttb, unlike commons
+    // Metadata.fromJson on the update:json verb path, which turns an absent
+    // one into 0. So a `ttb: 0` ("available with no delay") is cached as it
+    // stands rather than replaced by the gap between the record's
+    // updatedAt and its availableAt — which is not that record's ttb
+    // whenever the two were stamped from different clocks, as they are for
+    // a record reaching the cache with a ttb but no availableAt of its own
+    // (setTTB then stamps one here, from this server's clock, while
+    // updatedAt stays the origin's).
     return AtAssertedTimestamps(
         createdAt: metadata.createdAt,
         updatedAt: metadata.updatedAt,
         expiresAt: metadata.expiresAt,
         availableAt: metadata.availableAt,
-        deriveTtl: metadata.expiresAt != null &&
-            (metadata.ttl == null || metadata.ttl == 0),
-        deriveTtb: metadata.availableAt != null &&
-            (metadata.ttb == null || metadata.ttb == 0));
+        deriveTtl: metadata.expiresAt != null && metadata.ttl == null,
+        deriveTtb: metadata.availableAt != null && metadata.ttb == null);
   }
 
   /// Does the remote lookup - returns the Atsign Protocol string which it receives

--- a/packages/at_secondary_server/test/notify_timestamps_test.dart
+++ b/packages/at_secondary_server/test/notify_timestamps_test.dart
@@ -352,5 +352,80 @@ void main() {
       expect(cached.metaData!.updatedAt, uAt);
       expect(cached.metaData!.expiresAt, eAt);
     });
+
+    // A relative the origin actually holds is cached as it stands. The
+    // derive-the-missing-relative rule keys on null, and a 0 is not
+    // missing: this path parses the remote record with AtMetaData.fromJson,
+    // which preserves a null ttl/ttb rather than coercing it to 0 the way
+    // commons Metadata.fromJson does on the update:json verb path.
+    //
+    // The origin's availableAt/expiresAt sit a long way from its updatedAt
+    // in both tests, so a derivation would not merely be wrong, it would
+    // store an unmistakable ~year-in-milliseconds number.
+    test('a cached copy keeps the origin\'s ttb of 0 rather than deriving '
+        'one from its availableAt', () async {
+      inboundConnection.metadata.isAuthenticated = true;
+      const keyName = 'ttb_zero.some_namespace@bob';
+
+      final AtData bobData = createRandomAtData(bob);
+      bobData.metaData!.ttr = 10;
+      bobData.metaData!.ttl = null;
+      bobData.metaData!.ttb = 0;
+      bobData.metaData!.updatedAt = uAt;
+      bobData.metaData!.availableAt = aAt;
+      final String bobDataAsJsonWithKey = SecondaryUtil.prepareResponseData(
+          'all', bobData,
+          key: '$alice:$keyName')!;
+
+      when(() => mockOutboundConnection.write('lookup:all:$keyName\n'))
+          .thenAnswer((Invocation invocation) async {
+        socketOnDataFn("data:$bobDataAsJsonWithKey\n$alice@".codeUnits);
+      });
+
+      final lookupHandler = LookupVerbHandler(
+          keyValueStore, mockOutboundClientManager, cacheManager, enMgr,
+          accessLog: atAccessLog);
+      await lookupHandler.process('lookup:all:$keyName', inboundConnection);
+
+      final cached = await keyValueStore.get('cached:$alice:$keyName');
+      expect(cached!.metaData!.ttb, 0,
+          reason: 'ttb 0 means "available with no delay" — the origin\'s own '
+              'value, not a missing one. Deriving over it stores the gap '
+              'between the origin\'s updatedAt and its availableAt instead');
+      expect(cached.metaData!.availableAt, aAt,
+          reason: 'the absolute is still cached faithfully');
+    });
+
+    test('a cached copy keeps the origin\'s ttl of 0 rather than deriving '
+        'one from its expiresAt', () async {
+      inboundConnection.metadata.isAuthenticated = true;
+      const keyName = 'ttl_zero.some_namespace@bob';
+
+      final AtData bobData = createRandomAtData(bob);
+      bobData.metaData!.ttr = 10;
+      bobData.metaData!.ttb = null;
+      bobData.metaData!.ttl = 0;
+      bobData.metaData!.updatedAt = uAt;
+      bobData.metaData!.expiresAt = eAt;
+      final String bobDataAsJsonWithKey = SecondaryUtil.prepareResponseData(
+          'all', bobData,
+          key: '$alice:$keyName')!;
+
+      when(() => mockOutboundConnection.write('lookup:all:$keyName\n'))
+          .thenAnswer((Invocation invocation) async {
+        socketOnDataFn("data:$bobDataAsJsonWithKey\n$alice@".codeUnits);
+      });
+
+      final lookupHandler = LookupVerbHandler(
+          keyValueStore, mockOutboundClientManager, cacheManager, enMgr,
+          accessLog: atAccessLog);
+      await lookupHandler.process('lookup:all:$keyName', inboundConnection);
+
+      final cached = await keyValueStore.get('cached:$alice:$keyName');
+      expect(cached!.metaData!.ttl, 0,
+          reason: 'a ttl the origin holds is cached as it stands');
+      expect(cached.metaData!.expiresAt, eAt,
+          reason: 'the absolute is still cached faithfully');
+    });
   });
 }


### PR DESCRIPTION
**- What I did**

- Fixed the flaky `proxy_lookup_verb_test.dart` failure (Closes #2767): the lookup-driven cache overwrote a `ttl`/`ttb` of 0 that the origin actually holds, instead of caching it as it stands.
- Root cause: `_assertedFromRemote` treated a `0` as "no relative supplied" and asked the store to re-derive one. The stated reason — that a 0 beside an absolute is a coercion artefact — is false on this path. The remote record is parsed by `AtMetaData.fromJson`, which **preserves** a null ttl/ttb; it is commons `Metadata.fromJson`, on the `update:json` verb path, that turns an absent one into 0. So `ttb: 0` here means "available with no delay" and is the origin's own value.
- Why it looked random: the derived value is the gap between the record's `updatedAt` and its `availableAt`, and those come from different clocks whenever a record reaches the cache with a ttb but no `availableAt` of its own — `setTTB` stamps `availableAt` from this server's clock while `updatedAt` stays the origin's. The gap is however long caching happened to take: 0ms gives the `ttb: null` in the issue, 2ms gave `ttb: 2` when I reproduced it.
- Only the cache path was wrong. The notify receiver keys its flags on what the wire carried, and the verb layer keys on the request where the `update:json` coercion is real — both already correct, both unchanged.
- Corrected the 3.16.3 CHANGELOG sentence that claimed "a supplied 0 counts as unsupplied" without qualification. 3.16.3 is unreleased (last tag `c3.16.2`), so no released build ever had this.

**- How I did it**

See commit & diffs.

**- How to verify it**

Tests pass.

- The reported test is random by design (its ttb is 0 about 10% of the time): **2 failures in 40 runs before, 0 in 60 after**.
- Two deterministic regression tests added in `notify_timestamps_test.dart`, so the pin does not depend on that 10%. They put the origin's `availableAt`/`expiresAt` a year from its `updatedAt`, so a re-derivation stores an unmistakable ~year-in-milliseconds number rather than a plausible one.
- Mutation-proven one half at a time: restoring the ttb half reddens only the ttb test (`Actual: 34045261101`), the ttl half only the ttl test (`Actual: 281130893211`).
- at_secondary_server 1024/1024, at_persistence_secondary_server 369/369, functional suite via `runLocal.sh`, `dart analyze --fatal-warnings` clean across the workspace.

**- Description for the changelog**

The lookup-driven cache keeps a `ttl` or `ttb` of 0 that the origin holds, rather than replacing it with a value derived from the record's own timestamps.
