### PR TITLE
fix(ee): unbreak the EE and VE base images, and build an EE from the working tree

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,19 @@
+# Build outputs that `docker build` would otherwise copy into the image's
+# build stage at exactly the paths the compile step writes.
+#
+# `tests/at_functional_test/runLocal.sh` compiles the atDirectory and atServer
+# on the host (inside a Linux dart container, so they are Linux ELF binaries
+# indistinguishable from the ones the image builds) and leaves them here. Both
+# EE and VE Dockerfiles `COPY . .` into /app and then compile over them, so a
+# compile that fails leaves the host's build in place and the image ships it —
+# a stale atServer that looks entirely healthy.
+#
+# Anchored to the two exact paths: a `**/root` pattern would also exclude
+# tools/build_ephemeral_environment/ee_base/contents/atsign/root, which the
+# image genuinely needs.
+/packages/at_root_server/root
+/packages/at_secondary_server/secondary
+
+# Host tool state. Every path inside is absolute and belongs to the host, so it
+# is meaningless in the image; `dart pub get` regenerates what it needs.
+**/.dart_tool/

--- a/tools/build_ephemeral_environment/buildee.sh
+++ b/tools/build_ephemeral_environment/buildee.sh
@@ -8,9 +8,16 @@
 # the atServer or the atDirectory needs an image built from the branch they are
 # on, and needs to be able to prove that is what they got.
 #
-# Usage: buildee.sh [-t <tag>] [-q]
+# Usage: buildee.sh [-t <tag>] [-p <platform>] [-q]
 #   -t   image tag to produce (default: at_ephemeral:local)
+#   -p   platform to build for (default: the host's)
 #   -q   quieter docker output
+#
+# -p exists because a base-image pin can stop resolving for your architecture
+# without anything in this repo changing. If a build dies at "no match for
+# platform in manifest", check the pinned digest actually carries your platform
+# (`docker buildx imagetools inspect <image>@<digest>`) before assuming
+# emulation is the answer.
 #
 # The image is labelled with the commit it was built from, and the build is
 # verified afterwards by reading that label back and confirming the three
@@ -20,13 +27,15 @@
 set -euo pipefail
 
 TAG="at_ephemeral:local"
+PLATFORM=""
 PROGRESS="auto"
 
-while getopts ":t:qh" opt; do
+while getopts ":t:p:qh" opt; do
   case "$opt" in
     t) TAG="$OPTARG" ;;
+    p) PLATFORM="$OPTARG" ;;
     q) PROGRESS="plain" ;;
-    h) sed -n '2,20p' "$0"; exit 0 ;;
+    h) sed -n '2,25p' "$0"; exit 0 ;;
     \?) echo "buildee.sh: unknown option -$OPTARG" >&2; exit 2 ;;
     :) echo "buildee.sh: -$OPTARG needs an argument" >&2; exit 2 ;;
   esac
@@ -53,6 +62,8 @@ echo "  repo   : $REPO"
 echo "  branch : $BRANCH"
 echo "  commit : $REV$DIRTY"
 echo "  tag    : $TAG"
+HOST_PLATFORM=$(docker version --format '{{.Server.Os}}/{{.Server.Arch}}')
+echo "  platform: ${PLATFORM:-$HOST_PLATFORM (host default)}"
 echo
 
 # The .dockerignore keeps the host's own build outputs out of the context, so
@@ -65,11 +76,18 @@ for stale in packages/at_root_server/root packages/at_secondary_server/secondary
   fi
 done
 
+PLATFORM_ARGS=()
+if [[ -n "$PLATFORM" ]]; then
+  PLATFORM_ARGS=(--platform "$PLATFORM")
+fi
+
 docker build \
+  "${PLATFORM_ARGS[@]}" \
   --progress="$PROGRESS" \
   --label "org.opencontainers.image.revision=$REV" \
   --label "org.opencontainers.image.source=at_server" \
   --label "com.atsign.ee.branch=$BRANCH" \
+  --label "com.atsign.ee.platform=${PLATFORM:-$HOST_PLATFORM}" \
   -t "$TAG" \
   -f "$DOCKERFILE" \
   . || { echo "buildee.sh: docker build failed" >&2; exit 1; }
@@ -87,7 +105,7 @@ echo "  revision label matches HEAD"
 
 # `file` is not installed in the slim image, so read the ELF magic directly:
 # four bytes, 0x7f 'E' 'L' 'F'. A placeholder or a truncated copy fails this.
-docker run --rm "$TAG" /bin/sh -c '
+docker run --rm "${PLATFORM_ARGS[@]}" "$TAG" /bin/sh -c '
   set -e
   fail=0
   for f in /atsign/root/root /atsign/secondary/secondary /usr/local/bin/at_activate; do
@@ -103,7 +121,7 @@ docker run --rm "$TAG" /bin/sh -c '
 ' || { echo "buildee.sh: the image does not contain the three built artefacts" >&2; exit 1; }
 
 echo
-echo "Built $TAG from $BRANCH @ ${REV:0:9}"
+echo "Built $TAG from $BRANCH @ ${REV:0:9} for ${PLATFORM:-$HOST_PLATFORM}"
 echo
 echo "Run it with:"
 echo "  tools/build_ephemeral_environment/runee.sh <name> <base-port> $TAG"

--- a/tools/build_ephemeral_environment/buildee.sh
+++ b/tools/build_ephemeral_environment/buildee.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+#
+# buildee.sh — build an ephemeral environment (EE) image from THIS working
+# tree, rather than pulling the published atsigncompany/ephemeral image.
+#
+# runee.sh and docker-compose.yaml both name atsigncompany/ephemeral:latest,
+# which CI builds from the most recent release tag. Anyone testing a change to
+# the atServer or the atDirectory needs an image built from the branch they are
+# on, and needs to be able to prove that is what they got.
+#
+# Usage: buildee.sh [-t <tag>] [-q]
+#   -t   image tag to produce (default: at_ephemeral:local)
+#   -q   quieter docker output
+#
+# The image is labelled with the commit it was built from, and the build is
+# verified afterwards by reading that label back and confirming the three
+# artefacts exist and are executables. See "Why the verification is not
+# paranoia" at the bottom.
+
+set -euo pipefail
+
+TAG="at_ephemeral:local"
+PROGRESS="auto"
+
+while getopts ":t:qh" opt; do
+  case "$opt" in
+    t) TAG="$OPTARG" ;;
+    q) PROGRESS="plain" ;;
+    h) sed -n '2,20p' "$0"; exit 0 ;;
+    \?) echo "buildee.sh: unknown option -$OPTARG" >&2; exit 2 ;;
+    :) echo "buildee.sh: -$OPTARG needs an argument" >&2; exit 2 ;;
+  esac
+done
+
+REPO=$(git rev-parse --show-toplevel)
+cd "$REPO"
+
+DOCKERFILE="tools/build_ephemeral_environment/ee_base/Dockerfile"
+[[ -f "$DOCKERFILE" ]] || { echo "buildee.sh: no $DOCKERFILE under $REPO" >&2; exit 1; }
+
+REV=$(git rev-parse HEAD)
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+# A dirty tree is legitimate — it is usually the whole point — but the label
+# would then name a commit the image does not contain, so say so.
+DIRTY=""
+if [[ -n "$(git status --porcelain)" ]]; then
+  DIRTY=" (working tree has uncommitted changes; the image contains them, the label does not name them)"
+fi
+
+echo "Building EE image"
+echo "  repo   : $REPO"
+echo "  branch : $BRANCH"
+echo "  commit : $REV$DIRTY"
+echo "  tag    : $TAG"
+echo
+
+# The .dockerignore keeps the host's own build outputs out of the context, so
+# a compile failure cannot be masked by a stale binary at the same path. Say
+# out loud whether they are present, because their absence from the image is
+# what the ignore file is buying and a reader should not have to infer it.
+for stale in packages/at_root_server/root packages/at_secondary_server/secondary; do
+  if [[ -e "$stale" ]]; then
+    echo "note: $stale exists on the host and is excluded from the build context"
+  fi
+done
+
+docker build \
+  --progress="$PROGRESS" \
+  --label "org.opencontainers.image.revision=$REV" \
+  --label "org.opencontainers.image.source=at_server" \
+  --label "com.atsign.ee.branch=$BRANCH" \
+  -t "$TAG" \
+  -f "$DOCKERFILE" \
+  . || { echo "buildee.sh: docker build failed" >&2; exit 1; }
+
+echo
+echo "Verifying the image is the one this tree just built"
+
+BUILT_REV=$(docker image inspect --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' "$TAG")
+if [[ "$BUILT_REV" != "$REV" ]]; then
+  echo "buildee.sh: $TAG reports revision '$BUILT_REV', expected '$REV'." >&2
+  echo "            docker reused an image built from another commit." >&2
+  exit 1
+fi
+echo "  revision label matches HEAD"
+
+# `file` is not installed in the slim image, so read the ELF magic directly:
+# four bytes, 0x7f 'E' 'L' 'F'. A placeholder or a truncated copy fails this.
+docker run --rm "$TAG" /bin/sh -c '
+  set -e
+  fail=0
+  for f in /atsign/root/root /atsign/secondary/secondary /usr/local/bin/at_activate; do
+    if [ ! -f "$f" ]; then echo "  MISSING  $f"; fail=1; continue; fi
+    magic=$(head -c 4 "$f" | od -An -tx1 | tr -d " \n")
+    size=$(wc -c < "$f")
+    if [ "$magic" != "7f454c46" ]; then
+      echo "  NOT AN EXECUTABLE  $f (magic $magic, $size bytes)"; fail=1; continue
+    fi
+    echo "  ok  $f  ($size bytes)"
+  done
+  exit $fail
+' || { echo "buildee.sh: the image does not contain the three built artefacts" >&2; exit 1; }
+
+echo
+echo "Built $TAG from $BRANCH @ ${REV:0:9}"
+echo
+echo "Run it with:"
+echo "  tools/build_ephemeral_environment/runee.sh <name> <base-port> $TAG"
+echo
+echo "Remember -e DNS_FQDN=<name> if you are not on a build that carries the"
+echo "createConf.sh DNS_FQDN fix: without it every atServer's root_server.url"
+echo "is the literal string DNS_FQDN and no atSign can look up any other."
+
+# Why the verification is not paranoia
+# -----------------------------------
+# Two things this build used to do quietly, both fixed in this tree but not in
+# any published image:
+#
+#   * the RUN chain separated its steps with `;`, so only the last command's
+#     exit status reached Docker and a failed compile still produced an image;
+#   * there was no .dockerignore, so `COPY . .` carried the host's own
+#     packages/at_root_server/root and packages/at_secondary_server/secondary
+#     into the build stage at exactly the paths the compile writes. Those are
+#     built by tests/at_functional_test/runLocal.sh inside a Linux container,
+#     so they are ELF binaries of the right architecture: they run, and the
+#     container looks healthy.
+#
+# The failure mode was therefore an EE that served an atServer from whatever
+# branch happened to have been functional-tested last, with nothing anywhere
+# saying so. Reading the revision label back is what makes "I built this from
+# my branch" a measurement rather than an assumption.

--- a/tools/build_ephemeral_environment/ee_base/Dockerfile
+++ b/tools/build_ephemeral_environment/ee_base/Dockerfile
@@ -8,20 +8,20 @@ WORKDIR /app
 ## -f tools/build_virtual_environment/ee_base/Dockerfile .
 COPY . .
 RUN \
-  cd /app/packages/at_root_server ; \
-  dart pub get ; \
-  dart pub update ; \
-  dart compile exe bin/main.dart -o root ; \
-  cd /app/packages/at_persistence_secondary_server ; \
-  dart pub get ; \
-  dart pub update ; \
-  cd /app/packages/at_secondary_server ; \
-  dart pub get ; \
-  dart pub update ; \
-  dart compile exe bin/main.dart -o secondary; \
-  cd /app/tools/build_ephemeral_environment/at_activate ; \
-  dart pub get ; \
-  dart pub update ; \
+  cd /app/packages/at_root_server && \
+  dart pub get && \
+  dart pub update && \
+  dart compile exe bin/main.dart -o root && \
+  cd /app/packages/at_persistence_secondary_server && \
+  dart pub get && \
+  dart pub update && \
+  cd /app/packages/at_secondary_server && \
+  dart pub get && \
+  dart pub update && \
+  dart compile exe bin/main.dart -o secondary && \
+  cd /app/tools/build_ephemeral_environment/at_activate && \
+  dart pub get && \
+  dart pub update && \
   dart compile exe bin/at_activate.dart -o at_activate
 
 FROM debian:stable-20260824-slim@sha256:eb37f58646a901dc7727cf448cae36daaefaba79de33b5058dab79aa4c04aefb

--- a/tools/build_ephemeral_environment/ee_base/Dockerfile
+++ b/tools/build_ephemeral_environment/ee_base/Dockerfile
@@ -24,7 +24,7 @@ RUN \
   dart pub update && \
   dart compile exe bin/at_activate.dart -o at_activate
 
-FROM debian:stable-20260824-slim@sha256:eb37f58646a901dc7727cf448cae36daaefaba79de33b5058dab79aa4c04aefb
+FROM debian:stable-20260824-slim@sha256:04634311a8d5fc442b6eb06d792293c4f3e2268652ca7634e00ce8ef5cc0a28a
 # was debian:stable-20221114-slim
 USER root
 

--- a/tools/build_ephemeral_environment/ee_base/contents/tmp/setup/createConf.sh
+++ b/tools/build_ephemeral_environment/ee_base/contents/tmp/setup/createConf.sh
@@ -13,7 +13,7 @@ if [ -n "${DNS_FQDN+1}" ]; then
 else
   echo "\$DNS_FQDN is not set, setting to default"
   DNS_FQDN="vip.ve.atsign.zone"
-  sed -i 's/DNS_FQN/'$DNS_FQDN'/g' /atsign/secondary/base/config/config.yaml
+  sed -i 's/DNS_FQDN/'$DNS_FQDN'/g' /atsign/secondary/base/config/config.yaml
   echo "\$DNS_FQDN is set to $DNS_FQDN"
 fi
 

--- a/tools/build_ephemeral_environment/runee.sh
+++ b/tools/build_ephemeral_environment/runee.sh
@@ -3,7 +3,10 @@
 # runee.sh — bring up an ephemeral environment (EE) container with port-
 # shifted services so multiple EEs can run side-by-side on one host.
 #
-# Usage: runee.sh <container-name> <base-port>
+# Usage: runee.sh <container-name> <base-port> [image-tag]
+#
+# image-tag defaults to the published atsigncompany/ephemeral:latest. Pass the
+# tag buildee.sh produced to run an EE built from this working tree instead.
 #
 # The container will bind:
 #   atDirectory  -> <base>
@@ -14,13 +17,14 @@
 
 set -euo pipefail
 
-if [[ $# -ne 2 ]]; then
-  echo "usage: runee.sh <container-name> <base-port>" >&2
+if [[ $# -lt 2 || $# -gt 3 ]]; then
+  echo "usage: runee.sh <container-name> <base-port> [image-tag]" >&2
   exit 2
 fi
 
 NAME=$1
 BASE=$2
+IMAGE=${3:-atsigncompany/ephemeral:latest}
 
 if [[ ! "$BASE" =~ ^[0-9]+$ ]]; then
   echo "base-port must be numeric (got: $BASE)" >&2
@@ -44,13 +48,19 @@ name: ${NAME}
 services:
   ephemeral:
     container_name: ${NAME}
-    image: atsigncompany/ephemeral:latest
+    image: ${IMAGE}
     ports:
       - '127.0.0.1:${BASE}-${TOP}:${BASE}-${TOP}'
     extra_hosts:
       - 'vip.ve.atsign.zone:127.0.0.1'
     environment:
       - EPHEMERAL_BASE_PORT=${BASE}
+      # Named explicitly rather than left to createConf.sh's default branch,
+      # which until recently substituted a placeholder that is not in
+      # config.yaml — leaving every atServer's root_server.url as the literal
+      # string DNS_FQDN, so no atSign could look up any other. Passing it here
+      # makes runee.sh correct against published images too.
+      - DNS_FQDN=vip.ve.atsign.zone
 EOF
 
 docker compose -f "$COMPOSE_FILE" up -d

--- a/tools/build_virtual_environment/ve_base/Dockerfile
+++ b/tools/build_virtual_environment/ve_base/Dockerfile
@@ -17,7 +17,7 @@ RUN \
   dart pub update ; \
   dart compile exe bin/install_PKAM_Keys.dart -o install_PKAM_Keys
 
-FROM debian:stable-20260824-slim@sha256:eb37f58646a901dc7727cf448cae36daaefaba79de33b5058dab79aa4c04aefb
+FROM debian:stable-20260824-slim@sha256:04634311a8d5fc442b6eb06d792293c4f3e2268652ca7634e00ce8ef5cc0a28a
 # was debian:stable-20221114-slim
 USER root
 


### PR DESCRIPTION
Build tooling only — no package code. Three defects, one new script, all independent.

**- What I did**

**1. Repinned the debian base in `ee_base` + `ve_base`.** The pinned digest `eb37f586…` resolves to an OCI index with **zero manifests** — 90 bytes, no entries — so neither image can be built, on any architecture, by anyone. `docker build` reports it as `no match for platform in manifest`, which reads like an arch problem and isn't (`--platform linux/amd64` fails identically). Repinned to what the tag resolves to today, `04634311…`: 16 entries, `linux/amd64` and `linux/arm64/v8` among them.

**2. `createConf.sh`'s default branch substituted a name that isn't there** — it sets `DNS_FQDN`, then seds for `DNS_FQN`. The placeholder survives, so `root_server.url` is the literal string `DNS_FQDN` and, in the default configuration, an atServer cannot reach the atDirectory: no cross-atSign lookup, no `from:` handshake. Only the `DNS_FQDN`-is-set branch has ever produced a working EE, which is why the README's examples all pass it.

**3. A failed compile now fails the EE image build.** The `RUN` chain separated steps with `;`, so only the last exit status reached Docker. With no `.dockerignore`, `COPY . .` then carried the host's own build outputs into `/app` at exactly the paths the compile writes and the second stage reads — and `runLocal.sh` builds those *inside a Linux dart container*, so they're correct-architecture ELF binaries that run fine. Both were present on my host while writing this. Net effect: a compile failure shipped an image running whatever branch was functional-tested last. The ignore list is anchored to the two exact paths, since `**/root` would also exclude `ee_base/contents/atsign/root`, which the image needs.

**4. Added `buildee.sh`** — builds an EE from the working tree (previously impossible; `runee.sh` and the compose file both name the published `:latest`). It labels the image with its source commit and **reads that label back**, then checks the three artefacts carry ELF magic. `runee.sh` takes the tag as an optional third arg, defaulting to the published image, and now passes `DNS_FQDN` explicitly so it's correct against published images still carrying (2).

**CI note.** The bad digest landed 2026-08-25 (`5e0ac64e`, dependabot) and no CI run has ever exercised it: neither workflow that builds these Dockerfiles triggers on `pull_request`, `VE_base`'s weekly cron last ran 17h *before* the bump, and `ee_base` is built only by `vip_rebuild` (cert changes / manual dispatch), so it could have stayed broken indefinitely. A green trunk build is not evidence against this — `push_staging_virtual_env_images` builds `ve/Dockerfile.vip`, whose runtime stage is `FROM atsigncompany/vebase:latest`, a prebuilt image.

**Not fixed here:** `ve_base`'s `RUN` chain still uses `;`, so a failed compile there still goes green — same defect as (3), fixed only for EE. Say the word and I'll fold it in.

**- How I did it**

See commit & diffs.

**- How to verify it**

`tools/build_ephemeral_environment/buildee.sh`, green from the merged tree — revision label matches HEAD, all three artefacts ELF. That covers (1), (3) and (4): the image cannot build at all without the repin. For (2), `runee.sh <name> <base-port> at_ephemeral:local` and check a created atServer's `root_server.url` is a hostname, not the literal `DNS_FQDN`.

**- Description for the changelog**

Fixed the EE and VE base images, which could not be built at all — the pinned debian digest resolved to an empty manifest index. Fixed the EE's default `DNS_FQDN` configuration, which left every atServer unable to reach the atDirectory. A failed compile now fails the EE image build instead of silently shipping the host's own build outputs. Added `buildee.sh` for building and verifying an EE image from a working tree.
