### PR TITLE
feat(at_secondary_server): enroll:fetch returns the enrollment's client metadata

### DIFF
--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1139,6 +1139,23 @@
   exception ever being raised. A slot is now taken before connecting and
   given back if the connect fails.
 - build: `at_commons` 5.17.0 and `at_server_spec` 5.3.0.
+- feat: `enroll:fetch` returns `metadata`, the opaque map the enrolling client
+  supplied, verbatim. A caller that may fetch an enrollment can now read its
+  key package by id instead of calling `enroll:list` and filtering a whole
+  roster client-side.
+
+  It is returned to every caller the fetch gate admits, and is NOT redacted by
+  the caller's own `__manage` letter — which is what `enroll:list` does, giving
+  a read-only administrator `toJsonRoster` without `metadata`. The two verbs
+  deliberately disagree: the key package is a public bundle for sealing TO an
+  enrollment, not material that would let anyone use it. `enroll:list` is
+  unchanged.
+
+  The key is ALWAYS present, null when the record carries no metadata, so a
+  caller cannot mistake an absent field for one it failed to parse. The fetch
+  gate is unchanged: a caller may always fetch its own enrollment, and fetching
+  another still requires `__manage` plus access to every namespace the target
+  holds.
 
 # 3.16.3
 - fix: answer each cross-atSign request with its own response. A pooled

--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,3 +1,22 @@
+# 3.16.5
+- feat: `enroll:fetch` returns `metadata`, the opaque map the enrolling client
+  supplied, verbatim. A caller that may fetch an enrollment can now read its
+  key package by id instead of calling `enroll:list` and filtering a whole
+  roster client-side.
+
+  It is returned to every caller the fetch gate admits, and is NOT redacted by
+  the caller's own `__manage` letter — which is what `enroll:list` does, giving
+  a read-only administrator `toJsonRoster` without `metadata`. The two verbs
+  deliberately disagree: the key package is a public bundle for sealing TO an
+  enrollment, not material that would let anyone use it. `enroll:list` is
+  unchanged.
+
+  The key is ALWAYS present, null when the record carries no metadata, so a
+  caller cannot mistake an absent field for one it failed to parse. The fetch
+  gate is unchanged: a caller may always fetch its own enrollment, and fetching
+  another still requires `__manage` plus access to every namespace the target
+  holds.
+
 # 3.16.4
 - ⚠️ BREAKING at rest: `parentEnrollmentId` means something else than it did
   in released c3.16.x, and no migration can tell the two apart. Released
@@ -1139,23 +1158,6 @@
   exception ever being raised. A slot is now taken before connecting and
   given back if the connect fails.
 - build: `at_commons` 5.17.0 and `at_server_spec` 5.3.0.
-- feat: `enroll:fetch` returns `metadata`, the opaque map the enrolling client
-  supplied, verbatim. A caller that may fetch an enrollment can now read its
-  key package by id instead of calling `enroll:list` and filtering a whole
-  roster client-side.
-
-  It is returned to every caller the fetch gate admits, and is NOT redacted by
-  the caller's own `__manage` letter — which is what `enroll:list` does, giving
-  a read-only administrator `toJsonRoster` without `metadata`. The two verbs
-  deliberately disagree: the key package is a public bundle for sealing TO an
-  enrollment, not material that would let anyone use it. `enroll:list` is
-  unchanged.
-
-  The key is ALWAYS present, null when the record carries no metadata, so a
-  caller cannot mistake an absent field for one it failed to parse. The fetch
-  gate is unchanged: a caller may always fetch its own enrollment, and fetching
-  another still requires `__manage` plus access to every namespace the target
-  holds.
 
 # 3.16.3
 - fix: answer each cross-atSign request with its own response. A pooled

--- a/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
+++ b/packages/at_secondary_server/lib/src/verb/handler/enroll_verb_handler.dart
@@ -208,6 +208,11 @@ class EnrollVerbHandler extends AbstractVerbHandler {
   }
 
   /// Fetches the enrollment request with enrollment id.
+  ///
+  /// `metadata` is the enrolling client's opaque map, returned verbatim to
+  /// every caller this gate admits; it is not redacted by the caller's own
+  /// `__manage` letter, which is what `enroll:list` does with its roster
+  /// projection.
   Future<String> _fetchEnrollmentInfoById(
     EnrollmentManager enMgr,
     EnrollParams? enrollVerbParams,
@@ -249,7 +254,9 @@ class EnrollVerbHandler extends AbstractVerbHandler {
       }
     }
 
-    // `expiresAt` is the effective expiry, read from the record's metadata.
+    // NOTE two senses of metadata meet here: `expiresAt` is read from the
+    // STORED record's AtMetaData, while `metadata` is the opaque map the
+    // enrolling client supplied.
     return jsonEncode({
       'appName': enrollDataStoreValue.appName,
       'deviceName': enrollDataStoreValue.deviceName,
@@ -260,6 +267,7 @@ class EnrollVerbHandler extends AbstractVerbHandler {
       'expiresAt': EnrollmentManager.expiresAtField(
           await enMgr.effectiveExpiryOf(
               enMgr.buildEnrollmentKey(targetEnrollmentId))),
+      'metadata': enrollDataStoreValue.metadata,
     });
   }
 

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_secondary
 description: Implementation of secondary server.
-version: 3.16.4
+version: 3.16.5
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://www.example.com
 publish_to: none

--- a/packages/at_secondary_server/test/enroll_verb_test.dart
+++ b/packages/at_secondary_server/test/enroll_verb_test.dart
@@ -2149,7 +2149,8 @@ void main() {
 
     // enroll:fetch authorisation: self, or __manage plus access to ALL of
     // the target enrollment's namespaces.
-    Future<void> seedEnrollment(String id, Map<String, String> ns) async {
+    Future<void> seedEnrollment(String id, Map<String, String> ns,
+        {Map<String, dynamic>? metadata}) async {
       await keyValueStore.put(
           '$id.new.enrollments.__manage$alice',
           AtData()
@@ -2157,6 +2158,7 @@ void main() {
                 EnrollDataStoreValue('session', 'wavi', 'pixel', 'pubkey')
                   ..namespaces = ns
                   ..approval = EnrollApproval(EnrollmentStatus.approved.name)
+                  ..metadata = metadata
                   ..encryptedAPKAMSymmetricKey = 'secret-$id'));
     }
 
@@ -2268,6 +2270,68 @@ void main() {
       expect(record!['encryptedAPKAMSymmetricKey'], 'secret-peer1',
           reason: 'it covers every namespace the target holds, __manage '
               'included');
+    });
+
+    // ⚠️ RAW-LITERAL PIN of the enroll:fetch response shape. This is a wire
+    // contract other atServer implementations mirror, so an intended change
+    // edits this list in the same commit and that edit is the review.
+    test('enroll:fetch returns exactly these fields', () async {
+      await seedEnrollment('shape1', {'wavi': 'rw'},
+          metadata: {'keyPackage': 'pkg-shape1'});
+      final r = await fetchAs('shape1', 'shape1');
+      expect(
+          r.keys.toSet(),
+          {
+            'appName',
+            'deviceName',
+            'namespace',
+            'encryptedAPKAMSymmetricKey',
+            'status',
+            'expiresAt',
+            'metadata',
+          },
+          reason: 'a field added or removed here changes what every client '
+              'and every other atServer implementation reads');
+    });
+
+    test('enroll:fetch returns the client metadata verbatim', () async {
+      await seedEnrollment('mgr3', {'wavi': 'rw', '__manage': 'rw'});
+      await seedEnrollment('target4', {'wavi': 'rw'}, metadata: {
+        'keyPackage': {'alg': 'xwing', 'pub': 'AAAA'},
+        'anythingElse': 42,
+      });
+      final r = await fetchAs('mgr3', 'target4');
+      expect(
+          r['metadata'],
+          {
+            'keyPackage': {'alg': 'xwing', 'pub': 'AAAA'},
+            'anythingElse': 42,
+          },
+          reason: 'the map is opaque to the atServer, so it comes back whole '
+              'rather than reshaped or filtered');
+    });
+
+    test('enroll:fetch reports a null metadata rather than omitting the key',
+        () async {
+      await seedEnrollment('mgr4', {'wavi': 'rw', '__manage': 'rw'});
+      await seedEnrollment('target5', {'wavi': 'rw'});
+      final r = await fetchAs('mgr4', 'target5');
+      expect(r.containsKey('metadata'), isTrue,
+          reason: 'an absent key and a key a client failed to parse read the '
+              'same to a careless caller');
+      expect(r['metadata'], isNull);
+    });
+
+    test('enroll:fetch gives metadata to a read-only administrator too',
+        () async {
+      // NOTE fetch does NOT redact by the caller's own __manage letter, which
+      // is what enroll:list's roster projection does; the two verbs
+      // deliberately disagree, so the disagreement is pinned.
+      await seedEnrollment('readOnlyAdmin2', {'*': 'rw', '__manage': 'r'});
+      await seedEnrollment('peer2', {'*': 'rw', '__manage': 'r'},
+          metadata: {'keyPackage': 'pkg-peer2'});
+      final r = await fetchAs('readOnlyAdmin2', 'peer2');
+      expect(r['metadata'], {'keyPackage': 'pkg-peer2'});
     });
 
     tearDown(() async => await verbTestsTearDown());

--- a/tests/at_functional_test/test/enroll_verb_test.dart
+++ b/tests/at_functional_test/test/enroll_verb_test.dart
@@ -75,6 +75,32 @@ void main() {
           enrollMap['namespace'], {'wavi': 'rw', '__manage': 'rw', '*': 'rw'});
     });
 
+    test('enroll:fetch returns the metadata an enroll:request carried',
+        () async {
+      await firstAtSignConnection.authenticateConnection(
+          authType: AuthType.cram);
+      String deviceName = "pixel-${Uuid().v4().hashCode}";
+      // The server stores this map verbatim and has no opinion on its
+      // contents; keyPackage is what at_client seals secrets to.
+      String metadata =
+          '{"keyPackage":{"alg":"xwing","pub":"AAAA"},"note":"opaque"}';
+      String enrollRequest =
+          'enroll:request:{"appName":"wavi","deviceName":"$deviceName","namespaces":{"wavi":"rw"},"metadata":$metadata,"encryptedDefaultEncryptionPrivateKey":"${apkamEncryptedKeysMap['encryptedDefaultEncPrivateKey']}","encryptedDefaultSelfEncryptionKey":"${apkamEncryptedKeysMap['encryptedSelfEncKey']}","apkamPublicKey":"${mintApkamKeys().publicKey}"}\n';
+      var enrollJsonMap = jsonDecode(
+          (await firstAtSignConnection.sendRequestToServer(enrollRequest))
+              .replaceAll('data:', ''));
+      expect(enrollJsonMap['status'], 'approved');
+
+      Map<dynamic, dynamic> enrollMap = jsonDecode(
+          (await firstAtSignConnection.sendRequestToServer(
+                  'enroll:fetch:{"enrollmentId":"${enrollJsonMap['enrollmentId']}"}'))
+              .replaceAll('data:', ''));
+      expect(enrollMap['metadata'],
+          {'keyPackage': {'alg': 'xwing', 'pub': 'AAAA'}, 'note': 'opaque'},
+          reason: 'the map comes back off the wire whole, so a client can '
+              'fetch ONE enrollment instead of listing every one');
+    });
+
     test(
         'A test to verify denying of enroll request on an unauthenticated connection throws error',
         () async {


### PR DESCRIPTION
**- What I did**

- `enroll:fetch` returns the enrolling client's opaque `metadata` map, so a caller can read one enrollment's key package by id rather than listing every enrollment.
- ⚠️ To everyone the fetch gate admits, unlike `enroll:list`, which redacts by the caller's `__manage` letter. Deliberate, pinned by a test.
- Opens 3.16.5.
- enables improved client performance when dealing with enrollments 

**- How I did it**

See commit & diffs

**- How to verify it**

Tests pass. Unit 1515, functional 255.

**- Description for the changelog**

feat: `enroll:fetch` returns the enrolling client's opaque `metadata` map, so a caller can read one enrollment's key package by id rather than listing every enrollment.
