### PR TITLE
docs: ve and ee set up documentation

### DIFF
--- a/docs/how-to-set-up-ee.md
+++ b/docs/how-to-set-up-ee.md
@@ -14,6 +14,16 @@ An EE container includes:
 - supervisord managing all processes (web UI on port 9001)
 - A bundled `at_activate` binary for onboarding atKeys
 
+## Prerequisites
+
+When setting up locally, add `vip.ve.atsign.zone` to your `/etc/hosts` file so it resolves to localhost:
+
+```
+127.0.0.1 vip.ve.atsign.zone
+```
+
+The public DNS record for this hostname points to a private IP (`10.64.64.64`) that is not reachable from most networks.
+
 ## Quick start (recommended)
 
 Use docker compose. Copy this into a `docker-compose.yaml`:

--- a/docs/how-to-set-up-ee.md
+++ b/docs/how-to-set-up-ee.md
@@ -41,7 +41,7 @@ services:
     # https://github.com/atsign-foundation/at_services/tree/trunk/packages/at_secondary_proxy
 ```
 
-`vip.ve.atsign.zone` already points to `127.0.0.1` via public DNS. If you are offline, add it to `/etc/hosts`:
+The public DNS record for `vip.ve.atsign.zone` points to a private IP (`10.64.64.64`), not localhost. Add it to `/etc/hosts` so your host resolves it to `127.0.0.1`:
 
 ```
 127.0.0.1 vip.ve.atsign.zone
@@ -211,7 +211,6 @@ services:
       - 'vip.ve.atsign.zone:127.0.0.1'
     environment:
       - EPHEMERAL_BASE_PORT=2500
-      - DNS_FQDN=vip.ve.atsign.zone
 ```
 
 For a second EE, copy the file, change the name, container name, and base port (e.g. 2600), and `docker compose -f <file> up -d`.

--- a/docs/how-to-set-up-ee.md
+++ b/docs/how-to-set-up-ee.md
@@ -161,6 +161,40 @@ volumes:
 
 The atDirectory and atServers can share the same certificate. The DNS record must resolve to the container's IP.
 
+## Proxy server
+
+To route all atServer traffic through a single port instead of exposing the full `BASE+1` .. `BASE+80` range, add the `at_proxyserver` container alongside the EE:
+
+```yaml
+services:
+  ephemeral:
+    container_name: ee
+    image: atsigncompany/ephemeral:latest
+    ports:
+      - '127.0.0.1:2500:2500'
+    extra_hosts:
+      - 'vip.ve.atsign.zone:127.0.0.1'
+    environment:
+      - EPHEMERAL_BASE_PORT=2500
+
+  proxy:
+    container_name: ee-proxy
+    image: atsigncompany/at_proxyserver
+    command: >-
+      --proxy-url vip.ve.atsign.zone:443
+      --root-url vip.ve.atsign.zone:2500
+      --bind-port 443
+      --cert-dir /atsign/certs
+    ports:
+      - '443:443'
+    extra_hosts:
+      - 'vip.ve.atsign.zone:127.0.0.1'
+    # volumes:
+    #   - /path/to/certs:/atsign/certs  # mount your own certs for non-localhost
+```
+
+With this setup, clients connect to `vip.ve.atsign.zone:443` and the proxy routes to the correct atServer internally. You only expose two ports: 2500 (atDirectory) and 443 (proxy).
+
 ## Running multiple EEs side-by-side
 
 To run multiple EEs on one host, create a separate compose file per instance with a different base port:

--- a/docs/how-to-set-up-ee.md
+++ b/docs/how-to-set-up-ee.md
@@ -1,0 +1,197 @@
+# How to set up an ephemeral environment
+
+The ephemeral environment (EE) creates a full atPlatform instance in a single Docker container that can be spun up and torn down with no trace. Unlike the VE (see [how-to-set-up-ve.md](how-to-set-up-ve.md)), the EE generates atSigns and CRAM secrets at startup rather than shipping pre-provisioned demo keys. This makes it better suited for:
+
+- Staging and CI pipelines (fresh atSigns per run, no shared state)
+- Non-localhost deployments with your own DNS and TLS certificates
+- Scenarios where you want to control exactly which atSigns exist
+
+An EE container includes:
+
+- An atDirectory (root server)
+- Up to 80 atServers (secondaries), one per atSign
+- A Redis database backing the root server
+- supervisord managing all processes (web UI on port 9001)
+- A bundled `at_activate` binary for onboarding atKeys
+
+## Quick start (recommended)
+
+Use docker compose. Copy this into a `docker-compose.yaml`:
+
+```yaml
+services:
+  ephemeral:
+    container_name: ee
+    image: atsigncompany/ephemeral:latest
+    ports:
+      - '127.0.0.1:2500-2599:2500-2599'
+    extra_hosts:
+      - 'vip.ve.atsign.zone:127.0.0.1'
+    environment:
+      - EPHEMERAL_BASE_PORT=2500
+      # - DNS_FQDN=rainbow.example.com  # default: vip.ve.atsign.zone
+    # Uncomment below for custom DNS/TLS or custom atSigns:
+    # volumes:
+    #   - /path/to/certs:/atsign/root/certs
+    #   - /path/to/certs:/atsign/secondary/base/certs
+    #   - /path/to/atsigns-file:/tmp/setup/atsigns
+    #
+    # To route all atServer traffic through a single port (e.g. 443) instead
+    # of exposing a port range, set up the atProxyServer:
+    # https://github.com/atsign-foundation/at_services/tree/trunk/packages/at_secondary_proxy
+```
+
+`vip.ve.atsign.zone` already points to `127.0.0.1` via public DNS. If you are offline, add it to `/etc/hosts`:
+
+```
+127.0.0.1 vip.ve.atsign.zone
+```
+
+To start:
+
+```sh
+docker compose up -d
+```
+
+To stop:
+
+```sh
+docker compose down
+```
+
+## Port layout
+
+With `EPHEMERAL_BASE_PORT=2500`, services bind to:
+
+| Service | Port | Expose? |
+|---------|------|---------|
+| atDirectory | 2500 (`BASE`) | Yes |
+| atServers | 2501-2580 (`BASE+1` .. `BASE+80`) | Yes |
+| (reserved) | 2581-2598 (`BASE+81` .. `BASE+98`) | No |
+| Redis | 2599 (`BASE+99`) | Optional, localhost only |
+
+All ports in the compose example are bound to `127.0.0.1` to avoid exposing services to the network.
+
+## Activating atSigns
+
+### Getting CRAM secrets
+
+By default, 26 atSigns are created using the NATO phonetic alphabet (@alpha through @zulu). Their CRAM secrets are printed to the container log on startup:
+
+```sh
+docker compose logs ephemeral
+```
+
+The output contains lines like:
+
+```
+alpha		4df10914d207e8d70ec6d21801c4621b2e5f08bc783b8c6b182df34e3ba6c8ca
+bravo		a1b2c3d4e5f6...
+```
+
+The first column is the atSign name (without `@`), the second is the CRAM secret.
+
+If the logs are lost, the secrets are also stored inside the container at `/tmp/CRAM_Keys`:
+
+```sh
+docker exec ee cat /tmp/CRAM_Keys
+```
+
+To extract a single atSign's CRAM secret (e.g. @bravo):
+
+```sh
+docker exec ee grep '^bravo' /tmp/CRAM_Keys | awk '{print $2}'
+```
+
+### Onboarding with at_activate
+
+Use `at_activate` with a CRAM secret to generate .atKeys files:
+
+```sh
+at_activate onboard -a @bravo \
+  -c <cram-secret-from-logs> \
+  -r vip.ve.atsign.zone -v
+```
+
+If using a non-default root domain:
+
+```sh
+at_activate onboard -a @bravo \
+  -c <cram-secret-from-logs> \
+  -r rainbow.example.com -v
+```
+
+Once onboarded, the .atKeys file is written locally and the atSign is PKAM-ready. Use atPlatform apps as normal, passing the root domain if it is not the default:
+
+```sh
+sshnp --root-domain rainbow.example.com -f @alpha -t @bravo -d test -r @zulu
+```
+
+## Custom atSigns
+
+To override the default 26 atSigns, create a file listing one atSign name per line (without the `@` prefix):
+
+```txt
+one
+two
+three
+four
+five
+```
+
+Mount it into the container at `/tmp/setup/atsigns`:
+
+```yaml
+volumes:
+  - /path/to/my-atsigns:/tmp/setup/atsigns
+```
+
+## Custom DNS and TLS
+
+For non-localhost deployments, set `DNS_FQDN` and mount your TLS certificates:
+
+```yaml
+environment:
+  - EPHEMERAL_BASE_PORT=2500
+  - DNS_FQDN=rainbow.example.com
+volumes:
+  - /path/to/certs:/atsign/root/certs
+  - /path/to/certs:/atsign/secondary/base/certs
+```
+
+The atDirectory and atServers can share the same certificate. The DNS record must resolve to the container's IP.
+
+## Running multiple EEs side-by-side
+
+To run multiple EEs on one host, create a separate compose file per instance with a different base port:
+
+```yaml
+name: ee-a
+services:
+  ephemeral:
+    container_name: ee-a
+    image: atsigncompany/ephemeral:latest
+    ports:
+      - '127.0.0.1:2500-2599:2500-2599'
+    extra_hosts:
+      - 'vip.ve.atsign.zone:127.0.0.1'
+    environment:
+      - EPHEMERAL_BASE_PORT=2500
+      - DNS_FQDN=vip.ve.atsign.zone
+```
+
+For a second EE, copy the file, change the name, container name, and base port (e.g. 2600), and `docker compose -f <file> up -d`.
+
+ee-a's atDirectory is on port 2500, ee-b's on port 2600. No port collisions.
+
+## Monitoring
+
+Expose port 9001 to access the supervisord web UI at `http://localhost:9001/`. From there you can view logs and restart individual atSign processes.
+
+To expose it, add to the ports list:
+
+```yaml
+ports:
+  - '127.0.0.1:2500-2599:2500-2599'
+  - '127.0.0.1:9001:9001'
+```

--- a/docs/how-to-set-up-ee.md
+++ b/docs/how-to-set-up-ee.md
@@ -51,12 +51,6 @@ services:
     # https://github.com/atsign-foundation/at_services/tree/trunk/packages/at_secondary_proxy
 ```
 
-The public DNS record for `vip.ve.atsign.zone` points to a private IP (`10.64.64.64`), not localhost. Add it to `/etc/hosts` so your host resolves it to `127.0.0.1`:
-
-```
-127.0.0.1 vip.ve.atsign.zone
-```
-
 To start:
 
 ```sh

--- a/docs/how-to-set-up-ve.md
+++ b/docs/how-to-set-up-ve.md
@@ -1,44 +1,143 @@
 # How to set up a virtual environment
 
-A virutal environment contains a couple of things:
+The virtual environment (VE) is primarily useful for local atPlatform testing. It runs a self-contained atPlatform instance inside a single Docker container with pre-provisioned demo atSigns, so you can start writing and testing atPlatform apps immediately without registering real atSigns.
 
-- Virtual environment Atsigns. Their .atKeys can be fetched from https://github.com/atsign-foundation/at_demos/tree/trunk/packages/at_demo_data/lib/assets/atkeys
-- an atDirectory server
-- Everything that is needed to fulfill the two items above such as a redis database, the Dart runtime, and more.
+For a more persistent and secure setup (e.g. staging, CI, or non-localhost deployments with your own DNS/TLS), see [how-to-set-up-ee.md](how-to-set-up-ee.md).
 
-## Dockerfile
+A VE container includes:
 
-The most famous way to spin up a virtual environment is this Dockerfile
+- An atDirectory (root server) on port 64
+- 40 pre-provisioned atServers (secondaries) on ports 25000-25039
+- A Redis database backing the root server
+- supervisord managing all processes (web UI on port 9001)
+- Pre-installed PKAM keys for all demo atSigns
 
-https://hub.docker.com/r/atsigncompany/virtualenv
+The demo atSigns and their .atKeys files are available at:
+https://github.com/atsign-foundation/at_demos/tree/trunk/packages/at_demo_data/lib/assets/atkeys
 
-### docker-compose
+## Quick start (recommended)
 
-A sample docker compose file
+Use docker compose. Copy this into a `docker-compose.yaml`:
 
-```yml
-version: '2'
+```yaml
 services:
   virtualenv:
+    container_name: ve
     image: atsigncompany/virtualenv:vip
     ports:
-      - "127.0.0.1:6379:6379"
-      - "64:64"
-      - "443:443"
-      - "127.0.0.1:9001:9001"
-      - "25000-25999:25000-25999"
+      - '64:64'
+      - '25000-25039:25000-25039'
     extra_hosts:
-      - "vip.ve.atsign.zone:127.0.0.1"
+      - 'vip.ve.atsign.zone:127.0.0.1'
+    # Uncomment below for additional access:
+    # - '127.0.0.1:6379:6379'   # Redis (only needed for direct DB inspection)
+    # - '127.0.0.1:9001:9001'   # supervisord web UI (process manager)
+    # - '443:443'               # atProxyServer (TLS reverse proxy for atServers)
+    #
+    # To route all atServer traffic through a single port (e.g. 443) instead
+    # of exposing 25000-25039, set up the atProxyServer:
+    # https://github.com/atsign-foundation/at_services/tree/trunk/packages/at_secondary_proxy
 ```
 
-This makes it easy to view which ports to forward, such as 6379 which is the redis database, 64 for the atDirectry, 9001 for supervisord I think, and 25000-25999 for the atServers.
+| Port | Service | Expose? |
+|------|---------|---------|
+| 64 | atDirectory (root server) | Yes |
+| 25000-25039 | atServers (one per demo atSign) | Yes |
+| 443 | atProxyServer (TLS reverse proxy for atServers) | Optional |
+| 6379 | Redis | Optional, localhost only |
+| 9001 | supervisord web UI | Optional, localhost only |
 
-## Proxy Service
+`extra_hosts` maps `vip.ve.atsign.zone` to localhost inside the container. Your host machine also needs to resolve it. `vip.ve.atsign.zone` already points to `127.0.0.1` via public DNS, so this works automatically if you are online. If you are offline, add it to `/etc/hosts`:
 
-If you want everything to go through one egress port (such as 443), you can set up a proxy server. See
+```
+127.0.0.1 vip.ve.atsign.zone
+```
 
-at_proxyserver: https://github.com/atsign-foundation/at_services/tree/trunk/packages/at_secondary_proxy
+To start:
 
-More notably, there's `packages/at_secondary_proxy/tools/Dockerfile` and a `at_proxyserver.yml`.
+```sh
+docker compose up -d
+```
 
+To stop:
 
+```sh
+docker compose down
+```
+
+## Activating atSigns
+
+### CRAM auth with pkamLoad (easiest)
+
+The VE has a built-in `pkamLoad` supervisord task that CRAM-authenticates to every demo atSign and installs their PKAM public keys. It is disabled by default. To run it:
+
+```sh
+docker exec ve supervisorctl start pkamLoad
+```
+
+If running multiple VEs, replace `ve` with the `container_name` from your compose file.
+
+Once it finishes, all demo atSigns are PKAM-ready. Use the corresponding .atKeys files in your app:
+https://github.com/atsign-foundation/at_demos/tree/trunk/packages/at_demo_data/lib/assets/atkeys
+
+### CRAM auth with at_activate
+
+If you need to onboard a single atSign manually (or test CRAM auth), use `at_activate` with the atSign's CRAM secret:
+
+```sh
+at_activate onboard -a @alice🛠 \
+  -c b26455a907582760ebf35bc4847de549bc41c24b25c8b1c58d5964f7b4f8a43bc55b0e9a601c9a9657d9a8b8bbc32f88b4e38ffaca03c8710ebae1b14ca9f364 \
+  -r vip.ve.atsign.zone -v
+```
+
+The CRAM secrets for all demo atSigns are in the `at_demo_data` package:
+
+- All CRAM secrets (text): https://github.com/atsign-foundation/at_demos/blob/trunk/packages/at_demo_data/lib/assets/cramKeys.txt
+- CRAM secrets (Dart map): https://github.com/atsign-foundation/at_demos/blob/trunk/packages/at_demo_data/lib/src/at_demo_credentials.dart
+- .atKeys files: https://github.com/atsign-foundation/at_demos/tree/trunk/packages/at_demo_data/lib/assets/atkeys
+
+## Running multiple VEs side-by-side
+
+To run multiple VEs on one host without port collisions, create a separate compose file per instance. Each VE shifts all services into a contiguous 100-port range using the `VIRTUALENV_BASE_PORT` environment variable:
+
+```yaml
+services:
+  virtualenv:
+    container_name: my-ve
+    image: atsigncompany/virtualenv:vip
+    ports:
+      - '127.0.0.1:30000-30099:30000-30099'
+    extra_hosts:
+      - 'vip.ve.atsign.zone:127.0.0.1'
+    environment:
+      - VIRTUALENV_BASE_PORT=30000
+```
+
+With `VIRTUALENV_BASE_PORT=30000`, services bind to:
+
+| Service | Port |
+|---------|------|
+| atDirectory | 30000 (`BASE`) |
+| atServers | 30001-30080 (`BASE+1` .. `BASE+80`) |
+| atProxyServer | 30098 (`BASE+98`) |
+| Redis | 30099 (`BASE+99`) |
+
+For a second VE, copy the file, change the container name and base port, and run with `-f`:
+
+```yaml
+services:
+  virtualenv:
+    container_name: my-ve-2
+    image: atsigncompany/virtualenv:vip
+    ports:
+      - '127.0.0.1:31000-31099:31000-31099'
+    extra_hosts:
+      - 'vip.ve.atsign.zone:127.0.0.1'
+    environment:
+      - VIRTUALENV_BASE_PORT=31000
+```
+
+```sh
+docker compose -f docker-compose-ve2.yaml up -d
+docker exec my-ve-2 supervisorctl start pkamLoad
+```

--- a/docs/how-to-set-up-ve.md
+++ b/docs/how-to-set-up-ve.md
@@ -47,7 +47,7 @@ services:
 | 6379 | Redis | Optional, localhost only |
 | 9001 | supervisord web UI | Optional, localhost only |
 
-`extra_hosts` maps `vip.ve.atsign.zone` to localhost inside the container. Your host machine also needs to resolve it. `vip.ve.atsign.zone` already points to `127.0.0.1` via public DNS, so this works automatically if you are online. If you are offline, add it to `/etc/hosts`:
+`extra_hosts` maps `vip.ve.atsign.zone` to localhost inside the container. Your host machine also needs to resolve it to `127.0.0.1`. The public DNS record for `vip.ve.atsign.zone` points to a private IP (`10.64.64.64`), not localhost, so add it to `/etc/hosts`:
 
 ```
 127.0.0.1 vip.ve.atsign.zone
@@ -118,9 +118,12 @@ With `VIRTUALENV_BASE_PORT=30000`, services bind to:
 | Service | Port |
 |---------|------|
 | atDirectory | 30000 (`BASE`) |
-| atServers | 30001-30080 (`BASE+1` .. `BASE+80`) |
+| atServers | 30001-30040 (`BASE+1` .. `BASE+40`) |
+| (reserved) | 30041-30097 (`BASE+41` .. `BASE+97`) |
 | Root server HTTPS | 30098 (`BASE+98`) |
 | Redis | 30099 (`BASE+99`) |
+
+The entrypoint supports up to 80 atServers (`BASE+1` .. `BASE+80`) but only 40 are pre-provisioned.
 
 For a second VE, copy the file, change the container name and base port, and run with `-f`:
 

--- a/docs/how-to-set-up-ve.md
+++ b/docs/how-to-set-up-ve.md
@@ -32,7 +32,7 @@ services:
     # Uncomment below for additional access:
     # - '127.0.0.1:6379:6379'   # Redis (only needed for direct DB inspection)
     # - '127.0.0.1:9001:9001'   # supervisord web UI (process manager)
-    # - '443:443'               # atProxyServer (TLS reverse proxy for atServers)
+    # - '443:443'               # Root server HTTPS
     #
     # To route all atServer traffic through a single port (e.g. 443) instead
     # of exposing 25000-25039, set up the atProxyServer:
@@ -43,7 +43,7 @@ services:
 |------|---------|---------|
 | 64 | atDirectory (root server) | Yes |
 | 25000-25039 | atServers (one per demo atSign) | Yes |
-| 443 | atProxyServer (TLS reverse proxy for atServers) | Optional |
+| 443 | Root server HTTPS | Optional |
 | 6379 | Redis | Optional, localhost only |
 | 9001 | supervisord web UI | Optional, localhost only |
 
@@ -119,7 +119,7 @@ With `VIRTUALENV_BASE_PORT=30000`, services bind to:
 |---------|------|
 | atDirectory | 30000 (`BASE`) |
 | atServers | 30001-30080 (`BASE+1` .. `BASE+80`) |
-| atProxyServer | 30098 (`BASE+98`) |
+| Root server HTTPS | 30098 (`BASE+98`) |
 | Redis | 30099 (`BASE+99`) |
 
 For a second VE, copy the file, change the container name and base port, and run with `-f`:

--- a/docs/how-to-set-up-ve.md
+++ b/docs/how-to-set-up-ve.md
@@ -15,6 +15,16 @@ A VE container includes:
 The demo atSigns and their .atKeys files are available at:
 https://github.com/atsign-foundation/at_demos/tree/trunk/packages/at_demo_data/lib/assets/atkeys
 
+## Prerequisites
+
+When setting up locally, add `vip.ve.atsign.zone` to your `/etc/hosts` file so it resolves to localhost:
+
+```
+127.0.0.1 vip.ve.atsign.zone
+```
+
+The public DNS record for this hostname points to a private IP (`10.64.64.64`) that is not reachable from most networks.
+
 ## Quick start (recommended)
 
 Use docker compose. Copy this into a `docker-compose.yaml`:
@@ -46,12 +56,6 @@ services:
 | 443 | Root server HTTPS | Optional |
 | 6379 | Redis | Optional, localhost only |
 | 9001 | supervisord web UI | Optional, localhost only |
-
-`extra_hosts` maps `vip.ve.atsign.zone` to localhost inside the container. Your host machine also needs to resolve it to `127.0.0.1`. The public DNS record for `vip.ve.atsign.zone` points to a private IP (`10.64.64.64`), not localhost, so add it to `/etc/hosts`:
-
-```
-127.0.0.1 vip.ve.atsign.zone
-```
 
 To start:
 

--- a/docs/how-to-set-up-ve.md
+++ b/docs/how-to-set-up-ve.md
@@ -1,0 +1,44 @@
+# How to set up a virtual environment
+
+A virutal environment contains a couple of things:
+
+- Virtual environment Atsigns. Their .atKeys can be fetched from https://github.com/atsign-foundation/at_demos/tree/trunk/packages/at_demo_data/lib/assets/atkeys
+- an atDirectory server
+- Everything that is needed to fulfill the two items above such as a redis database, the Dart runtime, and more.
+
+## Dockerfile
+
+The most famous way to spin up a virtual environment is this Dockerfile
+
+https://hub.docker.com/r/atsigncompany/virtualenv
+
+### docker-compose
+
+A sample docker compose file
+
+```yml
+version: '2'
+services:
+  virtualenv:
+    image: atsigncompany/virtualenv:vip
+    ports:
+      - "127.0.0.1:6379:6379"
+      - "64:64"
+      - "443:443"
+      - "127.0.0.1:9001:9001"
+      - "25000-25999:25000-25999"
+    extra_hosts:
+      - "vip.ve.atsign.zone:127.0.0.1"
+```
+
+This makes it easy to view which ports to forward, such as 6379 which is the redis database, 64 for the atDirectry, 9001 for supervisord I think, and 25000-25999 for the atServers.
+
+## Proxy Service
+
+If you want everything to go through one egress port (such as 443), you can set up a proxy server. See
+
+at_proxyserver: https://github.com/atsign-foundation/at_services/tree/trunk/packages/at_secondary_proxy
+
+More notably, there's `packages/at_secondary_proxy/tools/Dockerfile` and a `at_proxyserver.yml`.
+
+


### PR DESCRIPTION
**- What I did**
- documentation on how to set up a virtual environment
- documentation on how to set up an ephemeral environment

**- Why I did it**
- it got annoying pointing Agents on how to set up a local environment to test different stuff or setting up stuff, so going to have documentation on how to do that.

**- How I did it**

- Claude opus 4.6

**- Description for the changelog**
docs: ve and ee set up documentation