### PR TITLE
fix(at_secondary_server): update:json moves ttl/ttb/ttr only when the request names one

### DIFF
--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -80,6 +80,17 @@
   The keystore canonicalizes keys to lowercase, so two case-variants of
   one update command name the same stored record; keyed on the original
   case they took different mutexes and raced.
+- fix: an `update:json` moves a record's ttl, ttb or ttr only when the
+  request names one, matching the metadata-fragment form of the same
+  request. commons `Metadata.fromJson` turns an absent — or explicitly
+  null — ttl/ttb/ttr into 0 and `Metadata.toJson` always writes the
+  three, so what a json request never mentioned arrived as an explicit
+  `ttl:0` (clear the record's expiry), `ttb:0` (available with no delay)
+  or `ttr:0` (do not cache): a value-only json update silently dropped a
+  record's expiry and stopped it being cached at the receiver. The verb
+  layer now reads the nulls back off the decoded map the DTO was built
+  from. A future at_commons that preserves them makes this a no-op
+  rather than a correction.
 
 # 3.16.2
 - fix(at_secondary_server): a closed `NotificationManager` now stops its

--- a/packages/at_secondary_server/lib/src/verb/handler/abstract_update_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/abstract_update_verb_handler.dart
@@ -254,6 +254,40 @@ abstract class AbstractUpdateVerbHandler extends ChangeVerbHandler {
     }
   }
 
+  /// Puts back the "this request said nothing about it" state that commons
+  /// `Metadata.fromJson` cannot represent.
+  ///
+  /// That parser turns an absent — or explicitly null — ttl/ttb/ttr into 0,
+  /// and `Metadata.toJson` always writes the three, so a null makes the
+  /// round trip as a 0. An `update:json` that never mentions expiry is then
+  /// indistinguishable from one asking for `ttl:0`, which clears the
+  /// record's expiry; the same goes for `ttb:0`, and for `ttr:0`, which
+  /// stops the record being cached at the receiver.
+  ///
+  /// The metadata-fragment form of the same request leaves an unmentioned
+  /// ttl/ttb/ttr null, and the retain-merge then keeps what the record
+  /// already holds — so without this the two encodings of one request store
+  /// different things, and only the json one moves an axis it never named.
+  /// Read from the decoded map the DTO was built from, which still has the
+  /// null.
+  ///
+  /// An at_commons that preserves the null makes this a no-op rather than a
+  /// correction: it reads the same map to the same answer either way.
+  void _restoreUnmentionedRelatives(Metadata? metadata, dynamic rawMetadata) {
+    if (metadata == null || rawMetadata is! Map) {
+      return;
+    }
+    if (rawMetadata[AtConstants.ttl] == null) {
+      metadata.ttl = null;
+    }
+    if (rawMetadata[AtConstants.ttb] == null) {
+      metadata.ttb = null;
+    }
+    if (rawMetadata[AtConstants.ttr] == null) {
+      metadata.ttr = null;
+    }
+  }
+
   /// The timestamps this write must store faithfully: the request's own
   /// assertions ([metadata]'s createdAt/updatedAt/expiresAt/availableAt,
   /// parsed off the wire by [getUpdateParams] or, for `update:json`, by
@@ -318,7 +352,9 @@ abstract class AbstractUpdateVerbHandler extends ChangeVerbHandler {
     if (verbParams['json'] != null) {
       var jsonString = verbParams['json']!;
       Map jsonMap = jsonDecode(jsonString);
-      return UpdateParams.fromJson(jsonMap);
+      final updateParams = UpdateParams.fromJson(jsonMap);
+      _restoreUnmentionedRelatives(updateParams.metadata, jsonMap['metadata']);
+      return updateParams;
     }
     var updateParams = UpdateParams();
     if (verbParams[AtConstants.atSign] != null) {

--- a/packages/at_secondary_server/test/protocol_timestamps_nc_verb_test.dart
+++ b/packages/at_secondary_server/test/protocol_timestamps_nc_verb_test.dart
@@ -378,16 +378,21 @@ void main() {
           reason: 'the explicit ttb re-derives availableAt = now + ttb');
     });
 
-    test('an expiry-silent update:json clears expiry (the json encoding '
-        'cannot say nothing about expiry)', () async {
-      // commons Metadata.fromJson coerces an absent ttl to 0, and a 0
-      // with no asserted expiry is indistinguishable from an explicit
-      // clear — so the no-slide carry is unreachable via update:json.
-      // This pins that documented limitation.
+    // The two encodings of one request must store the same thing. commons
+    // Metadata.fromJson turns an absent — or explicitly null — ttl/ttb/ttr
+    // into 0 and Metadata.toJson always writes the three, so what a json
+    // request never mentioned used to arrive as `0`: an explicit "clear the
+    // expiry" / "no delay" / "do not cache". getUpdateParams puts the null
+    // back from the decoded map, so a json request moves an axis only when
+    // it names one, exactly as the metadata-fragment form does.
+    test('an expiry-silent update:json leaves expiresAt alone, like the '
+        'metadata-fragment form', () async {
       await updateHandler.process(
           'update:ttl:86400000:@bob:phone.wavi$alice v1', inboundConnection);
       final before = await llookupAllAtMetaData('@bob:phone.wavi$alice');
-      expect(before.expiresAt, isNotNull);
+      expect(before.expiresAt, isNotNull,
+          reason: 'guards the comparison below — null == null would pass '
+              'without the axis ever having been populated');
 
       final json = jsonEncode({
         'atKey': 'phone.wavi',
@@ -398,10 +403,41 @@ void main() {
       });
       await updateHandler.process('update:json:$json', inboundConnection);
       final after = await llookupAllAtMetaData('@bob:phone.wavi$alice');
-      expect(after.expiresAt, isNull,
-          reason: 'the coerced ttl:0 counts as the request speaking, and '
-              'ttl:0 clears — an update:json client that wants to keep a '
-              'record\'s expiry must send its metadata back');
+      expect(after.expiresAt, before.expiresAt,
+          reason: 'this request named no expiry, so it must not clear one');
+      expect(after.ttl, 86400000);
+      await llookupHandler.process(
+          'llookup:@bob:phone.wavi$alice', inboundConnection);
+      expect(inboundConnection.lastWrittenData, startsWith('data:v2'),
+          reason: 'proves the json write actually happened — an unchanged '
+              'expiry must not be because the write was lost');
+    });
+
+    test('a ttr-silent update:json leaves the record cacheable', () async {
+      // ttr 0 means "do not cache", so the coerced 0 silently switched off
+      // caching for a key whose json update never mentioned ttr.
+      await updateHandler.process(
+          'update:ttr:100000:ccd:true:@bob:phone.wavi$alice v1',
+          inboundConnection);
+      final before = await llookupAllAtMetaData('@bob:phone.wavi$alice');
+      expect(before.ttr, 100000);
+
+      final json = jsonEncode({
+        'atKey': 'phone.wavi',
+        'value': 'v2',
+        'sharedBy': alice,
+        'sharedWith': '@bob',
+        'metadata': Metadata().toJson(),
+      });
+      await updateHandler.process('update:json:$json', inboundConnection);
+      final after = await llookupAllAtMetaData('@bob:phone.wavi$alice');
+      expect(after.ttr, 100000,
+          reason: 'this request named no ttr, so it must not stop the '
+              'record being cached at the receiver');
+      await llookupHandler.process(
+          'llookup:@bob:phone.wavi$alice', inboundConnection);
+      expect(inboundConnection.lastWrittenData, startsWith('data:v2'),
+          reason: 'proves the json write actually happened');
     });
 
     test('a write that says nothing about availability does not move '


### PR DESCRIPTION
**- What I did**

- Made `update:json` move a record's `ttl`, `ttb` or `ttr` only when the request names one — matching the metadata-fragment form of the same request, and the rule the rest of this surface follows.
- The cause: commons `Metadata.fromJson` turns an absent (or explicitly null) `ttl`/`ttb`/`ttr` into `0`, and `Metadata.toJson` always writes the three, so a null makes the round trip as a `0`. An `update:json` that never mentioned an axis therefore arrived asking for `ttl:0` (**clear the record's expiry**), `ttb:0` (available with no delay) or `ttr:0` (**do not cache**). A value-only json update silently dropped a record's expiry and stopped it being cached at the receiver.
- The metadata-fragment form leaves an unmentioned relative null and the retain-merge keeps what the record already holds, so the two encodings of one request stored different things — and only the json one moved an axis it never named. `getUpdateParams` now reads the nulls back off the decoded map the DTO was built from.
- Not a regression from the recent timestamp work: the coercion and the retain-merge's `??=` both predate it (verified at `96243830^1`). That work only documented the limitation, in a test that pinned it — this replaces that test.

**- How I did it**

See commit & diffs. Fixing this in at_commons is the root fix and is a separate PR against at_client_sdk; a version of at_commons that preserves the null makes this a no-op rather than a correction, since it reads the same map to the same answer either way.

**- How to verify it**

Tests pass.

- Both new tests are mutation-proven: disabling the restoration reddens the expiry test (`expiresAt` null where the record's own instant was expected) and the ttr test (`ttr` 0 where 100000 was expected), each quoting its own reason string.
- at_secondary_server 1025/1025, functional 239/239 via `runLocal.sh`, e2e 47/47 via `runLocal.sh`, `dart analyze --fatal-warnings` clean across the workspace.

**- Description for the changelog**

An `update:json` moves a record's ttl, ttb or ttr only when the request names one, instead of an unmentioned one arriving as an explicit 0 that cleared the record's expiry or stopped it being cached.
