### PR TITLE
feat(at_secondary_server)!: a retrofit predecessor is revoked, not capped, when its successor first authenticates

### DIFF
--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -487,12 +487,6 @@ jobs:
         working-directory: ${{ env.e2etest-working-directory }}
         run: dart pub get
 
-      - name: Cloning at_tools
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          repository: atsign-foundation/at_tools
-          path: at_tools
-          ref: trunk
 
       - name: Fetch Cram Keys
         id: cram_keys
@@ -603,13 +597,6 @@ jobs:
           tar -xvf sshnp-linux-x64.tgz sshnp/at_activate
           sshnp/at_activate -a @$AT_SIGN_1 -c $CRAM_KEY_1 -r root.atsign.wtf
           sshnp/at_activate -a @$AT_SIGN_2 -c $CRAM_KEY_2 -r root.atsign.wtf
-
-      - name: Generate the at_demo_data.dart
-        run: |
-          cd at_tools/packages/at_dump_atKeys/
-          dart pub get
-          dart bin/generate_at_demo_data.dart -d /home/runner/.atsign/keys/ -p pkam   
-          cp at_demo_data.dart ../../../${{ env.e2etest-working-directory }}/test
 
       - name: End-to-end test
         working-directory: ${{ env.e2etest-working-directory }}

--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -4,7 +4,7 @@
   c3.16.x wrote the field on ONE path — a self-enrolment — and wrote the
   SPAWNING enrollment into it. This build reads it as the APPROVER: a record
   carrying it is cascaded to when the enrollment it names is revoked, and it
-  is never capped as a retrofit predecessor. A record written by c3.16.x is
+  is never revoked as a retrofit predecessor. A record written by c3.16.x is
   therefore read as approved by the enrollment that spawned it, and nothing
   in the record distinguishes it from one this build wrote. No released
   client self-enrols, so the population that can hold such a record is
@@ -165,8 +165,7 @@
   expiry as `expiresAt` — ISO-8601 UTC, or null when the record never
   expires — on every projection of `enroll:list` (the whole record, the
   roster, and an enrollment's own entry). It is the record's own expiry,
-  whatever set it last: the key-expiry posture at approval or the retrofit
-  cap. A client used to read it with `llookup:meta` on the `__manage` record
+  the key-expiry posture at approval. A client used to read it with `llookup:meta` on the `__manage` record
   over a connection carrying no enrollment id; that connection now carries
   `primary`, and no enrollment may read a `__manage` record with a data verb,
   so without the field no client could learn when a credential stops
@@ -236,23 +235,30 @@
   stops NEW duplicates, which is where one can be prevented rather than
   discovered.
 
-- ⚠️ BREAKING: a fully privileged retrofit predecessor is not capped. A
-  predecessor holding `*:rw` and `__manage:rw` keeps its life when its
-  successor first authenticates: key management is its owner's
-  responsibility, and a clock on an atSign's root is a clock on the atSign's
-  ability to restore itself. Every other predecessor is still capped to
-  `min(apkamSelfEnrollmentGraceHours, what its own posture leaves it)`; a
-  non-root predecessor was created deliberately, by an app with enrollment
-  tooling, for one device, so a clock there is safe and useful, and it can
-  never be the atSign's last root, so no stranding question is asked of it.
-  The cap's stranding question and its decline memo are gone with it.
+- feat: a retrofit predecessor that is not fully privileged is REVOKED when
+  its successor first authenticates. The successor's first `pkam:` moves the
+  predecessor's approval children onto the successor, then revokes the
+  predecessor, recording it in the revocation history as `superseded`, by
+  the successor, with no cascade; `enroll:infons` counts that as a revocation
+  of the namespaces the predecessor held. Every other holder of the
+  predecessor's keyfile is refused with AT0027 on its next command, as after
+  any revoke. It happens at the successor's first authentication rather than
+  when the successor is stored, because storing proves nothing about the
+  client's keyfile: the private half lives client-side, and a write that
+  failed there leaves the predecessor the only credential that works.
 
-  The predecessor's approval children move onto the successor whenever the
-  successor's first authentication is recorded: off a capped predecessor,
-  off a root that keeps its life, and off one already deleted. That last
-  case was described and never done. A predecessor that is not approved is
-  still left alone and nothing is recorded, so an un-revoke restores it
-  with the question still open.
+  A predecessor holding `*:rw` and `__manage:rw` keeps its life, and only its
+  children move: key management is its owner's responsibility, and a clock
+  on an atSign's root is a clock on the atSign's ability to restore itself.
+  A predecessor found revoked, pending or already gone at that moment is
+  settled without a revoke and never re-asked, so an `enroll:unrevoke` of a
+  superseded enrollment, allowed as for any other, is not overturned by the
+  successor's next authentication; the once-off rule still refuses a second
+  retrofit of it.
+
+  Pre-release builds of this version capped the predecessor to a grace period
+  instead; the config key `apkamSelfEnrollmentGraceHours` they read is gone
+  and a value set for it is ignored.
 
 - ⚠️ BREAKING at rest: `parentEnrollmentId` is the enrollment that APPROVED
   this one, and `retrofitPredecessorEnrollmentId` is the enrollment a
@@ -260,7 +266,7 @@
   is set from the connection on `enroll:approve`, null for an enrollment
   approved over CRAM and for `primary`, and copied from the predecessor on
   a retrofit, so a successor is a SIBLING of what it replaced. The
-  replacement edge is read by the once-off rule, by the retrofit cap and by
+  replacement edge is read by the once-off rule, by the settlement and by
   tooling looking for a whole sibling set; `enroll:list` exposes both.
   Re-meaning the stored key is not free — released c3.16.x wrote it on a
   self-enrolment, as the spawning enrollment (see the at-rest entry at the
@@ -415,8 +421,8 @@
 - fix: every enrollment mutation now runs inside ONE store-wide critical
   section, and it covers the whole read-decide-write rather than the write:
   `enroll:request` (past the throttle and the OTP gate), `enroll:approve`,
-  `deny`, `revoke`, `unrevoke`, `update` and `delete`, the retrofit cap's
-  arming, and the adoption of a capped approver's children.
+  `deny`, `revoke`, `unrevoke`, `update` and `delete`, the settlement of a
+  retrofit predecessor, and the adoption of its children.
 
   The keystore has no compare-and-set, and the decision each write rests on
   is a question about the WHOLE store — "would any unexpiring root survive
@@ -426,32 +432,29 @@
 
   Measured on this tree before the change: two concurrent `enroll:revoke`
   commands each counted the root the other was about to remove and left the
-  atSign with none; a retrofit cap arming alongside an `enroll:revoke` did
-  the same, while both serial orderings are safe; and a revoke and a cap
-  arming writing the same record lost one of the two whole-record snapshots
+  atSign with none; a retrofit settlement alongside an `enroll:revoke` did
+  the same, while both serial orderings are safe; and a revoke and a
+  settlement writing the same record lost one of the two whole-record snapshots
   — the verb answering `{"status":"revoked"}` over a record the store held
   `approved`, with that credential's published `_apsk` back at the live
-  address. The adoption of a capped approver's children is the sharpest of
+  address. The adoption of a superseded approver's children is the sharpest of
   them, because its lost update is permanent and silent: nothing re-parents
   twice, so a child left naming its old approver is outside every later
   revocation cascade for the rest of its life.
 
-  The section replaces the arming-only lock, whose docstring claimed it made
-  the liveness answer safe to act on — true only against another arming.
+  The section replaces the settlement-only lock, whose docstring claimed it
+  made the liveness answer safe to act on — true only against another
+  settlement.
 
   ⚠️ Throughput: an enrollment mutation arriving while another is in flight
-  now waits for it. Measured at 100 enrollments, a retrofit cap arming takes
-  9-10ms with nothing to adopt and 36-39ms adopting 50 children, each adopted
-  child being a record write that walks the keystore.
+  now waits for it; a settlement adopting children is one record write per
+  child, each walking the keystore.
 
-  AUTHENTICATION is not affected. The retrofit cap's early exits sit outside
-  the section, so an APKAM authentication with nothing to arm — every
+  AUTHENTICATION is not affected. The settlement's early exits sit outside
+  the section, so an APKAM authentication with nothing to settle — every
   authentication except a retrofit successor's first — costs 2-8us whether or
-  not a mutation is in flight. With those exits inside the section, twenty
-  such authentications took as long as the arming they queued behind: 9.8ms,
-  21ms and 37-38ms at 0, 25 and 50 adopted children respectively. Reads are
-  outside the section entirely, so no verb queues behind an enrollment write
-  to read one.
+  not a mutation is in flight. Reads are outside the section entirely, so no
+  verb queues behind an enrollment write to read one.
 - fix: an enrollment id is canonicalised to the keystore's own fold wherever
   it enters the server or is used to build a keystore key, so handler-side
   identity and stored identity agree by construction. The keystore normalises
@@ -637,13 +640,6 @@
 
   An approver holding `__manage:r` may still admit an enrollment asking for
   `__manage:r`, and reaching a `__manage` key is unaffected.
-- fix: a revocation could be partly undone by a retrofit cap running
-  concurrently. `capEnrollmentExpiry` re-read the record but took the STATUS
-  from the caller's snapshot, taken before a keystore walk and a write — so a
-  revoke landing in that window was written back as approved, moving the
-  revoked enrollment's per-enrollment data (its published `_apsk` signing key
-  among it) back to the live address. The status is now read off the record it
-  just read, and a record that is no longer approved is not written at all.
 - fix: a revoke missed every descendant behind an EXPIRED link. Key
   enumeration hides records whose ttl has elapsed, so the expired enrollment's
   approver edge vanished with it while everything behind it survived approved —
@@ -887,27 +883,18 @@
   client that expected to authenticate without an enrollment id after
   onboarding will not be able to.
 
-- fix: capping a retrofitted approver moves the enrollments it admitted onto
+- fix: superseding a retrofitted approver moves the enrollments it admitted onto
   its successor. Nothing records ancestry beyond an enrollment's immediate
   approver, so a severed link orphans everything behind it — a later revoke of
   the chain above reaches the first live candidate and stops, and the
   reactivation refusal then permits un-revoking exactly what a cascade had
-  swept. `enroll:delete` and the expiry sweep could already sever a link; the
-  retrofit cap would have made it routine, putting a thirty-day deadline on an
-  administrator without asking what sat behind it. The successor is where those
+  swept. `enroll:delete` and the expiry sweep could already sever a link; a
+  retrofit would have made it routine, retiring an administrator without
+  asking what sat behind it. The successor is where those
   enrollments belong: it is the same principal re-keyed, it already inherits
   its predecessor's approver, and this is that substitution seen from the other
   side. It also stops retiring a superseded credential taking down everything
   that credential ever admitted.
-
-- fix: two enrollments authenticating for the first time at once no longer cap
-  BOTH of an atSign's roots. Arming a retrofit's cap asks whether any
-  unexpiring root would survive capping this predecessor and then caps, which
-  is read-modify-write across the whole keystore. Run twice concurrently, both
-  walks finished before either write, so each saw the other's root still
-  uncapped and both were capped — leaving the atSign with no root it could
-  restore itself from. Two devices reconnecting together was enough. The walk
-  and the cap that follows it are now one critical section.
 
 - fix: `update:meta` is authorised like `update` rather than refused to every
   enrollment (#2691). `UpdateMeta` extends `Verb` and not `Update`, and
@@ -956,38 +943,6 @@
   thing the app does rather than at the request that caused it. Asking for MORE
   than the predecessor holds is still refused, with its own message, so the two
   mistakes stay distinguishable.
-- feat: the retrofit expiry cap is armed by the successor's first
-  authentication rather than by storing it. Storing a successor proves only
-  that the atServer wrote a record: the successor's APKAM private half is
-  persisted client-side, so a keyfile write that fails, a read-only file, or a
-  process that dies before the flush each leave the successor existing on the
-  server and nowhere else — with a clock already started on the predecessor,
-  which is by then the only credential that still works. The cap now fires when
-  the successor first authenticates over a connection it opened, which is what
-  proves the private half survived and is usable. It still re-arms once per
-  successor, so a predecessor retires one grace period after the last sibling
-  upgrades, and a successor's own repeated connections never extend it.
-
-  Two conditions stop the cap, and neither is remembered: both are judgements
-  about state that can change, so they are re-made on the successor's next
-  authentication rather than frozen into the record. A predecessor that is not
-  approved is left alone — it is already retired, and capping it would hand it
-  a fresh expiry it has no business carrying; an unrevoke restores an ordinary
-  predecessor and must not find it permanently exempt. A predecessor holding
-  `*:rw` and `__manage:rw` is never capped at all — see the entry above on
-  fully privileged predecessors — and its children still move. Every other
-  predecessor is capped regardless of how long its successor lives: declining
-  more widely than that would switch retirement off for any fleet whose APKAM
-  keys are shorter-lived than the grace, and would make the grace setting
-  work backwards, a longer grace declining more often.
-
-  The expiry the cap measures against is taken from APPROVAL rather than from
-  the request. A record that carries no expiry does not expire, whatever
-  posture its stored value states, so nothing but the grace bounds the cap
-  there. The two differ by the approval latency, and a request-anchored
-  measurement went negative for an enrollment retrofitted between them —
-  capping it to one millisecond, killing a credential with hours of legitimate
-  life left and locking out every sibling clone that had still to upgrade.
 - fix: a published APKAM signing key is world-READABLE, not world-writable.
   The only cross-enrollment denial in the authorisation path short-circuited on
   the `public:` prefix, and its own comment justified that on read grounds —
@@ -1009,11 +964,8 @@
   mint-time check compared TERMS, and a term restarts its clock at the
   successor's own write — so an inherited term always expired later in
   absolute time than its predecessor's deadline, by exactly the predecessor's
-  age. It was also vacuous in the case that mattered most: it read the posture
-  off the predecessor's stored VALUE, while a capped predecessor's real
-  deadline lives only in its record metadata. A CRAM root carrying posture 0,
-  capped to now+grace, could therefore mint a successor asking for 0 — written
-  as "never expires", by a credential due to die inside the grace.
+  age. It also read the posture off the predecessor's stored VALUE, while the
+  predecessor's real deadline lives only in its record metadata.
 
   The successor's posture is now bounded by what is LEFT of the predecessor's
   stored deadline, carried to the write as an ABSOLUTE so it lands exactly
@@ -1030,9 +982,9 @@
   authenticated, that the named enrollment existed and was approved, and that
   grants did not escalate, but never asked whether that enrollment had itself
   replaced something. A non-root predecessor is refused for a second split
-  once its first successor has authenticated and capped it, since the clock
-  that cap started is what a later sibling would inherit; a sibling clone of
-  the keyfile enrols over an OTP instead, and a root, never being capped,
+  once its first successor has authenticated and settled it, whether it is
+  still revoked or has since been un-revoked; a sibling clone of the keyfile
+  enrols over an OTP instead, and a root, never revoked as a predecessor,
   stays splittable.
 
   What made repetition costly is the key-expiry clock: each link restarts it,
@@ -1047,8 +999,8 @@
   predecessor, so losing a replacement link orphans nothing.
 
   ⚠️ This bounds the REPLACEMENT edge only, and only its depth. Several
-  sibling clones of one keyfile may still each retrofit the same enrollment —
-  that is the behaviour the retrofit cap re-arms for — so the graph is one link
+  sibling clones of one keyfile may still each retrofit the same enrollment
+  until one of them authenticates, so the graph is one link
   deep and arbitrarily wide. Approval is a separate edge and is NOT bounded:
   an approver may admit an enrollment that admits another, to any depth, and
   the cascade is what governs that rather than any limit on minting.
@@ -1117,16 +1069,10 @@
   holding both `*` and a narrower grant at different access letters had its
   roster entry decided by which grant happened to be written first — and could
   report a letter the server itself would not act on.
-- fix: the retrofit cap computes its ttl against the record it just read,
-  rather than taking one the caller computed earlier. A ttl is a distance from
-  the instant it was computed at and the store re-anchors it at the instant of
-  the write, so the value the caller had already decided on was stamped as the
-  deadline it checked PLUS however long the intervening keystore walk took.
-  The parameter is gone rather than corrected, which also removes the last way
-  a caller's stale snapshot could reach the write.
-- fix: arming the cap no longer reverts a concurrent change to the successor.
+- fix: settling a predecessor no longer reverts a concurrent change to the
+  successor.
   The successor's record is read immediately before it is written rather than
-  before the predecessor lookup and the cap, so an `enroll:update` rotating its
+  before the predecessor lookup and the revoke, so an `enroll:update` rotating its
   APKAM public key, or an `enroll:revoke` of it, is no longer overwritten from
   a stale snapshot. The keystore has no compare-and-set, so on its own this
   narrowed the window rather than closing it; the enrollment-mutation critical
@@ -1137,43 +1083,24 @@
   this release. A record stamped by a pre-release build of this version
   under the name `predecessorCapArmedAt` reads back as settled and is
   written back under the current name.
-- `apkamSelfEnrollmentGraceHours` is now documented in `config.yaml` with its
-  720-hour default. It was already read from there and from the environment;
-  it governs every enrollment now that the first-enrollment exemption is gone,
-  so it should not have been invisible.
 - fix: approving an enrollment whose key-expiry posture is zero or negative no
   longer leaves it carrying the approval window as its deadline. The metadata
   builder derives an expiry only for a ttl of zero or more, so a negative one
   skipped the derivation and the PENDING record's expiry — the window the
   request had to be approved in, 48 hours by default — survived onto the
   approved enrollment. The credential then expired on a deadline nobody asked
-  for, and a retrofit cap measured against that stale value appeared to EXTEND
-  the enrollment rather than shorten it. A non-positive posture is now written
+  for. A non-positive posture is now written
   as the keystore's "never expires", which is what it asks for.
 - fix: amending or revoking an enrollment no longer restarts its expiry.
   `enroll:update`, `enroll:revoke`, `enroll:deny` and `enroll:unrevoke` each
   wrote the record with no statement about expiry, and the metadata builder
   re-derives `expiresAt` from the retained ttl on any such write — so every one
-  of them silently moved the deadline to a grace period from the moment of the
-  write. An enrollment could therefore postpone its own retirement indefinitely
-  by amending itself once per period, which would have made the retrofit cap
-  advisory rather than a deadline. These writes now carry the stored expiry
+  of them silently moved the deadline to one full term from the moment of the
+  write. An enrollment could therefore postpone its own expiry indefinitely
+  by amending itself once per term, which would have made any deadline
+  advisory. These writes now carry the stored expiry
   forward as an assertion. `enroll:approve` still sets the expiry deliberately,
   which is where an enrollment's key-expiry clock is meant to start.
-- BREAKING for operators: `preserveFirstEnrollmentOnRetrofit` is removed, from
-  `config.yaml` and from the environment. It exempted the atSign's first
-  enrollment from the retrofit cap, because capping it could leave an atSign
-  with no enrollment able to approve a replacement. The exemption asked
-  whether an enrollment was the FIRST; what mattered is whether it is fully
-  privileged, and a fully privileged predecessor is now never capped at all —
-  see the entry above. A deployment that still sets the key needs no change:
-  config is read by explicit key lookup with no schema validation, so an
-  unknown key is never read.
-
-  An atSign that retrofitted under the exemption has a root carrying no
-  expiry and a successor carrying no record of having settled anything. On
-  that successor's first connection after the upgrade the root keeps its
-  life, and what the root admitted moves onto the successor.
 - fix: assemble outbound responses correctly however the network splits them.
   A peer writes a response and the prompt that follows it as one string, but
   it arrives in however many pieces the network chooses, and the atServer

--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1131,10 +1131,12 @@
   a stale snapshot. The keystore has no compare-and-set, so on its own this
   narrowed the window rather than closing it; the enrollment-mutation critical
   section described above is what closes it.
-- `enroll:list` responses carry a new `predecessorCapArmedAt` field on an
-  enrollment that has retired the one it replaced: the UTC instant it did so.
-  Absent on every other enrollment, and on any record written before this
-  release.
+- `enroll:list` responses carry a new `predecessorSettledAt` field on an
+  enrollment that has settled the one it replaced: the UTC instant it did
+  so. Absent on every other enrollment, and on any record written before
+  this release. A record stamped by a pre-release build of this version
+  under the name `predecessorCapArmedAt` reads back as settled and is
+  written back under the current name.
 - `apkamSelfEnrollmentGraceHours` is now documented in `config.yaml` with its
   720-hour default. It was already read from there and from the environment;
   it governs every enrollment now that the first-enrollment exemption is gone,

--- a/packages/at_secondary_server/config/config.yaml
+++ b/packages/at_secondary_server/config/config.yaml
@@ -215,12 +215,3 @@ enrollment:
   # If the duration between the last received invalid OTP and the current date-time
   # exceeds the delayIntervalThreshold, trigger a reset to the default value.
   delayIntervalThreshold: 55
-  # How long a superseded enrollment keeps working after the enrollment that
-  # replaced it first authenticates. A retrofit (an APKAM self-enrollment)
-  # replaces the credential it authenticated as; the replaced one is capped
-  # rather than deleted, so sibling clones of the same keyfile can still
-  # upgrade until the cap elapses. The cap re-arms on each sibling, so the
-  # window runs from the LAST upgrade, and it never extends an enrollment past
-  # the expiry its own apkamKeysExpiryInMillis posture already imposes.
-  # Default: 720 (30 days)
-  apkamSelfEnrollmentGraceHours: 720

--- a/packages/at_secondary_server/lib/src/enroll/enroll_datastore_value.dart
+++ b/packages/at_secondary_server/lib/src/enroll/enroll_datastore_value.dart
@@ -60,14 +60,9 @@ class EnrollDataStoreValue {
   /// it.
   String? retrofitPredecessorEnrollmentId;
 
-  /// When this enrollment settled what it replaced: the predecessor's
-  /// approval children moved onto this one, and the predecessor was put on the
-  /// retrofit cap unless it holds full privilege. Null while that is still
-  /// open.
-  ///
-  /// Stamped by the successor's FIRST PKAM authentication rather than by the
-  /// write, and re-armed by each sibling replacing the same predecessor.
-  DateTime? predecessorCapArmedAt;
+  /// When this enrollment settled what it replaced, at its first PKAM
+  /// authentication; null while that is still open.
+  DateTime? predecessorSettledAt;
 
   /// The at-rest shape of this record: 1 for every record this build writes,
   /// 0 for one written before the field existed.
@@ -120,8 +115,8 @@ class EnrollDataStoreValue {
           'parentEnrollmentId': parentEnrollmentId,
         if (retrofitPredecessorEnrollmentId != null)
           'retrofitPredecessorEnrollmentId': retrofitPredecessorEnrollmentId,
-        if (predecessorCapArmedAt != null)
-          'predecessorCapArmedAt': predecessorCapArmedAt!.toIso8601String(),
+        if (predecessorSettledAt != null)
+          'predecessorSettledAt': predecessorSettledAt!.toIso8601String(),
       };
 }
 

--- a/packages/at_secondary_server/lib/src/enroll/enroll_datastore_value.g.dart
+++ b/packages/at_secondary_server/lib/src/enroll/enroll_datastore_value.g.dart
@@ -35,9 +35,8 @@ EnrollDataStoreValue _$EnrollDataStoreValueFromJson(
       ..parentEnrollmentId = json['parentEnrollmentId'] as String?
       ..retrofitPredecessorEnrollmentId =
           json['retrofitPredecessorEnrollmentId'] as String?
-      ..predecessorCapArmedAt = json['predecessorCapArmedAt'] == null
-          ? null
-          : DateTime.parse(json['predecessorCapArmedAt'] as String);
+      // NOTE records written before the rename carry `predecessorCapArmedAt`.
+      ..predecessorSettledAt = _settledAtFromJson(json);
 
 Map<String, dynamic> _$EnrollDataStoreValueToJson(
         EnrollDataStoreValue instance) =>
@@ -62,11 +61,17 @@ Map<String, dynamic> _$EnrollDataStoreValueToJson(
       if (instance.retrofitPredecessorEnrollmentId != null)
         'retrofitPredecessorEnrollmentId':
             instance.retrofitPredecessorEnrollmentId,
-      if (instance.predecessorCapArmedAt != null)
-        'predecessorCapArmedAt': instance.predecessorCapArmedAt!.toIso8601String(),
+      if (instance.predecessorSettledAt != null)
+        'predecessorSettledAt': instance.predecessorSettledAt!.toIso8601String(),
     };
 
 const _$EnrollRequestTypeEnumMap = {
   EnrollRequestType.newEnrollment: 'newEnrollment',
   EnrollRequestType.changeEnrollment: 'changeEnrollment',
 };
+
+DateTime? _settledAtFromJson(Map<String, dynamic> json) {
+  final Object? raw =
+      json['predecessorSettledAt'] ?? json['predecessorCapArmedAt'];
+  return raw == null ? null : DateTime.parse(raw as String);
+}

--- a/packages/at_secondary_server/lib/src/enroll/enrollment_manager.dart
+++ b/packages/at_secondary_server/lib/src/enroll/enrollment_manager.dart
@@ -5,28 +5,12 @@ import 'package:at_commons/at_commons.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:at_secondary/src/enroll/enroll_datastore_value.dart';
 import 'package:at_secondary/src/enroll/enrollment_revocation_event.dart';
-import 'package:at_secondary/src/server/at_secondary_config.dart';
 import 'package:at_secondary/src/utils/apkam_signature_verifier.dart';
 import 'package:at_secondary/src/utils/secondary_util.dart';
 import 'package:at_utils/at_logger.dart';
 import 'package:meta/meta.dart';
 import 'package:mutex/mutex.dart';
 import 'package:uuid/uuid.dart';
-
-/// What [EnrollmentManager.capEnrollmentExpiry] did.
-enum RetrofitCapOutcome {
-  /// The expiry was written.
-  capped,
-
-  /// The predecessor's record is gone, so the successor's stamp stands.
-  predecessorGone,
-
-  /// The predecessor was approved when the decision was made and is not now.
-  notApproved,
-
-  /// The record could not be read or decoded. Treated like [notApproved].
-  unreadable,
-}
 
 /// An atSign's enrollment records: reading and writing them, and the
 /// questions that have to be asked of the whole roster before a write.
@@ -773,15 +757,15 @@ class EnrollmentManager {
     final Map<String, EnrollmentRevocationEvent> lastRevoke = {};
     final Map<String, DateTime> lastUnrevoke = {};
     for (final event in await revocationEvents()) {
-      if (event.type == EnrollmentRevocationEventType.revoked) {
-        final prev = lastRevoke[event.enrollmentId];
-        if (prev == null || event.at.isAfter(prev.at)) {
-          lastRevoke[event.enrollmentId] = event;
-        }
-      } else {
+      if (event.type == EnrollmentRevocationEventType.unrevoked) {
         final prev = lastUnrevoke[event.enrollmentId];
         if (prev == null || event.at.isAfter(prev)) {
           lastUnrevoke[event.enrollmentId] = event.at;
+        }
+      } else {
+        final prev = lastRevoke[event.enrollmentId];
+        if (prev == null || event.at.isAfter(prev.at)) {
+          lastRevoke[event.enrollmentId] = event;
         }
       }
     }
@@ -895,31 +879,6 @@ class EnrollmentManager {
 
   /// Get the enrollmentId from any key where enrollmentId is the first part
   String getIdFromKey(String ek) => ek.substring(0, ek.indexOf('.'));
-
-  /// The ttl a retrofit cap would write onto a record right now:
-  /// `min(grace, what the enrollment's own key-expiry posture leaves it)`,
-  /// floored at one millisecond because a ttl of zero never expires.
-  @visibleForTesting
-  int retrofitCapTtlMillis(AtMetaData? recordMetaData,
-      EnrollDataStoreValue enrollment, DateTime now) {
-    int cappedTtl =
-        Duration(hours: AtSecondaryConfig.apkamSelfEnrollmentGraceHours)
-            .inMilliseconds;
-    final ownMs = enrollment.apkamKeysExpiryDuration.inMilliseconds;
-    final stored = recordMetaData?.expiresAt?.toUtc();
-    // NOTE a record with no stored expiry never expires, whatever posture its
-    // value carries, so it must not be folded against one.
-    if (ownMs > 0 && stored != null) {
-      final fromCreation = (recordMetaData?.createdAt ?? now)
-          .toUtc()
-          .add(Duration(milliseconds: ownMs));
-      final postureDeadline =
-          stored.isAfter(fromCreation) ? stored : fromCreation;
-      final remainingMs = postureDeadline.difference(now).inMilliseconds;
-      if (remainingMs < cappedTtl) cappedTtl = remainingMs;
-    }
-    return cappedTtl < 1 ? 1 : cappedTtl;
-  }
 
   /// Whether any enrollment outside [excluding] is an APPROVED root that will
   /// NOT expire: `rw` on both `*` and `__manage`, and no expiry at all.
@@ -1089,21 +1048,24 @@ class EnrollmentManager {
           assertedTimestamps: storedExpiry == null
               ? null
               : AtAssertedTimestamps(expiresAt: storedExpiry));
-      logger.info('Enrollment $childId was approved by $predecessorId, which '
-          'has just been capped; it now hangs off its successor $successorId');
+      logger.info('Enrollment $childId was approved by $predecessorId; it '
+          'now hangs off the successor $successorId');
     }
   }
 
-  /// Revokes each of [enrollmentIds] that is currently approved, and returns
-  /// the ids it actually revoked.
+  /// Revokes each of [enrollmentIds] that is currently approved, recording
+  /// one history event of [type] each, and returns the ids it revoked.
   ///
-  /// [byEnrollmentId] is the enrollment on the connection that issued the
-  /// command, null for a CRAM connection; [cascadedFrom] is the enrollment it
-  /// named; [at] is the moment of the command, one timestamp for the set.
+  /// Must be called inside [serialiseMutation]. [byEnrollmentId] is the
+  /// enrollment on the acting connection, null for a CRAM connection;
+  /// [cascadedFrom] the enrollment a revoke command named, null otherwise;
+  /// [at] one timestamp for the set.
   Future<List<String>> revokeAll(Iterable<String> enrollmentIds,
       {required String? byEnrollmentId,
-      required String cascadedFrom,
-      required DateTime at}) async {
+      required String? cascadedFrom,
+      required DateTime at,
+      EnrollmentRevocationEventType type =
+          EnrollmentRevocationEventType.revoked}) async {
     final List<String> revoked = [];
     // The grants each one held, captured before the write, because the event
     // outlives the record they are stored on.
@@ -1115,7 +1077,7 @@ class EnrollmentManager {
       try {
         atData = await keyStore.get(ek);
       } on KeyNotFoundException {
-        logger.info('Cascade: enrollment $id is already gone; skipping');
+        logger.info('Revoking $id: it is already gone; skipping');
         continue;
       }
       final String? raw = atData?.data;
@@ -1124,7 +1086,7 @@ class EnrollmentManager {
       try {
         value = EnrollDataStoreValue.fromJson(jsonDecode(raw));
       } catch (e) {
-        logger.severe('Cascade could not decode enrollment $id: $e');
+        logger.severe('Revoking $id: its record does not decode: $e');
         continue;
       }
       if (value.approval?.state != EnrollmentStatus.approved.name) continue;
@@ -1140,7 +1102,7 @@ class EnrollmentManager {
     await recordRevocationEvents([
       for (final String id in revoked)
         EnrollmentRevocationEvent(
-          type: EnrollmentRevocationEventType.revoked,
+          type: type,
           enrollmentId: id,
           at: at,
           namespaces: grantsHeld[id]!,
@@ -1165,156 +1127,79 @@ class EnrollmentManager {
     return revoked;
   }
 
-  /// Takes back a `predecessorSettledAt` stamp whose cap did not happen,
-  /// best-effort and inside [serialiseMutation].
-  Future<void> _clearCapStamp(String successorEnrollmentId, String key) async {
-    try {
-      final AtData? atData = await keyStore.get(key);
-      final String? raw = atData?.data;
-      if (atData == null || raw == null) return;
-      final value = EnrollDataStoreValue.fromJson(jsonDecode(raw));
-      if (value.predecessorSettledAt == null) return;
-      final status =
-          EnrollmentStatus.values.asNameMap()[value.approval?.state ?? ''];
-      if (status == null) return;
-      value.predecessorSettledAt = null;
-      atData.data = jsonEncode(value.toJson());
-      final storedExpiry = atData.metaData?.expiresAt;
-      await put(successorEnrollmentId, atData, status,
-          assertedTimestamps: storedExpiry == null
-              ? null
-              : AtAssertedTimestamps(expiresAt: storedExpiry));
-      logger.info(
-          'Took back the retrofit-cap stamp on $successorEnrollmentId: the '
-          'cap it recorded did not happen, and the reason was transient');
-    } catch (e) {
-      logger.warning(
-          'Could not take back the retrofit-cap stamp on '
-          '$successorEnrollmentId: $e');
-    }
-  }
-
-  /// Caps [enrollmentId] to expire [retrofitCapTtlMillis] from this moment,
-  /// leaving the record in place.
-  Future<RetrofitCapOutcome> capEnrollmentExpiry(String enrollmentId) async {
-    final key = buildEnrollmentKey(enrollmentId);
-    final AtData? atData;
-    try {
-      atData = await keyStore.get(key);
-    } on KeyNotFoundException {
-      return RetrofitCapOutcome.predecessorGone;
-    }
-    if (atData == null) return RetrofitCapOutcome.predecessorGone;
-
-    // NOTE the status must come off the record just read, never off a
-    // caller's snapshot.
-    final String? raw = atData.data;
-    if (raw == null) return RetrofitCapOutcome.unreadable;
-    final EnrollDataStoreValue fresh;
-    final EnrollmentStatus? current;
-    try {
-      fresh = EnrollDataStoreValue.fromJson(jsonDecode(raw));
-      current =
-          EnrollmentStatus.values.asNameMap()[fresh.approval?.state ?? ''];
-    } catch (e) {
-      logger.severe('Not capping $enrollmentId: its record does not decode: $e');
-      return RetrofitCapOutcome.unreadable;
-    }
-    if (current == null) {
-      logger.severe('Not capping $enrollmentId: unreadable approval state');
-      return RetrofitCapOutcome.unreadable;
-    }
-    if (current != EnrollmentStatus.approved) {
-      logger.info(
-          'Not capping $enrollmentId: it is ${current.name} as of this write, '
-          'though it was approved when the cap was decided');
-      return RetrofitCapOutcome.notApproved;
-    }
-    atData.metaData = (atData.metaData ?? AtMetaData())
-      ..ttl = retrofitCapTtlMillis(
-          atData.metaData, fresh, DateTime.now().toUtc());
-    await put(enrollmentId, atData, current);
-    return RetrofitCapOutcome.capped;
-  }
-
   /// Settles what the enrollment [successorEnrollmentId] replaced, ONCE, at
-  /// the successor's first authentication: the successor is stamped, the
-  /// predecessor's approval children move onto it, and a predecessor that is
-  /// not fully privileged is capped.
+  /// the successor's first authentication: the predecessor's approval
+  /// children move onto the successor, a predecessor that is approved and not
+  /// fully privileged is revoked as superseded, and the successor is stamped.
   ///
   /// A no-op for an enrollment that replaced nothing, and it never throws.
-  Future<void> armRetrofitCapOnFirstAuth(String successorEnrollmentId) async {
+  Future<void> settlePredecessorOnFirstAuth(
+      String successorEnrollmentId) async {
     try {
       final EnrollDataStoreValue cached =
           await getEnrollmentById(successorEnrollmentId);
       if (cached.retrofitPredecessorEnrollmentId == null) return;
       if (cached.predecessorSettledAt != null) return;
     } catch (e) {
-      logger.warning('Could not decide whether to arm the retrofit cap for '
-          '$successorEnrollmentId: $e');
+      logger.warning('Could not decide whether $successorEnrollmentId has a '
+          'predecessor to settle: $e');
       return;
     }
     await serialiseMutation(
-        () => _armRetrofitCapOnFirstAuth(successorEnrollmentId));
+        () => _settlePredecessorOnFirstAuth(successorEnrollmentId));
   }
 
-  Future<void> _armRetrofitCapOnFirstAuth(String successorEnrollmentId) async {
+  Future<void> _settlePredecessorOnFirstAuth(
+      String successorEnrollmentId) async {
     try {
       // NOTE both tests are re-asked here, inside the critical section.
       final EnrollDataStoreValue cached =
           await getEnrollmentById(successorEnrollmentId);
-      final predecessorId = cached.retrofitPredecessorEnrollmentId;
+      final String? predecessorId = cached.retrofitPredecessorEnrollmentId;
       if (predecessorId == null) return;
       if (cached.predecessorSettledAt != null) return;
 
-      final key = buildEnrollmentKey(successorEnrollmentId);
+      await _adoptApprovalChildren(predecessorId, successorEnrollmentId);
 
+      final DateTime now = DateTime.now().toUtc();
       EnrollDataStoreValue? predecessor;
       try {
         predecessor = await getEnrollmentById(predecessorId);
       } on KeyNotFoundException {
-        logger.info('Enrollment $successorEnrollmentId replaced '
-            '$predecessorId, which is already gone — nothing to cap');
+        predecessor = null;
       }
-
-      bool settled = false;
-      bool capPredecessor = false;
-      final bool predecessorGone = predecessor == null;
-
-      if (predecessorGone) {
-        settled = true;
-      } else if (predecessor.approval?.state != EnrollmentStatus.approved.name) {
-        // NOTE deliberately left unstamped, so the question is re-asked at
-        // the next authentication.
-        logger.info('Enrollment $successorEnrollmentId replaced $predecessorId, '
-            'which is ${predecessor.approval?.state} — not capping it');
+      if (predecessor == null) {
+        logger.info('Enrollment $successorEnrollmentId replaced '
+            '$predecessorId, which is already gone');
       } else if (predecessor.isRootEnrollment) {
         logger.info('Enrollment $successorEnrollmentId replaced $predecessorId, '
             'which holds full privilege and keeps its life; what it admitted '
             'now hangs off its successor');
-        settled = true;
+      } else if (predecessor.approval?.state !=
+          EnrollmentStatus.approved.name) {
+        logger.info('Enrollment $successorEnrollmentId replaced $predecessorId, '
+            'which is ${predecessor.approval?.state}; leaving it as it is');
       } else {
-        settled = true;
-        capPredecessor = true;
+        final List<String> revoked = await revokeAll([predecessorId],
+            byEnrollmentId: successorEnrollmentId,
+            cascadedFrom: null,
+            at: now,
+            type: EnrollmentRevocationEventType.superseded);
+        logger.info(revoked.isEmpty
+            ? 'Enrollment $predecessorId was no longer approved when its '
+                'supersession by $successorEnrollmentId came to be written'
+            : 'Enrollment $predecessorId is superseded by '
+                '$successorEnrollmentId and revoked');
       }
 
-      if (!settled) return;
-
-      // NOTE read immediately before the write, not from a snapshot taken
-      // before the lookups above.
+      // NOTE the stamp goes last, read immediately before its write; a
+      // failure before it is re-asked at the next authentication.
+      final key = buildEnrollmentKey(successorEnrollmentId);
       final AtData? atData = await keyStore.get(key);
       final String? raw = atData?.data;
       if (atData == null || raw == null) return;
       final successor = EnrollDataStoreValue.fromJson(jsonDecode(raw));
-      // NOTE this uncached re-test is what makes "first" hold; the cached
-      // checks at the entry point are only a fast path.
       if (successor.predecessorSettledAt != null) return;
-
-      successor.predecessorSettledAt = DateTime.now().toUtc();
-      atData.data = jsonEncode(successor.toJson());
-      // NOTE the successor's own expiry must not move.
-      final storedExpiry = atData.metaData?.expiresAt;
-      // NOTE the record's own status, never a default.
       final EnrollmentStatus? successorStatus =
           EnrollmentStatus.values.asNameMap()[successor.approval?.state ?? ''];
       if (successorStatus == null) {
@@ -1323,26 +1208,16 @@ class EnrollmentManager {
             'state ${successor.approval?.state}; not stamping it');
         return;
       }
+      successor.predecessorSettledAt = now;
+      atData.data = jsonEncode(successor.toJson());
+      // NOTE the successor's own expiry must not move.
+      final storedExpiry = atData.metaData?.expiresAt;
       await put(successorEnrollmentId, atData, successorStatus,
           assertedTimestamps: storedExpiry == null
               ? null
               : AtAssertedTimestamps(expiresAt: storedExpiry));
-
-      // NOTE the cap goes after the stamp.
-      if (capPredecessor) {
-        final RetrofitCapOutcome outcome =
-            await capEnrollmentExpiry(predecessorId);
-        // NOTE a transient refusal takes the stamp back, so the question is
-        // re-asked at the next authentication.
-        if (outcome == RetrofitCapOutcome.notApproved ||
-            outcome == RetrofitCapOutcome.unreadable) {
-          await _clearCapStamp(successorEnrollmentId, key);
-          return;
-        }
-      }
-      await _adoptApprovalChildren(predecessorId, successorEnrollmentId);
     } catch (e) {
-      logger.warning('Could not arm the retrofit cap for '
+      logger.warning('Could not settle the predecessor of '
           '$successorEnrollmentId: $e');
     }
   }

--- a/packages/at_secondary_server/lib/src/enroll/enrollment_manager.dart
+++ b/packages/at_secondary_server/lib/src/enroll/enrollment_manager.dart
@@ -1165,7 +1165,7 @@ class EnrollmentManager {
     return revoked;
   }
 
-  /// Takes back a `predecessorCapArmedAt` stamp whose cap did not happen,
+  /// Takes back a `predecessorSettledAt` stamp whose cap did not happen,
   /// best-effort and inside [serialiseMutation].
   Future<void> _clearCapStamp(String successorEnrollmentId, String key) async {
     try {
@@ -1173,11 +1173,11 @@ class EnrollmentManager {
       final String? raw = atData?.data;
       if (atData == null || raw == null) return;
       final value = EnrollDataStoreValue.fromJson(jsonDecode(raw));
-      if (value.predecessorCapArmedAt == null) return;
+      if (value.predecessorSettledAt == null) return;
       final status =
           EnrollmentStatus.values.asNameMap()[value.approval?.state ?? ''];
       if (status == null) return;
-      value.predecessorCapArmedAt = null;
+      value.predecessorSettledAt = null;
       atData.data = jsonEncode(value.toJson());
       final storedExpiry = atData.metaData?.expiresAt;
       await put(successorEnrollmentId, atData, status,
@@ -1248,7 +1248,7 @@ class EnrollmentManager {
       final EnrollDataStoreValue cached =
           await getEnrollmentById(successorEnrollmentId);
       if (cached.retrofitPredecessorEnrollmentId == null) return;
-      if (cached.predecessorCapArmedAt != null) return;
+      if (cached.predecessorSettledAt != null) return;
     } catch (e) {
       logger.warning('Could not decide whether to arm the retrofit cap for '
           '$successorEnrollmentId: $e');
@@ -1265,7 +1265,7 @@ class EnrollmentManager {
           await getEnrollmentById(successorEnrollmentId);
       final predecessorId = cached.retrofitPredecessorEnrollmentId;
       if (predecessorId == null) return;
-      if (cached.predecessorCapArmedAt != null) return;
+      if (cached.predecessorSettledAt != null) return;
 
       final key = buildEnrollmentKey(successorEnrollmentId);
 
@@ -1308,9 +1308,9 @@ class EnrollmentManager {
       final successor = EnrollDataStoreValue.fromJson(jsonDecode(raw));
       // NOTE this uncached re-test is what makes "first" hold; the cached
       // checks at the entry point are only a fast path.
-      if (successor.predecessorCapArmedAt != null) return;
+      if (successor.predecessorSettledAt != null) return;
 
-      successor.predecessorCapArmedAt = DateTime.now().toUtc();
+      successor.predecessorSettledAt = DateTime.now().toUtc();
       atData.data = jsonEncode(successor.toJson());
       // NOTE the successor's own expiry must not move.
       final storedExpiry = atData.metaData?.expiresAt;

--- a/packages/at_secondary_server/lib/src/enroll/enrollment_revocation_event.dart
+++ b/packages/at_secondary_server/lib/src/enroll/enrollment_revocation_event.dart
@@ -5,6 +5,10 @@ enum EnrollmentRevocationEventType {
 
   /// A revocation was withdrawn: the enrollment went back to approved.
   unrevoked,
+
+  /// The enrollment became revoked because the one that replaced it in a
+  /// retrofit authenticated for the first time.
+  superseded,
 }
 
 /// One moment an enrollment's revocation state changed.
@@ -21,7 +25,8 @@ class EnrollmentRevocationEvent {
   final Map<String, String> namespaces;
 
   /// The enrollment on the connection that issued the command, or null when
-  /// the connection carried no enrollment id, a CRAM connection.
+  /// the connection carried no enrollment id, a CRAM connection; for a
+  /// supersession, the successor.
   final String? byEnrollmentId;
 
   /// The enrollment the command NAMED when this event is a consequence of
@@ -41,12 +46,10 @@ class EnrollmentRevocationEvent {
   /// including an event kind it does not know.
   factory EnrollmentRevocationEvent.fromJson(Map<String, dynamic> json) {
     final Object? kind = json['event'];
-    final EnrollmentRevocationEventType type;
-    if (kind == EnrollmentRevocationEventType.revoked.name) {
-      type = EnrollmentRevocationEventType.revoked;
-    } else if (kind == EnrollmentRevocationEventType.unrevoked.name) {
-      type = EnrollmentRevocationEventType.unrevoked;
-    } else {
+    final EnrollmentRevocationEventType? type = kind is String
+        ? EnrollmentRevocationEventType.values.asNameMap()[kind]
+        : null;
+    if (type == null) {
       throw FormatException('unknown revocation event kind: $kind');
     }
     final Object? enrollmentId = json['enrollmentId'];

--- a/packages/at_secondary_server/lib/src/server/at_secondary_config.dart
+++ b/packages/at_secondary_server/lib/src/server/at_secondary_config.dart
@@ -727,15 +727,6 @@ class AtSecondaryConfig {
         48;
   }
 
-  /// How long a superseded enrollment keeps authenticating after the
-  /// enrollment that replaced it first authenticates.
-  static int get apkamSelfEnrollmentGraceHours {
-    return _getIntEnvVar('apkamSelfEnrollmentGraceHours') ??
-        getNullableIntFromYaml(
-            ['enrollment', 'apkamSelfEnrollmentGraceHours']) ??
-        720;
-  }
-
   static final int _enrollmentResponseDelayIntervalInSeconds = 55;
 
   static int? _maxEnrollRequestsAllowed;

--- a/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
@@ -398,6 +398,13 @@ class EnrollVerbHandler extends AbstractVerbHandler {
             'Predecessor enrollment $predecessorId does not exist or has '
             'expired');
       }
+      if (!predecessor.isRootEnrollment &&
+          await _predecessorAlreadySettled(enMgr, predecessorId)) {
+        throw UnAuthorizedException(
+            'Enrollment $predecessorId has already been replaced, and its '
+            'replacement has authenticated; a second replacement is not '
+            'allowed. A sibling clone of this keyfile enrols over an OTP');
+      }
       if (predecessor.approval?.state != EnrollmentStatus.approved.name) {
         throw UnAuthorizedException(
             'Predecessor enrollment $predecessorId is not approved');
@@ -414,21 +421,13 @@ class EnrollVerbHandler extends AbstractVerbHandler {
             'Enrollment $predecessorId is itself a replacement, and a '
             'replacement may not be replaced without an approver');
       }
-      if (!predecessor.isRootEnrollment &&
-          await _retrofitCapAlreadyArmed(enMgr, predecessorId)) {
-        throw UnAuthorizedException(
-            'Enrollment $predecessorId has already been replaced, and its '
-            'replacement has authenticated; a second split is not allowed '
-            'once the first successor has authenticated. A sibling clone of '
-            'this keyfile enrols over an OTP');
-      }
       // Escalation first, so a request naming MORE keeps its own diagnosis.
       verifyNoEscalation(predecessor.namespaces, enrollNamespaces);
       requireGrantsMatchPredecessor(predecessor.namespaces, enrollParams.namespaces);
       enrollmentValue.namespaces = Map.of(predecessor.namespaces);
 
       enrollmentValue.approval = EnrollApproval(EnrollmentStatus.approved.name);
-      // What this successor REPLACED, which the retrofit cap reads.
+      // What this successor REPLACED, which the settlement reads.
       // ⛔ Not for revocation: the revoke path does NOT walk this edge.
       enrollmentValue.retrofitPredecessorEnrollmentId = predecessorId;
       // A retrofit takes the predecessor's place in the approval graph.
@@ -454,9 +453,9 @@ class EnrollVerbHandler extends AbstractVerbHandler {
             predecessor.apkamKeysExpiryDuration;
       }
 
-      // The clamp above compares TERMS, and a capped predecessor's real
-      // deadline lives only in its RECORD metadata, so bound the successor by
-      // that stored DEADLINE. The POSTURE is narrowed rather than the ttl.
+      // The clamp above compares TERMS, and the predecessor's real deadline
+      // lives only in its RECORD metadata, so bound the successor by that
+      // stored DEADLINE. The POSTURE is narrowed rather than the ttl.
       DateTime? boundedDeadline;
       final DateTime? predecessorExpiresAt =
           (await keyStore.getMeta(enMgr.buildEnrollmentKey(predecessorId)))
@@ -503,7 +502,7 @@ class EnrollVerbHandler extends AbstractVerbHandler {
               ? null
               : AtAssertedTimestamps(expiresAt: boundedDeadline));
 
-      // NOTE the predecessor is NOT capped here; the cap is armed by the
+      // NOTE the predecessor is NOT settled here; that happens at the
       // successor's FIRST PKAM authentication.
       return;
     }
@@ -1335,9 +1334,9 @@ class EnrollVerbHandler extends AbstractVerbHandler {
     return md.isAuthenticated && id != null && id.isNotEmpty;
   }
 
-  /// Whether a retrofit of [predecessorId] has already capped it: a stored
-  /// enrollment naming it as the one it replaced, whose cap is armed.
-  Future<bool> _retrofitCapAlreadyArmed(
+  /// Whether a stored enrollment that replaced [predecessorId] has already
+  /// settled it.
+  Future<bool> _predecessorAlreadySettled(
       EnrollmentManager enMgr, String predecessorId) async {
     final String canonical =
         EnrollmentManager.canonicalEnrollmentId(predecessorId);

--- a/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
@@ -1343,7 +1343,7 @@ class EnrollVerbHandler extends AbstractVerbHandler {
         EnrollmentManager.canonicalEnrollmentId(predecessorId);
     for (final (_, EnrollDataStoreValue existing)
         in await enMgr.storedEnrollments()) {
-      if (existing.predecessorCapArmedAt == null) continue;
+      if (existing.predecessorSettledAt == null) continue;
       if (EnrollmentManager.canonicalEnrollmentIdOrNull(
               existing.retrofitPredecessorEnrollmentId) ==
           canonical) {

--- a/packages/at_secondary_server/lib/src/verb/handler/pkam_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/pkam_verb_handler.dart
@@ -133,11 +133,11 @@ class PkamVerbHandler extends AbstractVerbHandler {
       response.data = 'success';
       enrollId = atConnectionMetadata.enrollmentId;
 
-      // NOTE the retrofit cap is armed here, on the first authentication that
-      // proves the successor's APKAM private half is usable, and never throws.
+      // NOTE a retrofit predecessor is settled here, on the first
+      // authentication proving the successor's private half is usable.
       if (enrollId != null && enrollId.isNotEmpty) {
         final enMgr = AtSecondaryServerImpl.getInstance().enrollmentManager;
-        await enMgr.armRetrofitCapOnFirstAuth(enrollId);
+        await enMgr.settlePredecessorOnFirstAuth(enrollId);
       }
     } else {
       atConnectionMetadata.isAuthenticated = false;

--- a/packages/at_secondary_server/test/apkam_self_enrollment_test.dart
+++ b/packages/at_secondary_server/test/apkam_self_enrollment_test.dart
@@ -12,7 +12,6 @@ import 'package:at_secondary/src/verb/handler/pkam_verb_handler.dart';
 import 'package:at_secondary/src/enroll/enroll_datastore_value.dart';
 import 'package:at_secondary/src/enroll/enrollment_manager.dart';
 import 'package:at_secondary/src/enroll/enrollment_revocation_event.dart';
-import 'package:at_secondary/src/server/at_secondary_config.dart';
 import 'package:at_secondary/src/utils/handler_util.dart';
 import 'package:at_server_spec/at_server_spec.dart';
 import 'package:test/test.dart';
@@ -44,6 +43,12 @@ void main() {
 
   /// Issues `enroll:request` on an APKAM-authenticated connection carrying
   /// [predecessorId], with no OTP.
+  Future<String?> stateOf(String id) async => EnrollDataStoreValue.fromJson(
+          jsonDecode((await keyValueStore.get(enMgr.buildEnrollmentKey(id)))!
+              .data!))
+      .approval
+      ?.state;
+
   Future<Response> selfEnroll({
     required String predecessorId,
     Map<String, String>? namespaces,
@@ -158,9 +163,9 @@ void main() {
     expect(successor.approval?.state, EnrollmentStatus.approved.name);
     expect(successor.retrofitPredecessorEnrollmentId, predecessorId,
         reason: 'the successor records what it replaced, which is what the '
-            'retrofit cap reads to know whose expiry to put a clock on. NOT '
-            'for revocation: that follows the approver the successor '
-            'inherits, never this edge');
+            'settlement reads to know what to revoke. NOT for revocation by '
+            'cascade: that follows the approver the successor inherits, '
+            'never this edge');
     expect(successor.namespaces.containsKey('__manage'), isFalse,
         reason: 'auto-approve must NOT carry the CRAM branch\'s __manage/* '
             'grant — that grant is what makes CRAM the atSign\'s root, and a '
@@ -170,17 +175,18 @@ void main() {
     final predecessorAfter = await enMgr.getEnrollmentById(predecessorId);
     expect(predecessorAfter.approval?.state, EnrollmentStatus.approved.name,
         reason: 'sibling clones of the same keyfile still authenticate as the '
-            'predecessor until the cap elapses');
+            'predecessor until a successor does');
     final predecessorData =
         await keyValueStore.get(enMgr.buildEnrollmentKey(predecessorId));
     expect(predecessorData?.metaData?.expiresAt, isNull,
-        reason: 'the cap is armed by the successor\'s first authentication, '
-            'not by storing it. A successor whose keyfile write failed exists '
-            'here and nowhere else, and starting a clock on the predecessor — '
-            'by then the only credential that still works — on the strength '
-            'of a record only this server has seen is exactly the hazard');
+        reason: 'the predecessor is settled by the successor\'s first '
+            'authentication, not by storing it. A successor whose keyfile '
+            'write failed exists here and nowhere else, and revoking the '
+            'predecessor, by then the only credential that still works, on '
+            'the strength of a record only this server has seen is exactly '
+            'the hazard');
     expect(successor.predecessorSettledAt, isNull,
-        reason: 'and the successor records that it has armed nothing yet');
+        reason: 'and the successor records that it has settled nothing yet');
   });
 
   test('escalation is refused: a namespace the predecessor does not hold', () async {
@@ -228,7 +234,7 @@ void main() {
         reason: 'a retrofit replaces its predecessor, so it carries those '
             'grants exactly — __manage included, which is what leaves the '
             'atSign able to approve a replacement once the predecessor is '
-            'capped');
+            'revoked');
   });
 
   test('naming a subset of a wildcard predecessor is refused', () async {
@@ -293,64 +299,32 @@ void main() {
   });
 
   test(
-      'the cap re-arms on each sibling\'s first authentication rather than '
-      'keeping the first deadline', () async {
+      'siblings that both enrolled before either authenticated settle the same '
+      'predecessor: the first revokes it, the second finds it revoked',
+      () async {
     final predecessorId = (await etu.createEnrollments(n: 1)).$1.first;
     final (firstId, firstKey) = await retrofitWithRealKey(predecessorId,
         appName: 'sib1', deviceName: 'sib1-device');
-    // NOTE both siblings enrol before either authenticates: once the first
-    // has capped the predecessor, the predecessor no longer splits.
     final (secondId, secondKey) = await retrofitWithRealKey(predecessorId,
         appName: 'sib2', deviceName: 'sib2-device');
-    await authenticateAs(firstId, firstKey, sessionId: 'sib1-session');
 
-    final key = enMgr.buildEnrollmentKey(predecessorId);
-    final aged = await keyValueStore.get(key);
-    aged!.metaData!.ttl = 60000;
-    await enMgr.put(predecessorId, aged, EnrollmentStatus.approved);
+    await authenticateAs(firstId, firstKey, sessionId: 'sib1-session');
+    expect(await stateOf(predecessorId), EnrollmentStatus.revoked.name,
+        reason: 'the first sibling to authenticate supersedes the predecessor');
 
     await authenticateAs(secondId, secondKey, sessionId: 'sib2-session');
-
-    final graceMillis =
-        Duration(hours: AtSecondaryConfig.apkamSelfEnrollmentGraceHours)
-            .inMilliseconds;
-    final ttl = (await keyValueStore.get(key))!.metaData!.ttl!;
-    expect(ttl, greaterThan(60000),
-        reason: 'a min-fold against the previously capped ttl keeps the '
-            'first sibling\'s deadline and strands every later one — the cap '
-            'must re-arm to a full grace period from the moment the newest '
-            'sibling proves itself');
-    expect(ttl, lessThanOrEqualTo(graceMillis));
-  });
-
-  test(
-      'the cap never extends past the expiry the predecessor\'s own posture '
-      'imposes', () async {
-    final predecessorId = (await etu.createEnrollments(n: 1)).$1.first;
-    final key = enMgr.buildEnrollmentKey(predecessorId);
-    final atData = await keyValueStore.get(key);
-    final value = EnrollDataStoreValue.fromJson(jsonDecode(atData!.data!));
-    value.apkamKeysExpiryDuration = Duration(hours: 1);
-    atData.data = jsonEncode(value.toJson());
-    atData.metaData!.ttl = Duration(hours: 1).inMilliseconds;
-    await enMgr.put(predecessorId, atData, EnrollmentStatus.approved);
-
-    // NOTE the successor must authenticate, or no cap is armed at all.
-    final (successorId, successorKey) = await retrofitWithRealKey(predecessorId);
-    await authenticateAs(successorId, successorKey, sessionId: 'posture-session');
-
-    final ttl = (await keyValueStore.get(key))!.metaData!.ttl!;
-    expect(ttl, greaterThan(0),
-        reason: 'control: a cap was actually written, so the bound below is '
-            'measuring the fold and not an uncapped record');
-    expect(ttl, lessThanOrEqualTo(Duration(hours: 1).inMilliseconds),
-        reason: 'the re-arm applies only within the enrollment\'s own '
-            'key-expiry posture — a 1h apkamKeysExpiryDuration must not '
-            'become a 30-day grace');
-    expect(ttl, greaterThan(Duration(minutes: 55).inMilliseconds),
-        reason: 'and it is the posture\'s REMAINING life, not an arbitrary '
-            'smaller number: an upper bound alone is satisfied by any '
-            'mistake that shortens the cap, including writing 1ms');
+    expect((await enMgr.getEnrollmentById(secondId)).predecessorSettledAt,
+        isNotNull,
+        reason: 'the second is settled too, or every later authentication '
+            're-asks the question');
+    final supersessions = (await enMgr.revocationEvents())
+        .where((e) =>
+            e.enrollmentId == predecessorId &&
+            e.type == EnrollmentRevocationEventType.superseded)
+        .toList();
+    expect(supersessions.map((e) => e.byEnrollmentId), [firstId],
+        reason: 'one supersession, by the sibling that revoked it; the '
+            'second found it revoked and wrote none');
   });
 
   test('the successor record expires per the posture it inherited', () async {
@@ -776,7 +750,7 @@ void main() {
           reason: 'whoever admitted the predecessor admitted this');
       expect(successor.retrofitPredecessorEnrollmentId, predecessorId,
           reason: 'control: the replacement edge is still recorded, because '
-              'the retrofit cap needs to know what it replaced');
+              'the settlement needs to know what it replaced');
     });
 
     test('revoking a predecessor does NOT revoke what replaced it', () async {
@@ -935,32 +909,59 @@ void main() {
             deviceName: 'sibling-dev-$i');
         expect(r.isError, false,
             reason: 'sibling $i must still be able to retrofit the root, no '
-                'successor having authenticated and capped it yet: '
+                'successor having authenticated and settled it yet: '
                 '${r.errorMessage}');
       }
     });
 
-    test('a predecessor its first successor has capped is not split again',
+    test('a predecessor its first successor has settled is not split again',
         () async {
       final predecessorId = (await etu.createEnrollments(n: 1)).$1.first;
       final (firstId, firstKey) = await retrofitWithRealKey(predecessorId,
-          appName: 'capped-app', deviceName: 'capped-dev');
-      await authenticateAs(firstId, firstKey, sessionId: 'capped-session');
+          appName: 'settled-app', deviceName: 'settled-dev');
+      await authenticateAs(firstId, firstKey, sessionId: 'settled-session');
       expect((await enMgr.getEnrollmentById(firstId)).predecessorSettledAt,
           isNotNull,
           reason: 'precondition: the first successor has authenticated, and '
-              'the cap it armed is what the refusal reads');
+              'the settlement it recorded is what the refusal reads');
 
       await expectLater(
           () => selfEnroll(
               predecessorId: predecessorId,
-              appName: 'capped-app-2',
-              deviceName: 'capped-dev-2'),
+              appName: 'settled-app-2',
+              deviceName: 'settled-dev-2'),
           throwsA(isA<UnAuthorizedException>().having((e) => e.message,
-              'message', contains('a second split is not allowed'))),
-          reason: 'the predecessor is on a clock nothing takes it off, so a '
-              'successor minted now inherits a life measured in hours; a '
-              'sibling clone of the keyfile enrols over an OTP instead');
+              'message', contains('a second replacement is not allowed'))),
+          reason: 'a superseded predecessor is revoked, and stays settled '
+              'even if un-revoked; a sibling clone of the keyfile enrols '
+              'over an OTP instead');
+    });
+
+    test('an un-revoked predecessor is still not split again', () async {
+      final predecessorId = (await etu.createEnrollments(n: 1)).$1.first;
+      final (firstId, firstKey) = await retrofitWithRealKey(predecessorId,
+          appName: 'revived-app', deviceName: 'revived-dev');
+      await authenticateAs(firstId, firstKey, sessionId: 'revived-session');
+      expect(await stateOf(predecessorId), EnrollmentStatus.revoked.name,
+          reason: 'precondition: superseded');
+
+      final k = enMgr.buildEnrollmentKey(predecessorId);
+      final revived = (await keyValueStore.get(k))!;
+      final value = EnrollDataStoreValue.fromJson(jsonDecode(revived.data!))
+        ..approval = EnrollApproval(EnrollmentStatus.approved.name);
+      revived.data = jsonEncode(value.toJson());
+      await enMgr.put(predecessorId, revived, EnrollmentStatus.approved);
+
+      await expectLater(
+          () => selfEnroll(
+              predecessorId: predecessorId,
+              appName: 'revived-app-2',
+              deviceName: 'revived-dev-2'),
+          throwsA(isA<UnAuthorizedException>().having((e) => e.message,
+              'message', contains('a second replacement is not allowed'))),
+          reason: 'an un-revoke restores the credential, not the once-off '
+              'migration it has already spent; the approval check alone would '
+              'let it through');
     });
 
     test('a ROOT predecessor is split again after its first successor '
@@ -981,106 +982,8 @@ void main() {
           deviceName: 'root-split-dev-2');
 
       expect(r.isError, false,
-          reason: 'a root is never capped, so it keeps its life and stays '
-              'splittable: ${r.errorMessage}');
-    });
-  });
-
-  group('the retrofit cap fold', () {
-    final now = DateTime.utc(2026, 1, 1, 12);
-    final graceMs =
-        Duration(hours: AtSecondaryConfig.apkamSelfEnrollmentGraceHours)
-            .inMilliseconds;
-
-    EnrollDataStoreValue withPosture(Duration d) =>
-        EnrollDataStoreValue('s', 'app', 'device', 'pk')
-          ..apkamKeysExpiryDuration = d;
-
-    test('a record that never expires is bounded only by the grace', () {
-      expect(
-          enMgr.retrofitCapTtlMillis(
-              AtMetaData()..createdAt = now, withPosture(Duration.zero), now),
-          graceMs);
-      expect(enMgr.retrofitCapTtlMillis(null, withPosture(Duration.zero), now),
-          graceMs,
-          reason: 'and a record with no metadata at all is the same case');
-    });
-
-    test('a POSTURE with no stored expiry does not bound anything', () {
-      expect(
-          enMgr.retrofitCapTtlMillis(
-              AtMetaData()..createdAt = now.subtract(Duration(days: 60)),
-              withPosture(Duration(days: 7)),
-              now),
-          graceMs,
-          reason: 'the record stores no expiry, so it does not expire, and '
-              'only the migration grace bounds the cap');
-    });
-
-    test('a stored expiry sooner than the grace wins', () {
-      expect(
-          enMgr.retrofitCapTtlMillis(
-              AtMetaData()
-                ..createdAt = now.subtract(Duration(minutes: 10))
-                ..expiresAt = now.add(Duration(minutes: 50)),
-              withPosture(Duration(hours: 1)),
-              now),
-          Duration(minutes: 50).inMilliseconds,
-          reason: 'the cap may never outlive the expiry the enrollment '
-              'already carries');
-    });
-
-    test('a stored expiry later than the grace does not extend it', () {
-      expect(
-          enMgr.retrofitCapTtlMillis(
-              AtMetaData()
-                ..createdAt = now
-                ..expiresAt = now.add(Duration(days: 3650)),
-              withPosture(Duration(days: 3650)),
-              now),
-          graceMs,
-          reason: 'the fold is a min, not a max');
-    });
-
-    test('an elapsed expiry is floored at 1ms, never at zero', () {
-      expect(
-          enMgr.retrofitCapTtlMillis(
-              AtMetaData()
-                ..createdAt = now.subtract(Duration(hours: 5))
-                ..expiresAt = now.subtract(Duration(hours: 4)),
-              withPosture(Duration(hours: 1)),
-              now),
-          1,
-          reason: 'a ttl of zero is the keystore\'s "never expires", so an '
-              'elapsed record must not be written as 0 — that would turn a '
-              'spent credential into a permanent one');
-    });
-
-    test('the deadline is taken from approval, not from creation', () {
-      expect(
-          enMgr.retrofitCapTtlMillis(
-              AtMetaData()
-                ..createdAt = now.subtract(Duration(hours: 8))
-                ..expiresAt = now.add(Duration(hours: 7)),
-              withPosture(Duration(hours: 1)),
-              now),
-          Duration(hours: 7).inMilliseconds,
-          reason: 'createdAt + posture is 7 hours in the PAST here; the '
-              'stored expiry is what the record actually carries');
-    });
-
-    test('an expiry already shortened by a previous cap does not bound the '
-        're-arm', () {
-      expect(
-          enMgr.retrofitCapTtlMillis(
-              AtMetaData()
-                ..createdAt = now.subtract(Duration(minutes: 10))
-                ..expiresAt = now.add(Duration(minutes: 1)),
-              withPosture(Duration(hours: 1)),
-              now),
-          Duration(minutes: 50).inMilliseconds,
-          reason: 'a previously written cap is not the posture: the posture '
-              'still has 50 minutes to run, and the re-arm may use them');
+          reason: 'a root is never revoked as a predecessor, so it keeps its '
+              'life and stays splittable: ${r.errorMessage}');
     });
   });
 
@@ -1470,7 +1373,8 @@ void main() {
               'enrollment part-way up no longer severs the chain');
     });
 
-    test('a retrofit cap re-parents a child whose ttl has elapsed', () async {
+    test('settling a predecessor re-parents a child whose ttl has elapsed',
+        () async {
       await mintApprovedBy('rp-predecessor', etu.primaryEnId);
       await mintApprovedBy('rp-child', 'rp-predecessor',
           ttl: Duration(milliseconds: 1));
@@ -1491,31 +1395,11 @@ void main() {
       expect(r.isError, false, reason: '${r.errorMessage}');
       final String successor = jsonDecode(r.data!)['enrollmentId'] as String;
 
-      await enMgr.armRetrofitCapOnFirstAuth(successor);
+      await enMgr.settlePredecessorOnFirstAuth(successor);
 
       expect(await approverIdOf('rp-child'), successor,
           reason: 'the successor stands where its predecessor stood, and the '
-              'predecessor is now on a clock — a child left naming it is '
-              'orphaned the moment that clock runs out');
-    });
-
-    test('capping refuses on a record that is no longer approved', () async {
-      await mintUnder('cap-target', null);
-      final stale = await enMgr.getEnrollmentById('cap-target');
-      expect(stale.approval?.state, EnrollmentStatus.approved.name,
-          reason: 'precondition: the snapshot says approved');
-
-      await revoke(etu.primaryEnId, 'cap-target');
-      final key = enMgr.buildEnrollmentKey('cap-target');
-      final before = (await keyValueStore.get(key))?.metaData?.expiresAt;
-
-      await enMgr.capEnrollmentExpiry('cap-target');
-
-      expect((await keyValueStore.get(key))?.metaData?.expiresAt, before,
-          reason: 'the cap must read the status off the record it just read, '
-              'not off the caller\'s snapshot, and must not write at all once '
-              'the record is no longer approved');
-      expect(await statusOf('cap-target'), EnrollmentStatus.revoked.name);
+              'predecessor is revoked; a child left naming it is orphaned');
     });
 
     test('a revoke whose cascade would remove the caller is refused', () async {
@@ -1844,8 +1728,7 @@ void main() {
           reason: 'a revoke says nothing about expiry, and the metadata '
               'builder re-derives it from the retained ttl unless the stored '
               'value is asserted back — so a cascade would hand every '
-              'enrollment it revoked a fresh full lifetime, and restart any '
-              'retrofit cap standing on it');
+              'enrollment it revoked a fresh full lifetime');
     });
 
     /// The revocation history: one record per moment an enrollment's
@@ -1860,6 +1743,30 @@ void main() {
         // Control: the log does not record every enrollment operation.
         await etu.createEnrollments(n: 1);
         expect(await enMgr.revocationEvents(), isEmpty);
+      });
+
+      test('a supersession writes one event of its own kind, by the '
+          'successor, with no cascade', () async {
+        final predecessorId = (await etu.createEnrollments(n: 1)).$1.first;
+        final grants = Map<String, String>.from(
+            (await enMgr.getEnrollmentById(predecessorId)).namespaces);
+        final (successorId, key) = await retrofitWithRealKey(predecessorId);
+        final before = DateTime.now().toUtc();
+
+        await authenticateAs(successorId, key, sessionId: 'supersede-log');
+
+        final events = await eventsFor(predecessorId);
+        expect(events, hasLength(1),
+            reason: 'one event for the supersession, and no plain revoke '
+                'beside it');
+        final e = events.single;
+        expect(e.type, EnrollmentRevocationEventType.superseded,
+            reason: 'the history says what happened, not that the successor '
+                'revoked its predecessor by name');
+        expect(e.byEnrollmentId, successorId);
+        expect(e.cascadedFrom, isNull);
+        expect(e.namespaces, grants);
+        expect(e.at.isBefore(before), isFalse);
       });
 
       test('a revoke writes one event, naming who did it and what it held',
@@ -2017,13 +1924,33 @@ void main() {
         return jsonDecode(r.data!) as Map<String, dynamic>;
       }
 
+      test('a supersession counts as a revocation of what the predecessor '
+          'held', () async {
+        final predecessorId = (await etu.createEnrollments(n: 1)).$1.first;
+        final namespace =
+            (await enMgr.getEnrollmentById(predecessorId)).namespaces.keys.first;
+        expect(await enMgr.lastRevocationForNamespace(namespace), isNull,
+            reason: 'control: nothing holding $namespace has been revoked yet');
+        final (successorId, key) = await retrofitWithRealKey(predecessorId);
+
+        await authenticateAs(successorId, key, sessionId: 'supersede-infons');
+
+        final supersededAt = (await enMgr.revocationEvents())
+            .singleWhere((e) => e.enrollmentId == predecessorId)
+            .at;
+        expect(await enMgr.lastRevocationForNamespace(namespace), supersededAt,
+            reason: 'a superseded credential stopped holding $namespace at '
+                'that moment, and a client reading infons must learn it; an '
+                'event kind read as a withdrawal would hide it');
+      });
+
       /// The moment the LOG says [id] was revoked, read straight off the
       /// stored event rather than through the derivation under test.
       Future<DateTime> soleRevocationOf(String id) async {
         final es = (await enMgr.revocationEvents())
             .where((e) =>
                 e.enrollmentId == id &&
-                e.type == EnrollmentRevocationEventType.revoked)
+                e.type != EnrollmentRevocationEventType.unrevoked)
             .toList();
         expect(es, hasLength(1),
             reason: 'meaningful only for an enrollment revoked exactly once');
@@ -2251,80 +2178,74 @@ void main() {
     });
   });
 
-  group('the retrofit cap is armed by the successor\'s first authentication',
+  group('the predecessor is settled by the successor\'s first authentication',
       () {
     test('a successor that never authenticates leaves its predecessor alone',
         () async {
       final predecessorId = (await etu.createEnrollments(n: 1)).$1.first;
       await selfEnroll(predecessorId: predecessorId);
 
-      final rec = await keyValueStore.get(enMgr.buildEnrollmentKey(predecessorId));
-      expect(rec?.metaData?.expiresAt, isNull,
+      expect(await stateOf(predecessorId), EnrollmentStatus.approved.name,
           reason: 'a retrofit whose keyfile never reached disk must not '
               'retire the credential that still works');
     });
 
     test(
-        'the first authentication caps the predecessor, through the real PKAM '
-        'handler', () async {
+        'the first authentication revokes the predecessor, through the real '
+        'PKAM handler', () async {
       final predecessorId = (await etu.createEnrollments(n: 1)).$1.first;
       final (successorId, key) = await retrofitWithRealKey(predecessorId);
-
-      final before =
-          await keyValueStore.get(enMgr.buildEnrollmentKey(predecessorId));
-      expect(before?.metaData?.expiresAt, isNull,
-          reason: 'control: uncapped right up until the successor proves '
+      expect(await stateOf(predecessorId), EnrollmentStatus.approved.name,
+          reason: 'control: approved right up until the successor proves '
               'itself, so the assertion below measures the authentication');
 
       await authenticateAs(successorId, key);
 
-      final after =
-          await keyValueStore.get(enMgr.buildEnrollmentKey(predecessorId));
-      expect(after?.metaData?.expiresAt, isNotNull,
-          reason: 'the arming is wired into the production PKAM path rather '
-              'than merely implemented on EnrollmentManager — a mechanism '
-              'nothing calls is not delivered');
+      expect(await stateOf(predecessorId), EnrollmentStatus.revoked.name,
+          reason: 'the settlement is wired into the production PKAM path '
+              'rather than merely implemented on EnrollmentManager');
       expect((await enMgr.getEnrollmentById(successorId)).predecessorSettledAt,
           isNotNull,
-          reason: 'and the successor records that it armed');
+          reason: 'and the successor records that it settled');
     });
 
-    test('a second authentication does not push the deadline out again',
-        () async {
+    test('a second authentication does not revoke an un-revoked predecessor '
+        'again', () async {
       final predecessorId = (await etu.createEnrollments(n: 1)).$1.first;
       final (successorId, key) = await retrofitWithRealKey(predecessorId);
       await authenticateAs(successorId, key, sessionId: 'first-session');
-
-      final k = enMgr.buildEnrollmentKey(predecessorId);
-      expect((await keyValueStore.get(k))?.metaData?.expiresAt, isNotNull,
-          reason: 'control: the first authentication did arm it');
-      final armedAt =
+      expect(await stateOf(predecessorId), EnrollmentStatus.revoked.name,
+          reason: 'control: the first authentication did revoke it');
+      final settledAt =
           (await enMgr.getEnrollmentById(successorId)).predecessorSettledAt;
 
-      final aged = await keyValueStore.get(k);
-      aged!.metaData!.ttl = 60000;
-      await enMgr.put(predecessorId, aged, EnrollmentStatus.approved);
+      final k = enMgr.buildEnrollmentKey(predecessorId);
+      final revived = (await keyValueStore.get(k))!;
+      final value = EnrollDataStoreValue.fromJson(jsonDecode(revived.data!))
+        ..approval = EnrollApproval(EnrollmentStatus.approved.name);
+      revived.data = jsonEncode(value.toJson());
+      await enMgr.put(predecessorId, revived, EnrollmentStatus.approved);
 
       await authenticateAs(successorId, key, sessionId: 'second-session');
 
-      expect((await keyValueStore.get(k))!.metaData!.ttl!,
-          lessThanOrEqualTo(60000),
-          reason: 'a successor authenticates on every reconnect. Arming on '
-              'each one would rewrite a full grace period onto the '
-              'predecessor forever and it would never retire at all');
+      expect(await stateOf(predecessorId), EnrollmentStatus.approved.name,
+          reason: 'a successor authenticates on every reconnect; settling '
+              'on each one would revoke a deliberately un-revoked '
+              'predecessor again');
       expect((await enMgr.getEnrollmentById(successorId)).predecessorSettledAt,
-          armedAt,
-          reason: 'the stamp records the FIRST arming and does not move');
+          settledAt,
+          reason: 'the stamp records the FIRST settlement and does not move');
     });
 
-    test('an enrollment that replaced nothing arms nothing', () async {
-      await enMgr.armRetrofitCapOnFirstAuth(etu.primaryEnId);
+    test('an enrollment that replaced nothing settles nothing', () async {
+      await enMgr.settlePredecessorOnFirstAuth(etu.primaryEnId);
 
-      final rec =
-          await keyValueStore.get(enMgr.buildEnrollmentKey(etu.primaryEnId));
-      expect(rec?.metaData?.expiresAt, isNull,
+      expect(await stateOf(etu.primaryEnId), EnrollmentStatus.approved.name,
           reason: 'an enrollment with no predecessor must pass through the '
-              'arming untouched');
+              'settlement untouched');
+      expect((await enMgr.getEnrollmentById(etu.primaryEnId))
+              .predecessorSettledAt,
+          isNull);
     });
 
     test('the successor\'s OWN expiry is not restarted by the stamp',
@@ -2353,8 +2274,8 @@ void main() {
               'long it waited to authenticate');
     });
 
-    test('a REVOKED predecessor is not capped, and is not written back',
-        () async {
+    test('a REVOKED predecessor is left as it is, and the successor is '
+        'settled all the same', () async {
       final predecessorId = (await etu.createEnrollments(n: 1)).$1.first;
       final (successorId, successorKey) = await retrofitWithRealKey(predecessorId);
 
@@ -2369,19 +2290,22 @@ void main() {
 
       final after = await keyValueStore.get(key);
       expect(after?.metaData?.expiresAt, isNull,
-          reason: 'a revoked predecessor is not on a retirement clock — it is '
-              'already retired, and capping it would rewrite the record');
-      expect(
-          EnrollDataStoreValue.fromJson(jsonDecode(after!.data!))
-              .approval
-              ?.state,
-          EnrollmentStatus.revoked.name,
+          reason: 'a revoked predecessor is already retired; nothing is '
+              'written onto it');
+      expect(await stateOf(predecessorId), EnrollmentStatus.revoked.name,
           reason: 'and it stays revoked');
+      expect(
+          (await enMgr.revocationEvents())
+              .where((e) => e.enrollmentId == predecessorId)
+              .map((e) => e.type),
+          isNot(contains(EnrollmentRevocationEventType.superseded)),
+          reason: 'a predecessor found revoked is not revoked again, so no '
+              'supersession is recorded');
       expect((await enMgr.getEnrollmentById(successorId)).predecessorSettledAt,
-          isNull,
-          reason: 'and nothing is recorded as armed, because nothing was: an '
-              'unrevoke restores an ordinary predecessor and the decision has '
-              'to be re-made rather than frozen');
+          isNotNull,
+          reason: 'settled all the same: an un-revoke later restores the '
+              'predecessor, and the successor\'s next authentication must '
+              'not take it away again');
     });
 
     // A fully privileged predecessor keeps its life, whatever the successor's
@@ -2393,7 +2317,7 @@ void main() {
       ('31 days, just past the grace', Duration(days: 31)),
       ('ten years', Duration(days: 3650)),
     ]) {
-      test('a ROOT predecessor is not capped by a successor expiring in $label',
+      test('a ROOT predecessor is not revoked by a successor expiring in $label',
           () async {
         final rootId = etu.primaryEnId;
         expect((await enMgr.getEnrollmentById(rootId)).isRootEnrollment, isTrue,
@@ -2410,7 +2334,9 @@ void main() {
                 ?.metaData
                 ?.expiresAt,
             isNull,
-            reason: 'a root is never put on the retrofit cap');
+            reason: 'a root is never put on a clock');
+        expect(await stateOf(rootId), EnrollmentStatus.approved.name,
+            reason: 'and never revoked as a predecessor');
         expect(
             (await enMgr.getEnrollmentById(successorId)).predecessorSettledAt,
             isNotNull,
@@ -2450,30 +2376,26 @@ void main() {
     });
 
     test(
-        'an ORDINARY predecessor is capped even by a short-lived successor',
+        'an ORDINARY predecessor is revoked even by a short-lived successor',
         () async {
       final predecessorId = (await etu.createEnrollments(n: 1)).$1.first;
       final predecessorBefore = await enMgr.getEnrollmentById(predecessorId);
       expect(predecessorBefore.namespaces.containsKey('__manage'), isFalse,
           reason: 'precondition: an ordinary predecessor, not an approver, so '
-              'capping it strands nothing');
+              'revoking it strands nothing');
 
       final (successorId, successorKey) = await retrofitWithRealKey(predecessorId,
           apkamKeysExpiryDuration: Duration(minutes: 1));
       await authenticateAs(successorId, successorKey, sessionId: 'ordinary-short');
 
-      expect(
-          (await keyValueStore.get(enMgr.buildEnrollmentKey(predecessorId)))
-              ?.metaData
-              ?.expiresAt,
-          isNotNull,
+      expect(await stateOf(predecessorId), EnrollmentStatus.revoked.name,
           reason: 'a short-lived successor still retires an ordinary '
               'predecessor: there are other approvers behind it, so nothing '
               'is stranded and the migration must still make progress');
     });
 
     test(
-        'an ordinary predecessor is capped even when NOTHING could restore a '
+        'an ordinary predecessor is revoked even when NOTHING could restore a '
         'root', () async {
       final predecessorId = (await etu.createEnrollments(n: 1)).$1.first;
       expect((await enMgr.getEnrollmentById(predecessorId)).isRootEnrollment,
@@ -2491,24 +2413,20 @@ void main() {
       expect(
           await enMgr.hasUnexpiringRootEnrollment({predecessorId}),
           isFalse,
-          reason: 'precondition: nothing could restore a root, so a cap that '
-              'asked the stranding question here would decline');
+          reason: 'precondition: nothing could restore a root, so a revoke '
+              'that asked the stranding question here would decline');
 
       final (successorId, successorKey) = await retrofitWithRealKey(predecessorId,
           apkamKeysExpiryDuration: Duration(minutes: 1));
       await authenticateAs(successorId, successorKey, sessionId: 'ordinary-noroot');
 
-      expect(
-          (await keyValueStore.get(enMgr.buildEnrollmentKey(predecessorId)))
-              ?.metaData
-              ?.expiresAt,
-          isNotNull,
+      expect(await stateOf(predecessorId), EnrollmentStatus.revoked.name,
           reason: 'the migration must still make progress for ordinary '
               'credentials, whatever state the atSign\'s roots are in');
     });
 
-    test('a cap that declines LATE takes its stamp back', () async {
-      // NOTE the stamp goes on before the cap, deliberately.
+    test('a predecessor revoked between the decision and the write is not '
+        'revoked twice, and the successor is settled', () async {
       final predecessorId = (await etu.createEnrollments(n: 1)).$1.first;
       final (successorId, successorKey) =
           await retrofitWithRealKey(predecessorId);
@@ -2526,14 +2444,21 @@ void main() {
       await authenticateAs(successorId, successorKey,
           sessionId: 'late-decline');
 
+      expect(await stateOf(predecessorId), EnrollmentStatus.revoked.name);
+      expect(
+          (await enMgr.revocationEvents())
+              .where((e) => e.enrollmentId == predecessorId)
+              .map((e) => e.type),
+          isNot(contains(EnrollmentRevocationEventType.superseded)),
+          reason: 'the revoke reads the record it is about to write, not '
+              'the cached snapshot the decision was made on');
       expect((await enMgr.getEnrollmentById(successorId)).predecessorSettledAt,
-          isNull,
-          reason: 'the cap did not happen, so the stamp saying it did must not '
-              'stand — otherwise the early exit short-circuits every later '
-              'authentication and the predecessor is never capped again');
+          isNotNull,
+          reason: 'and the successor is settled, so nothing is re-asked');
     });
 
-    test('a declined cap is re-decided on the next authentication', () async {
+    test('a predecessor found revoked is settled for good: un-revoking it does '
+        'not get it revoked by the next authentication', () async {
       final predecessorId = (await etu.createEnrollments(n: 1)).$1.first;
       final (successorId, successorKey) = await retrofitWithRealKey(predecessorId);
 
@@ -2546,9 +2471,8 @@ void main() {
 
       await authenticateAs(successorId, successorKey, sessionId: 'declined-1');
       expect((await enMgr.getEnrollmentById(successorId)).predecessorSettledAt,
-          isNull,
-          reason: 'nothing was armed, so nothing is recorded as armed — the '
-              'successor must ask again rather than carry a stale verdict');
+          isNotNull,
+          reason: 'settled: nothing was revoked, and nothing will be');
 
       final back = await keyValueStore.get(key);
       final restored = EnrollDataStoreValue.fromJson(jsonDecode(back!.data!));
@@ -2557,11 +2481,9 @@ void main() {
       await enMgr.put(predecessorId, back, EnrollmentStatus.approved);
 
       await authenticateAs(successorId, successorKey, sessionId: 'declined-2');
-      expect((await keyValueStore.get(key))?.metaData?.expiresAt, isNotNull,
-          reason: 'and once the condition clears it arms, rather than staying '
-              'exempt for the life of the atSign');
-      expect((await enMgr.getEnrollmentById(successorId)).predecessorSettledAt,
-          isNotNull);
+      expect(await stateOf(predecessorId), EnrollmentStatus.approved.name,
+          reason: 'an un-revoke is an operator\'s decision, and the '
+              'successor\'s next authentication must not overturn it');
     });
 
     test('a predecessor that is already gone is not an error, and its '
@@ -2582,11 +2504,11 @@ void main() {
       final successorId = jsonDecode(r.data!)['enrollmentId'] as String;
 
       await enMgr.remove(enId: predecessorId);
-      await enMgr.armRetrofitCapOnFirstAuth(successorId);
+      await enMgr.settlePredecessorOnFirstAuth(successorId);
 
       expect((await enMgr.getEnrollmentById(successorId)).predecessorSettledAt,
           isNotNull,
-          reason: 'stamped even with nothing to cap, or every later '
+          reason: 'stamped even with nothing to revoke, or every later '
               'connection re-walks the lookup for a predecessor that is '
               'never coming back');
       expect(await enMgr.descendantsOf(successorId), contains(childId),
@@ -2594,7 +2516,7 @@ void main() {
               'it should have been hanging off');
     });
 
-    test('capping an approver moves what it admitted onto its successor',
+    test('superseding an approver moves what it admitted onto its successor',
         () async {
       final middleId = await etu.createPendingEnrollment(
           appName: 'middle',
@@ -2618,27 +2540,10 @@ void main() {
       expect(r.isError, false, reason: '${r.errorMessage}');
       final successorId = jsonDecode(r.data!)['enrollmentId'] as String;
 
-      await enMgr.armRetrofitCapOnFirstAuth(successorId);
+      await enMgr.settlePredecessorOnFirstAuth(successorId);
 
-      final DateTime? capped =
-          (await keyValueStore.get(enMgr.buildEnrollmentKey(middleId)))
-              ?.metaData
-              ?.expiresAt;
-      expect(capped, isNotNull,
-          reason: 'precondition: the cap really did arm — otherwise nothing '
-              'was adopted because nothing was being retired');
-
-      inboundConnection.metaData.isAuthenticated = true;
-      inboundConnection.metaData.enrollmentId = etu.primaryEnId;
-      final fetched = Response();
-      await etu.evh.processVerb(
-          fetched,
-          getVerbParam(VerbSyntax.enroll,
-              'enroll:fetch:{"enrollmentId":"$middleId"}'),
-          inboundConnection);
-      expect(DateTime.parse(jsonDecode(fetched.data!)['expiresAt']),
-          capped!.toUtc(),
-          reason: 'what a client reads through enroll:fetch is the cap itself');
+      expect(await stateOf(middleId), EnrollmentStatus.revoked.name,
+          reason: 'precondition: the predecessor really was superseded');
       expect(await enMgr.descendantsOf(successorId), contains(behindId),
           reason: 'the successor stands where its predecessor stood, so what '
               'the predecessor admitted hangs off it now');
@@ -2669,7 +2574,7 @@ void main() {
 
       final String childKey = enMgr.buildEnrollmentKey(childId);
       // NOTE the stored expiry is pulled in ahead of the hour its retained ttl
-      // would re-derive, which is what a cap on the child leaves behind.
+      // would re-derive.
       final DateTime shortened =
           DateTime.now().toUtc().add(Duration(minutes: 5));
       await enMgr.put(
@@ -2693,7 +2598,7 @@ void main() {
       expect(r.isError, false, reason: '${r.errorMessage}');
       final successorId = jsonDecode(r.data!)['enrollmentId'] as String;
 
-      await enMgr.armRetrofitCapOnFirstAuth(successorId);
+      await enMgr.settlePredecessorOnFirstAuth(successorId);
 
       expect(await enMgr.descendantsOf(successorId), contains(childId),
           reason: 'precondition: the child really was re-parented, so the '

--- a/packages/at_secondary_server/test/apkam_self_enrollment_test.dart
+++ b/packages/at_secondary_server/test/apkam_self_enrollment_test.dart
@@ -179,7 +179,7 @@ void main() {
             'here and nowhere else, and starting a clock on the predecessor — '
             'by then the only credential that still works — on the strength '
             'of a record only this server has seen is exactly the hazard');
-    expect(successor.predecessorCapArmedAt, isNull,
+    expect(successor.predecessorSettledAt, isNull,
         reason: 'and the successor records that it has armed nothing yet');
   });
 
@@ -946,7 +946,7 @@ void main() {
       final (firstId, firstKey) = await retrofitWithRealKey(predecessorId,
           appName: 'capped-app', deviceName: 'capped-dev');
       await authenticateAs(firstId, firstKey, sessionId: 'capped-session');
-      expect((await enMgr.getEnrollmentById(firstId)).predecessorCapArmedAt,
+      expect((await enMgr.getEnrollmentById(firstId)).predecessorSettledAt,
           isNotNull,
           reason: 'precondition: the first successor has authenticated, and '
               'the cap it armed is what the refusal reads');
@@ -970,7 +970,7 @@ void main() {
           appName: 'root-split-app', deviceName: 'root-split-dev');
       await authenticateAs(firstId, firstKey,
           sessionId: 'root-split-session');
-      expect((await enMgr.getEnrollmentById(firstId)).predecessorCapArmedAt,
+      expect((await enMgr.getEnrollmentById(firstId)).predecessorSettledAt,
           isNotNull,
           reason: 'precondition: the successor has authenticated and settled '
               'what it replaced');
@@ -2284,7 +2284,7 @@ void main() {
           reason: 'the arming is wired into the production PKAM path rather '
               'than merely implemented on EnrollmentManager — a mechanism '
               'nothing calls is not delivered');
-      expect((await enMgr.getEnrollmentById(successorId)).predecessorCapArmedAt,
+      expect((await enMgr.getEnrollmentById(successorId)).predecessorSettledAt,
           isNotNull,
           reason: 'and the successor records that it armed');
     });
@@ -2299,7 +2299,7 @@ void main() {
       expect((await keyValueStore.get(k))?.metaData?.expiresAt, isNotNull,
           reason: 'control: the first authentication did arm it');
       final armedAt =
-          (await enMgr.getEnrollmentById(successorId)).predecessorCapArmedAt;
+          (await enMgr.getEnrollmentById(successorId)).predecessorSettledAt;
 
       final aged = await keyValueStore.get(k);
       aged!.metaData!.ttl = 60000;
@@ -2312,7 +2312,7 @@ void main() {
           reason: 'a successor authenticates on every reconnect. Arming on '
               'each one would rewrite a full grace period onto the '
               'predecessor forever and it would never retire at all');
-      expect((await enMgr.getEnrollmentById(successorId)).predecessorCapArmedAt,
+      expect((await enMgr.getEnrollmentById(successorId)).predecessorSettledAt,
           armedAt,
           reason: 'the stamp records the FIRST arming and does not move');
     });
@@ -2377,7 +2377,7 @@ void main() {
               ?.state,
           EnrollmentStatus.revoked.name,
           reason: 'and it stays revoked');
-      expect((await enMgr.getEnrollmentById(successorId)).predecessorCapArmedAt,
+      expect((await enMgr.getEnrollmentById(successorId)).predecessorSettledAt,
           isNull,
           reason: 'and nothing is recorded as armed, because nothing was: an '
               'unrevoke restores an ordinary predecessor and the decision has '
@@ -2412,7 +2412,7 @@ void main() {
             isNull,
             reason: 'a root is never put on the retrofit cap');
         expect(
-            (await enMgr.getEnrollmentById(successorId)).predecessorCapArmedAt,
+            (await enMgr.getEnrollmentById(successorId)).predecessorSettledAt,
             isNotNull,
             reason: 'settled all the same: the stamp is what stops every later '
                 'authentication re-asking, and what records that the '
@@ -2526,7 +2526,7 @@ void main() {
       await authenticateAs(successorId, successorKey,
           sessionId: 'late-decline');
 
-      expect((await enMgr.getEnrollmentById(successorId)).predecessorCapArmedAt,
+      expect((await enMgr.getEnrollmentById(successorId)).predecessorSettledAt,
           isNull,
           reason: 'the cap did not happen, so the stamp saying it did must not '
               'stand — otherwise the early exit short-circuits every later '
@@ -2545,7 +2545,7 @@ void main() {
       await enMgr.put(predecessorId, atData, EnrollmentStatus.revoked);
 
       await authenticateAs(successorId, successorKey, sessionId: 'declined-1');
-      expect((await enMgr.getEnrollmentById(successorId)).predecessorCapArmedAt,
+      expect((await enMgr.getEnrollmentById(successorId)).predecessorSettledAt,
           isNull,
           reason: 'nothing was armed, so nothing is recorded as armed — the '
               'successor must ask again rather than carry a stale verdict');
@@ -2560,7 +2560,7 @@ void main() {
       expect((await keyValueStore.get(key))?.metaData?.expiresAt, isNotNull,
           reason: 'and once the condition clears it arms, rather than staying '
               'exempt for the life of the atSign');
-      expect((await enMgr.getEnrollmentById(successorId)).predecessorCapArmedAt,
+      expect((await enMgr.getEnrollmentById(successorId)).predecessorSettledAt,
           isNotNull);
     });
 
@@ -2584,7 +2584,7 @@ void main() {
       await enMgr.remove(enId: predecessorId);
       await enMgr.armRetrofitCapOnFirstAuth(successorId);
 
-      expect((await enMgr.getEnrollmentById(successorId)).predecessorCapArmedAt,
+      expect((await enMgr.getEnrollmentById(successorId)).predecessorSettledAt,
           isNotNull,
           reason: 'stamped even with nothing to cap, or every later '
               'connection re-walks the lookup for a predecessor that is '

--- a/packages/at_secondary_server/test/enroll_data_store_value_test.dart
+++ b/packages/at_secondary_server/test/enroll_data_store_value_test.dart
@@ -82,28 +82,45 @@ void main() {
       expect(EnrollDataStoreValue.fromJson(withBare.toJson()).apskLegacy, bare);
     });
 
-    test('predecessorCapArmedAt round-trips under its at-rest name', () {
+    test('predecessorSettledAt round-trips under its at-rest name', () {
       // ⚠️ AT-REST PIN on the raw field name; frozen for stored records.
       final armedAt = DateTime.utc(2026, 8, 31, 12, 34, 56, 789);
       final v = EnrollDataStoreValue('123', 'testclient', 'iphone', 'mykey')
-        ..predecessorCapArmedAt = armedAt;
+        ..predecessorSettledAt = armedAt;
 
-      expect(v.toJson()['predecessorCapArmedAt'], '2026-08-31T12:34:56.789Z',
+      expect(v.toJson()['predecessorSettledAt'], '2026-08-31T12:34:56.789Z',
           reason: 'raw literal: the key name and the ISO-8601 encoding are '
               'what a record written by an earlier server is read back '
               'through');
-      expect(EnrollDataStoreValue.fromJson(v.toJson()).predecessorCapArmedAt,
+      expect(EnrollDataStoreValue.fromJson(v.toJson()).predecessorSettledAt,
           armedAt);
 
       final unarmed =
           EnrollDataStoreValue('123', 'testclient', 'iphone', 'mykey');
-      expect(unarmed.toJson().containsKey('predecessorCapArmedAt'), false,
+      expect(unarmed.toJson().containsKey('predecessorSettledAt'), false,
           reason: 'omitted rather than written null, so a record from before '
               'this field existed reads back as "never armed"');
       expect(
           EnrollDataStoreValue.fromJson(unarmed.toJson())
-              .predecessorCapArmedAt,
+              .predecessorSettledAt,
           isNull);
+    });
+
+    test('a record stamped under the former name predecessorCapArmedAt reads '
+        'back as settled', () {
+      // ⚠️ AT-REST PIN: the former name is frozen for records already stored.
+      final v = EnrollDataStoreValue('123', 'testclient', 'iphone', 'mykey');
+      final json = v.toJson()
+        ..['predecessorCapArmedAt'] = '2026-08-31T12:34:56.789Z';
+
+      expect(EnrollDataStoreValue.fromJson(json).predecessorSettledAt,
+          DateTime.utc(2026, 8, 31, 12, 34, 56, 789),
+          reason: 'a successor stamped by an earlier build must not read back '
+              'as unsettled, or it settles its predecessor a second time');
+      expect(
+          EnrollDataStoreValue.fromJson(json).toJson().keys,
+          isNot(contains('predecessorCapArmedAt')),
+          reason: 'and it is written back under the current name only');
     });
 
     test('parentEnrollmentId round-trips under its at-rest name', () {

--- a/packages/at_secondary_server/test/enroll_revocation_event_test.dart
+++ b/packages/at_secondary_server/test/enroll_revocation_event_test.dart
@@ -43,6 +43,23 @@ void main() {
               'wrong way');
     });
 
+    test('a supersession is the same shape with its own kind', () {
+      final json = EnrollmentRevocationEvent(
+        type: EnrollmentRevocationEventType.superseded,
+        enrollmentId: 'aaaa-1111',
+        at: at,
+        namespaces: {'wavi': 'rw'},
+        byEnrollmentId: 'ssss-4444',
+        cascadedFrom: null,
+      ).toJson();
+
+      expect(json['event'], 'superseded');
+      expect(EnrollmentRevocationEvent.fromJson(json).type,
+          EnrollmentRevocationEventType.superseded,
+          reason: 'a kind the reader refuses would drop the event from the '
+              'history that answers which namespaces were revoked when');
+    });
+
     test('the optional fields are omitted, not written null', () {
       final json = EnrollmentRevocationEvent(
         type: EnrollmentRevocationEventType.revoked,

--- a/packages/at_secondary_server/test/enrollment_fault_injection_test.dart
+++ b/packages/at_secondary_server/test/enrollment_fault_injection_test.dart
@@ -287,7 +287,7 @@ void main() {
           recordFor(liveChildId, approvedBy: predecessorId));
       store.reapOnEnumeration.add(mgr.buildEnrollmentKey(goneChildId));
 
-      await mgr.armRetrofitCapOnFirstAuth(successorId);
+      await mgr.settlePredecessorOnFirstAuth(successorId);
 
       expect((await mgr.getEnrollmentById(liveChildId)).parentEnrollmentId,
           successorId,

--- a/packages/at_secondary_server/test/enrollment_id_canonicalisation_test.dart
+++ b/packages/at_secondary_server/test/enrollment_id_canonicalisation_test.dart
@@ -424,7 +424,7 @@ void main() {
       await mint('upper-kid',
           namespaces: {'wavi': 'rw'}, approvedBy: 'UPPER-PRED');
 
-      await enMgr.armRetrofitCapOnFirstAuth('upper-succ');
+      await enMgr.settlePredecessorOnFirstAuth('upper-succ');
 
       expect((await enMgr.getEnrollmentById('upper-kid')).parentEnrollmentId,
           'upper-succ',

--- a/packages/at_secondary_server/test/enrollment_mutation_serialisation_test.dart
+++ b/packages/at_secondary_server/test/enrollment_mutation_serialisation_test.dart
@@ -164,7 +164,7 @@ void main() {
     });
   });
 
-  group('a revoke and a cap arming writing the same record', () {
+  group('a revoke and a settlement writing the same record', () {
     /// A successor of `primary` that published an `_apsk`.
     Future<String> lostUpdateArrangement() async {
       final successor = await selfEnroll(etu.primaryEnId,
@@ -180,15 +180,15 @@ void main() {
     }
 
     // NOTE this arm stays green with the critical section removed: nothing in
-    // a test can park the arming between its read and its write, so what it
-    // pins is the outcome, not the serialisation.
+    // a test can park the settlement between its read and its write, so what
+    // it pins is the outcome, not the serialisation.
     test('run together, the store holds the revoke the verb answered',
         () async {
       final successor = await lostUpdateArrangement();
 
       final outcomes = await Future.wait([
         revoke(etu.primaryEnId, successor),
-        enMgr.armRetrofitCapOnFirstAuth(successor).then((_) => null),
+        enMgr.settlePredecessorOnFirstAuth(successor).then((_) => null),
       ]);
       expect(outcomes.first, isNull,
           reason: 'precondition: the revoke was allowed and answered revoked');
@@ -209,15 +209,15 @@ void main() {
           reason: 'it belongs at the parked address');
     });
 
-    test('SERIAL CONTROL: revoking then arming leaves the record revoked',
+    test('SERIAL CONTROL: revoking then settling leaves the record revoked',
         () async {
       final successor = await lostUpdateArrangement();
 
       expect(await revoke(etu.primaryEnId, successor), isNull);
-      await enMgr.armRetrofitCapOnFirstAuth(successor);
+      await enMgr.settlePredecessorOnFirstAuth(successor);
 
       expect(await stateOf(successor), EnrollmentStatus.revoked.name,
-          reason: 'the arming reads the record it is about to write, so run '
+          reason: 'the settlement reads the record it is about to write, so run '
               'after the revoke it carries the revoked state forward — no '
               'serialisation needed, so this stays green when the critical '
               'section is removed');
@@ -228,7 +228,7 @@ void main() {
     });
   });
 
-  group('adopting a capped approver\'s children', () {
+  group('adopting a superseded approver\'s children', () {
     /// A predecessor P that admitted three children, and a short-lived
     /// successor S of P. Returns P, one child, and S.
     Future<(String, String, String)> adoptionArrangement() async {
@@ -265,49 +265,49 @@ void main() {
                 (await keyValueStore.get(enMgr.buildEnrollmentKey(id)))!.data!))
             .parentEnrollmentId;
 
-    test('the stamp, the cap and the adoption are all inside the section',
+    test('the stamp, the revoke and the adoption are all inside the section',
         () async {
       final (predecessor, child, successor) = await adoptionArrangement();
 
       final gate = Completer<void>();
       final holder = enMgr.serialiseMutation(() => gate.future);
-      final arming = enMgr.armRetrofitCapOnFirstAuth(successor);
+      final settling = enMgr.settlePredecessorOnFirstAuth(successor);
       await Future<void>.delayed(Duration(milliseconds: 100));
 
-      final armedDuringHold =
+      final settledDuringHold =
           (await enMgr.getEnrollmentById(successor)).predecessorSettledAt;
-      final cappedDuringHold = await expiryOf(predecessor);
+      final predecessorDuringHold = await stateOf(predecessor);
       final approverDuringHold = await approverOf(child);
 
       gate.complete();
-      await Future.wait([holder, arming]);
+      await Future.wait([holder, settling]);
 
       expect(approverDuringHold, predecessor,
           reason: 'the re-parent must not happen while another mutation holds '
               'the section: it is a read-modify-write of a whole child '
               'record, and the write that overtakes it is never repeated');
-      expect(armedDuringHold, isNull,
+      expect(settledDuringHold, isNull,
           reason: 'nor the stamp on the successor');
-      expect(cappedDuringHold, isNull,
-          reason: 'nor the cap on the predecessor');
+      expect(predecessorDuringHold, EnrollmentStatus.approved.name,
+          reason: 'nor the revoke of the predecessor');
 
       expect(await approverOf(child), successor,
           reason: 'and all three land once the section is free — otherwise '
-              'this would be measuring an arming that simply never ran');
+              'this would be measuring a settlement that simply never ran');
       expect(
           (await enMgr.getEnrollmentById(successor)).predecessorSettledAt,
           isNotNull);
-      expect(await expiryOf(predecessor), isNotNull);
+      expect(await stateOf(predecessor), EnrollmentStatus.revoked.name);
     });
 
-    test('SERIAL CONTROL: revoking then arming leaves both writes standing',
+    test('SERIAL CONTROL: revoking then settling leaves both writes standing',
         () async {
       final (predecessor, child, successor) = await adoptionArrangement();
 
       expect(await revoke(etu.primaryEnId, child), isNull);
-      await enMgr.armRetrofitCapOnFirstAuth(successor);
+      await enMgr.settlePredecessorOnFirstAuth(successor);
 
-      expect(await expiryOf(predecessor), isNotNull);
+      expect(await stateOf(predecessor), EnrollmentStatus.revoked.name);
       expect(await approverOf(child), successor,
           reason: 'the adoption reads each child immediately before writing '
               'it, so run after the revoke it re-parents the revoked child '
@@ -372,7 +372,7 @@ void main() {
       expect(reachedTheSection, isTrue);
     });
 
-    test('the cap arming takes no section when there is nothing to arm',
+    test('settling takes no section when there is nothing to settle',
         () async {
       final plain = await addUnexpiringRoot('replaced-nothing');
 
@@ -380,12 +380,12 @@ void main() {
         await Future<void>.delayed(Duration(milliseconds: 300));
       });
       final sw = Stopwatch()..start();
-      await enMgr.armRetrofitCapOnFirstAuth(plain);
+      await enMgr.settlePredecessorOnFirstAuth(plain);
       sw.stop();
       await held;
 
       expect(sw.elapsedMilliseconds, lessThan(200),
-          reason: 'an enrollment that replaced nothing has nothing to arm, so '
+          reason: 'an enrollment that replaced nothing has nothing to settle, so '
               'it must answer while a mutation is in flight rather than queue '
               'behind it');
     });

--- a/packages/at_secondary_server/test/enrollment_mutation_serialisation_test.dart
+++ b/packages/at_secondary_server/test/enrollment_mutation_serialisation_test.dart
@@ -275,7 +275,7 @@ void main() {
       await Future<void>.delayed(Duration(milliseconds: 100));
 
       final armedDuringHold =
-          (await enMgr.getEnrollmentById(successor)).predecessorCapArmedAt;
+          (await enMgr.getEnrollmentById(successor)).predecessorSettledAt;
       final cappedDuringHold = await expiryOf(predecessor);
       final approverDuringHold = await approverOf(child);
 
@@ -295,7 +295,7 @@ void main() {
           reason: 'and all three land once the section is free — otherwise '
               'this would be measuring an arming that simply never ran');
       expect(
-          (await enMgr.getEnrollmentById(successor)).predecessorCapArmedAt,
+          (await enMgr.getEnrollmentById(successor)).predecessorSettledAt,
           isNotNull);
       expect(await expiryOf(predecessor), isNotNull);
     });

--- a/tests/at_end2end_test/test/e2e_test_utils.dart
+++ b/tests/at_end2end_test/test/e2e_test_utils.dart
@@ -227,7 +227,8 @@ class SimpleOutboundSocketConnection extends SimpleOutboundConnection {
     response = response.replaceAll('data:', '');
     String pkamDigest = await generatePKAMDigest(atSign, response);
 
-    await writeCommand('pkam:$pkamDigest', log: false);
+    await writeCommand(pkamCommand(pkamDigest, await enrollmentIdOf(atSign)),
+        log: false);
     response = await read(timeoutMillis: 5000);
     print('pkam verb response $response');
     assert(response.contains('data:success'));
@@ -303,7 +304,8 @@ class SimpleOutboundWebsocketConnection extends SimpleOutboundConnection {
     response = response.replaceAll('data:', '');
     String pkamDigest = await generatePKAMDigest(atSign, response);
 
-    await writeCommand('pkam:$pkamDigest', log: false);
+    await writeCommand(pkamCommand(pkamDigest, await enrollmentIdOf(atSign)),
+        log: false);
     response = await read(timeoutMillis: 5000);
     print('pkam verb response $response');
     assert(response.contains('data:success'));

--- a/tests/at_end2end_test/test/pkam_command_test.dart
+++ b/tests/at_end2end_test/test/pkam_command_test.dart
@@ -1,0 +1,15 @@
+import 'package:test/test.dart';
+
+import 'pkam_utils.dart';
+
+/// ⚠️ WIRE PIN: the pkam verb's two spellings, as raw literals.
+void main() {
+  test('a legacy pkam carries the digest alone', () {
+    expect(pkamCommand('c2lnbmF0dXJl', null), 'pkam:c2lnbmF0dXJl');
+  });
+
+  test('an enrolled pkam names the enrollment ahead of the digest', () {
+    expect(pkamCommand('c2lnbmF0dXJl', '7f3a1b2c-enrollment'),
+        'pkam:enrollmentId:7f3a1b2c-enrollment:c2lnbmF0dXJl');
+  });
+}

--- a/tests/at_end2end_test/test/pkam_utils.dart
+++ b/tests/at_end2end_test/test/pkam_utils.dart
@@ -6,12 +6,31 @@ import 'package:at_auth/at_auth.dart';
 import 'package:crypton/crypton.dart';
 import 'at_demo_data.dart';
 
+/// Enrollment ids read off local keyfiles, by atSign; absent for an atSign
+/// whose key came from [pkamPrivateKeyMap].
+final Map<String, String> enrollmentIdMap = {};
+
+Future<void> _loadKeyfile(String atSign) async {
+  AtKeys keys = await FileAtKeysIo().read(atSign);
+  pkamPrivateKeyMap[atSign] = keys.apkamPrivateKey!.toString();
+  final String? id = keys.enrollmentId;
+  if (id != null && id.isNotEmpty) enrollmentIdMap[atSign] = id;
+}
+
+/// The enrollment id [atSign] authenticates as, or null for a legacy `pkam:`.
+Future<String?> enrollmentIdOf(String atSign) async {
+  if (!pkamPrivateKeyMap.containsKey(atSign)) await _loadKeyfile(atSign);
+  return enrollmentIdMap[atSign];
+}
+
+/// ⚠️ WIRE PIN: the two spellings of the pkam verb; frozen, the atServer
+/// parses them by shape.
+String pkamCommand(String digest, String? enrollmentId) => enrollmentId == null
+    ? 'pkam:$digest'
+    : 'pkam:enrollmentId:$enrollmentId:$digest';
+
 Future<String> generatePKAMDigest(String atSign, String challenge) async {
-  if (!pkamPrivateKeyMap.containsKey(atSign)) {
-    // look for local atKeys file, and load it
-    AtKeys keys = await FileAtKeysIo().read(atSign);
-    pkamPrivateKeyMap[atSign] = keys.apkamPrivateKey!.toString();
-  }
+  if (!pkamPrivateKeyMap.containsKey(atSign)) await _loadKeyfile(atSign);
   String privateKey = pkamPrivateKeyMap[atSign]!;
   privateKey = privateKey.trim();
   var key = RSAPrivateKey.fromString(privateKey);

--- a/tests/at_functional_test/test/apkam_self_enrollment_test.dart
+++ b/tests/at_functional_test/test/apkam_self_enrollment_test.dart
@@ -141,7 +141,7 @@ void main() {
   }
 
   /// Opens a fresh connection and authenticates it as [enrollmentId], which
-  /// is what arms a retrofit's cap on the enrollment it replaced.
+  /// is what settles the enrollment it replaced.
   Future<void> authenticateAsEnrollment(String enrollmentId) async {
     OutboundConnectionFactory conn = await newConnection();
     expect(
@@ -276,7 +276,7 @@ void main() {
 
       final successor = await enrollmentRecord(owner, successorId);
       expect(successor.value['retrofitPredecessorEnrollmentId'], predecessorId,
-          reason: 'the replacement edge, which the retrofit cap needs — it '
+          reason: 'the replacement edge, which the settlement needs; it '
               'does NOT cascade');
       expect(successor.value['parentEnrollmentId'], approverId,
           reason: 'a retrofit produces a PEER, so the successor stands where '
@@ -565,46 +565,54 @@ void main() {
     });
   });
 
-  group('The predecessor survives a retrofit, capped rather than removed',
+  group('The predecessor is revoked when its successor first authenticates',
       () {
-    test('a CAPPED predecessor still authenticates', () async {
-      // The whole reason the predecessor is capped rather than removed: sibling
-      // clones of one keyfile retrofit on their own schedules and must keep
-      // authenticating until the cap elapses. The successor has to authenticate
-      // first, or the predecessor is not capped and this asserts nothing — the
-      // fixture already authenticates as the predecessor to send the request.
+    Future<String> stateOf(OutboundConnectionFactory owner, String id) async =>
+        (await enrollmentRecord(owner, id)).value['approval']['state'];
+
+    /// Authenticates as [id] and reports what happened; a refused APKAM
+    /// authentication may close the socket rather than answer.
+    Future<String> tryAuthenticateAs(String id) async {
+      try {
+        return (await (await newConnection()).authenticateConnection(
+                authType: AuthType.apkam,
+                enrollmentId: id,
+                privateKey: privateKeyOf(id)))
+            .trim();
+      } catch (e) {
+        return 'threw: $e';
+      }
+    }
+
+    test('a SUPERSEDED predecessor no longer authenticates', () async {
       OutboundConnectionFactory owner = await ownerConnection();
       String predecessorId =
           await createApprovedEnrollment(owner, namespaces: {'wavi': 'rw'});
       String successorId = await selfEnrollId(predecessorId);
+      expect(await tryAuthenticateAs(predecessorId), 'data:success',
+          reason: 'control: the predecessor authenticates until its successor '
+              'does');
+
       await authenticateAsEnrollment(successorId);
 
-      expect((await enrollmentRecord(owner, predecessorId)).metaData['expiresAt'],
-          isNotNull,
-          reason: 'control: the predecessor really is capped, so the '
-              'authentication below is a capped credential authenticating and '
-              'not an uncapped one');
-
-      OutboundConnectionFactory predecessor = await newConnection();
-      expect(
-          (await predecessor.authenticateConnection(
-                  authType: AuthType.apkam,
-                  enrollmentId: predecessorId,
-                  privateKey: privateKeyOf(predecessorId)))
-              .trim(),
-          'data:success',
-          reason: 'a capped credential keeps working until its deadline — a '
-              'cap written as "already expired" would lock every laggard '
-              'sibling out of the upgrade it still has to perform');
+      expect(await stateOf(owner, predecessorId), 'revoked',
+          reason: 'the successor\'s first authentication revokes what it '
+              'replaced');
+      final String refusal = await tryAuthenticateAs(predecessorId);
+      expect(refusal, isNot('data:success'),
+          reason: 'every other holder of the predecessor\'s keyfile is cut '
+              'off at that moment; got: $refusal');
+      expect(refusal, contains('AT0027'),
+          reason: 'refused as revoked, the code a client shows for it');
     });
 
-    test('the successor records WHEN it armed, under a stable at-rest name',
+    test('the successor records WHEN it settled, under a stable at-rest name',
         () async {
       // Raw-literal pin. Every other assertion reads this through the typed
       // getter, so writer and reader are the same hand-maintained pair in
       // enroll_datastore_value.g.dart: rename the JSON key symmetrically and
       // they all still pass, while every already-stored record silently loses
-      // its stamp and re-arms once more.
+      // its stamp and settles once more.
       OutboundConnectionFactory owner = await ownerConnection();
       String predecessorId =
           await createApprovedEnrollment(owner, namespaces: {'wavi': 'rw'});
@@ -612,16 +620,16 @@ void main() {
 
       expect((await enrollmentRecord(owner, successorId)).value,
           isNot(contains('predecessorSettledAt')),
-          reason: 'absent until it arms, so an unarmed successor is '
-              'distinguishable from an armed one at rest');
+          reason: 'absent until it settles, so an unsettled successor is '
+              'distinguishable from a settled one at rest');
 
       await authenticateAsEnrollment(successorId);
 
-      final armed = (await enrollmentRecord(owner, successorId)).value;
-      expect(armed['predecessorSettledAt'], isA<String>(),
+      final settled = (await enrollmentRecord(owner, successorId)).value;
+      expect(settled['predecessorSettledAt'], isA<String>(),
           reason: 'the at-rest key name and its ISO-8601 encoding are what a '
               'record written by an earlier server is read back through');
-      expect(DateTime.parse(armed['predecessorSettledAt']).isUtc, isTrue);
+      expect(DateTime.parse(settled['predecessorSettledAt']).isUtc, isTrue);
     });
 
     test('revoking an enrollment does not restart its expiry either',
@@ -653,110 +661,106 @@ void main() {
               'visible');
     });
 
-    test('an enrollment cannot postpone its own retirement with enroll:update',
+    test('an enrollment cannot postpone its own expiry with enroll:update',
         () async {
       // A write that says nothing about expiry must not move expiry. The
       // metadata builder re-derives expiresAt from the retained ttl, so
-      // without an asserted carry one enroll:update per grace period would
-      // renew a capped credential indefinitely and the cap would be advisory.
+      // without an asserted carry one enroll:update per lifetime would renew
+      // a bounded credential indefinitely.
       OutboundConnectionFactory owner = await ownerConnection();
-      String predecessorId =
-          await createApprovedEnrollment(owner, namespaces: {'wavi': 'rw'});
-      String successorId = await selfEnrollId(predecessorId);
-      await authenticateAsEnrollment(successorId);
-
-      final capped = (await enrollmentRecord(owner, predecessorId));
-      final DateTime deadline = DateTime.parse(capped.metaData['expiresAt']);
+      String id = await createApprovedEnrollment(owner,
+          namespaces: {'wavi': 'rw'}, apkamKeysExpiryInMillis: 3600000);
+      final DateTime deadline = DateTime.parse(
+          (await enrollmentRecord(owner, id)).metaData['expiresAt']);
 
       await Future.delayed(Duration(seconds: 2));
 
-      OutboundConnectionFactory predecessor = await newConnection();
+      OutboundConnectionFactory holder = await newConnection();
       expect(
-          (await predecessor.authenticateConnection(
+          (await holder.authenticateConnection(
                   authType: AuthType.apkam,
-                  enrollmentId: predecessorId,
-                  privateKey: privateKeyOf(predecessorId)))
+                  enrollmentId: id,
+                  privateKey: privateKeyOf(id)))
               .trim(),
           'data:success');
-      String response = await predecessor.sendRequestToServer(
-          'enroll:update:{"enrollmentId":"$predecessorId","metadata":{"note":"x"}}');
+      String response = await holder.sendRequestToServer(
+          'enroll:update:{"enrollmentId":"$id","metadata":{"note":"x"}}');
       expect(response, startsWith('data:'), reason: response);
 
       expect(
           DateTime.parse(
-              (await enrollmentRecord(owner, predecessorId)).metaData['expiresAt']),
+              (await enrollmentRecord(owner, id)).metaData['expiresAt']),
           deadline,
           reason: 'amending an enrollment must leave its deadline exactly '
               'where it was; a two-second delay makes any re-derivation from '
               '"now" visible');
     });
 
-    test('storing a successor does not cap the predecessor', () async {
+    test('storing a successor does not revoke the predecessor', () async {
       OutboundConnectionFactory owner = await ownerConnection();
       String predecessorId =
           await createApprovedEnrollment(owner, namespaces: {'wavi': 'rw'});
 
       await selfEnrollId(predecessorId);
 
-      expect((await enrollmentRecord(owner, predecessorId)).metaData['expiresAt'],
-          isNull,
+      expect(await stateOf(owner, predecessorId), 'approved',
           reason: 'storing a successor proves only that the atServer wrote a '
               'record. The successor\'s APKAM private half lives '
               'client-side, so a keyfile write that failed would leave it '
-              'existing here and nowhere else — and the predecessor is by '
+              'existing here and nowhere else, and the predecessor is by '
               'then the only credential that still works');
+      expect((await enrollmentRecord(owner, predecessorId)).metaData['expiresAt'],
+          isNull, reason: 'and nothing puts it on a clock either');
     });
 
     test(
-        'the cap is armed by the successor\'s first authentication, and '
-        're-arms for each sibling', () async {
-      // A deadline fixed by the first sibling's upgrade would strand every
-      // laggard whose next run fell outside that window.
+        'two siblings that enrolled before either authenticated both settle '
+        'the predecessor, and the second still authenticates', () async {
       OutboundConnectionFactory owner = await ownerConnection();
       String predecessorId =
           await createApprovedEnrollment(owner, namespaces: {'wavi': 'rw'});
 
       // NOTE both siblings enrol before either authenticates: once the first
-      // has capped the predecessor, the predecessor no longer splits.
+      // has settled the predecessor, the predecessor no longer splits.
       String firstId = await selfEnrollId(predecessorId);
       String secondId = await selfEnrollId(predecessorId);
       await authenticateAsEnrollment(firstId);
-      DateTime firstCap = DateTime.parse(
-          (await enrollmentRecord(owner, predecessorId)).metaData['expiresAt']);
+      expect(await stateOf(owner, predecessorId), 'revoked',
+          reason: 'the first sibling to authenticate supersedes it');
 
-      await Future.delayed(Duration(seconds: 2));
-
-      await authenticateAsEnrollment(secondId);
-      DateTime secondCap = DateTime.parse(
-          (await enrollmentRecord(owner, predecessorId)).metaData['expiresAt']);
-
-      expect(secondCap.isAfter(firstCap), isTrue,
-          reason: 'the second sibling proving itself must push the '
-              'predecessor\'s expiry out, not leave the first sibling\'s '
-              'deadline in place');
+      expect(await tryAuthenticateAs(secondId), 'data:success',
+          reason: 'the second sibling is a live successor in its own right; '
+              'finding the predecessor already revoked must not refuse it');
+      expect((await enrollmentRecord(owner, secondId)).value['predecessorSettledAt'],
+          isA<String>(),
+          reason: 'and it is settled too, or every later authentication '
+              're-asks');
     });
 
-    test('a successor re-authenticating does not push the deadline out again',
-        () async {
+    test('an un-revoked predecessor is not revoked again by its successor '
+        're-authenticating', () async {
       OutboundConnectionFactory owner = await ownerConnection();
       String predecessorId =
           await createApprovedEnrollment(owner, namespaces: {'wavi': 'rw'});
-
       String successorId = await selfEnrollId(predecessorId);
       await authenticateAsEnrollment(successorId);
-      DateTime firstCap = DateTime.parse(
-          (await enrollmentRecord(owner, predecessorId)).metaData['expiresAt']);
+      expect(await stateOf(owner, predecessorId), 'revoked',
+          reason: 'precondition: superseded');
 
-      await Future.delayed(Duration(seconds: 2));
+      String response = await owner.sendRequestToServer(
+          'enroll:unrevoke:{"enrollmentId":"$predecessorId"}');
+      expect(response, startsWith('data:'),
+          reason: 'a superseded enrollment may be un-revoked like any other; '
+              'got: $response');
+      expect(await stateOf(owner, predecessorId), 'approved');
+
       await authenticateAsEnrollment(successorId);
 
-      expect(
-          DateTime.parse(
-              (await enrollmentRecord(owner, predecessorId)).metaData['expiresAt']),
-          firstCap,
-          reason: 'a successor authenticates on every reconnect. Arming on '
-              'each one would rewrite a full grace period onto the '
-              'predecessor forever and it would never retire at all');
+      expect(await stateOf(owner, predecessorId), 'approved',
+          reason: 'a successor authenticates on every reconnect; settling on '
+              'each one would overturn the operator\'s un-revoke');
+      expect(await tryAuthenticateAs(predecessorId), 'data:success',
+          reason: 'and the revived credential works beside its successor');
     });
   });
 
@@ -793,10 +797,9 @@ void main() {
       String predecessorId =
           await createApprovedEnrollment(owner, namespaces: {'wavi': 'rw'});
       String successorId = await selfEnrollId(predecessorId);
-
-      expect(await tryAuthenticateAs(successorId), 'data:success',
-          reason: 'precondition: the successor authenticates while its '
-              'predecessor stands');
+      expect(await stateOf(owner, successorId), 'approved',
+          reason: 'precondition: the successor is stored approved and has '
+              'not yet authenticated, so the predecessor still stands');
 
       String response = await owner
           .sendRequestToServer('enroll:revoke:{"enrollmentId":"$predecessorId"}');

--- a/tests/at_functional_test/test/apkam_self_enrollment_test.dart
+++ b/tests/at_functional_test/test/apkam_self_enrollment_test.dart
@@ -611,17 +611,17 @@ void main() {
       String successorId = await selfEnrollId(predecessorId);
 
       expect((await enrollmentRecord(owner, successorId)).value,
-          isNot(contains('predecessorCapArmedAt')),
+          isNot(contains('predecessorSettledAt')),
           reason: 'absent until it arms, so an unarmed successor is '
               'distinguishable from an armed one at rest');
 
       await authenticateAsEnrollment(successorId);
 
       final armed = (await enrollmentRecord(owner, successorId)).value;
-      expect(armed['predecessorCapArmedAt'], isA<String>(),
+      expect(armed['predecessorSettledAt'], isA<String>(),
           reason: 'the at-rest key name and its ISO-8601 encoding are what a '
               'record written by an earlier server is read back through');
-      expect(DateTime.parse(armed['predecessorCapArmedAt']).isUtc, isTrue);
+      expect(DateTime.parse(armed['predecessorSettledAt']).isUtc, isTrue);
     });
 
     test('revoking an enrollment does not restart its expiry either',


### PR DESCRIPTION
**- What I did**
- A non-root retrofit predecessor is REVOKED at its successor's first `pkam:`, after its approval children move onto the successor; recorded in the revocation history as `superseded`, by the successor. A root predecessor keeps its life.
- A predecessor found revoked, pending or gone is settled without a revoke and never re-asked, so `enroll:unrevoke` of a superseded enrollment stands; the once-off rule still refuses a second retrofit of it.
- The cap is deleted with `apkamSelfEnrollmentGraceHours`; none of it shipped in c3.16.3, so the 3.16.4 CHANGELOG entries narrating it are collapsed into the shipped behaviour.
- ⚠️ At rest and on `enroll:list`, the stamp is `predecessorSettledAt`; the decoder still reads `predecessorCapArmedAt` from pre-release stores.

**- How I did it**
See commit & diffs

**- How to verify it**
Tests pass: unit 1512, functional 254, e2e 47 at `0b16e097`.

**- Description for the changelog**
A retrofit predecessor that is not fully privileged is revoked, as `superseded` by its successor, when the successor first authenticates; the retrofit cap and `apkamSelfEnrollmentGraceHours` are gone, and the successor's stamp is `predecessorSettledAt`.
