### PR TITLE
fix: a store and its factory honour the storagePath they are given

### DIFF
--- a/packages/at_persistence_secondary_server/CHANGELOG.md
+++ b/packages/at_persistence_secondary_server/CHANGELOG.md
@@ -1,5 +1,19 @@
 ## 5.3.0
 
+- fix: a store now honours the `storagePath` it is given. Hive keeps its box
+  registry and home path on a `HiveImpl` *instance*, and this package ran
+  everything through the one global instance `package:hive` exposes — so a
+  box's identity was `(the single global registry, box name)`. Box names here
+  derive from the atSign, so two stores for one atSign in one process always
+  resolved to one box however different the paths they were handed: the second
+  silently attached to the first's, and its own `storagePath` reached nothing
+  but the encryption-secret file beside it. Box lifecycle and type-adapter
+  registration now run on a `HiveInstances.forPath(...)` instance, shared per
+  canonical path. Callers passing one path keep exactly one store, with no box
+  renamed and no data moved; a caller passing a different path now gets the
+  separate store it asked for. Found from the client side, where two
+  enrollments of one atSign shared a notification replay watermark and one
+  consumed the other's offline backlog with nothing logged.
 - fix: the dual-write mirror purges the secondary's commit entry when the
   primary holds none for a just-written key. A skipCommit put/create/putMeta
   purges the primary's entry while the key lives on, so "no entry to replay"

--- a/packages/at_persistence_secondary_server/CHANGELOG.md
+++ b/packages/at_persistence_secondary_server/CHANGELOG.md
@@ -21,6 +21,20 @@
   target are one instance rather than two over one directory; `forPath` creates
   the directory in order to resolve it, and refuses with a `StateError` while
   that path's instance is being closed.
+- fix: `AtPersistenceFactory.initialize` no longer ignores the storage
+  locations it is handed. A factory caches one bundle per atSign — `bundleFor`
+  and `closeFor` key on the atSign alone, so there is nowhere for a second to
+  live — and on a cache hit it returned that bundle without ever reading the
+  config, so a caller asking for a second location was answered with the first
+  one's store. On SQLite the second `storagePath` reached nothing at all: its
+  directory was never created. Asking for an atSign that already has an open
+  bundle rooted somewhere else now throws a `StateError` naming both locations;
+  the same locations still return the same bundle, and two spellings of one
+  directory (`foo/./bar`, a symlink and its target) are not a conflict. Applies
+  to the Hive, SQLite and dual-write factories; the dual one compares its two
+  arms separately, since `DualWritePersistenceConfig` delegates every path
+  getter to its primary and would otherwise agree while the secondary had
+  moved.
 - fix: the dual-write mirror purges the secondary's commit entry when the
   primary holds none for a just-written key. A skipCommit put/create/putMeta
   purges the primary's entry while the key lives on, so "no entry to replay"

--- a/packages/at_persistence_secondary_server/CHANGELOG.md
+++ b/packages/at_persistence_secondary_server/CHANGELOG.md
@@ -35,6 +35,25 @@
   arms separately, since `DualWritePersistenceConfig` delegates every path
   getter to its primary and would otherwise agree while the secondary had
   moved.
+- fix: an empty storage path is refused instead of resolving to the process
+  working directory. Resolving a path on the filesystem meant creating it
+  first, and `Directory('').createSync()` throws a `FileSystemException`, so
+  the fallback caught it and `p.canonicalize('')` returned the CWD — a server
+  handed `secondaryStoragePath=` (an unset variable interpolated into a
+  manifest arrives as an empty string, not as absent) would have started
+  normally, rooted in its own image layer rather than the mounted volume, and
+  with an unencrypted keystore, since the secret file could not be written
+  there either and that failure is swallowed. `HiveInstances.closeFor` no
+  longer creates the directory it was asked to close.
+- fix: the storage-location comparison no longer treats two absent paths as the
+  same location. The filesystem arm was `_resolved(a) == _resolved(b)`, and an
+  unresolvable path resolved to null, so two unrelated missing roots compared
+  equal and the conflict guard was skipped. `backendMarkerPath` is no longer
+  among the compared locations — both config classes derive it from
+  `storagePath`, and as a file that does not exist until a backend is chosen it
+  could only produce false conflicts. A refusal now names the location that
+  actually differs rather than `storagePath`, which for the dual-write config
+  always read "rooted at X, and was asked for one at X".
 - fix: the dual-write mirror purges the secondary's commit entry when the
   primary holds none for a just-written key. A skipCommit put/create/putMeta
   purges the primary's entry while the key lives on, so "no entry to replay"

--- a/packages/at_persistence_secondary_server/CHANGELOG.md
+++ b/packages/at_persistence_secondary_server/CHANGELOG.md
@@ -14,6 +14,13 @@
   separate store it asked for. Found from the client side, where two
   enrollments of one atSign shared a notification replay watermark and one
   consumed the other's offline backlog with nothing logged.
+  `HiveInstances` is exported from `package:at_persistence_secondary_server/hive.dart`,
+  alongside `closeAll()` / `closeFor(path)` for tearing storage down: a global
+  `Hive.close()` does not reach boxes opened on a per-path instance. Paths are
+  matched by their resolved location on the filesystem, so a symlink and its
+  target are one instance rather than two over one directory; `forPath` creates
+  the directory in order to resolve it, and refuses with a `StateError` while
+  that path's instance is being closed.
 - fix: the dual-write mirror purges the secondary's commit entry when the
   primary holds none for a just-written key. A skipCommit put/create/putMeta
   purges the primary's entry while the key lives on, so "no entry to replay"

--- a/packages/at_persistence_secondary_server/lib/hive.dart
+++ b/packages/at_persistence_secondary_server/lib/hive.dart
@@ -9,3 +9,4 @@ export 'package:at_persistence_secondary_server/src/impl/hive/adapters/at_meta_d
 export 'package:at_persistence_secondary_server/src/impl/hive/adapters/commit_entry_adapter.dart';
 export 'package:at_persistence_secondary_server/src/impl/hive/adapters/access_log_entry_adapter.dart';
 export 'package:at_persistence_secondary_server/src/impl/hive/adapters/at_notification_adapter.dart';
+export 'package:at_persistence_secondary_server/src/impl/hive/hive_instances.dart';

--- a/packages/at_persistence_secondary_server/lib/src/dual/dual_write_persistence.dart
+++ b/packages/at_persistence_secondary_server/lib/src/dual/dual_write_persistence.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:at_commons/at_commons.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_persistence_secondary_server/src/impl/persistence_config_identity.dart';
 
 /// A persistence layer that serves all reads from a **primary** backend while
 /// mirroring every write into a **secondary** backend, so a real workload
@@ -51,6 +52,13 @@ class DualWriteAtPersistenceFactory implements AtPersistenceFactory {
 
   final Map<String, DualWriteBundle> _bundles = {};
 
+  /// The config each open bundle was built from. Compared arm by arm rather
+  /// than through [DualWritePersistenceConfig] itself, whose path getters all
+  /// delegate to [DualWritePersistenceConfig.primary] — so comparing the
+  /// wrapper would agree while the SECONDARY had been pointed somewhere else,
+  /// which is the arm the whole dual-write comparison depends on.
+  final Map<String, DualWritePersistenceConfig> _configs = {};
+
   DualWriteAtPersistenceFactory(this.primaryFactory, this.secondaryFactory);
 
   @override
@@ -64,13 +72,30 @@ class DualWriteAtPersistenceFactory implements AtPersistenceFactory {
           'DualWritePersistenceConfig, got ${config.runtimeType}');
     }
     final existing = _bundles[atSign];
-    if (existing != null && !existing.isClosed) return existing;
+    if (existing != null && !existing.isClosed) {
+      final held = _configs[atSign];
+      if (held != null &&
+          !(sameStorageLocations(held.primary, config.primary) &&
+              sameStorageLocations(held.secondary, config.secondary))) {
+        throw conflictingStorageError(
+            factory: 'DualWriteAtPersistenceFactory',
+            atSign: atSign,
+            held: held,
+            requested: config);
+      }
+      return existing;
+    }
+    if (existing != null) {
+      _bundles.remove(atSign);
+      _configs.remove(atSign);
+    }
 
     final primary = await primaryFactory.initialize(atSign, config.primary);
     final secondary =
         await secondaryFactory.initialize(atSign, config.secondary);
     final bundle = DualWriteBundle._(atSign, primary, secondary);
     _bundles[atSign] = bundle;
+    _configs[atSign] = config;
     return bundle;
   }
 
@@ -82,6 +107,7 @@ class DualWriteAtPersistenceFactory implements AtPersistenceFactory {
 
   @override
   Future<void> closeFor(String atSign) async {
+    _configs.remove(atSign);
     await _bundles.remove(atSign)?.close();
   }
 
@@ -91,6 +117,7 @@ class DualWriteAtPersistenceFactory implements AtPersistenceFactory {
       await b.close();
     }
     _bundles.clear();
+    _configs.clear();
     await primaryFactory.close();
     await secondaryFactory.close();
   }

--- a/packages/at_persistence_secondary_server/lib/src/dual/dual_write_persistence.dart
+++ b/packages/at_persistence_secondary_server/lib/src/dual/dual_write_persistence.dart
@@ -74,14 +74,28 @@ class DualWriteAtPersistenceFactory implements AtPersistenceFactory {
     final existing = _bundles[atSign];
     if (existing != null && !existing.isClosed) {
       final held = _configs[atSign];
-      if (held != null &&
-          !(sameStorageLocations(held.primary, config.primary) &&
-              sameStorageLocations(held.secondary, config.secondary))) {
-        throw conflictingStorageError(
-            factory: 'DualWriteAtPersistenceFactory',
-            atSign: atSign,
-            held: held,
-            requested: config);
+      if (held != null) {
+        // Raised against the ARM that differs, never against the wrapper.
+        // DualWritePersistenceConfig delegates every path getter to its
+        // primary, so describing the difference from the wrapper finds none
+        // when it is the secondary that moved, and falls back to printing the
+        // primary's path as both the held and the requested location — a
+        // refusal that reads "at X, and was asked for one at X" for exactly
+        // the case this comparison exists to catch.
+        if (!sameStorageLocations(held.primary, config.primary)) {
+          throw conflictingStorageError(
+              factory: 'DualWriteAtPersistenceFactory (primary arm)',
+              atSign: atSign,
+              held: held.primary,
+              requested: config.primary);
+        }
+        if (!sameStorageLocations(held.secondary, config.secondary)) {
+          throw conflictingStorageError(
+              factory: 'DualWriteAtPersistenceFactory (secondary arm)',
+              atSign: atSign,
+              held: held.secondary,
+              requested: config.secondary);
+        }
       }
       return existing;
     }

--- a/packages/at_persistence_secondary_server/lib/src/impl/hive/hive_access_log_keystore.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/hive/hive_access_log_keystore.dart
@@ -18,8 +18,8 @@ class HiveAccessLogKeyStore with HiveBase<AccessLogEntry?> {
   Future<void> initialize() async {
     _boxName = 'access_log_${AtUtils.getShaForAtSign(_currentAtSign)}';
 
-    if (!Hive.isAdapterRegistered(AccessLogEntryAdapter().typeId)) {
-      Hive.registerAdapter(AccessLogEntryAdapter());
+    if (!hive.isAdapterRegistered(AccessLogEntryAdapter().typeId)) {
+      hive.registerAdapter(AccessLogEntryAdapter());
     }
     await super.openBox(_boxName);
   }

--- a/packages/at_persistence_secondary_server/lib/src/impl/hive/hive_at_keyvalue_store.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/hive/hive_at_keyvalue_store.dart
@@ -186,14 +186,14 @@ class HiveAtKeyValueStore
   @override
   Future<void> initialize() async {
     try {
-      if (!Hive.isAdapterRegistered(AtDataAdapter().typeId)) {
-        Hive.registerAdapter(AtDataAdapter());
+      if (!hive.isAdapterRegistered(AtDataAdapter().typeId)) {
+        hive.registerAdapter(AtDataAdapter());
       }
-      if (!Hive.isAdapterRegistered(AtMetaDataAdapter().typeId)) {
-        Hive.registerAdapter(AtMetaDataAdapter());
+      if (!hive.isAdapterRegistered(AtMetaDataAdapter().typeId)) {
+        hive.registerAdapter(AtMetaDataAdapter());
       }
-      if (!Hive.isAdapterRegistered(PublicKeyHashAdapter().typeId)) {
-        Hive.registerAdapter(PublicKeyHashAdapter());
+      if (!hive.isAdapterRegistered(PublicKeyHashAdapter().typeId)) {
+        hive.registerAdapter(PublicKeyHashAdapter());
       }
       final secret = await _getHiveSecretFromFile(atSign, storagePath);
       await openBox(AtUtils.getShaForAtSign(atSign), hiveSecret: secret);

--- a/packages/at_persistence_secondary_server/lib/src/impl/hive/hive_at_notification_keystore.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/hive/hive_at_notification_keystore.dart
@@ -128,7 +128,6 @@ class HiveAtNotificationKeystore
 
   final _logger = AtSignLogger('HiveAtNotificationKeystore');
 
-
   @override
   Future<void> initialize() async {
     _boxName = 'notifications_${AtUtils.getShaForAtSign(currentAtSign)}';

--- a/packages/at_persistence_secondary_server/lib/src/impl/hive/hive_at_notification_keystore.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/hive/hive_at_notification_keystore.dart
@@ -128,11 +128,11 @@ class HiveAtNotificationKeystore
 
   final _logger = AtSignLogger('HiveAtNotificationKeystore');
 
-  static bool _typesRegistered = false;
 
   @override
   Future<void> initialize() async {
     _boxName = 'notifications_${AtUtils.getShaForAtSign(currentAtSign)}';
+    _registerAdapters();
     await super.openBox(_boxName);
     await _populateExpiryIndex();
   }
@@ -150,21 +150,49 @@ class HiveAtNotificationKeystore
 
   /// You **must** subsequently call [init]
   HiveAtNotificationKeystore(this.currentAtSign,
-      {this.compactionPercentage = 30}) {
-    if (!_typesRegistered) {
-      Hive.registerAdapter(AtNotificationAdapter());
-      Hive.registerAdapter(OperationTypeAdapter());
-      Hive.registerAdapter(NotificationTypeAdapter());
-      Hive.registerAdapter(NotificationStatusAdapter());
-      Hive.registerAdapter(NotificationPriorityAdapter());
-      Hive.registerAdapter(MessageTypeAdapter());
-      if (!Hive.isAdapterRegistered(AtMetaDataAdapter().typeId)) {
-        Hive.registerAdapter(AtMetaDataAdapter());
-      }
-      if (!Hive.isAdapterRegistered(PublicKeyHashAdapter().typeId)) {
-        Hive.registerAdapter(PublicKeyHashAdapter());
-      }
-      _typesRegistered = true;
+      {this.compactionPercentage = 30});
+
+  /// Registers this store's adapters on the instance that owns its box.
+  ///
+  /// ⚠️ These used to run in the CONSTRUCTOR, behind a `static` flag meaning
+  /// "already done in this process". Neither survives per-instance registries:
+  /// the constructor runs before [init] chooses the instance, and a static
+  /// flag would leave every instance after the first with no adapters, so its
+  /// box would fail to decode its own contents. `isAdapterRegistered` is
+  /// per-instance and answers the same question correctly, so the flag is
+  /// gone rather than replaced.
+  /// ⚠️ Written out one call at a time, and it must stay that way.
+  /// `registerAdapter<T>` infers `T` from the ARGUMENT at each call site, and
+  /// Hive dispatches on that resolved type. Loop these through a
+  /// `List<TypeAdapter>` — which is tidier and was tried — and the element
+  /// type erases the inference, so every adapter registers under the wrong
+  /// type and writes dispatch to the wrong one. It compiles, and it fails at
+  /// runtime with `type 'MessageType' is not a subtype of type
+  /// 'AtNotification'` from inside `AtNotificationAdapter.write`.
+  void _registerAdapters() {
+    if (!hive.isAdapterRegistered(AtNotificationAdapter().typeId)) {
+      hive.registerAdapter(AtNotificationAdapter());
+    }
+    if (!hive.isAdapterRegistered(OperationTypeAdapter().typeId)) {
+      hive.registerAdapter(OperationTypeAdapter());
+    }
+    if (!hive.isAdapterRegistered(NotificationTypeAdapter().typeId)) {
+      hive.registerAdapter(NotificationTypeAdapter());
+    }
+    if (!hive.isAdapterRegistered(NotificationStatusAdapter().typeId)) {
+      hive.registerAdapter(NotificationStatusAdapter());
+    }
+    if (!hive.isAdapterRegistered(NotificationPriorityAdapter().typeId)) {
+      hive.registerAdapter(NotificationPriorityAdapter());
+    }
+    if (!hive.isAdapterRegistered(MessageTypeAdapter().typeId)) {
+      hive.registerAdapter(MessageTypeAdapter());
+    }
+    if (!hive.isAdapterRegistered(AtMetaDataAdapter().typeId)) {
+      hive.registerAdapter(AtMetaDataAdapter());
+    }
+    if (!hive.isAdapterRegistered(PublicKeyHashAdapter().typeId)) {
+      hive.registerAdapter(PublicKeyHashAdapter());
     }
   }
 

--- a/packages/at_persistence_secondary_server/lib/src/impl/hive/hive_at_persistence_factory.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/hive/hive_at_persistence_factory.dart
@@ -3,6 +3,7 @@ import 'package:at_persistence_secondary_server/hive.dart';
 import 'package:at_persistence_secondary_server/src/impl/hive/hive_commit_log_keystore.dart';
 import 'package:at_utils/at_logger.dart';
 
+import '../persistence_config_identity.dart';
 import 'hive_access_log_keystore.dart';
 
 /// Hive-backed [AtPersistenceFactory]. Produces
@@ -11,6 +12,11 @@ class HiveAtPersistenceFactory implements AtPersistenceFactory {
   final _logger = AtSignLogger('HiveAtPersistenceFactory');
 
   final Map<String, HiveAtPersistenceBundle> _bundles = {};
+
+  /// The config each open bundle was built from, so a second
+  /// [initialize] for one atSign can tell 'the same store again' from
+  /// 'a different store, which this factory cannot hold'.
+  final Map<String, HivePersistenceConfig> _configs = {};
 
   @override
   AtPersistenceBackendId get backendId => AtPersistenceBackendId.hive;
@@ -31,8 +37,19 @@ class HiveAtPersistenceFactory implements AtPersistenceFactory {
     // going through [closeFor] / [close].
     final existing = _bundles[atSign];
     if (existing != null) {
-      if (!existing.isClosed) return existing;
+      if (!existing.isClosed) {
+        final held = _configs[atSign];
+        if (held != null && !sameStorageLocations(held, config)) {
+          throw conflictingStorageError(
+              factory: 'HiveAtPersistenceFactory',
+              atSign: atSign,
+              held: held,
+              requested: config);
+        }
+        return existing;
+      }
       _bundles.remove(atSign);
+      _configs.remove(atSign);
     }
 
     _logger.info('Initialising Hive persistence for $atSign');
@@ -79,6 +96,7 @@ class HiveAtPersistenceFactory implements AtPersistenceFactory {
       notificationKeystore: notificationKeystore,
     );
     _bundles[atSign] = bundle;
+    _configs[atSign] = config;
     return bundle;
   }
 
@@ -91,6 +109,7 @@ class HiveAtPersistenceFactory implements AtPersistenceFactory {
       // stale entry so subsequent `initialize` / `bundleFor` calls
       // see a clean slate.
       _bundles.remove(atSign);
+      _configs.remove(atSign);
       return null;
     }
     return bundle;
@@ -98,6 +117,7 @@ class HiveAtPersistenceFactory implements AtPersistenceFactory {
 
   @override
   Future<void> closeFor(String atSign) async {
+    _configs.remove(atSign);
     final bundle = _bundles.remove(atSign);
     if (bundle == null) return;
     try {
@@ -111,6 +131,7 @@ class HiveAtPersistenceFactory implements AtPersistenceFactory {
   Future<void> close() async {
     final bundles = _bundles.values.toList();
     _bundles.clear();
+    _configs.clear();
     for (final b in bundles) {
       try {
         await b.close();

--- a/packages/at_persistence_secondary_server/lib/src/impl/hive/hive_base.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/hive/hive_base.dart
@@ -28,6 +28,24 @@ mixin HiveBase<E> {
     _isLazy = isLazy;
     this.storagePath = storagePath;
     hive = HiveInstances.forPath(storagePath);
+    // Retained deliberately, and it no longer decides anything in this
+    // package: box identity here comes from [hive] above.
+    //
+    // Consumers outside this package depend on this call having happened as a
+    // SIDE EFFECT of keystore initialisation, and open their own boxes on the
+    // global instance. at_client says so in two places - `LocalSecondary`
+    // ("must run AFTER ... HiveAtPersistenceFactory.initialize(...) has called
+    // Hive.init(...) ... we intentionally do not call Hive.init here") and
+    // `AtSyncQueue` ("Hive must already have been initialised ...; this class
+    // never calls Hive.init itself"). Dropping it left 42 of at_client's tests
+    // failing with "You need to initialize Hive or provide a path to store the
+    // box", which is the whole contract stated as an error message.
+    //
+    // ⚠️ So a box opened on the GLOBAL instance by such a consumer still has
+    // the collision this change fixes here: one registry, one name, one box.
+    // at_client's sync queue is one. Moving those is a separate change on
+    // their side; this line keeps them working exactly as they do today.
+    Hive.init(storagePath);
     await initialize();
   }
 

--- a/packages/at_persistence_secondary_server/lib/src/impl/hive/hive_base.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/hive/hive_base.dart
@@ -3,15 +3,31 @@ import 'dart:io';
 import 'package:at_utils/at_logger.dart';
 import 'package:hive/hive.dart';
 
+import 'hive_instances.dart';
+
 mixin HiveBase<E> {
   bool _isLazy = true;
   late String _boxName;
   late String storagePath;
   final _logger = AtSignLogger('HiveBase');
+
+  /// The Hive instance that owns this store's box.
+  ///
+  /// Per storage path rather than the package-global `Hive` — see
+  /// [HiveInstances] for why. Exposed rather than private because a keystore
+  /// has to register its type adapters on the SAME instance: `TypeRegistry`
+  /// is per-instance too, so an adapter registered on the global `Hive` is
+  /// invisible to a box opened here, and the box would fail to decode its own
+  /// contents.
+  ///
+  /// Not `late final`: [init] is idempotent for callers that re-initialise a
+  /// store, and a second assignment to a `late final` throws.
+  late HiveInterface hive;
+
   Future<void> init(String storagePath, {bool isLazy = true}) async {
     _isLazy = isLazy;
     this.storagePath = storagePath;
-    Hive.init(storagePath);
+    hive = HiveInstances.forPath(storagePath);
     await initialize();
   }
 
@@ -21,17 +37,17 @@ mixin HiveBase<E> {
     _boxName = boxName;
     if (_isLazy) {
       if (hiveSecret != null) {
-        await Hive.openLazyBox(_boxName,
+        await hive.openLazyBox(_boxName,
             encryptionCipher: HiveAesCipher(hiveSecret));
       } else {
-        await Hive.openLazyBox(boxName);
+        await hive.openLazyBox(boxName);
       }
     } else {
       if (hiveSecret != null) {
-        await Hive.openBox(_boxName,
+        await hive.openBox(_boxName,
             encryptionCipher: HiveAesCipher(hiveSecret));
       } else {
-        await Hive.openBox(boxName);
+        await hive.openBox(boxName);
       }
     }
     if (getBox().isOpen) {
@@ -43,9 +59,9 @@ mixin HiveBase<E> {
 
   BoxBase getBox() {
     if (_isLazy) {
-      return Hive.lazyBox(_boxName);
+      return hive.lazyBox(_boxName);
     }
-    return Hive.box(_boxName);
+    return hive.box(_boxName);
   }
 
   Future<E?> getValue(dynamic key) async {

--- a/packages/at_persistence_secondary_server/lib/src/impl/hive/hive_commit_log_keystore.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/hive/hive_commit_log_keystore.dart
@@ -49,11 +49,11 @@ class HiveCommitLogKeyStore with HiveBase<CommitEntry?> {
   @override
   Future<void> initialize() async {
     _boxName = 'commit_log_${AtUtils.getShaForAtSign(currentAtSign)}';
-    if (!Hive.isAdapterRegistered(CommitEntryAdapter().typeId)) {
-      Hive.registerAdapter(CommitEntryAdapter());
+    if (!hive.isAdapterRegistered(CommitEntryAdapter().typeId)) {
+      hive.registerAdapter(CommitEntryAdapter());
     }
-    if (!Hive.isAdapterRegistered(CommitOpAdapter().typeId)) {
-      Hive.registerAdapter(CommitOpAdapter());
+    if (!hive.isAdapterRegistered(CommitOpAdapter().typeId)) {
+      hive.registerAdapter(CommitOpAdapter());
     }
     await super.openBox(_boxName);
     _logger.finer('Commit log key store is initialized');

--- a/packages/at_persistence_secondary_server/lib/src/impl/hive/hive_instances.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/hive/hive_instances.dart
@@ -1,0 +1,54 @@
+import 'package:hive/hive.dart';
+// ignore: implementation_imports
+import 'package:hive/src/hive_impl.dart';
+import 'package:path/path.dart' as p;
+
+/// One Hive instance per storage path.
+///
+/// **Why this exists.** A Hive box's identity is `(instance registry, box
+/// name)`. Both the registry and the home path are *instance* fields of
+/// `HiveImpl` — `package:hive` merely exposes one global instance
+/// (`final HiveInterface Hive = HiveImpl();`), and everything in this package
+/// used to run through it. So the path a store was given reached
+/// `Hive.init(...)`, a process-wide setting that the next store overwrote, and
+/// the box itself was opened by name alone.
+///
+/// Box names here derive from the atSign, so two stores for one atSign in one
+/// process always collided however different the paths they were handed: the
+/// second silently attached to the first's box, and its own `storagePath`
+/// reached nothing but the encryption-secret file beside it.
+///
+/// **Why the instance is shared per path rather than created per store.** Two
+/// instances over one directory do not throw and do not lock each other out.
+/// They open two independent boxes over the same files, whose in-memory views
+/// then diverge silently — measured: after writing through the second, the
+/// first still read its own older value. Sharing by path is what keeps
+/// same-path callers on exactly one box, which is what they have always had.
+///
+/// **What this changes for an existing deployment: nothing.** A process whose
+/// stores all use one path resolves to one instance and opens the same box
+/// files under the same names. No box is renamed and no data moves. Only a
+/// caller that asks for a *different* path sees a difference — it now gets the
+/// separate store it asked for.
+class HiveInstances {
+  HiveInstances._();
+
+  static final Map<String, HiveInterface> _byPath = <String, HiveInterface>{};
+
+  /// The instance owning [storagePath], created on first use.
+  static HiveInterface forPath(String storagePath) {
+    final key = canonicalPathFor(storagePath);
+    return _byPath.putIfAbsent(key, () => HiveImpl()..init(key));
+  }
+
+  /// How two spellings of one directory are recognised as one.
+  ///
+  /// Without this, `foo/bar` and `foo/./bar` would take separate instances
+  /// over the same files and diverge — the exact failure this class exists to
+  /// prevent, reintroduced by a string comparison.
+  static String canonicalPathFor(String storagePath) =>
+      p.canonicalize(storagePath);
+
+  /// Instances built so far, for tests that assert the sharing rule.
+  static int get instanceCount => _byPath.length;
+}

--- a/packages/at_persistence_secondary_server/lib/src/impl/hive/hive_instances.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/hive/hive_instances.dart
@@ -157,7 +157,11 @@ class HiveInstances {
     try {
       await close;
     } finally {
-      _closing.remove(key);
+      // Named rather than discarded: the removed value IS the future just
+      // awaited above, not a new async call being dropped on the floor, and
+      // the analyzer cannot tell those apart.
+      final settled = _closing.remove(key);
+      assert(identical(settled, close));
       _byPath.remove(key);
     }
   }

--- a/packages/at_persistence_secondary_server/lib/src/impl/hive/hive_instances.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/hive/hive_instances.dart
@@ -85,11 +85,14 @@ class HiveInstances {
   /// while its real path is `/private/var/folders/...`.
   ///
   /// So the directory is resolved on the filesystem, which needs it to exist:
-  /// it is created first when [create] is true (idempotent, and Hive would
-  /// create it moments later at box open anyway). The close path passes false,
-  /// because a teardown verb must not write. Were it left to come into existence on its own, a
-  /// caller arriving before it did would key on the unresolved spelling and a
-  /// caller arriving after would key on the resolved one — two instances again.
+  /// it is created first (idempotent, and Hive would create it moments later at
+  /// box open anyway). Were it left to come into existence on its own, a caller
+  /// arriving before it did would key on the unresolved spelling and a caller
+  /// arriving after would key on the resolved one — two instances again.
+  ///
+  /// [create] is false only on the close path, where a teardown verb must not
+  /// write. Nothing is filed under a path that does not exist, so there the
+  /// lexical form is enough to miss cleanly.
   ///
   /// Falls back to the lexical form only if the filesystem refuses (a
   /// permission error, a path that cannot be a directory). That fallback

--- a/packages/at_persistence_secondary_server/lib/src/impl/hive/hive_instances.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/hive/hive_instances.dart
@@ -1,4 +1,12 @@
+import 'dart:io';
+
+import 'package:at_utils/at_logger.dart';
 import 'package:hive/hive.dart';
+// `HiveImpl` is not exported from `package:hive/hive.dart` — the library
+// declares `final HiveInterface Hive = HiveImpl();` and exposes only that one
+// instance — so there is no supported way to construct a second one. If a
+// future hive moves or renames the class this import is what breaks, loudly
+// and at compile time.
 // ignore: implementation_imports
 import 'package:hive/src/hive_impl.dart';
 import 'package:path/path.dart' as p;
@@ -33,11 +41,32 @@ import 'package:path/path.dart' as p;
 class HiveInstances {
   HiveInstances._();
 
+  static final AtSignLogger _logger = AtSignLogger('HiveInstances');
+
   static final Map<String, HiveInterface> _byPath = <String, HiveInterface>{};
 
+  /// Paths whose instance is being closed right now, and the close in flight.
+  ///
+  /// A close is not instantaneous — it awaits every open box — and for that
+  /// window the instance is neither usable nor gone. Handing it out would let
+  /// a caller open a box that is about to be closed underneath them; building
+  /// a replacement instead would put two instances over one directory, which
+  /// is the silent divergence this whole class exists to prevent. [forPath]
+  /// refuses instead, and says what to await.
+  static final Map<String, Future<void>> _closing = <String, Future<void>>{};
+
   /// The instance owning [storagePath], created on first use.
+  ///
+  /// Throws a [StateError] if that path's instance is mid-close — see
+  /// [_closing]. Closing storage is a quiescent-point operation, so a caller
+  /// reaching this has a genuine ordering bug and wants to hear about it.
   static HiveInterface forPath(String storagePath) {
     final key = canonicalPathFor(storagePath);
+    if (_closing.containsKey(key)) {
+      throw StateError('The Hive instance for "$key" is being closed. Await'
+          ' the closeAll()/closeFor() future before opening storage there'
+          ' again.');
+    }
     return _byPath.putIfAbsent(key, () => HiveImpl()..init(key));
   }
 
@@ -46,8 +75,40 @@ class HiveInstances {
   /// Without this, `foo/bar` and `foo/./bar` would take separate instances
   /// over the same files and diverge — the exact failure this class exists to
   /// prevent, reintroduced by a string comparison.
-  static String canonicalPathFor(String storagePath) =>
-      p.canonicalize(storagePath);
+  ///
+  /// Lexical canonicalisation alone is NOT enough, and believing it was would
+  /// leave the same hole open under a different spelling. `p.canonicalize` is
+  /// pure string work: it does not follow symlinks, so a link and its target
+  /// canonicalise to two different strings and would take two instances over
+  /// one directory. That is not exotic — `/data -> /mnt/data` is an ordinary
+  /// deployment, and on macOS `Directory.systemTemp` is `/var/folders/...`
+  /// while its real path is `/private/var/folders/...`.
+  ///
+  /// So the directory is resolved on the filesystem, which needs it to exist:
+  /// it is created first (idempotent, and Hive would create it moments later
+  /// at box open anyway). Were it left to come into existence on its own, a
+  /// caller arriving before it did would key on the unresolved spelling and a
+  /// caller arriving after would key on the resolved one — two instances again.
+  ///
+  /// Falls back to the lexical form only if the filesystem refuses (a
+  /// permission error, a path that cannot be a directory). That fallback
+  /// restores the symlink hole for that path, so it logs rather than passing
+  /// silently.
+  static String canonicalPathFor(String storagePath) {
+    try {
+      final dir = Directory(storagePath);
+      if (!dir.existsSync()) {
+        dir.createSync(recursive: true);
+      }
+      return p.canonicalize(dir.resolveSymbolicLinksSync());
+    } on FileSystemException catch (e) {
+      _logger.warning('Could not resolve "$storagePath" on the filesystem'
+          ' ($e); falling back to a lexical path. Two spellings of this'
+          ' directory that differ by a symlink would now take separate Hive'
+          ' instances over the same files.');
+      return p.canonicalize(storagePath);
+    }
+  }
 
   /// Closes every box this registry has opened, and forgets the instances.
   ///
@@ -60,18 +121,45 @@ class HiveInstances {
   ///
   /// Call this instead of, or alongside, `Hive.close()` wherever storage is
   /// torn down and reopened in one process.
-  static Future<void> closeAll() async {
-    final instances = List<HiveInterface>.from(_byPath.values);
-    _byPath.clear();
-    for (final hive in instances) {
-      await hive.close();
-    }
-  }
+  /// ⚠️ Every store built from these instances holds its own reference to
+  /// one, and this cannot reach them: after a close their `hive` field points
+  /// at a closed instance, and the next box access throws. Storage is torn
+  /// down as a unit — close the stores too, and build new ones on the way
+  /// back up.
+  static Future<void> closeAll() =>
+      Future.wait(_byPath.keys.toList().map(_closeKey));
 
   /// Closes and forgets the instance owning [storagePath], if there is one.
-  static Future<void> closeFor(String storagePath) async {
-    final hive = _byPath.remove(canonicalPathFor(storagePath));
-    await hive?.close();
+  ///
+  /// Note this keys on a storage PATH, unlike the same-named
+  /// `AtPersistenceFactory.closeFor`, which keys on an atSign.
+  static Future<void> closeFor(String storagePath) =>
+      _closeKey(canonicalPathFor(storagePath));
+
+  /// Closes one already-canonical path's instance, marking it closing for the
+  /// duration.
+  ///
+  /// The entry is dropped only once the close has completed. Dropping it up
+  /// front — the obvious way to write this — is what lets a caller arriving
+  /// during the await build a second instance over a directory the first is
+  /// still closing.
+  static Future<void> _closeKey(String key) async {
+    final inFlight = _closing[key];
+    if (inFlight != null) {
+      return inFlight;
+    }
+    final hive = _byPath[key];
+    if (hive == null) {
+      return;
+    }
+    final close = hive.close();
+    _closing[key] = close;
+    try {
+      await close;
+    } finally {
+      _closing.remove(key);
+      _byPath.remove(key);
+    }
   }
 
   /// Instances built so far, for tests that assert the sharing rule.

--- a/packages/at_persistence_secondary_server/lib/src/impl/hive/hive_instances.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/hive/hive_instances.dart
@@ -49,6 +49,31 @@ class HiveInstances {
   static String canonicalPathFor(String storagePath) =>
       p.canonicalize(storagePath);
 
+  /// Closes every box this registry has opened, and forgets the instances.
+  ///
+  /// **Why a consumer needs this.** A teardown that calls the package-global
+  /// `Hive.close()` closes the boxes in the GLOBAL registry, and the boxes
+  /// opened here are not in it. They stay open over a directory the teardown
+  /// then deletes, and the next open returns the cached box with its stale
+  /// in-memory contents — a write appears to succeed and the read that follows
+  /// returns the previous test's value. Nothing throws.
+  ///
+  /// Call this instead of, or alongside, `Hive.close()` wherever storage is
+  /// torn down and reopened in one process.
+  static Future<void> closeAll() async {
+    final instances = List<HiveInterface>.from(_byPath.values);
+    _byPath.clear();
+    for (final hive in instances) {
+      await hive.close();
+    }
+  }
+
+  /// Closes and forgets the instance owning [storagePath], if there is one.
+  static Future<void> closeFor(String storagePath) async {
+    final hive = _byPath.remove(canonicalPathFor(storagePath));
+    await hive?.close();
+  }
+
   /// Instances built so far, for tests that assert the sharing rule.
   static int get instanceCount => _byPath.length;
 }

--- a/packages/at_persistence_secondary_server/lib/src/impl/hive/hive_instances.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/hive/hive_instances.dart
@@ -85,8 +85,9 @@ class HiveInstances {
   /// while its real path is `/private/var/folders/...`.
   ///
   /// So the directory is resolved on the filesystem, which needs it to exist:
-  /// it is created first (idempotent, and Hive would create it moments later
-  /// at box open anyway). Were it left to come into existence on its own, a
+  /// it is created first when [create] is true (idempotent, and Hive would
+  /// create it moments later at box open anyway). The close path passes false,
+  /// because a teardown verb must not write. Were it left to come into existence on its own, a
   /// caller arriving before it did would key on the unresolved spelling and a
   /// caller arriving after would key on the resolved one — two instances again.
   ///
@@ -94,10 +95,29 @@ class HiveInstances {
   /// permission error, a path that cannot be a directory). That fallback
   /// restores the symlink hole for that path, so it logs rather than passing
   /// silently.
-  static String canonicalPathFor(String storagePath) {
+  static String canonicalPathFor(String storagePath, {bool create = true}) {
+    // An empty path is not a location, and every step below would launder it
+    // into one: createSync('') throws PathNotFoundException, which is a
+    // FileSystemException, so the fallback catches it and p.canonicalize('')
+    // hands back the PROCESS WORKING DIRECTORY. The server would then start
+    // normally, rooted in its own image layer instead of the mounted volume,
+    // and - because the secret file cannot be written there either, and that
+    // failure is swallowed - with an UNENCRYPTED keystore. An unset
+    // `${STORAGE_PATH}` in a compose or k8s manifest arrives here as '',
+    // because Platform.environment reports an unset-but-interpolated variable
+    // as present with an empty value.
+    if (storagePath.trim().isEmpty) {
+      throw ArgumentError.value(
+          storagePath, 'storagePath', 'must not be empty or blank');
+    }
     try {
       final dir = Directory(storagePath);
       if (!dir.existsSync()) {
+        if (!create) {
+          // Closing must not write. Nothing is filed under a path that does
+          // not exist, so the lexical form is enough to miss cleanly.
+          return p.canonicalize(storagePath);
+        }
         dir.createSync(recursive: true);
       }
       return p.canonicalize(dir.resolveSymbolicLinksSync());
@@ -133,8 +153,12 @@ class HiveInstances {
   ///
   /// Note this keys on a storage PATH, unlike the same-named
   /// `AtPersistenceFactory.closeFor`, which keys on an atSign.
+  /// Close BEFORE deleting the directory, not after: a path whose directory
+  /// has already been removed can only be matched lexically, which will not
+  /// find an instance filed under its resolved location. [closeAll] is immune,
+  /// since it works from the keys already in the map.
   static Future<void> closeFor(String storagePath) =>
-      _closeKey(canonicalPathFor(storagePath));
+      _closeKey(canonicalPathFor(storagePath, create: false));
 
   /// Closes one already-canonical path's instance, marking it closing for the
   /// duration.

--- a/packages/at_persistence_secondary_server/lib/src/impl/persistence_config_identity.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/persistence_config_identity.dart
@@ -1,0 +1,88 @@
+import 'dart:io';
+
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:path/path.dart' as p;
+
+/// Where an [AtPersistenceConfig] puts its data, as a comparable value.
+///
+/// [AtPersistenceFactory] caches one bundle per atSign — that is the
+/// interface's stated contract, and [AtPersistenceFactory.bundleFor] and
+/// [AtPersistenceFactory.closeFor] both key on the atSign alone, so there is
+/// nowhere for a second bundle to live. A factory therefore cannot honour two
+/// different storage locations for one atSign, and must say so rather than
+/// return the bundle it happens to hold: a caller handed a bundle rooted
+/// somewhere other than the path it asked for has no way to notice, and reads
+/// another store's records as its own.
+///
+/// Hive spreads an atSign across four directories and SQLite keeps one file
+/// under a storage root, so the comparison is over every path the interface
+/// exposes rather than over `storagePath` alone.
+List<String> storageLocationsOf(AtPersistenceConfig config) => [
+      config.storagePath,
+      config.commitLogPath,
+      config.accessLogPath,
+      config.notificationStoragePath,
+      config.backendMarkerPath,
+    ];
+
+/// Whether two configurations name the same storage locations.
+///
+/// Compared lexically first (`foo/bar` and `foo/./bar` are one location, and
+/// calling them two would refuse a caller who is doing nothing wrong). Only
+/// when that disagrees is the filesystem consulted, which is where a symlink
+/// and its target are recognised as one directory — an ordinary deployment
+/// shape (`/data -> /mnt/data`), and not worth a spurious refusal.
+///
+/// A path that does not exist cannot be resolved, so it stands on its lexical
+/// form: two paths that differ lexically and are not both present are
+/// different.
+bool sameStorageLocations(AtPersistenceConfig a, AtPersistenceConfig b) {
+  final left = storageLocationsOf(a);
+  final right = storageLocationsOf(b);
+  for (var i = 0; i < left.length; i++) {
+    if (!_sameLocation(left[i], right[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool _sameLocation(String a, String b) {
+  if (p.canonicalize(a) == p.canonicalize(b)) {
+    return true;
+  }
+  return _resolved(a) == _resolved(b);
+}
+
+/// The real location of [path], or null when it cannot be resolved.
+///
+/// Returns null rather than falling back to the lexical form, so that two
+/// unresolvable paths are never reported equal by both being null — they have
+/// already failed the lexical comparison above.
+String? _resolved(String path) {
+  try {
+    final entity = Directory(path);
+    if (!entity.existsSync()) {
+      return null;
+    }
+    return p.canonicalize(entity.resolveSymbolicLinksSync());
+  } on FileSystemException {
+    return null;
+  }
+}
+
+/// The refusal an [AtPersistenceFactory] raises when it is asked to build a
+/// bundle for an atSign it already holds one for, somewhere else.
+StateError conflictingStorageError({
+  required String factory,
+  required String atSign,
+  required AtPersistenceConfig held,
+  required AtPersistenceConfig requested,
+}) =>
+    StateError('$factory already holds an open bundle for $atSign rooted at'
+        ' "${held.storagePath}", and was asked for one at'
+        ' "${requested.storagePath}". A factory keeps one bundle per atSign —'
+        ' bundleFor() and closeFor() have no way to name a second — so it'
+        ' cannot serve both. Returning the bundle it holds would answer with'
+        ' another store\'s records. Call closeFor("$atSign") first, or use a'
+        ' separate factory instance for the second location.');

--- a/packages/at_persistence_secondary_server/lib/src/impl/persistence_config_identity.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/persistence_config_identity.dart
@@ -17,12 +17,18 @@ import 'package:path/path.dart' as p;
 /// Hive spreads an atSign across four directories and SQLite keeps one file
 /// under a storage root, so the comparison is over every path the interface
 /// exposes rather than over `storagePath` alone.
+/// [AtPersistenceConfig.backendMarkerPath] is deliberately NOT among them.
+/// Both config classes derive it from [AtPersistenceConfig.storagePath] when it
+/// is not given, and nothing in the server ever gives it, so it carries no
+/// information `storagePath` has not already supplied. It is also a FILE, and
+/// one that does not exist until a backend has been chosen — so including it
+/// could only ever manufacture a refusal between two configs that name the same
+/// directories, which is what it did when it was first written in.
 List<String> storageLocationsOf(AtPersistenceConfig config) => [
       config.storagePath,
       config.commitLogPath,
       config.accessLogPath,
       config.notificationStoragePath,
-      config.backendMarkerPath,
     ];
 
 /// Whether two configurations name the same storage locations.
@@ -51,21 +57,35 @@ bool _sameLocation(String a, String b) {
   if (p.canonicalize(a) == p.canonicalize(b)) {
     return true;
   }
-  return _resolved(a) == _resolved(b);
+  final resolvedA = _resolved(a);
+  final resolvedB = _resolved(b);
+  // Both must resolve, and this must not be written as
+  // `_resolved(a) == _resolved(b)`: that reads correctly and FAILS OPEN,
+  // because two paths that are merely absent both resolve to null and null
+  // equals null. Two locations that have already disagreed lexically are the
+  // same place only if the filesystem says so, and it cannot say anything
+  // about a path that is not there.
+  if (resolvedA == null || resolvedB == null) {
+    return false;
+  }
+  return resolvedA == resolvedB;
 }
 
 /// The real location of [path], or null when it cannot be resolved.
 ///
-/// Returns null rather than falling back to the lexical form, so that two
-/// unresolvable paths are never reported equal by both being null — they have
-/// already failed the lexical comparison above.
+/// Null means "the filesystem cannot answer", and every caller must treat that
+/// as *not equal* rather than letting two nulls meet.
+///
+/// Typed by existence rather than as a [Directory], so that a location which
+/// is not a directory still resolves rather than silently reporting itself
+/// unresolvable — `Directory(aFile).existsSync()` is false for a file that is
+/// plainly there.
 String? _resolved(String path) {
   try {
-    final entity = Directory(path);
-    if (!entity.existsSync()) {
+    if (FileSystemEntity.typeSync(path) == FileSystemEntityType.notFound) {
       return null;
     }
-    return p.canonicalize(entity.resolveSymbolicLinksSync());
+    return p.canonicalize(File(path).resolveSymbolicLinksSync());
   } on FileSystemException {
     return null;
   }
@@ -79,10 +99,40 @@ StateError conflictingStorageError({
   required AtPersistenceConfig held,
   required AtPersistenceConfig requested,
 }) =>
-    StateError('$factory already holds an open bundle for $atSign rooted at'
-        ' "${held.storagePath}", and was asked for one at'
-        ' "${requested.storagePath}". A factory keeps one bundle per atSign —'
+    StateError('$factory already holds an open bundle for $atSign at'
+        ' ${_describeDifference(held, requested)}.'
+        ' A factory keeps one bundle per atSign —'
         ' bundleFor() and closeFor() have no way to name a second — so it'
         ' cannot serve both. Returning the bundle it holds would answer with'
         ' another store\'s records. Call closeFor("$atSign") first, or use a'
         ' separate factory instance for the second location.');
+
+/// Names the locations that actually differ, rather than `storagePath`.
+///
+/// Reporting `storagePath` alone produces a refusal that reads "rooted at X,
+/// and was asked for one at X" whenever the difference is in one of the other
+/// four paths — and always for the dual-write config, whose every path getter
+/// delegates to its primary. A message that appears to contradict itself sends
+/// the reader after the check rather than after the difference.
+String _describeDifference(
+    AtPersistenceConfig held, AtPersistenceConfig requested) {
+  const labels = [
+    'storagePath',
+    'commitLogPath',
+    'accessLogPath',
+    'notificationStoragePath',
+  ];
+  final left = storageLocationsOf(held);
+  final right = storageLocationsOf(requested);
+  final differences = <String>[];
+  for (var i = 0; i < left.length; i++) {
+    if (!_sameLocation(left[i], right[i])) {
+      differences.add('${labels[i]} "${left[i]}" vs "${right[i]}"');
+    }
+  }
+  if (differences.isEmpty) {
+    return '"${held.storagePath}", and was asked for one at'
+        ' "${requested.storagePath}"';
+  }
+  return 'a different ${differences.join('; ')}';
+}

--- a/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_at_persistence_factory.dart
+++ b/packages/at_persistence_secondary_server/lib/src/impl/sqlite/sqlite_at_persistence_factory.dart
@@ -1,6 +1,7 @@
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:at_utils/at_logger.dart';
 
+import '../persistence_config_identity.dart';
 import 'sqlite_at_access_log.dart';
 import 'sqlite_at_commit_log.dart';
 import 'sqlite_at_keyvalue_store.dart';
@@ -17,6 +18,11 @@ class SqliteAtPersistenceFactory implements AtPersistenceFactory {
 
   final Map<String, SqliteAtPersistenceBundle> _bundles = {};
 
+  /// The config each open bundle was built from — see the Hive factory
+  /// and [conflictingStorageError] for why a second location cannot be
+  /// served and must not be silently ignored.
+  final Map<String, SqlitePersistenceConfig> _configs = {};
+
   @override
   AtPersistenceBackendId get backendId => AtPersistenceBackendId.sqlite;
 
@@ -31,8 +37,19 @@ class SqliteAtPersistenceFactory implements AtPersistenceFactory {
 
     final existing = _bundles[atSign];
     if (existing != null) {
-      if (!existing.isClosed) return existing;
+      if (!existing.isClosed) {
+        final held = _configs[atSign];
+        if (held != null && !sameStorageLocations(held, config)) {
+          throw conflictingStorageError(
+              factory: 'SqliteAtPersistenceFactory',
+              atSign: atSign,
+              held: held,
+              requested: config);
+        }
+        return existing;
+      }
       _bundles.remove(atSign);
+      _configs.remove(atSign);
     }
 
     _logger.info('Initialising SQLite persistence for $atSign');
@@ -57,6 +74,7 @@ class SqliteAtPersistenceFactory implements AtPersistenceFactory {
       notificationKeystore: notificationKeystore,
     );
     _bundles[atSign] = bundle;
+    _configs[atSign] = config;
     return bundle;
   }
 
@@ -66,6 +84,7 @@ class SqliteAtPersistenceFactory implements AtPersistenceFactory {
     if (bundle == null) return null;
     if (bundle.isClosed) {
       _bundles.remove(atSign);
+      _configs.remove(atSign);
       return null;
     }
     return bundle;
@@ -73,6 +92,7 @@ class SqliteAtPersistenceFactory implements AtPersistenceFactory {
 
   @override
   Future<void> closeFor(String atSign) async {
+    _configs.remove(atSign);
     final bundle = _bundles.remove(atSign);
     if (bundle == null) return;
     try {
@@ -86,6 +106,7 @@ class SqliteAtPersistenceFactory implements AtPersistenceFactory {
   Future<void> close() async {
     final bundles = _bundles.values.toList();
     _bundles.clear();
+    _configs.clear();
     for (final b in bundles) {
       try {
         await b.close();

--- a/packages/at_persistence_secondary_server/lib/src/spec/at_persistence_factory.dart
+++ b/packages/at_persistence_secondary_server/lib/src/spec/at_persistence_factory.dart
@@ -13,13 +13,27 @@ abstract class AtPersistenceFactory {
 
   /// Build a fully-initialised [AtPersistenceBundle] for [atSign].
   ///
-  /// Calling this twice for the same atSign returns the **same**
-  /// bundle — the factory owns the per-atSign lifecycle. Callers
-  /// should not try to manage it themselves.
+  /// Calling this twice for the same atSign **with the same storage
+  /// locations** returns the same bundle — the factory owns the
+  /// per-atSign lifecycle. Callers should not try to manage it
+  /// themselves.
+  ///
+  /// Calling it for an atSign that already has an open bundle rooted
+  /// somewhere else throws a [StateError]. One bundle per atSign is
+  /// this interface's contract and [bundleFor] and [closeFor] both key
+  /// on the atSign alone, so there is nowhere for a second bundle to
+  /// live; returning the one it holds would answer a caller with
+  /// another store's records, and the caller has no way to notice.
+  /// Close the first bundle, or use a separate factory instance.
+  ///
+  /// Two spellings of one location are one location: the comparison is
+  /// lexical first and resolves symlinks on disagreement, so `foo/bar`
+  /// and `foo/./bar`, and a link and its target, are not a conflict.
   ///
   /// If a previous bundle for [atSign] has been closed (whether
   /// directly via [AtPersistenceBundle.close] or via [closeFor]),
-  /// the stale entry is dropped and a fresh bundle is built.
+  /// the stale entry is dropped and a fresh bundle is built — at
+  /// whatever locations the new [config] names.
   ///
   /// Throws [ArgumentError] if [config] does not match
   /// [backendId].

--- a/packages/at_persistence_secondary_server/test/hive_instances_test.dart
+++ b/packages/at_persistence_secondary_server/test/hive_instances_test.dart
@@ -1,5 +1,7 @@
 import 'dart:io';
 
+import 'package:path/path.dart' as p;
+
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 // Deliberately the public barrel, not `src/impl/hive/hive_instances.dart`.
 // A consumer outside this package can only reach `HiveInstances` through an
@@ -203,5 +205,57 @@ void main() {
     expect(HiveInstances.instanceCount, 0,
         reason: 'an entry left behind points at a closed instance, and the '
             'next caller for that path would get it back');
+  });
+
+  test('an empty storage path is refused, not laundered into the CWD',
+      () async {
+    // The fallback makes this dangerous rather than merely wrong.
+    // `createSync('')` throws PathNotFoundException, which IS a
+    // FileSystemException, so the catch swallows it and `p.canonicalize('')`
+    // returns the PROCESS WORKING DIRECTORY — measured. A server would then
+    // start normally, rooted in its own image layer rather than the mounted
+    // volume, and with an unencrypted keystore, because the secret file cannot
+    // be written there either and that failure is swallowed too. An unset
+    // `${STORAGE_PATH}` in a manifest arrives here as '', since
+    // Platform.environment reports an interpolated-but-unset variable as
+    // present with an empty value.
+    expect(() => HiveInstances.forPath(''), throwsA(isA<ArgumentError>()),
+        reason: 'an empty path is not a location, and silently choosing one '
+            'for the caller puts the whole store somewhere nobody asked for');
+    expect(() => HiveInstances.forPath('   '), throwsA(isA<ArgumentError>()),
+        reason: 'blank is empty for this purpose');
+
+    // The control, and it is what stops the guard being "reject everything":
+    // an ordinary relative path must still resolve, and must still resolve
+    // RELATIVE TO THE CWD, which is the very behaviour that makes '' unsafe.
+    final relative = p.relative(pathFor('relative_ok'));
+    expect(HiveInstances.forPath(relative), isNotNull,
+        reason: 'a real relative path is a location and must keep working');
+  });
+
+  test('closing a path does not create it', () async {
+    // canonicalPathFor creates the directory so it can resolve it, and
+    // closeFor used to go through the same door — so a teardown that deleted
+    // the tree and then closed the instance found the directory back, empty,
+    // with nothing thrown and nothing logged.
+    final path = pathFor('close_no_create');
+    final store = await storeAt(path);
+    await store.put('shared_key@alice', data('v'));
+    await HiveInstances.closeFor(path);
+
+    Directory(path).deleteSync(recursive: true);
+    await HiveInstances.closeFor(path);
+    expect(Directory(path).existsSync(), isFalse,
+        reason: 'closing is a teardown verb and must not write; recreating '
+            'the directory makes a later "is the storage gone?" check lie');
+
+    // The control: closing a path that IS open still works, so the fix has
+    // not simply made closeFor a no-op.
+    final second = pathFor('close_still_closes');
+    await storeAt(second);
+    final before = HiveInstances.instanceCount;
+    await HiveInstances.closeFor(second);
+    expect(HiveInstances.instanceCount, before - 1,
+        reason: 'closeFor must still close the instance it names');
   });
 }

--- a/packages/at_persistence_secondary_server/test/hive_instances_test.dart
+++ b/packages/at_persistence_secondary_server/test/hive_instances_test.dart
@@ -2,7 +2,11 @@ import 'dart:io';
 
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:at_persistence_secondary_server/src/impl/hive/hive_at_keyvalue_store.dart';
-import 'package:at_persistence_secondary_server/src/impl/hive/hive_instances.dart';
+// Deliberately the public barrel, not `src/impl/hive/hive_instances.dart`.
+// A consumer outside this package can only reach `HiveInstances` through an
+// export, and at_client needs it: importing it here the way they do is what
+// keeps the export from being dropped by a tidy-up.
+import 'package:at_persistence_secondary_server/hive.dart';
 import 'package:test/test.dart';
 
 /// Two stores for one atSign, in one process, at different storage paths.
@@ -91,8 +95,8 @@ void main() {
     // two boxes over one directory is the dangerous state, because they drift
     // in memory with no error on either side.
     await first.put('shared_key@alice', data('written-after-both-open'));
-    expect((await second.get('shared_key@alice'))?.data,
-        'written-after-both-open',
+    expect(
+        (await second.get('shared_key@alice'))?.data, 'written-after-both-open',
         reason: 'one path must mean one box, not two boxes over one set of '
             'files. Two would each stay internally consistent while telling '
             'their callers different things, which is the failure this whole '
@@ -117,5 +121,88 @@ void main() {
             'prevent');
     expect(HiveInstances.instanceCount, before + 1,
         reason: 'three spellings, one instance');
+  });
+
+  test('a symlinked spelling of a path is the same instance as its target',
+      () async {
+    // `p.canonicalize` is pure string work — it does not follow symlinks, so
+    // on its own a link and its target are two instances over one directory:
+    // two boxes, drifting in memory, which is exactly the state this class
+    // exists to prevent. Not exotic either — `/data -> /mnt/data` is an
+    // ordinary deployment, and on macOS `Directory.systemTemp` is
+    // `/var/folders/...` whose real path is `/private/var/folders/...`.
+    final target = pathFor('link_target');
+    final link = '${root.path}/link_alias';
+    Link(link).createSync(target);
+
+    final before = HiveInstances.instanceCount;
+    final viaTarget = HiveInstances.forPath(target);
+    final viaLink = HiveInstances.forPath(link);
+
+    expect(identical(viaTarget, viaLink), isTrue,
+        reason: 'a link and its target are one directory, so they must be one '
+            'instance — a lexical canonicalisation calls them different and '
+            'reopens the hole');
+    expect(HiveInstances.instanceCount, before + 1,
+        reason: 'two spellings, one instance');
+  });
+
+  test('a path is resolved the same way before and after it exists', () async {
+    // The reason the directory is created rather than left to appear on its
+    // own: an unresolvable path can only be keyed lexically, so a caller
+    // arriving before the directory existed and one arriving after would key
+    // on two different strings for one directory.
+    final target = pathFor('late_target');
+    final link = '${root.path}/late_alias';
+    Link(link).createSync(target);
+    final notYet = '$link/child';
+
+    final before = HiveInstances.instanceCount;
+    final first = HiveInstances.forPath(notYet); // creates it
+    final second = HiveInstances.forPath('$target/child'); // already there
+
+    expect(Directory(notYet).existsSync(), isTrue,
+        reason: 'forPath must create the directory, or it cannot resolve it');
+    expect(identical(first, second), isTrue,
+        reason: 'the same directory reached before and after it existed, and '
+            'by two spellings, is one instance');
+    expect(HiveInstances.instanceCount, before + 1);
+  });
+
+  test('an instance mid-close is refused rather than handed out or replaced',
+      () async {
+    // Neither alternative is safe. Handing back the closing instance lets a
+    // caller open a box that is about to be closed underneath them; building
+    // a fresh one puts two live instances over one directory, which is the
+    // silent divergence. Refusing is the only loud option.
+    final path = pathFor('closing');
+    final store = await storeAt(path);
+    await store.put('shared_key@alice', data('v'));
+
+    final closing = HiveInstances.closeFor(path);
+    expect(() => HiveInstances.forPath(path), throwsA(isA<StateError>()),
+        reason: 'a caller arriving during the close has an ordering bug and '
+            'must hear about it, not silently get a second instance over the '
+            'same files');
+
+    await closing;
+    // The control: once the close has completed the path is usable again, so
+    // the refusal above is about the window and not about the path being
+    // permanently poisoned.
+    expect(HiveInstances.forPath(path), isNotNull);
+    await HiveInstances.closeFor(path);
+  });
+
+  test('closeAll drops the instances it closed', () async {
+    final a = await storeAt(pathFor('close_a'));
+    final b = await storeAt(pathFor('close_b'));
+    await a.put('shared_key@alice', data('a'));
+    await b.put('shared_key@alice', data('b'));
+
+    expect(HiveInstances.instanceCount, greaterThanOrEqualTo(2));
+    await HiveInstances.closeAll();
+    expect(HiveInstances.instanceCount, 0,
+        reason: 'an entry left behind points at a closed instance, and the '
+            'next caller for that path would get it back');
   });
 }

--- a/packages/at_persistence_secondary_server/test/hive_instances_test.dart
+++ b/packages/at_persistence_secondary_server/test/hive_instances_test.dart
@@ -1,0 +1,121 @@
+import 'dart:io';
+
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_persistence_secondary_server/src/impl/hive/hive_at_keyvalue_store.dart';
+import 'package:at_persistence_secondary_server/src/impl/hive/hive_instances.dart';
+import 'package:test/test.dart';
+
+/// Two stores for one atSign, in one process, at different storage paths.
+///
+/// A Hive box's identity is `(instance registry, box name)`, and box names in
+/// this package derive from the atSign alone. Everything here used to run
+/// through the package-global `Hive`, so two stores for one atSign were always
+/// one box however different the paths they were given: the second attached to
+/// the first's, and its own `storagePath` reached nothing but the
+/// encryption-secret file beside it.
+///
+/// The failure that made it visible was not an error. It was a client reading
+/// its own stale value after a sibling had written — no exception, no log, and
+/// each side internally consistent.
+void main() {
+  const atSign = '@alice';
+  late Directory root;
+
+  setUp(() => root = Directory.systemTemp.createTempSync('hive_instances'));
+  tearDown(() {
+    if (root.existsSync()) root.deleteSync(recursive: true);
+  });
+
+  String pathFor(String name) =>
+      (Directory('${root.path}/$name')..createSync(recursive: true)).path;
+
+  Future<HiveAtKeyValueStore> storeAt(String path) async {
+    final store = HiveAtKeyValueStore(atSign);
+    await store.init(path);
+    return store;
+  }
+
+  AtData data(String v) => AtData()..data = v;
+
+  test('two stores for one atSign at different paths do not share a box',
+      () async {
+    final a = await storeAt(pathFor('a'));
+    final b = await storeAt(pathFor('b'));
+
+    await a.put('shared_key@alice', data('written-by-a'));
+
+    // The claim. Before this change b resolved to a's box and read
+    // 'written-by-a' — with nothing to indicate the path it asked for had
+    // been ignored.
+    expect(await b.exists('shared_key@alice'), isFalse,
+        reason: 'these stores were given different storage paths, so a write '
+            'through one must not be visible through the other. Sharing here '
+            'is not a tidiness problem: the two boxes drift silently, each '
+            'side internally consistent, and neither can tell');
+
+    // The control, and it is what stops the assertion above passing for the
+    // wrong reason: if `b` could see nothing at all — a broken store, a wrong
+    // key name — the expectation would hold just as well.
+    await b.put('shared_key@alice', data('written-by-b'));
+    expect((await b.get('shared_key@alice'))?.data, 'written-by-b',
+        reason: 'b must be a working store, or its not-seeing-a proves '
+            'nothing');
+    expect((await a.get('shared_key@alice'))?.data, 'written-by-a',
+        reason: 'and a keeps its own value — the separation holds in both '
+            'directions, not just the one the write happened to go');
+
+    await a.close();
+    await b.close();
+  });
+
+  test('a store re-opened at the SAME path sees what was written there',
+      () async {
+    // The other half of the rule, and the one that makes this change safe for
+    // every existing deployment: same path resolves to the same instance and
+    // the same box, exactly as before. Without this the fix would "pass" by
+    // isolating everything from everything.
+    final path = pathFor('same');
+    final first = await storeAt(path);
+    await first.put('shared_key@alice', data('written-once'));
+
+    final second = await storeAt(path);
+    expect((await second.get('shared_key@alice'))?.data, 'written-once',
+        reason: 'callers passing one path must keep one store — that is what '
+            'every deployment does today, and nothing about it may move');
+
+    // ⚠️ The assertion above is NOT sufficient on its own, and a mutation
+    // proved it: give every store its own instance and this still passes,
+    // because a fresh instance reads the same files from disk and picks up
+    // anything written before it opened. Only a write made AFTER both are
+    // open separates one shared box from two boxes over one directory — and
+    // two boxes over one directory is the dangerous state, because they drift
+    // in memory with no error on either side.
+    await first.put('shared_key@alice', data('written-after-both-open'));
+    expect((await second.get('shared_key@alice'))?.data,
+        'written-after-both-open',
+        reason: 'one path must mean one box, not two boxes over one set of '
+            'files. Two would each stay internally consistent while telling '
+            'their callers different things, which is the failure this whole '
+            'change exists to make impossible');
+
+    await first.close();
+  });
+
+  test('one instance per path, and two spellings of a path are one instance',
+      () async {
+    final path = pathFor('canon');
+    final before = HiveInstances.instanceCount;
+
+    final direct = HiveInstances.forPath(path);
+    final viaDot = HiveInstances.forPath('$path/.');
+    final viaParent = HiveInstances.forPath('$path/sub/..');
+
+    expect(identical(direct, viaDot), isTrue);
+    expect(identical(direct, viaParent), isTrue,
+        reason: 'a string comparison would make these separate instances over '
+            'the same files, reintroducing the divergence this exists to '
+            'prevent');
+    expect(HiveInstances.instanceCount, before + 1,
+        reason: 'three spellings, one instance');
+  });
+}

--- a/packages/at_persistence_secondary_server/test/hive_instances_test.dart
+++ b/packages/at_persistence_secondary_server/test/hive_instances_test.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
-import 'package:at_persistence_secondary_server/src/impl/hive/hive_at_keyvalue_store.dart';
 // Deliberately the public barrel, not `src/impl/hive/hive_instances.dart`.
 // A consumer outside this package can only reach `HiveInstances` through an
 // export, and at_client needs it: importing it here the way they do is what

--- a/packages/at_persistence_secondary_server/test/hive_keystore_impl_test.dart
+++ b/packages/at_persistence_secondary_server/test/hive_keystore_impl_test.dart
@@ -4,7 +4,6 @@ import 'dart:io';
 
 import 'package:at_commons/at_commons.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
-import 'package:at_persistence_secondary_server/src/impl/hive/hive_instances.dart';
 import 'package:at_persistence_secondary_server/hive.dart';
 import 'package:crypto/crypto.dart';
 import 'package:test/test.dart';

--- a/packages/at_persistence_secondary_server/test/hive_keystore_impl_test.dart
+++ b/packages/at_persistence_secondary_server/test/hive_keystore_impl_test.dart
@@ -4,9 +4,9 @@ import 'dart:io';
 
 import 'package:at_commons/at_commons.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_persistence_secondary_server/src/impl/hive/hive_instances.dart';
 import 'package:at_persistence_secondary_server/hive.dart';
 import 'package:crypto/crypto.dart';
-import 'package:hive/hive.dart';
 import 'package:test/test.dart';
 
 import 'test_utils.dart';
@@ -796,8 +796,15 @@ void main() async {
 }
 
 Future<void> tearDownFunc(String atSign) async {
-  await Hive.deleteBoxFromDisk('commit_log_$atSign');
-  await Hive.deleteBoxFromDisk(_getShaForAtSign(atSign));
+  // Deleted through the instance that OWNS these boxes, not the package-global
+  // `Hive`. Box lifecycle now lives on a per-storage-path instance, so the
+  // global's `homePath` is never set and its `deleteBoxFromDisk` fails with
+  // `Invalid argument(s) (path): Must not be null` — which is how this
+  // surfaced: every test in this file went red in its tearDown while its body
+  // had passed.
+  final hive = HiveInstances.forPath('test/hive');
+  await hive.deleteBoxFromDisk('commit_log_$atSign');
+  await hive.deleteBoxFromDisk(_getShaForAtSign(atSign));
   await tearDownTestPersistence(storageDir: 'test/hive');
 }
 

--- a/packages/at_persistence_secondary_server/test/hive_keystore_impl_test.dart
+++ b/packages/at_persistence_secondary_server/test/hive_keystore_impl_test.dart
@@ -797,11 +797,22 @@ void main() async {
 
 Future<void> tearDownFunc(String atSign) async {
   // Deleted through the instance that OWNS these boxes, not the package-global
-  // `Hive`. Box lifecycle now lives on a per-storage-path instance, so the
-  // global's `homePath` is never set and its `deleteBoxFromDisk` fails with
-  // `Invalid argument(s) (path): Must not be null` — which is how this
-  // surfaced: every test in this file went red in its tearDown while its body
-  // had passed.
+  // `Hive`.
+  //
+  // The global still works, and that is the problem. `HiveBase.init` keeps
+  // calling `Hive.init(storagePath)` for consumers outside this package, so
+  // the global's `homePath` is this same directory — measured, it is set, and
+  // `Hive.deleteBoxFromDisk` there does not throw. What it does instead is
+  // take the "box not open in MY registry" branch and delete the files
+  // straight off disk, out from under the per-path instance that has those
+  // boxes open. The per-path instance then fails when it closes them:
+  //
+  //   PathNotFoundException: Cannot delete file, path = '.../<sha>.lock'
+  //     package:hive/src/backend/vm/storage_backend_vm.dart  _closeInternal
+  //
+  // which is how this surfaced — every test in this file went red in its
+  // tearDown while its body had passed. File-level operations do not respect
+  // the registry split; only the instance holding a box may delete it.
   final hive = HiveInstances.forPath('test/hive');
   await hive.deleteBoxFromDisk('commit_log_$atSign');
   await hive.deleteBoxFromDisk(_getShaForAtSign(atSign));

--- a/packages/at_persistence_secondary_server/test/persistence_factory_storage_path_test.dart
+++ b/packages/at_persistence_secondary_server/test/persistence_factory_storage_path_test.dart
@@ -151,4 +151,74 @@ void main() {
       await factory.close();
     });
   });
+
+  group('the comparison itself', () {
+    test('two different locations that do not exist are NOT the same location',
+        () async {
+      // The guard used to fail OPEN here, and it read as correct: the
+      // filesystem arm was `_resolved(a) == _resolved(b)`, and an absent path
+      // resolves to null, so two entirely unrelated missing roots compared
+      // equal and the factory handed back the bundle it held. Measured:
+      // lexically different, both resolve null, null == null is true.
+      final factory = HiveAtPersistenceFactory();
+      final held = dir('held');
+      await factory.initialize('@alice', hiveAt(held));
+
+      // BOTH sides must be unresolvable to reach the bug, and the delete is
+      // what gets it there: while the held path still exists it resolves to a
+      // real location, so `real == null` is false and even the broken version
+      // refused. A first attempt at this test skipped the delete, stayed green
+      // under the mutation, and was asserting nothing.
+      Directory(held).deleteSync(recursive: true);
+      final requested = '${root.path}/never_created_one';
+      await expectLater(() => factory.initialize('@alice', hiveAt(requested)),
+          throwsA(isA<StateError>()),
+          reason: 'a path that is merely absent says nothing about where it '
+              'would be, so two absences are not one location; agreeing they '
+              'are hands back a bundle rooted somewhere else, which is the '
+              'silent mis-route this guard exists to prevent');
+      await factory.close();
+    });
+
+    test('the refusal names the location that actually differs', () async {
+      // Reporting storagePath alone produced "rooted at X, and was asked for
+      // one at X" whenever the difference was in one of the other four paths —
+      // always so for the dual config, whose getters all delegate to primary.
+      // A message that contradicts itself sends the reader after the check.
+      final factory = HiveAtPersistenceFactory();
+      final shared = dir('shared_root');
+      final firstCommitLog = dir('commit_a');
+      final secondCommitLog = dir('commit_b');
+
+      await factory.initialize(
+          '@alice',
+          HivePersistenceConfig(
+              storagePath: shared,
+              commitLogPath: firstCommitLog,
+              accessLogPath: shared,
+              notificationStoragePath: shared));
+
+      Object? thrown;
+      try {
+        await factory.initialize(
+            '@alice',
+            HivePersistenceConfig(
+                storagePath: shared,
+                commitLogPath: secondCommitLog,
+                accessLogPath: shared,
+                notificationStoragePath: shared));
+      } catch (e) {
+        thrown = e;
+      }
+      expect(thrown, isA<StateError>());
+      final message = thrown.toString();
+      expect(message, contains('commitLogPath'),
+          reason: 'the reader needs to know WHICH location moved; storagePath '
+              'is identical in both configs here');
+      expect(message, contains(secondCommitLog),
+          reason: 'and the requested value, or they cannot tell which side '
+              'they are looking at');
+      await factory.close();
+    });
+  });
 }

--- a/packages/at_persistence_secondary_server/test/persistence_factory_storage_path_test.dart
+++ b/packages/at_persistence_secondary_server/test/persistence_factory_storage_path_test.dart
@@ -76,15 +76,38 @@ void main() {
           '@alice',
           DualWritePersistenceConfig(
               primary: primary, secondary: sqliteAt(dir('s1'))));
-      await expectLater(
-          () => factory.initialize(
-              '@alice',
-              DualWritePersistenceConfig(
-                  primary: primary, secondary: sqliteAt(dir('s2')))),
-          throwsA(isA<StateError>()),
+      final secondCommitLocation = dir('s2');
+      Object? thrown;
+      try {
+        await factory.initialize(
+            '@alice',
+            DualWritePersistenceConfig(
+                primary: primary, secondary: sqliteAt(secondCommitLocation)));
+      } catch (e) {
+        thrown = e;
+      }
+      expect(thrown, isA<StateError>(),
           reason: 'the primary is unchanged, so every path getter on the '
               'wrapper agrees; only comparing the arms separately catches a '
               'moved secondary');
+
+      // Asserting the THROW alone is what let a real defect through: the
+      // message was built from the wrapper, whose getters all delegate to the
+      // primary, so it found no difference and fell back to printing the
+      // primary's path as both sides — "at X, and was asked for one at X", for
+      // exactly the case the comparison exists to catch. The message for the
+      // Hive factory was asserted, and it was fine; the gap sat between the
+      // type whose message was checked and the type whose message was broken.
+      final message = thrown.toString();
+      expect(message, contains('secondary arm'),
+          reason: 'a refusal must say which arm moved — the operator reading '
+              'it is deciding which of two backends to look at');
+      expect(message, contains(secondCommitLocation),
+          reason: 'and must name the location actually requested, not the '
+              'primary\'s, which did not move');
+      expect(message, isNot(contains('primary arm')),
+          reason: 'the primary is identical here; naming it would send the '
+              'reader to the wrong backend');
       await factory.close();
     });
   });

--- a/packages/at_persistence_secondary_server/test/persistence_factory_storage_path_test.dart
+++ b/packages/at_persistence_secondary_server/test/persistence_factory_storage_path_test.dart
@@ -1,0 +1,154 @@
+import 'dart:io';
+
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_persistence_secondary_server/dual.dart';
+import 'package:at_persistence_secondary_server/hive.dart';
+import 'package:at_persistence_secondary_server/sqlite.dart';
+import 'package:test/test.dart';
+
+/// One atSign, one factory, two storage locations.
+///
+/// A factory keeps one bundle per atSign — [AtPersistenceFactory.bundleFor]
+/// and [AtPersistenceFactory.closeFor] key on the atSign alone, so there is
+/// nowhere for a second to live. It used to hand back the bundle it held
+/// without ever reading the config's paths, so the second caller was answered
+/// with the first's store. Measured before the fix, with one factory and two
+/// directories: the Hive bundle returned `from-a` for the second path, and the
+/// SQLite one did too while never creating the second directory at all — the
+/// `storagePath` reached nothing whatsoever.
+///
+/// The remedy is a refusal rather than a second bundle: the interface cannot
+/// express two, and a caller reading another store's records has no way to
+/// notice.
+void main() {
+  late Directory root;
+
+  setUp(() => root = Directory.systemTemp.createTempSync('factory_paths'));
+  tearDown(() {
+    if (root.existsSync()) root.deleteSync(recursive: true);
+  });
+
+  String dir(String name) =>
+      (Directory('${root.path}/$name')..createSync(recursive: true)).path;
+
+  HivePersistenceConfig hiveAt(String d) => HivePersistenceConfig(
+      storagePath: d,
+      commitLogPath: d,
+      accessLogPath: d,
+      notificationStoragePath: d);
+
+  SqlitePersistenceConfig sqliteAt(String d) =>
+      SqlitePersistenceConfig(storagePath: d);
+
+  group('a factory refuses a second storage location for one atSign', () {
+    test('hive', () async {
+      final factory = HiveAtPersistenceFactory();
+      await factory.initialize('@alice', hiveAt(dir('a')));
+      await expectLater(() => factory.initialize('@alice', hiveAt(dir('b'))),
+          throwsA(isA<StateError>()),
+          reason: 'returning the bundle rooted at a/ would answer a caller '
+              'that asked for b/ with another store\'s records, and nothing '
+              'in the bundle tells them which directory they got');
+      await factory.close();
+    });
+
+    test('sqlite', () async {
+      final factory = SqliteAtPersistenceFactory();
+      await factory.initialize('@alice', sqliteAt(dir('a')));
+      await expectLater(() => factory.initialize('@alice', sqliteAt(dir('b'))),
+          throwsA(isA<StateError>()),
+          reason: 'the sqlite factory did not merely answer from the wrong '
+              'directory, it never created the second one — the storagePath '
+              'reached nothing at all');
+      await factory.close();
+    });
+
+    test('dual, when only the SECONDARY arm moves', () async {
+      // The arm that would slip through a wrapper comparison.
+      // DualWritePersistenceConfig delegates every path getter to `primary`,
+      // so comparing the wrapper agrees here while the secondary — the arm the
+      // whole dual-write comparison exists to populate — has been pointed
+      // somewhere else.
+      final factory = DualWriteAtPersistenceFactory(
+          HiveAtPersistenceFactory(), SqliteAtPersistenceFactory());
+      final primary = hiveAt(dir('p'));
+      await factory.initialize(
+          '@alice',
+          DualWritePersistenceConfig(
+              primary: primary, secondary: sqliteAt(dir('s1'))));
+      await expectLater(
+          () => factory.initialize(
+              '@alice',
+              DualWritePersistenceConfig(
+                  primary: primary, secondary: sqliteAt(dir('s2')))),
+          throwsA(isA<StateError>()),
+          reason: 'the primary is unchanged, so every path getter on the '
+              'wrapper agrees; only comparing the arms separately catches a '
+              'moved secondary');
+      await factory.close();
+    });
+  });
+
+  group('and does not refuse a caller doing nothing wrong', () {
+    test('the identical config returns the same bundle', () async {
+      // The control. Without it the refusal above could be a factory that
+      // rejects every second call, which would break every existing caller.
+      final factory = HiveAtPersistenceFactory();
+      final path = dir('same');
+      final first = await factory.initialize('@alice', hiveAt(path));
+      final second = await factory.initialize('@alice', hiveAt(path));
+      expect(identical(first, second), isTrue,
+          reason: 'one bundle per atSign is the contract, and two calls with '
+              'the same locations must keep getting it');
+      await factory.close();
+    });
+
+    test('a lexically different spelling of one directory is not a conflict',
+        () async {
+      final factory = HiveAtPersistenceFactory();
+      final path = dir('lexical');
+      final first = await factory.initialize('@alice', hiveAt(path));
+      final second = await factory.initialize('@alice', hiveAt('$path/./'));
+      expect(identical(first, second), isTrue,
+          reason: 'foo/bar and foo/./bar are one directory; refusing here '
+              'would fail a caller who has done nothing wrong');
+      await factory.close();
+    });
+
+    test('a symlinked spelling of one directory is not a conflict', () async {
+      // Lexical canonicalisation alone calls these two different. macOS hands
+      // this case to anyone using Directory.systemTemp, whose real path is
+      // under /private/var.
+      final factory = HiveAtPersistenceFactory();
+      final target = dir('link_target');
+      final alias = '${root.path}/link_alias';
+      Link(alias).createSync(target);
+
+      final first = await factory.initialize('@alice', hiveAt(target));
+      final second = await factory.initialize('@alice', hiveAt(alias));
+      expect(identical(first, second), isTrue,
+          reason: 'a link and its target are one directory on disk, so this '
+              'is the same store reached by another name');
+      await factory.close();
+    });
+
+    test('after closeFor, a different location is allowed', () async {
+      final factory = SqliteAtPersistenceFactory();
+      await factory.initialize('@alice', sqliteAt(dir('first')));
+      await factory.closeFor('@alice');
+      final moved = await factory.initialize('@alice', sqliteAt(dir('second')));
+      expect(moved.isClosed, isFalse,
+          reason: 'the refusal is about an OPEN bundle; once it is closed the '
+              'atSign is free to be built somewhere else');
+      await factory.close();
+    });
+
+    test('a different atSign at a different location is unaffected', () async {
+      final factory = SqliteAtPersistenceFactory();
+      final a = await factory.initialize('@alice', sqliteAt(dir('alice')));
+      final b = await factory.initialize('@bob', sqliteAt(dir('bob')));
+      expect(identical(a, b), isFalse);
+      await factory.close();
+    });
+  });
+}

--- a/packages/at_persistence_secondary_server/test/persistence_restart_cycle_test.dart
+++ b/packages/at_persistence_secondary_server/test/persistence_restart_cycle_test.dart
@@ -1,0 +1,199 @@
+import 'dart:io';
+
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_persistence_secondary_server/hive.dart';
+import 'package:at_persistence_secondary_server/sqlite.dart';
+import 'package:test/test.dart';
+
+/// The restart cycle, at the persistence layer.
+///
+/// `AtCertificateValidationJob` restarts the atServer **in process** when the
+/// TLS certificates on disk are replaced: `AtSecondaryServerImpl.stop()`, which
+/// closes persistence through `persistenceFactory.close()`, and then `start()`
+/// again on the same singleton, which calls `initialize` on the same factory
+/// with a config rebuilt from the same static settings. That happens twice a
+/// day on a live server, unattended, and nothing in the unit tree exercised it.
+///
+/// What must hold across it: the second `initialize` returns a working store
+/// rooted at the SAME place, so records written before the restart are still
+/// there afterwards, and the commit log carries on rather than starting again.
+/// A defect that re-roots storage — an empty path resolving to the process
+/// working directory, a stale cache entry answering with another location —
+/// does not throw. It produces a server that comes back up looking healthy and
+/// serving an empty or wrong store, which is why this is asserted by VALUE
+/// rather than by "the store opened".
+void main() {
+  late Directory root;
+
+  setUp(() => root = Directory.systemTemp.createTempSync('restart_cycle'));
+  tearDown(() async {
+    await HiveInstances.closeAll();
+    if (root.existsSync()) root.deleteSync(recursive: true);
+  });
+
+  String dir(String name) =>
+      (Directory('${root.path}/$name')..createSync(recursive: true)).path;
+
+  AtData data(String v) => AtData()..data = v;
+
+  /// One config, rebuilt each time — the server does not reuse the object
+  /// either; `PersistenceBackendManager.configFor` builds a fresh one per
+  /// start from the same static settings.
+  HivePersistenceConfig hiveConfig(String d) => HivePersistenceConfig(
+      storagePath: '$d/hive',
+      commitLogPath: '$d/commitLog',
+      accessLogPath: '$d/accessLog',
+      notificationStoragePath: '$d/notificationLog');
+
+  group('a restart keeps the same storage', () {
+    test('hive: records written before a restart survive it', () async {
+      const atSign = '@alice';
+      final storage = dir('hive_survives');
+      final factory = HiveAtPersistenceFactory();
+
+      // ---- first start ----
+      var bundle = await factory.initialize(atSign, hiveConfig(storage));
+      await bundle.keyValueStore.put('before@alice', data('written-before'));
+      final notification = (AtNotificationBuilder()
+            ..toAtSign = '@bob'
+            ..fromAtSign = atSign
+            ..id = 'notification-before')
+          .build();
+      await bundle.notificationKeystore!.put(notification.id!, notification);
+      final commitIdBefore =
+          bundle.keyValueStore.commitLog!.lastCommittedSequenceNumber();
+      expect(commitIdBefore, greaterThanOrEqualTo(0),
+          reason: 'the write above must have reached the commit log, or the '
+              'commit-log half of this test is asserting nothing');
+
+      // ---- the restart: exactly what AtSecondaryServerImpl.stop() does ----
+      await factory.close();
+      // Deliberately NOT asserting `factory.bundleFor(atSign) == null` here.
+      // It is null either way: bundleFor drops a CLOSED bundle from its map and
+      // returns null regardless of whether close() cleared it, so the
+      // assertion passes under a close() that clears nothing. Verified by
+      // mutation — it stayed green. What close() must actually achieve is
+      // observable further down: the next initialize returns a live store at
+      // the same location.
+
+      // ---- second start, same factory, config rebuilt ----
+      bundle = await factory.initialize(atSign, hiveConfig(storage));
+
+      expect((await bundle.keyValueStore.get('before@alice'))?.data,
+          'written-before',
+          reason: 'the keystore record written before the restart must still '
+              'be there. If storage were re-rooted — an empty path resolving '
+              'to the CWD, a cached bundle answering for another location — '
+              'nothing throws and this is the only thing that notices');
+      expect(
+          (await bundle.notificationKeystore!.get('notification-before'))?.id,
+          'notification-before',
+          reason: 'the notification keystore is a separate box under a '
+              'separate path, so it can be re-rooted independently of the '
+              'keystore');
+      expect(bundle.keyValueStore.commitLog!.lastCommittedSequenceNumber(),
+          greaterThanOrEqualTo(commitIdBefore!),
+          reason: 'the commit log must carry on, not start again — a sequence '
+              'that reset would resend the whole store to every client');
+
+      // The control. Without it, "the record is there" could be satisfied by a
+      // store that was never closed at all, and the test would pass for a
+      // factory whose close() did nothing.
+      await bundle.keyValueStore.put('after@alice', data('written-after'));
+      expect((await bundle.keyValueStore.get('after@alice'))?.data,
+          'written-after',
+          reason: 'the store must be live after the restart, not merely '
+              'readable');
+
+      await factory.close();
+    });
+
+    test('sqlite: records written before a restart survive it', () async {
+      const atSign = '@alice';
+      final storage = dir('sqlite_survives');
+      final factory = SqliteAtPersistenceFactory();
+      final config = SqlitePersistenceConfig(storagePath: storage);
+
+      var bundle = await factory.initialize(atSign, config);
+      await bundle.keyValueStore.put('before@alice', data('written-before'));
+      await factory.close();
+
+      bundle = await factory.initialize(
+          atSign, SqlitePersistenceConfig(storagePath: storage));
+      expect((await bundle.keyValueStore.get('before@alice'))?.data,
+          'written-before',
+          reason: 'the sqlite backend is reached by the same restart path and '
+              'must hold the same guarantee');
+      await factory.close();
+    });
+
+    test('the storage-conflict guard stays inert across restarts', () async {
+      // The guard added to initialize() throws when a factory already holds an
+      // open bundle for an atSign rooted somewhere else. A restart re-enters
+      // initialize() on the SAME factory instance, so if close() failed to
+      // clear what it holds, the second start would throw — and because
+      // restartServer does not await start(), that throw reaches the
+      // bootstrapper's zone handler and exits the process with status 0.
+      const atSign = '@alice';
+      final storage = dir('guard_inert');
+      final factory = HiveAtPersistenceFactory();
+
+      for (var restart = 0; restart < 3; restart++) {
+        final bundle = await factory.initialize(atSign, hiveConfig(storage));
+        await bundle.keyValueStore
+            .put('cycle$restart@alice', data('cycle-$restart'));
+        await factory.close();
+      }
+
+      final bundle = await factory.initialize(atSign, hiveConfig(storage));
+      for (var restart = 0; restart < 3; restart++) {
+        expect((await bundle.keyValueStore.get('cycle$restart@alice'))?.data,
+            'cycle-$restart',
+            reason: 'every cycle wrote to the same store, so every cycle\'s '
+                'record must still be readable from the last one');
+      }
+      await factory.close();
+    });
+
+    test('restarting does not accumulate Hive instances', () async {
+      // `HiveInstances._byPath` is static and outlives a restart by design.
+      // If a restart added instances rather than reusing them, a long-lived
+      // server would accrue one set per certificate rotation, each holding its
+      // own view of the same files — the divergence the per-path instances
+      // exist to prevent, arriving through the back door.
+      const atSign = '@alice';
+      final storage = dir('no_accumulate');
+      final factory = HiveAtPersistenceFactory();
+
+      await factory.initialize(atSign, hiveConfig(storage));
+      final afterFirstStart = HiveInstances.instanceCount;
+      // Identity, not just the count: a count cannot see an instance being
+      // REPLACED at the same key, and a replacement is the dangerous case —
+      // two live HiveImpl over one directory, each with its own in-memory view
+      // of the same files. Verified by mutation: a `_byPath[key] = HiveImpl()`
+      // that overwrites keeps the count identical and passes a count-only
+      // assertion.
+      final instanceForStorage = HiveInstances.forPath('$storage/hive');
+      await factory.close();
+
+      for (var restart = 0; restart < 3; restart++) {
+        await factory.initialize(atSign, hiveConfig(storage));
+        await factory.close();
+      }
+      expect(
+          identical(HiveInstances.forPath('$storage/hive'), instanceForStorage),
+          isTrue,
+          reason: 'one path means one instance, across a restart as much as '
+              'within a start — a replacement puts two views over one set of '
+              'files, which is the divergence per-path instances exist to '
+              'prevent');
+      expect(HiveInstances.instanceCount, afterFirstStart,
+          reason: 'and no path gained an instance either: a server that added '
+              'a set per certificate rotation would accrue them for as long as '
+              'it runs');
+      expect(afterFirstStart, greaterThan(0),
+          reason: 'the count must be non-zero, or the assertion above holds '
+              'trivially for a run that never opened anything');
+    });
+  });
+}

--- a/packages/at_secondary_server/lib/src/server/at_secondary_impl.dart
+++ b/packages/at_secondary_server/lib/src/server/at_secondary_impl.dart
@@ -180,9 +180,25 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
   /// day, and the `checkCertificateReload` modifiable config, which fires a
   /// forced check as soon as it is set. Both reach [stop]/[start] via
   /// `AtCertificateValidationJob.restartServer`, which does **not** await
-  /// [start] — so an exception thrown out of here on a restart has no caller
-  /// waiting to catch it, and the server is left stopped rather than crashing
-  /// visibly.
+  /// [start].
+  ///
+  /// That unawaited call does not mean an exception here goes unnoticed — it
+  /// means it arrives somewhere surprising. `SecondaryServerBootStrapper.run`
+  /// starts the first [start] inside a `runZonedGuarded`, and every timer,
+  /// cron and stream listener created during that start inherits the zone,
+  /// the certificate job's cron among them. So a throw from a restart-time
+  /// [start] has no `await` to propagate to and goes to the zone's error
+  /// handler instead, which passes anything that is not a `SocketException`
+  /// to `handleTerminateSignal`. That awaits [stop], finds `isRunning()`
+  /// false — a [start] that threw before reaching `_isRunning = true` never
+  /// set it — and calls `exit(0)`.
+  ///
+  /// **So a failed certificate-rotation restart terminates the process, with a
+  /// success status.** Under an orchestration policy of `restart: on-failure`
+  /// that reads as a deliberate shutdown and the atServer is not brought back.
+  /// Anything added here that can throw should be weighed against that, not
+  /// against the assumption that a restart failure leaves something running to
+  /// inspect.
   ///
   /// What that asks of anything added to this method: process-wide state that
   /// outlives [stop] must either be safe to pick up again as it is, or be torn

--- a/packages/at_secondary_server/lib/src/server/at_secondary_impl.dart
+++ b/packages/at_secondary_server/lib/src/server/at_secondary_impl.dart
@@ -166,6 +166,31 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
   /// Check various parameters required to start the secondary server. Invokes call to [_startSecuredServer] to start secondary server in secure mode and
   /// [_startUnSecuredServer] to start secondary server in un-secure mode.
   /// Throws [AtServerException] if exception occurs in starting the secondary server.
+  ///
+  /// ## This runs more than once per process
+  ///
+  /// [AtCertificateValidationJob] restarts the server **in process** when the
+  /// TLS certificates on disk have been replaced: it calls [stop] and then
+  /// [start] again on this same singleton. So a long-lived server may run this
+  /// method many times over its life, and everything it touches has to be
+  /// correct on the second and hundredth call, not only the first.
+  ///
+  /// Two things trigger that restart, and neither is under an operator's eye at
+  /// the time: a cron inside the job that looks for the restart file twice a
+  /// day, and the `checkCertificateReload` modifiable config, which fires a
+  /// forced check as soon as it is set. Both reach [stop]/[start] via
+  /// `AtCertificateValidationJob.restartServer`, which does **not** await
+  /// [start] — so an exception thrown out of here on a restart has no caller
+  /// waiting to catch it, and the server is left stopped rather than crashing
+  /// visibly.
+  ///
+  /// What that asks of anything added to this method: process-wide state that
+  /// outlives [stop] must either be safe to pick up again as it is, or be torn
+  /// down there. Persistence takes the second route — [stop] closes it through
+  /// `persistenceFactory.close()` and this method builds it again from
+  /// scratch — while [certificateReloadJob] deliberately takes the first, and
+  /// is created only when it is null so that the job driving the restart is not
+  /// replaced underneath itself.
   @override
   Future<void> start() async {
     pause();
@@ -788,6 +813,26 @@ class AtSecondaryServerImpl implements AtSecondaryServer {
 
   /// Removes all the active connections and stops the secondary server
   /// Throws [AtServerException] if exception occurs in stop the server.
+  ///
+  /// ## This is not only a shutdown — it is half of a restart
+  ///
+  /// [AtCertificateValidationJob] calls this and then [start] again on the same
+  /// singleton, in the same process, to pick up replaced TLS certificates. So
+  /// this method is usually followed by the server coming back, not by the
+  /// process ending, and it runs unattended: a cron checks for the restart file
+  /// twice a day, and setting the `checkCertificateReload` config forces a
+  /// check immediately.
+  ///
+  /// Anything acquired in [start] therefore has to be released here, or it
+  /// leaks once per certificate rotation and is still held when [start] runs
+  /// again. Timers, sockets, cron schedules, stream subscriptions and pooled
+  /// connections all count. Persistence is closed through
+  /// `persistenceFactory.close()` rather than left open, so the next [start]
+  /// builds a fresh bundle instead of inheriting a half-torn-down one.
+  ///
+  /// The exception is [certificateReloadJob] itself, which survives on purpose:
+  /// it is the thing calling this method, and [start] only creates one when it
+  /// is null.
   @override
   Future<void> stop() async {
     pause();

--- a/tests/at_functional_test/test/certs_reload_test.dart
+++ b/tests/at_functional_test/test/certs_reload_test.dart
@@ -1,9 +1,26 @@
+import 'dart:convert';
+
 import 'package:at_functional_test/conf/config_util.dart';
 import 'package:at_functional_test/connection/outbound_connection_wrapper.dart';
 import 'package:test/test.dart';
+import 'package:uuid/uuid.dart';
 
 void log(String prefix, String command, String response) {
   print('$prefix SENT ${command.padRight(45)} RCVD $response');
+}
+
+/// The commit id out of a `stats:3` response.
+///
+/// `stats` returns a list of `{"id":..,"name":..,"value":..}`, and `value` is
+/// itself a JSON string, so it needs decoding twice. Whether the inner decode
+/// yields an int or a String is a property of the server's encoder, not
+/// something to guess at from the outside, so this accepts either. Parsing the
+/// inner value directly as a String compiles cleanly whatever it is, because
+/// `jsonDecode` returns `dynamic`, and throws at runtime on the int branch.
+int commitIdFromStats(String statsResponse) {
+  final stats = jsonDecode(statsResponse.replaceAll('data:', '').trim());
+  final value = jsonDecode(stats[0]['value'].toString());
+  return value is int ? value : int.parse(value.toString());
 }
 
 void main() async {
@@ -69,6 +86,44 @@ void main() async {
   test('test soft restart', () async {
     String command, response;
 
+    /// A soft restart must come back on the SAME storage. It is an in-process
+    /// stop()/start() rather than a new container, so the whole persistence
+    /// stack is torn down and rebuilt from config while the process lives —
+    /// and a defect that re-roots it (a storage path that resolves to the
+    /// working directory, a cached bundle answering for another location)
+    /// throws nothing. The server comes back up looking healthy and serving an
+    /// empty store. Only records written before the restart and read after it
+    /// can tell the difference, so write one into each of the three stores
+    /// that are rebuilt independently, under a run-unique id.
+    final String uniqueId = Uuid().v4().hashCode.toString();
+    final String keyName = 'restart-probe-$uniqueId';
+    final String keyValue = 'value-$uniqueId';
+
+    /// 1. Keystore, and with it the commit log.
+    command = 'update:public:$keyName$atSign $keyValue';
+    response = await firstAtSignConnection.sendRequestToServer(command);
+    log('', command, response);
+    expect(response, startsWith('data:'),
+        reason: 'the record this test is about must actually be created, or '
+            'the assertion after the restart proves nothing');
+
+    /// 2. The commit log's own sequence, which lives in a separate box under a
+    /// separate path and so can be re-rooted on its own. A sequence that
+    /// restarted from zero would make every client resync from scratch.
+    command = 'stats:3';
+    response = await firstAtSignConnection.sendRequestToServer(command);
+    log('', command, response);
+    final int commitIdBeforeRestart = commitIdFromStats(response);
+
+    /// 3. Notification keystore — a third box, a third path.
+    command =
+        'notify:update:messageType:key:ttr:-1:$atSign:$keyName$atSign:$keyValue';
+    response = await firstAtSignConnection.sendRequestToServer(command);
+    log('', command, response);
+    expect(response, startsWith('data:'),
+        reason: 'the notification must be accepted before the restart, or its '
+            'absence afterwards would say nothing');
+
     /// Create the 'restart' file to indicate that the server should restart
     command = 'config:set:shouldReloadCertificates=true';
     response = await firstAtSignConnection.sendRequestToServer(command);
@@ -127,6 +182,46 @@ void main() async {
         await Future.delayed(Duration(seconds: 2));
       }
     }
+
+    /// The server is back. Everything below is deliberately OUTSIDE the
+    /// reconnect loop above, whose `catch` would otherwise swallow a failed
+    /// expectation and retry it until the loop happened to pass.
+    ///
+    /// This is the part that proves the restart came back on the same storage
+    /// rather than merely coming back.
+    String authResponse = await firstAtSignConnection.authenticateConnection();
+    expect(authResponse, 'data:success',
+        reason: 'the assertions below need an authenticated connection, so a '
+            'failure here must not be read as the records being gone');
+
+    /// 1. The keystore record, by VALUE. A fresh store would answer
+    /// "key not found"; a store rooted elsewhere would too.
+    command = 'llookup:public:$keyName$atSign';
+    response = await firstAtSignConnection.sendRequestToServer(command);
+    log('', command, response);
+    expect(response, 'data:$keyValue',
+        reason: 'a record written before the restart must still be readable '
+            'after it, with the value it was written with — that is what '
+            'makes this the same storage and not a new one');
+
+    /// 2. The commit log carried on rather than starting again.
+    command = 'stats:3';
+    response = await firstAtSignConnection.sendRequestToServer(command);
+    log('', command, response);
+    final int commitIdAfterRestart = commitIdFromStats(response);
+    expect(commitIdAfterRestart, greaterThanOrEqualTo(commitIdBeforeRestart),
+        reason: 'the commit log is a separate box under a separate path; a '
+            'sequence that went backwards would mean it was rebuilt empty, '
+            'and every client would resync the whole atSign');
+
+    /// 3. The notification, still in its own store.
+    command = 'notify:list';
+    response = await firstAtSignConnection.sendRequestToServer(command);
+    log('', command, response);
+    expect(response, contains(keyName),
+        reason: 'the notification keystore is the third of three stores torn '
+            'down and rebuilt by the restart, and it can be re-rooted '
+            'independently of the other two');
   });
 
   tearDown(() async {


### PR DESCRIPTION
**- Why**

**This is for at_client, not for the atServer.** It paves the way for an application to run several `AtClientImpl`s at once, for the same atSign but _different enrollmentIds_, each with its own storage, safely. 

Note: (1) there has never been a problem with separate storage for different atSigns; and (2) what this change enables (same atSign, multiple enrollments, running at the same time in the same app) is highly unlikely to ever be a production requirement - but it is **_extremely_** useful for test harnesses.

It could not do that today for the same atSign. A store ignored the `storagePath` it was given: two stores for one atSign in one process always resolved to the same Hive box, however different the paths they were handed. The second silently attached to the first's, and the failure was not an error — it was a client reading its own stale value after a sibling had written, each side internally consistent and neither able to tell.

The fix is in `at_persistence_secondary_server`, which the atServer also depends on. **So the second half of this PR is about proving the atServer is unaffected**: the storage identity work is a handful of files, and most of what follows is the tests establishing that nothing the atServer does has moved — including its in-process restart on certificate rotation, which is now checked end to end for the first time.

**- What I did**

Box lifecycle and type-adapter registration now run on a Hive instance owned by the storage path rather than on the one global instance `package:hive` exposes, and the factory above them stops ignoring the paths it is handed.

`+1474/−45` — 822 test, 598 lib (62 of them dartdoc-only), 54 CHANGELOG. The split below follows the two questions a reviewer of this PR actually has.

---

# Part 1 — Is the atServer affected?

**No working atServer configuration changes behaviour.** This is the half of the PR that matters most to review, so it is first, and it is argued from measurements rather than from the diff.

**What cannot have moved.** Every store keeps the exact directory it was already given. The atServer's four (`storage/hive`, `storage/commitLog`, `storage/accessLog`, `storage/notificationLog.v1`) now own a Hive instance each instead of sharing the one global instance — **no box is renamed, no path is recomputed, and no data moves.** The change is which *registry* a box is opened in, not where its bytes live.

**What the atServer never reaches.** Three of the new mechanisms are unreachable from a running server, which bounds the review surface:

- `HiveInstances.closeAll()` / `closeFor()` have **no production caller anywhere in this repo** — the only references are the package's own test file. The server's teardown is `persistenceFactory.close()`.
- Consequently `forPath`'s mid-close `StateError` cannot fire on a server: `_closing` is never populated.
- Nothing in the server process opens a box on the global Hive. The single `Hive.` reference in `at_secondary_server` is `bin/hive_main.dart`, a standalone offline dump tool that passes an explicit `path:`.

**The soft restart, which is where a storage change would do its damage.** `AtCertificateValidationJob` restarts the server **in process** on certificate rotation — `stop()`, then `start()` again on the same singleton, unattended. That path was never covered. It is now, at both levels, and an adversarial review drove it end to end against a real bootstrapper, TLS socket and persistence for **all three backends** (hive, sqlite, dual) across `start → stop → start → stop → start`: no throw, records written before each restart still readable after, commit-log sequence advancing, `HiveInstances.instanceCount` steady, no boxes or `.lock` files retained across a `stop()`.

The new conflict guard cannot fire there either, and for a reason worth checking rather than trusting: `stop()` closes persistence through `persistenceFactory.close()`, which clears both `_bundles` and `_configs` **before** closing any bundle, so the second `start()` misses the cache entirely and never consults the comparison.

**The three behaviour changes a server could in principle see**, each stated as what it does rather than as what it prevents:

| change | effect on a running atServer |
|---|---|
| two stores for one atSign at *different* paths are now separate | none — the atServer's four paths are distinct and were never the colliding case |
| a factory asked for an atSign it already holds *somewhere else* now refuses | none — storage paths are frozen per process, and the migration path builds a fresh factory per side |
| an empty storage path now throws `ArgumentError` | a misconfigured server still fails to start, as it did on trunk — earlier, and with a named error instead of a `PathNotFoundException` at box open |

**The one thing added *for* the atServer** is a warning label, in `at_secondary_impl.dart` — dartdoc only, 62 added lines, every one a `///`, none removed. `start()` and `stop()` run **more than once per process**. `AtCertificateValidationJob` restarts the server in place when the certificates on disk have been replaced — unattended, off a cron that looks for the restart file twice a day, or as soon as `config:set:checkCertificateReload=true` is set. State acquired in `start()` and not released in `stop()` therefore leaks once per rotation and is still held when `start()` runs again.

Recorded there because it bounds what may safely throw in `start()`: the restart's `start()` is not awaited, its error reaches the bootstrapper's `runZonedGuarded`, and anything that is not a `SocketException` goes to `handleTerminateSignal` → **`exit(0)`**. A failed certificate rotation terminates the process with a *success* status, which under `restart: on-failure` is not brought back.

---

# Part 2 — What changed to deliver the at_client enablement

Every production hunk that decides anything, hardest first; the rest is in the skip list.

---

**1. `hive_base.dart` — box calls leave the global Hive.** A Hive box's identity is `(instance registry, box name)`, and both the registry and the home path are *instance* fields of `HiveImpl`; `package:hive` exposes one global instance (`final HiveInterface Hive = HiveImpl();`). So the path went into a process-wide setting the next store overwrote, and the box was opened by name alone.

```dart
// before
Future<void> init(String storagePath, {bool isLazy = true}) async {
  this.storagePath = storagePath;
  Hive.init(storagePath);              // global, last writer wins
}
Future<void> openBox(String boxName, ...) async {
  await Hive.openBox(_boxName, ...);   // no path:, global registry
}
BoxBase getBox() => Hive.box(_boxName);
```

The mixin holds the instance that owns its path, and every box call goes through it.

```dart
// after
late HiveInterface hive;               // not `late final`: init is idempotent
hive = HiveInstances.forPath(storagePath);
await hive.openBox(_boxName, ...);
BoxBase getBox() => hive.box(_boxName);
```

---

**2. `hive_instances.dart` (new) — one instance per path, *shared*.** This is the judgement to check. Two instances over one directory neither throw nor lock each other out: they open two independent boxes over the same files whose in-memory views then diverge silently — measured, after a write through the second the first still read its own older value.

```dart
// the alternative, rejected: an instance per store
static HiveInterface forPath(String p) => HiveImpl()..init(p);
```

Shared per canonical path, so same-path callers stay on exactly one box — which is what they have always had.

```dart
// after
static HiveInterface forPath(String storagePath) {
  final key = canonicalPathFor(storagePath);
  if (_closing.containsKey(key)) {
    throw StateError('The Hive instance for "$key" is being closed. Await ...');
  }
  return _byPath.putIfAbsent(key, () => HiveImpl()..init(key));
}
```

---

**3. `hive_instances.dart` — a path is matched by where it actually is.** A link and its target must be one instance, or the divergence above returns under a different spelling.

```dart
// the shape to avoid: pure string work, does not follow symlinks
static String canonicalPathFor(String p) => path.canonicalize(p);
```

Resolved on the filesystem — which means creating the directory, since an unresolvable path can only be keyed lexically and a caller arriving before it existed would key differently from one arriving after.

```dart
// after
if (storagePath.trim().isEmpty) {
  throw ArgumentError.value(storagePath, 'storagePath', 'must not be empty or blank');
}
final dir = Directory(storagePath);
if (!dir.existsSync()) {
  if (!create) return p.canonicalize(storagePath);   // the close path: must not write
  dir.createSync(recursive: true);
}
return p.canonicalize(dir.resolveSymbolicLinksSync());
// FileSystemException -> lexical fallback, logged: it reopens the symlink hole for that path
```

⚠️ **The empty-path guard is load-bearing, not defensive**, and it is the one thing here worth an operator's attention. Without it: `createSync('')` throws `PathNotFoundException`, which *is* a `FileSystemException`, so the fallback catches it and `p.canonicalize('')` returns the **process working directory**. The server would then start with its boxes in the image layer rather than the mounted volume — and, because the encryption-secret file is built from the raw path and so lands at `/<sha>.hash` where the non-root server user cannot write it, and that failure is already swallowed, with an **unencrypted** keystore. An unset `${STORAGE_PATH}` interpolated into a manifest arrives as an empty string, not as absent, and the config getter tests only for null. On trunk this aborted the start at box open, so the guard restores a loud refusal rather than adding one.

---

**4. `hive_instances.dart` — teardown.** A global `Hive.close()` closes the boxes in the global registry; boxes opened here are not in it. They stay open over a directory the teardown then deletes, and the next open returns the cached box with its stale contents — a write appears to succeed and the read after it returns the previous run's value.

```dart
// the shape to avoid: the map cleared before the closes are awaited
_byPath.clear();
for (final hive in instances) { await hive.close(); }
```

The entry is dropped in a `finally`, only once its close has completed, and `forPath` refuses that path meanwhile (the `StateError` in **2**) — clearing up front lets a caller arriving during the await build a second instance over a directory the first is still closing, and handing back the closing instance is no better.

```dart
// after
static Future<void> _closeKey(String key) async {
  final close = hive.close();
  _closing[key] = close;
  try { await close; } finally { _closing.remove(key); _byPath.remove(key); }
}
```

⚠️ **Consumer-visible, and not a swap:** a teardown needs `HiveInstances.closeAll()` **as well as** `Hive.close()`. Boxes a consumer opens on the global instance are still in the global registry and still collide by name.

---

**5. The three factories — `initialize` stops ignoring the paths it is handed.** `AtPersistenceFactory` caches one bundle per atSign and, on a cache hit, returned it without ever reading the config — so for any caller reaching storage through a shared factory, everything above never ran.

```dart
// before — the Hive and SQLite factories (the dual one is the same, without the stale-entry drop)
final existing = _bundles[atSign];
if (existing != null) {
  if (!existing.isClosed) return existing;   // config, and its storagePath, never consulted
  _bundles.remove(atSign);
}
```

The remedy is a refusal rather than a second bundle, because `bundleFor`/`closeFor` key on the atSign alone and the interface has nowhere to put one.

```dart
// after
if (!existing.isClosed) {
  final held = _configs[atSign];
  if (held != null && !sameStorageLocations(held, config)) {
    throw conflictingStorageError(factory: '…', atSign: atSign, held: held, requested: config);
  }
  return existing;
}
```

⚠️ **The dual factory compares — and reports — its two arms separately, and must do both.** `DualWritePersistenceConfig` delegates every path getter to its `primary`, so the wrapper agrees while the **secondary** has moved; and a message built from the wrapper finds no difference and prints the primary's path as *both* sides, giving "at X, and was asked for one at X" for exactly the case the check exists to catch. It raises against the differing arm, labelled `(primary arm)` / `(secondary arm)`.

---

**6. `persistence_config_identity.dart` (new) — the comparison must not fail open.** It decides whether two configs name the same place, so its failure direction is the whole point.

```dart
// the shape to avoid — reads correctly, and is wrong
return _resolved(a) == _resolved(b);
```

An unresolvable path resolves to `null`, so two unrelated *absent* roots compared equal: paths that had already disagreed lexically were declared the same location and the guard was skipped.

```dart
// after
if (resolvedA == null || resolvedB == null) return false;
return resolvedA == resolvedB;
```

`backendMarkerPath` is deliberately **not** among the compared locations: both config classes derive it from `storagePath` and nothing in the server sets it, and as a *file* that does not exist until a backend is chosen it could only manufacture false refusals — it did, breaking the symlink case the moment the resolve arm was corrected.

---

**7. `hive_at_notification_keystore.dart` — adapter registration leaves the constructor.** `TypeRegistry` is per-instance, so an adapter registered on the global is invisible to a box opened here and the box cannot decode its own contents. Registration ran in the constructor — before `init` has chosen an instance — behind a `static` "already done in this process" flag, which would leave every instance after the first with none.

```dart
// before
HiveAtNotificationKeystore(this.currentAtSign, {...}) {
  if (!_typesRegistered) {
    Hive.registerAdapter(AtNotificationAdapter());
    ...
    _typesRegistered = true;                 // static
  }
}
```

Moved into `initialize()`, and the static flag deleted rather than replaced — `isAdapterRegistered` is per-instance and answers the question correctly.

```dart
// after
void _registerAdapters() {
  if (!hive.isAdapterRegistered(AtNotificationAdapter().typeId)) {
    hive.registerAdapter(AtNotificationAdapter());
  }
  ... one call per adapter, deliberately
}
```

⚠️ **The repetition is load-bearing and there is a comment saying so.** `registerAdapter<T>` infers `T` from the argument at each call site. Looping these through a `List<TypeAdapter>` erases that, so adapters register under the wrong type and writes dispatch to the wrong one — it compiles, and fails at runtime inside `AtNotificationAdapter.write` with a `TypeError` such as *type 'MessageType' is not a subtype of type 'AtNotification'*.

---

**8. `hive_base.dart` — the global `Hive.init` call is kept, deliberately.**

```dart
// unchanged — the only added lines in this hunk are the comment explaining why
Hive.init(storagePath);
```

Consumers outside this package rely on this call having happened as a side effect of keystore initialisation, and open their own boxes on the global instance; removing it breaks at_client's suite. Two consequences a reviewer should hold: a box a consumer opens on the global instance still collides by name, and **file-level** operations there act behind the per-path registry's back — a global `deleteBoxFromDisk` deletes files out from under an open per-path box, which is why `tearDownFunc` in `hive_keystore_impl_test.dart` is re-pointed through `HiveInstances.forPath('test/hive')`.

---

**9. `at_persistence_factory.dart` — the contract.** It promised the cache hit without qualifying it.

```dart
// before
/// Calling this twice for the same atSign returns the **same**
/// bundle — the factory owns the per-atSign lifecycle.
```

Now states the refusal, why one bundle per atSign is structural rather than incidental, and that two spellings of one location are one location.

```dart
// after
/// Calling this twice for the same atSign **with the same storage
/// locations** returns the same bundle … Calling it for an atSign that
/// already has an open bundle rooted somewhere else throws a [StateError].
```

---

**Skip list**

- `hive_access_log_keystore.dart`, `hive_at_keyvalue_store.dart`, `hive_commit_log_keystore.dart` — 12 lines, the same mechanical `Hive.` → `hive.` swap on adapter registration. Nothing to judge. (`Hive.generateSecureKey()` stays global: stateless.)
- `lib/hive.dart` — one line, exporting `HiveInstances`; a teardown outside this package needs `closeAll()` and the only other route is a `src/impl/hive/…` implementation import.
- `test/*` (822 lines) — the review surface is named below.
- `CHANGELOG.md` — folded under the existing unpublished 5.3.0 heading; no version bump.

**- How I did it**

See commit & diffs.

**- How to verify it**

Tests pass. The review surface, split by which of the two questions each file answers:

**Part 1 — the atServer is unaffected**

| file | what it pins |
|---|---|
| `tests/at_functional_test/test/certs_reload_test.dart` | the soft-restart case writes a run-unique record into the keystore, the commit log and the notification keystore, triggers a real certificate-rotation restart, and reads all three back **by value** — so "a soft restart comes back on the same storage" is checked on every PR |
| `test/persistence_restart_cycle_test.dart` (4) | the same at unit level: records survive `close()` → `initialize()` on one factory, the commit sequence does not go backwards, one path keeps one instance across restarts, Hive and SQLite both |

**Part 2 — the enablement is correct**

| file | what it pins |
|---|---|
| `test/hive_instances_test.dart` (9) | one path is one instance — across spellings, symlinks, and a path that did not exist yet; an empty path refused; closing does not create |
| `test/persistence_factory_storage_path_test.dart` (10) | the factory refuses a second location per backend and names the arm that moved, and does *not* refuse a caller doing nothing wrong |

Every assertion is mutation-proven individually. Three were rewritten because mutation showed they proved nothing: `bundleFor` returns null after `close()` whether or not `close()` cleared anything, and an instance *count* cannot see an instance replaced at the same key.

The third is worth naming as a shape, because it looked like coverage and was not: **the assertion landed on the sibling that happened to be correct.** The refusal message was asserted for the Hive factory, where it worked; the dual factory — the one whose message was broken, and the case the fix existed for — was asserted only to *throw*. The gap sat exactly between the type whose message was checked and the type whose message was wrong, and no amount of re-reading either test would have shown it. Both are now asserted.

`at_persistence_secondary_server` **369 → 392, exit 0**; `at_secondary_server` **1098, exit 0**; `dart analyze --fatal-warnings` **exit 0** on both packages and on `tests/at_functional_test` and `tests/at_end2end_test`, with no analyzer finding introduced by this branch; the functional pack **239, exit 0** against a live virtualenv.

**- Description for the changelog**

`at_persistence_secondary_server`: a store, and the factory that builds it, honour the `storagePath` they are given. Box lifecycle and type-adapter registration run on a per-path Hive instance instead of the package-global one, so two stores for one atSign in one process no longer share a box; a factory asked for an atSign it already holds somewhere else refuses instead of silently answering from the first location; and an empty storage path is refused rather than resolving to the process working directory. Callers keep the exact directories they already had — nothing renamed, no data moved.


