### PR TITLE
fix(tests): create the VE secondary staging directory before copying into it

### DIFF
--- a/tests/at_end2end_test/runLocal.sh
+++ b/tests/at_end2end_test/runLocal.sh
@@ -122,6 +122,7 @@ docker run --rm \
 echo "copy root and secondary binaries to tools/build_virtual_environment/ve"
 cd "$repoDir"
 mkdir -p tools/build_virtual_environment/ve/contents/atsign/root
+mkdir -p tools/build_virtual_environment/ve/contents/atsign/secondary
 cp packages/at_root_server/root tools/build_virtual_environment/ve/contents/atsign/root/
 cp packages/at_root_server/pubspec.yaml tools/build_virtual_environment/ve/contents/atsign/root/
 chmod 755 tools/build_virtual_environment/ve/contents/atsign/root/root

--- a/tests/at_functional_test/runLocal.sh
+++ b/tests/at_functional_test/runLocal.sh
@@ -61,6 +61,7 @@ docker run --rm \
 echo "copy root and secondary binaries to tools/build_virtual_environment/ve"
 cd $repoDir
 mkdir -p tools/build_virtual_environment/ve/contents/atsign/root
+mkdir -p tools/build_virtual_environment/ve/contents/atsign/secondary
 cp packages/at_root_server/root tools/build_virtual_environment/ve/contents/atsign/root/
 cp packages/at_root_server/pubspec.yaml tools/build_virtual_environment/ve/contents/atsign/root/
 chmod 755 tools/build_virtual_environment/ve/contents/atsign/root/root


### PR DESCRIPTION
## Why

Both local runners copy the compiled secondary into `contents/atsign/secondary`, which nothing creates. Only `entrypoint.sh` is tracked under `contents/atsign` — the two subdirectories are build products, and git does not carry empty directories — so any checkout that has never run these scripts fails with `cp: .../contents/atsign/secondary: No such file or directory`, while one that has run them before succeeds.

## What I did

Added the missing `mkdir -p` for the secondary staging directory, alongside the one that already exists for root, in both `tests/at_functional_test/runLocal.sh` and `tests/at_end2end_test/runLocal.sh`.

## How I did it

See commits and diffs.

## How to verify it

No automated test added — this is shell in a local runner, and neither suite exercises its own setup.

Verified by reproduction against a tree holding only the tracked `entrypoint.sh`, which is what a fresh clone has:

- as it stands on trunk: the copy sequence exits 1 with `cp: .../contents/atsign/secondary: No such file or directory`
- with the added `mkdir`: exits 0 and the secondary is staged

The failure is invisible in any checkout that has run these scripts before, since the directory then already exists.
