### PR TITLE
fix(at_secondary_server): answer each cross-atSign request with its own response

### DIFF
--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -6,6 +6,10 @@
   socket could each be answered with the other's record — well formed, but
   not what was asked for. Each request/response pair now completes on the
   socket before the next request is written to it.
+- fix: `OutboundClientManager.getClient` is now atomic per pool key, so two
+  concurrent callers that both find no client for a key no longer each
+  create and pool one. Locking is per key so that connecting to one atSign
+  does not hold up connecting to another.
 - feat: implement the at_commons 5.10.0 protocol enhancements on the
   update/update:meta/update:json/delete surface (#2678):
   - `:cAt`/`:uAt`/`:eAt`/`:aAt` — caller-asserted

--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,4 +1,11 @@
 # 3.16.3
+- fix: answer each cross-atSign request with its own response. A pooled
+  `OutboundClient` is shared by every caller that needs the same remote
+  atServer, and its response queue is in arrival order with nothing pairing
+  a response to the request that caused it, so two requests in flight on one
+  socket could each be answered with the other's record — well formed, but
+  not what was asked for. Each request/response pair now completes on the
+  socket before the next request is written to it.
 - feat: implement the at_commons 5.10.0 protocol enhancements on the
   update/update:meta/update:json/delete surface (#2678):
   - `:cAt`/`:uAt`/`:eAt`/`:aAt` — caller-asserted

--- a/packages/at_secondary_server/lib/src/connection/outbound/outbound_client.dart
+++ b/packages/at_secondary_server/lib/src/connection/outbound/outbound_client.dart
@@ -16,6 +16,7 @@ import 'package:at_secondary/src/utils/secondary_util.dart';
 import 'package:at_server_spec/at_server_spec.dart';
 import 'package:at_utils/at_logger.dart';
 import 'package:meta/meta.dart';
+import 'package:mutex/mutex.dart';
 
 // Connects to an secondary and performs required handshake to be ready to run rest of the commands
 /// Handshake involves running "from", "pol" verbs on the secondary
@@ -41,6 +42,26 @@ class OutboundClient {
   int notifyTimeoutMillis = 10 * 1000;
 
   at_lookup.SecondaryAddressFinder secondaryAddressFinder;
+
+  /// Serialises each request/response pair on this client's outbound socket.
+  ///
+  /// A pooled [OutboundClient] is shared by every caller needing the same
+  /// remote atServer, and a request is two steps: write the verb, then take
+  /// the next message off [OutboundMessageListener]'s queue. That queue is
+  /// in arrival order with nothing tying a response back to the request which
+  /// caused it, so two callers interleaving those steps on one socket are
+  /// each answered with whichever response arrives first — a well-formed
+  /// record, but not the one that was asked for.
+  ///
+  /// Held across the write and the read of a single exchange only, never
+  /// across [connect], so establishing one client does not block requests on
+  /// another. [_establishHandShake] is one critical section rather than two
+  /// because its `from:` and `pol:` exchanges must not be split.
+  ///
+  /// The lock is not reentrant: anything called while it is held must reach
+  /// the socket through the `...OnWire` methods, not through the public
+  /// operations that take it.
+  final Mutex _requestResponseMutex = Mutex();
 
   /// When unit testing, we don't need to do all the things necessary
   /// to support server-to-server handshake - for example, actually signing
@@ -258,7 +279,12 @@ class OutboundClient {
   /// [checkRemotePublicKey], which [connect] calls before the handshake), so it
   /// declares the target tenant to the peer before any `from:`.
   /// Mirrors [scan]'s raw write/read; only used when toVerbOutboundEnabled.
-  Future<String> _sendToVerb() async {
+  Future<String> _sendToVerb() =>
+      _requestResponseMutex.protect(_sendToVerbOnWire);
+
+  /// Writes the `to:` request and reads its response. Runs under
+  /// [_requestResponseMutex].
+  Future<String> _sendToVerbOnWire() async {
     var toRequest = AtRequestFormatter.createToRequest(toAtSign);
     try {
       await outboundConnection!.write(toRequest);
@@ -283,7 +309,12 @@ class OutboundClient {
     return address.toString();
   }
 
-  Future<bool> _establishHandShake() async {
+  Future<bool> _establishHandShake() =>
+      _requestResponseMutex.protect(_establishHandShakeOnWire);
+
+  /// Runs the `from:`/`pol:` exchanges as a single unit. Runs under
+  /// [_requestResponseMutex].
+  Future<bool> _establishHandShakeOnWire() async {
     if (!isConnectionCreated) {
       throw HandShakeException(
           'Handshake cannot be initiated without an outbound connection');
@@ -358,8 +389,15 @@ class OutboundClient {
   /// Throws a [UnAuthorizedException] if lookup if invoked with handshake=true and without a successful handshake
   /// Throws a [LookupException] if there is exception during lookup
   /// Throws a [OutBoundConnectionInvalidException] if we are trying to write to an invalid connection
-  Future<String?> lookUp(String key, {bool handshake = true}) async {
+  Future<String?> lookUp(String key, {bool handshake = true}) {
     logger.finer('lookUp($key, handshake:$handshake) called for $toAtSign');
+    return _requestResponseMutex
+        .protect(() => _lookUpOnWire(key, handshake: handshake));
+  }
+
+  /// Writes the lookup request and reads its response. Runs under
+  /// [_requestResponseMutex].
+  Future<String?> _lookUpOnWire(String key, {bool handshake = true}) async {
     if (handshake && !isHandShakeDone) {
       throw LookupException(
           'OutboundClient.lookUp: Handshake not done, but lookUp was called with handshake: true');
@@ -388,7 +426,13 @@ class OutboundClient {
     return lookupResult;
   }
 
-  Future<String?> scan({bool handshake = true, String? regex}) async {
+  Future<String?> scan({bool handshake = true, String? regex}) =>
+      _requestResponseMutex
+          .protect(() => _scanOnWire(handshake: handshake, regex: regex));
+
+  /// Writes the scan request and reads its response. Runs under
+  /// [_requestResponseMutex].
+  Future<String?> _scanOnWire({bool handshake = true, String? regex}) async {
     if (handshake && !isHandShakeDone) {
       throw UnAuthorizedException(
           'Handshake did not succeed. Cannot perform a outbound scan');
@@ -419,6 +463,8 @@ class OutboundClient {
   /// @param key - key to be looked up
   /// @returns result of the plookup returned by the secondary
   /// Throws a [LookupException] if there is exception during lookup
+  /// Delegates to [lookUp], which takes [_requestResponseMutex]; this method
+  /// must not take it as well, since the lock is not reentrant.
   Future<String?> plookUp(String key) async {
     var result = await lookUp(key, handshake: false);
     lastUsed = DateTime.now();
@@ -448,6 +494,13 @@ class OutboundClient {
   }
 
   Future<String?> notify(String notifyCommandBody,
+          {bool handshake = true}) =>
+      _requestResponseMutex.protect(
+          () => _notifyOnWire(notifyCommandBody, handshake: handshake));
+
+  /// Writes the notify request and reads its response. Runs under
+  /// [_requestResponseMutex].
+  Future<String?> _notifyOnWire(String notifyCommandBody,
       {bool handshake = true}) async {
     if (handshake && !isHandShakeDone) {
       throw UnAuthorizedException('Handshake failed. Cannot perform a lookup');

--- a/packages/at_secondary_server/lib/src/connection/outbound/outbound_client_manager.dart
+++ b/packages/at_secondary_server/lib/src/connection/outbound/outbound_client_manager.dart
@@ -1,10 +1,12 @@
 import 'package:at_commons/at_commons.dart';
 import 'package:at_lookup/at_lookup.dart';
+import 'package:at_secondary/src/connection/inbound/dummy_inbound_connection.dart';
 import 'package:at_secondary/src/connection/outbound/outbound_client.dart';
 import 'package:at_secondary/src/connection/outbound/outbound_client_pool.dart';
 import 'package:at_server_spec/at_server_spec.dart';
 import 'package:at_utils/at_logger.dart';
 import 'package:meta/meta.dart';
+import 'package:mutex/mutex.dart';
 
 /// Class to retrieve and manage [OutboundClient] from [OutboundClientPool]
 class OutboundClientManager {
@@ -33,6 +35,29 @@ class OutboundClientManager {
 
   int get poolSize => _pool.size;
 
+  /// One mutex per pool key. Looking a client up in the pool and adding a
+  /// newly created one back are separated by an await — [OutboundClient.connect]
+  /// — so without this two callers that both miss for the same key each
+  /// create and add a client for it, and the pool then holds two connections
+  /// where the caller asked for one shared connection.
+  ///
+  /// Per key rather than one lock for the whole manager, so that connecting
+  /// to one atSign does not hold up connecting to another.
+  final Map<(String, Object, bool), _MutexRef> _getClientMutexes = {};
+
+  /// Which callers contend for the same lock, following the rule
+  /// [OutboundClientPool.get] matches on.
+  ///
+  /// Any [DummyInboundConnection] matches any other, so every caller holding
+  /// a dummy shares one lock. Every other kind of connection matches on
+  /// something no two simultaneously live inbound connections share — a
+  /// remote address and port, or a web socket — so the connection object
+  /// itself separates them.
+  Object _lockScope(InboundConnection inboundConnection) =>
+      inboundConnection is DummyInboundConnection
+          ? DummyInboundConnection
+          : inboundConnection;
+
   /// If the pool is already initialized, checks and returns an outbound client if it is already in pool.
   /// Otherwise clears idle clients and creates a new outbound client if the pool has capacity. Returns null if pool does not have capacity.
   ///  If the pool is not initialized, initializes the pool with [defaultPoolSize] and creates a new client
@@ -46,6 +71,33 @@ class OutboundClientManager {
     if (closed) {
       throw StateError('getClient called but we are in closed state');
     }
+    final lockKey =
+        (toAtSign, _lockScope(inboundConnection), handshakeRequired);
+    final mutexRef = _getClientMutexes.putIfAbsent(lockKey, _MutexRef.new);
+    mutexRef.waiters++;
+    try {
+      return await mutexRef.mutex.protect(() => _getClient(
+            toAtSign,
+            inboundConnection,
+            handshakeRequired: handshakeRequired,
+            connect: connect,
+          ));
+    } finally {
+      mutexRef.waiters--;
+      if (mutexRef.waiters == 0) {
+        _getClientMutexes.remove(lockKey);
+      }
+    }
+  }
+
+  /// Looks the client up, creating and pooling one if there is no match.
+  /// Runs under this key's entry in [_getClientMutexes].
+  Future<OutboundClient> _getClient(
+    String toAtSign,
+    InboundConnection inboundConnection, {
+    required bool handshakeRequired,
+    bool connect = true,
+  }) async {
     _pool.clearInvalidClients();
     // Get OutboundClient for a given atSign and InboundConnection
     OutboundClient? client =
@@ -90,4 +142,14 @@ class OutboundClientManager {
   int getActiveConnectionSize() {
     return _pool.getActiveConnectionSize();
   }
+
+  @visibleForTesting
+  int get pendingGetClientLocks => _getClientMutexes.length;
+}
+
+/// Mutable holder for a per-pool-key mutex and the number of callers waiting
+/// on it, so an entry can be dropped once nobody is contending for that key.
+class _MutexRef {
+  final Mutex mutex = Mutex();
+  int waiters = 0;
 }

--- a/packages/at_secondary_server/lib/src/connection/outbound/outbound_client_manager.dart
+++ b/packages/at_secondary_server/lib/src/connection/outbound/outbound_client_manager.dart
@@ -43,6 +43,13 @@ class OutboundClientManager {
   ///
   /// Per key rather than one lock for the whole manager, so that connecting
   /// to one atSign does not hold up connecting to another.
+  ///
+  /// The guarantee is per key and nothing more. [OutboundClientPool]'s
+  /// capacity check, its eviction of the least recently used client and its
+  /// add are shared across every key, and callers for different keys hold
+  /// different locks, so concurrent misses for different keys can each pass
+  /// the capacity check before either adds: [poolSize] bounds the pool only
+  /// when misses do not overlap.
   final Map<(String, Object, bool), _MutexRef> _getClientMutexes = {};
 
   /// Which callers contend for the same lock, following the rule

--- a/packages/at_secondary_server/test/outbound_client_concurrency_test.dart
+++ b/packages/at_secondary_server/test/outbound_client_concurrency_test.dart
@@ -1,0 +1,114 @@
+import 'package:at_secondary/src/connection/outbound/outbound_client.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+import 'test_utils.dart';
+
+/// Covers concurrent use of a pooled [OutboundClient].
+///
+/// A pooled client is shared: every caller wanting the same remote atServer
+/// under the same pool key is handed the same object, and therefore the same
+/// socket. The tests below drive two callers at once and assert on what each
+/// one gets back.
+void main() {
+  setUpAll(() async {
+    await verbTestsSetUpAll();
+  });
+
+  setUp(() async {
+    await verbTestsSetUp();
+  });
+
+  tearDown(() async {
+    await verbTestsTearDown();
+  });
+
+  group('concurrent requests on one pooled OutboundClient', () {
+    test(
+        'two lookups in flight together each receive the response to their own'
+        ' request, even when the peer answers them out of order', () async {
+      // The peer answers the second request long before the first. A caller
+      // that takes whatever arrives first is answered with the other
+      // caller's record: well-formed, but not what it asked for.
+      final events = <String>[];
+
+      when(() => mockOutboundConnection.write('lookup:all:slow$bob\n'))
+          .thenAnswer((_) async {
+        events.add('wrote slow');
+        Future.delayed(Duration(milliseconds: 150), () {
+          events.add('peer answered slow');
+          socketOnDataFn('data:SLOW_RECORD\n$alice@'.codeUnits);
+        });
+      });
+      when(() => mockOutboundConnection.write('lookup:all:fast$bob\n'))
+          .thenAnswer((_) async {
+        events.add('wrote fast');
+        Future.delayed(Duration(milliseconds: 10), () {
+          events.add('peer answered fast');
+          socketOnDataFn('data:FAST_RECORD\n$alice@'.codeUnits);
+        });
+      });
+
+      await outboundClientWithoutHandshake.connect();
+      // The harness sets a 100ms budget, which the deliberately slow peer
+      // response here exceeds. The read budget is not what is under test.
+      outboundClientWithoutHandshake.lookupTimeoutMillis = 5000;
+
+      final slow = outboundClientWithoutHandshake.lookUp('all:slow$bob',
+          handshake: false);
+      final fast = outboundClientWithoutHandshake.lookUp('all:fast$bob',
+          handshake: false);
+
+      expect(await slow, 'data:SLOW_RECORD',
+          reason: 'the caller that asked for the slow record must receive the'
+              ' slow record, not whichever response arrived first');
+      expect(await fast, 'data:FAST_RECORD',
+          reason: 'the caller that asked for the fast record must receive the'
+              ' fast record');
+
+      // Asserting the values alone would also pass if the two exchanges
+      // happened to be written together and the responses happened to be
+      // paired up correctly. Pin the mechanism: the second request is not
+      // written until the first exchange has completed.
+      expect(
+          events,
+          [
+            'wrote slow',
+            'peer answered slow',
+            'wrote fast',
+            'peer answered fast'
+          ],
+          reason: 'each request/response pair must complete on the shared'
+              ' socket before the next request is written to it');
+    });
+
+    test(
+        'a lookup and a notify in flight together do not take each'
+        ' other\'s response', () async {
+      when(() => mockOutboundConnection.write('lookup:all:key$bob\n'))
+          .thenAnswer((_) async {
+        Future.delayed(Duration(milliseconds: 150),
+            () => socketOnDataFn('data:LOOKUP_RESULT\n$alice@'.codeUnits));
+      });
+      when(() => mockOutboundConnection.write('notify:the-notification\n'))
+          .thenAnswer((_) async {
+        Future.delayed(Duration(milliseconds: 10),
+            () => socketOnDataFn('data:NOTIFY_RESULT\n$alice@'.codeUnits));
+      });
+
+      await outboundClientWithoutHandshake.connect();
+      outboundClientWithoutHandshake.lookupTimeoutMillis = 5000;
+      outboundClientWithoutHandshake.notifyTimeoutMillis = 5000;
+
+      final lookup = outboundClientWithoutHandshake.lookUp('all:key$bob',
+          handshake: false);
+      final notify = outboundClientWithoutHandshake
+          .notify('the-notification', handshake: false);
+
+      expect(await lookup, 'data:LOOKUP_RESULT',
+          reason: 'the serialisation must hold across different verbs on the'
+              ' shared socket, not just between two lookups');
+      expect(await notify, 'data:NOTIFY_RESULT');
+    });
+  });
+}

--- a/packages/at_secondary_server/test/outbound_client_concurrency_test.dart
+++ b/packages/at_secondary_server/test/outbound_client_concurrency_test.dart
@@ -117,10 +117,15 @@ void main() {
   });
 
   group('concurrent OutboundClientManager.getClient for one pool key', () {
-    /// Long enough that two of these running together and two running one
-    /// after the other are far apart in wall clock, so the assertion below
-    /// has room either side of its threshold on a loaded machine.
-    const connectDelay = Duration(milliseconds: 150);
+    /// Wide enough that a caller reaching address resolution while another
+    /// is still inside it will do so within the window. Nothing asserts on
+    /// elapsed time, so the value only has to exceed scheduling jitter.
+    const connectDelay = Duration(milliseconds: 50);
+
+    /// Records entry to and exit from address resolution, so a test can say
+    /// whether two callers were inside [OutboundClient.connect] together
+    /// rather than inferring it from how long they took.
+    final resolutionEvents = <String>[];
 
     /// Delays address resolution so that both callers are inside
     /// [OutboundClient.connect] at once — the window between finding no
@@ -128,10 +133,14 @@ void main() {
     void slowDownConnecting() {
       when(() => mockSecondaryAddressFinder.findSecondary(bob))
           .thenAnswer((_) async {
+        resolutionEvents.add('enter $bob');
         await Future.delayed(connectDelay);
+        resolutionEvents.add('exit $bob');
         return at_lookup.SecondaryAddress(bobHost, bobPort);
       });
     }
+
+    setUp(resolutionEvents.clear);
 
     test('two callers that both miss share one client rather than each'
         ' creating one', () async {
@@ -162,7 +171,9 @@ void main() {
       slowDownConnecting();
       when(() => mockSecondaryAddressFinder.findSecondary(alice))
           .thenAnswer((_) async {
+        resolutionEvents.add('enter $alice');
         await Future.delayed(connectDelay);
+        resolutionEvents.add('exit $alice');
         return at_lookup.SecondaryAddress(bobHost, bobPort);
       });
       when(() => mockOutboundConnectionFactory.createOutboundConnection(
@@ -174,23 +185,21 @@ void main() {
           mockSecondaryAddressFinder, mockOutboundConnectionFactory,
           poolSize: 5);
 
-      final stopwatch = Stopwatch()..start();
       await Future.wait([
         manager.getClient(bob, DummyInboundConnection(),
             handshakeRequired: false),
         manager.getClient(alice, DummyInboundConnection(),
             handshakeRequired: false),
       ]);
-      stopwatch.stop();
 
       expect(manager.getActiveConnectionSize(), 2);
-      // Two resolutions run together take about one [connectDelay];
-      // serialised they take two. Measured on the fixed build: ~170ms
-      // together, ~320ms when getClient takes one lock for the whole
-      // manager rather than one per pool key.
-      expect(stopwatch.elapsedMilliseconds, lessThan(250),
+      // Assert the overlap itself rather than how long the pair took: both
+      // callers must be inside address resolution before either leaves it.
+      // A lock covering the whole manager would produce
+      // [enter, exit, enter, exit] instead.
+      expect(resolutionEvents.take(2), containsAll(['enter $bob', 'enter $alice']),
           reason: 'connecting to one atSign must not hold up connecting to'
-              ' another');
+              ' another: both callers should be inside connect() together');
     });
 
     test('the per-key lock table does not retain entries', () async {

--- a/packages/at_secondary_server/test/outbound_client_concurrency_test.dart
+++ b/packages/at_secondary_server/test/outbound_client_concurrency_test.dart
@@ -1,15 +1,19 @@
+import 'package:at_lookup/at_lookup.dart' as at_lookup;
+import 'package:at_secondary/src/connection/inbound/dummy_inbound_connection.dart';
 import 'package:at_secondary/src/connection/outbound/outbound_client.dart';
+import 'package:at_secondary/src/connection/outbound/outbound_client_manager.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
 import 'test_utils.dart';
 
-/// Covers concurrent use of a pooled [OutboundClient].
+/// Covers concurrent use of a pooled [OutboundClient] and of
+/// [OutboundClientManager.getClient].
 ///
 /// A pooled client is shared: every caller wanting the same remote atServer
 /// under the same pool key is handed the same object, and therefore the same
-/// socket. The tests below drive two callers at once and assert on what each
-/// one gets back.
+/// socket. Both groups below drive two callers at once and assert on what
+/// each one gets back.
 void main() {
   setUpAll(() async {
     await verbTestsSetUpAll();
@@ -109,6 +113,93 @@ void main() {
           reason: 'the serialisation must hold across different verbs on the'
               ' shared socket, not just between two lookups');
       expect(await notify, 'data:NOTIFY_RESULT');
+    });
+  });
+
+  group('concurrent OutboundClientManager.getClient for one pool key', () {
+    /// Long enough that two of these running together and two running one
+    /// after the other are far apart in wall clock, so the assertion below
+    /// has room either side of its threshold on a loaded machine.
+    const connectDelay = Duration(milliseconds: 150);
+
+    /// Delays address resolution so that both callers are inside
+    /// [OutboundClient.connect] at once — the window between finding no
+    /// client in the pool and adding a newly created one to it.
+    void slowDownConnecting() {
+      when(() => mockSecondaryAddressFinder.findSecondary(bob))
+          .thenAnswer((_) async {
+        await Future.delayed(connectDelay);
+        return at_lookup.SecondaryAddress(bobHost, bobPort);
+      });
+    }
+
+    test('two callers that both miss share one client rather than each'
+        ' creating one', () async {
+      slowDownConnecting();
+      final manager = OutboundClientManager(
+          mockSecondaryAddressFinder, mockOutboundConnectionFactory,
+          poolSize: 5);
+
+      // Two distinct dummies: the pool matches any dummy against any other,
+      // so these are one pool key.
+      final results = await Future.wait([
+        manager.getClient(bob, DummyInboundConnection(),
+            handshakeRequired: false),
+        manager.getClient(bob, DummyInboundConnection(),
+            handshakeRequired: false),
+      ]);
+
+      expect(identical(results[0], results[1]), isTrue,
+          reason: 'both callers asked for the same pool key, so both must be'
+              ' handed the same client');
+      expect(manager.getActiveConnectionSize(), 1,
+          reason: 'a second client for one pool key is a connection the pool'
+              ' holds but no caller asked for');
+    });
+
+    test('callers for different atSigns are not held up by each other',
+        () async {
+      slowDownConnecting();
+      when(() => mockSecondaryAddressFinder.findSecondary(alice))
+          .thenAnswer((_) async {
+        await Future.delayed(connectDelay);
+        return at_lookup.SecondaryAddress(bobHost, bobPort);
+      });
+      when(() => mockOutboundConnectionFactory.createOutboundConnection(
+          bobHost, bobPort, alice)).thenAnswer((_) async {
+        return mockOutboundConnection;
+      });
+
+      final manager = OutboundClientManager(
+          mockSecondaryAddressFinder, mockOutboundConnectionFactory,
+          poolSize: 5);
+
+      final stopwatch = Stopwatch()..start();
+      await Future.wait([
+        manager.getClient(bob, DummyInboundConnection(),
+            handshakeRequired: false),
+        manager.getClient(alice, DummyInboundConnection(),
+            handshakeRequired: false),
+      ]);
+      stopwatch.stop();
+
+      expect(manager.getActiveConnectionSize(), 2);
+      // Two resolutions run together take about one [connectDelay];
+      // serialised they take two. Measured on the fixed build: ~170ms
+      // together, ~320ms when getClient takes one lock for the whole
+      // manager rather than one per pool key.
+      expect(stopwatch.elapsedMilliseconds, lessThan(250),
+          reason: 'connecting to one atSign must not hold up connecting to'
+              ' another');
+    });
+
+    test('the per-key lock table does not retain entries', () async {
+      final manager = OutboundClientManager(
+          mockSecondaryAddressFinder, mockOutboundConnectionFactory,
+          poolSize: 5);
+      await manager.getClient(bob, DummyInboundConnection(),
+          handshakeRequired: false);
+      expect(manager.pendingGetClientLocks, 0);
     });
   });
 }


### PR DESCRIPTION
## What I did

Fix a race affecting high-concurrency lookup requests to other atServers

- Hold a mutex across the write and the read of each exchange on `OutboundClient` (`lookUp`, `scan`, `notify`, `_sendToVerb`, and `_establishHandShake` as one critical section covering both its `from:` and `pol:` exchanges). `plookUp` deliberately does not take it — it delegates to `lookUp`, and the mutex is not reentrant.
- Made `OutboundClientManager.getClient` atomic per pool key, so two concurrent misses for one key no longer each create and pool a client. Per key rather than one lock for the whole manager, so connecting to one atSign does not hold up connecting to another.
- Left `DummyInboundConnection.equals` alone: `NotifyConnectionsPool` depends on the any-dummy match, and the request/response lock covers that path.

Pool keying is deliberately unchanged — outbound pooling and its concurrency are a separate discussion.

## How I did it

See commits and diffs.

## How to verify it

New unit tests in `packages/at_secondary_server/test/outbound_client_concurrency_test.dart`:

- `two lookups in flight together each receive the response to their own request, even when the peer answers them out of order`
- `a lookup and a notify in flight together do not take each other's response`
- `two callers that both miss share one client rather than each creating one`
- `callers for different atSigns are not held up by each other`
- `the per-key lock table does not retain entries`

Each was mutation-proven: removing the client mutex reddens the first two with the value swap itself (`Expected: 'data:SLOW_RECORD' Actual: 'data:FAST_RECORD'`), and removing or globalising the per-key mutex reddens the third and fourth respectively.
