### PR TITLE
build: at_commons 5.17.0; the Enroll verb takes its syntax upstream again

### DIFF
--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -746,14 +746,8 @@
   that response as "if this is not a list, the namespace has no members", so an
   unrecognised shape there would silently empty every roster rather than fail.
 
-  ⚠️ The enroll operation alternation lives in at_commons, which does not yet
-  list `infons`, so `at_server_spec`'s `Enroll` verb adds it locally by
-  INSERTING into at_commons' pattern — not by copying it, so every other
-  upstream change still reaches this server, and it throws rather than
-  returning an unmodified pattern if the insertion point ever moves. This is a
-  temporary divergence between what the server accepts and what at_commons
-  describes; `enroll_verb_syntax_test.dart` fails deliberately once a published
-  at_commons defines `infons`, which is the signal to delete the override.
+  The enroll operation alternation lives in at_commons, and at_commons 5.17.0
+  lists `infons`; `at_server_spec` 5.3.0 takes it from there unchanged.
 - feat: a revocation history. Every moment an enrollment's revocation state
   changes is written as a record of its OWN, carrying the enrollment id, the
   moment, the namespace grants it held, the enrollment that issued the command
@@ -1144,6 +1138,7 @@
   and add one, taking the pool past its configured maximum without the limit
   exception ever being raised. A slot is now taken before connecting and
   given back if the connect fails.
+- build: `at_commons` 5.17.0 and `at_server_spec` 5.3.0.
 
 # 3.16.3
 - fix: answer each cross-atSign request with its own response. A pooled

--- a/packages/at_secondary_server/lib/src/verb/handler/abstract_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/abstract_verb_handler.dart
@@ -150,11 +150,10 @@ abstract class AbstractVerbHandler implements VerbHandler {
     return '$enrollmentId.${EnrollmentConstants.perEnrollmentApproved}';
   }
 
-  /// Matches a per-enrollment reserved-namespace key (`<EnId>.a|r|d.__e@…`),
-  /// capturing the owning enrollment id in the `EnId` group.
-  /// at_commons 5.17.0's `regexForPerEnrollmentNamespaces`, carried here
-  /// until that release is consumed: the id may start the key or follow a
-  /// colon, not only a dot.
+  /// Matches a per-enrollment reserved-namespace key (`<EnId>.a|r|d.__e@…`)
+  /// whether the id starts the key or follows a colon or a dot, capturing the
+  /// owning enrollment id in the `EnId` group. Wider than at_commons'
+  /// `regexForPerEnrollmentNamespaces`, which requires the leading dot.
   static final RegExp _perEnrollmentReservedKeyRegex =
       RegExp(r'(?:^|[.:])(?<EnId>[^.:]+)\.[ard]\.__e@');
 

--- a/packages/at_secondary_server/pubspec.lock
+++ b/packages/at_secondary_server/pubspec.lock
@@ -69,10 +69,10 @@ packages:
     dependency: "direct main"
     description:
       name: at_commons
-      sha256: bd67ecae7e963ae2662b6d8fc50f13dd783b3ec4044dcd16e84a6af1a3327f2a
+      sha256: "1a394f2e668e1116cee450883fdbe3751acc9bebe20b4176f34484e33a5309d5"
       url: "https://pub.dev"
     source: hosted
-    version: "5.16.0"
+    version: "5.17.0"
   at_lookup:
     dependency: "direct main"
     description:
@@ -94,7 +94,7 @@ packages:
       path: "../at_server_spec"
       relative: true
     source: path
-    version: "5.2.1"
+    version: "5.3.0"
   at_utf7:
     dependency: transitive
     description:

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -19,11 +19,11 @@ dependencies:
   basic_utils: ^5.7.0
   ecdsa: ^0.1.2
   encrypt: ^5.0.3
-  at_commons: ^5.16.0
+  at_commons: ^5.17.0
   at_utils: ^3.4.0
   at_chops: ^3.6.0
   at_lookup: ^3.6.0
-  at_server_spec: ^5.1.0
+  at_server_spec: ^5.3.0
   at_persistence_secondary_server: ^5.3.0
   intl: ^0.20.3
   json_annotation: ^4.12.0

--- a/packages/at_secondary_server/test/enroll_verb_syntax_test.dart
+++ b/packages/at_secondary_server/test/enroll_verb_syntax_test.dart
@@ -1,21 +1,16 @@
-import 'package:at_commons/at_commons.dart';
 import 'package:at_server_spec/verbs.dart';
 import 'package:test/test.dart';
 
-/// This server accepts one enroll operation that at_commons does not describe.
-///
-/// `enroll:infons:<namespace>` answers facts about a namespace. at_commons
-/// owns the enroll operation alternation and does not list `infons`, so
-/// [Enroll] inserts it locally. That is a real divergence between what this
-/// server accepts and what at_commons documents, and it is meant to be short
-/// lived — these tests are what makes it visible rather than forgotten.
+/// The enroll operation alternation the server parses comes from at_commons.
+/// `enroll:infons:<namespace>` is its newest member, and these pins are what
+/// goes red if the at_commons floor slips below the release that lists it.
 void main() {
   final RegExp enroll = RegExp(Enroll().syntax(), caseSensitive: false);
 
   RegExpMatch? match(String command) => enroll.firstMatch(command);
 
-  group('the locally-added enroll:infons operation', () {
-    test('parses, and carries the namespace', () {
+  group('enroll operation syntax', () {
+    test('infons parses, and carries the namespace', () {
       final m = match('enroll:infons:wavi');
       expect(m, isNotNull,
           reason: 'if this fails the verb does not exist as far as the '
@@ -23,27 +18,22 @@ void main() {
               'handler being missing');
       expect(m!.namedGroup('operation'), 'infons');
       expect(m.namedGroup('listNamespace'), 'wavi',
-          reason: 'infons reuses at_commons\' existing listNamespace capture '
-              'group, so nothing else in the pattern had to move');
+          reason: 'infons shares the listNamespace capture group with listns');
     });
 
-    test('an unknown operation is still refused', () {
-      // The negative control, and the one assertion most worth keeping when
-      // somebody deletes the override: it is what proves the insertion widened
-      // the alternation by exactly one token rather than loosening it into
-      // accepting anything.
+    test('an unknown operation is refused', () {
       expect(match('enroll:bogusop:wavi'), isNull);
       expect(match('enroll:'), isNull);
     });
 
     test('infons is exactly as strict as the operations around it', () {
-      // Measured, because the first version of this test asserted a
-      // strictness at_commons\' pattern has never had: a trailing suffix is
-      // absorbed into enrollParams for EVERY operation, so `enroll:listnsX:w`
-      // parses as listns with params `X:w`. That is upstream behaviour and
-      // not something the insertion should change either way. What matters is
+      // A trailing suffix is absorbed into enrollParams for EVERY operation,
+      // so `enroll:listnsX:w` parses as listns with params `X:w`. The pin is
       // that infons behaves like its neighbours rather than specially.
-      for (final pair in [['infons', 'listns'], ['infons', 'list']]) {
+      for (final pair in [
+        ['infons', 'listns'],
+        ['infons', 'list']
+      ]) {
         final mine = match('enroll:${pair[0]}X:wavi');
         final theirs = match('enroll:${pair[1]}X:wavi');
         expect(mine != null, theirs != null,
@@ -53,10 +43,7 @@ void main() {
       }
     });
 
-    test('every operation at_commons defines still parses', () {
-      // The override INSERTS into at_commons\' pattern rather than replacing
-      // it, so an upstream change still reaches this server. These are the
-      // shapes that would break if it ever became a stale copy.
+    test('every operation at_commons defines parses', () {
       for (final command in [
         'enroll:request:{"appName":"a"}',
         'enroll:approve:{"enrollmentId":"x"}',
@@ -69,6 +56,7 @@ void main() {
         'enroll:fetch:{"enrollmentId":"x"}',
         'enroll:list',
         'enroll:listns:wavi',
+        'enroll:infons:wavi',
       ]) {
         expect(match(command), isNotNull, reason: command);
       }
@@ -76,22 +64,7 @@ void main() {
 
     test('listns is not shadowed by list', () {
       // Alternation order decides this, and `list` is a prefix of `listns`.
-      // Inserting `infons` must not have disturbed it.
       expect(match('enroll:listns:wavi')!.namedGroup('operation'), 'listns');
-    });
-
-    test('DELETE THE OVERRIDE when this fails: at_commons has caught up', () {
-      // A tripwire, not a preference. When a published at_commons lists
-      // `infons` itself, the local insertion in at_server_spec's Enroll verb
-      // becomes a stale fork of a pattern this package should be taking
-      // unchanged — and nothing else would ever tell us.
-      //
-      // To clear it: delete `_buildSyntax`/`_syntaxWithInfons` from
-      // at_server_spec's Enroll, return VerbSyntax.enroll again, raise the
-      // at_commons floor in the same commit, and delete this test.
-      expect(VerbSyntax.enroll.contains('infons'), isFalse,
-          reason: 'at_commons now defines the infons operation, so this '
-              'server no longer needs to add it locally');
     });
   });
 }

--- a/packages/at_secondary_server/test/enrollment_authz_tightening_test.dart
+++ b/packages/at_secondary_server/test/enrollment_authz_tightening_test.dart
@@ -284,7 +284,7 @@ void main() {
     });
 
     // ⚠️ RAW-LITERAL PIN of the reserved-namespace match: the id may start
-    // the key or follow a colon, not only a dot (at_commons 5.17.0).
+    // the key or follow a colon, not only a dot.
     for (final String shape in ['ID.a.__e', '@bob:ID.a.__e']) {
       test('*:rw enrollment cannot UPDATE the bare spelling $shape', () async {
         await bindWildcardEnrollment();

--- a/packages/at_server_spec/CHANGELOG.md
+++ b/packages/at_server_spec/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 5.3.0
+- build: `at_commons` to `^5.17.0`, which lists `enroll:infons`. The `Enroll`
+  verb takes its syntax from at_commons unchanged again; the local insertion
+  of `infons` is gone.
+
 ## 5.2.1
 - docs: the Scan/Update/UpdateMeta/Delete verb dartdocs describe the
   at_commons 5.10.0 wire options: `scan:cl`, `:nc`, `delete:dAt` and the

--- a/packages/at_server_spec/lib/src/verb/enroll.dart
+++ b/packages/at_server_spec/lib/src/verb/enroll.dart
@@ -12,57 +12,11 @@ import 'package:at_commons/at_commons.dart';
 /// otp - timebased OTP which has to fetched from an already enrolled app
 /// apkamPublicKey - new pkam public key from the requesting app/client
 class Enroll extends Verb {
-  /// ⚠️ TEMPORARY LOCAL OVERRIDE. Delete this and return [VerbSyntax.enroll]
-  /// once a published at_commons lists `infons` itself.
-  ///
-  /// at_commons owns the enroll operation alternation, and it does not yet
-  /// know `infons` — so `enroll:infons:<namespace>` is rejected as invalid
-  /// syntax before it reaches a handler. Every other verb in this package
-  /// takes its syntax from at_commons unchanged, and this one should again.
-  ///
-  /// Built by INSERTING into at_commons's pattern rather than by copying it,
-  /// so that any other upstream change to the enroll syntax still reaches this
-  /// server. Only the one addition is local.
-  static final String _syntaxWithInfons = _buildSyntax();
-
-  /// Never throws, and that is deliberate: this runs per command, so an
-  /// exception here takes out EVERY enroll operation — `enroll:request`
-  /// included, which is unauthenticated onboarding — rather than just the one
-  /// operation it is about.
-  ///
-  /// Two ways the insertion can fail to apply, both benign:
-  ///
-  /// * at_commons already lists `infons`. Inserting a second alternative would
-  ///   be inert — a regex alternation matches the same strings either way —
-  ///   but there is nothing to add, so the upstream pattern is returned whole.
-  ///   `enroll_verb_syntax_test.dart` fails deliberately in this case, which is
-  ///   the signal to delete this override; a running server keeps working.
-  /// * the anchor has moved. `replaceFirst` returns the pattern unchanged,
-  ///   `enroll:infons` is rejected as a syntax error, and every other enroll
-  ///   operation still works. Caught by the syntax test rather than at
-  ///   runtime, which is the right place for it: the alternative was throwing,
-  ///   and that took the whole verb down to report that one operation was
-  ///   missing.
-  static String _buildSyntax() {
-    const insertionPoint = '(request|';
-    final String upstream = VerbSyntax.enroll;
-    if (upstream.contains('infons')) {
-      return upstream;
-    }
-    // `replaceFirst` is already a no-op on a missing anchor, so this needs no
-    // branch of its own: a moved anchor returns the pattern unchanged and
-    // `enroll_verb_syntax_test.dart`'s first test — which asserts
-    // `enroll:infons:wavi` parses — goes red. That test is the detector,
-    // deliberately, because this package has no logger dependency and adding
-    // one to a published package for a single line is the wrong trade.
-    return upstream.replaceFirst(insertionPoint, '${insertionPoint}infons|');
-  }
-
   @override
   String name() => 'enroll';
 
   @override
-  String syntax() => _syntaxWithInfons;
+  String syntax() => VerbSyntax.enroll;
 
   @override
   Verb? dependsOn() {

--- a/packages/at_server_spec/pubspec.yaml
+++ b/packages/at_server_spec/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_server_spec
 description: A Dart library containing abstract classes that defines what implementations of the root and secondary servers are responsible for.
-version: 5.2.1
+version: 5.3.0
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://docs.atsign.com
 documentation: https://docs.atsign.com/atplatform/secondaryserver
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   meta: ^1.11.0
-  at_commons: ^5.12.0
+  at_commons: ^5.17.0
 
 dev_dependencies:
   lints: ^5.0.0


### PR DESCRIPTION
**- What I did**
- Removed local copy of Enroll verb syntax now that at_commons 5.17.0 has been published, remove a tripwire test
- Bump dependencies: `at_commons` to `^5.17.0`, `at_server_spec` to `^5.3.0`, lockfile updated
- `_perEnrollmentReservedKeyRegex` stays local. at_commons 5.17.0's `regexForPerEnrollmentNamespaces` is still dot-only (the widened form in at_client_sdk `c7cb76892` will be in a future release),

**- How I did it**
See commit & diffs

**- How to verify it**
Tests pass

**- Description for the changelog**
build: at_commons 5.17.0; the Enroll verb takes its syntax from at_commons unchanged, the local `infons` insertion is gone; at_server_spec 5.3.0.
