### PR TITLE
fix(at_secondary_server): frame inbound commands one per terminator

### DIFF
--- a/packages/at_secondary_server/CHANGELOG.md
+++ b/packages/at_secondary_server/CHANGELOG.md
@@ -1,3 +1,22 @@
+# 3.16.6
+- fix: a client that writes a second command without waiting for the first
+  one's response now gets two responses. The inbound buffer dispatched
+  everything it held as a single command, so two commands landing in one read
+  event — a client writing them back to back, or one TLS record carrying both
+  — reached the verb layer as one string with a terminator in the middle,
+  which no verb syntax matches. Commands are now framed one per terminator and
+  dispatched one at a time, in arrival order.
+
+  The case this was found on is `monitor` immediately followed by `noop:0`, as
+  a notification connection carrying its own heartbeat does. The client got a
+  single `error:AT0003` frame, the monitor was never registered and the
+  `noop:0` never ran, on a connection that stayed open — a client reporting
+  itself as listening while the atServer had no monitor for it. Note that
+  `monitor:multiplexed` is still accepted and ignored, so a notification can
+  still be written between a command on a monitor connection and its reply.
+
+  A read that carries no bytes no longer closes the connection.
+
 # 3.16.5
 - fix: `plookup:all:publickey@<atSign>` and `plookup:meta:publickey@<atSign>`
   report `ttr` -1 with no `ttl`, instead of `ttl` 86400000 with no `ttr`. The

--- a/packages/at_secondary_server/lib/src/connection/inbound/inbound_message_listener.dart
+++ b/packages/at_secondary_server/lib/src/connection/inbound/inbound_message_listener.dart
@@ -20,6 +20,14 @@ class InboundMessageListener {
   var logger = AtSignLogger('InboundListener');
   final _buffer = StreamableByteBuffer(capacity: 10240000);
 
+  /// True while [_drain] is dispatching. Append signals arriving during a
+  /// dispatch are dropped: the running loop re-reads the buffer after every
+  /// command, so it takes whatever they appended. Without this, a second
+  /// invocation of the buffer listener would take commands from the same
+  /// buffer while the first is still awaiting a handler, dispatching them
+  /// out of order.
+  bool _draining = false;
+
   InboundMessageListener(this.connection);
 
   late Function(String, InboundConnection) onBufferEndCallBack;
@@ -37,32 +45,12 @@ class InboundMessageListener {
           onDone: _finishedHandler, onError: _errorHandler);
       _buffer.stream.listen(
         (Uint8List _) async {
+          if (_draining) return;
+          _draining = true;
           try {
-            _buffer.validate(connection);
-          } on Exception catch (e) {
-            logger.warning(logger.getAtConnectionLogMessage(
-              connection.metaData,
-              e.toString(),
-            ));
-            await GlobalExceptionHandler.getInstance()
-                .handle(e, atConnection: connection);
-            _buffer.clear();
-            return;
-          }
-          if (_buffer.isEnd()) {
-            var command = utf8.decode(_buffer.getData());
-            command = command.trim();
-            if (logger.logger.isLoggable(Level.INFO)) {
-              logger.info(logger.getAtConnectionLogMessage(connection.metaData,
-                  'RCVD: ${BaseSocketConnection.truncateForLogging(command)}'));
-            }
-            // if command is '@exit', close the connection.
-            if (command == '@exit') {
-              await _finishedHandler();
-              return;
-            }
-            _buffer.clear();
-            await onBufferEndCallBack(command, connection);
+            await _drain();
+          } finally {
+            _draining = false;
           }
         },
         onError: (e, st) {
@@ -77,6 +65,52 @@ class InboundMessageListener {
           'runZonedGuarded received error $error - calling _errorHandler to close connection');
       _errorHandler(error, st);
     });
+  }
+
+  /// Dispatches every complete command the buffer holds, in arrival order,
+  /// awaiting each one's handler before taking the next.
+  ///
+  /// What arrives on the connection is a byte stream, not a command: a client
+  /// that writes a second command without waiting for the first one's
+  /// response puts both in the buffer, and everything past the first
+  /// terminator belongs to the next command rather than to this one.
+  Future<void> _drain() async {
+    while (true) {
+      try {
+        _buffer.validate(connection);
+      } on Exception catch (e) {
+        logger.warning(logger.getAtConnectionLogMessage(
+          connection.metaData,
+          e.toString(),
+        ));
+        await GlobalExceptionHandler.getInstance()
+            .handle(e, atConnection: connection);
+        _buffer.clear();
+        return;
+      }
+      final commandBytes = _buffer.takeCommand();
+      if (commandBytes == null) {
+        return;
+      }
+      final command = utf8.decode(commandBytes).trim();
+      if (logger.logger.isLoggable(Level.INFO)) {
+        logger.info(logger.getAtConnectionLogMessage(connection.metaData,
+            'RCVD: ${BaseSocketConnection.truncateForLogging(command)}'));
+      }
+      // if command is '@exit', close the connection.
+      if (command == '@exit') {
+        await _finishedHandler();
+        return;
+      }
+      await onBufferEndCallBack(command, connection);
+      // NOTE A handler may have closed the connection - a revoked
+      // enrollment, an invalid stream id. Anything queued behind it must not
+      // be dispatched onto it.
+      if (connection.metaData.isClosed || connection.metaData.isStale) {
+        _buffer.clear();
+        return;
+      }
+    }
   }
 
   /// Handles messages on the inbound client's connection and adds them to _buffer's stream.
@@ -143,46 +177,87 @@ class InboundMessageListener {
   }
 }
 
+/// A [at_commons.ByteBuffer] that signals its reader on every append and
+/// hands out one terminator-delimited command at a time.
 class StreamableByteBuffer extends at_commons.ByteBuffer {
   /// Shared sentinel for the append signal — the stream listener discards
-  /// the payload (it reads getData() instead), so we don't need to copy
+  /// the payload (it reads the buffer itself), so we don't need to copy
   /// the bytes per chunk.
   static final Uint8List _appendSignal = Uint8List(0);
 
   final StreamController<Uint8List> _controller = StreamController<Uint8List>();
   Stream<Uint8List> get stream => _controller.stream;
+
+  /// Whether the command at the head of the buffer has already been through
+  /// [InboundCommandValidator.validate].
   bool validated = false;
 
+  /// Offset of the terminator that ends the command at the head of the
+  /// buffer, or -1 while the buffer holds no complete command.
+  int _terminatorAt = -1;
+
   StreamableByteBuffer({super.capacity});
+
+  int get _terminator => terminatingChar as int;
+
+  /// True when the buffer holds at least one complete command.
+  bool get hasCommand => _terminatorAt >= 0;
 
   @override
   void append(dynamic data) {
     List<int> bytes = data as List<int>;
-    _controller.add(_appendSignal);
+    if (_terminatorAt < 0) {
+      final offset = bytes.indexOf(_terminator);
+      if (offset >= 0) {
+        _terminatorAt = length() + offset;
+      }
+    }
     super.append(bytes);
+    _controller.add(_appendSignal);
+  }
+
+  /// Removes the command at the head of the buffer and returns its bytes
+  /// without the terminator, leaving whatever followed the terminator
+  /// buffered as the start of the next command. Null when the buffer holds
+  /// no complete command.
+  List<int>? takeCommand() {
+    if (_terminatorAt < 0) return null;
+    final buffered = getData();
+    final command = buffered.sublist(0, _terminatorAt);
+    final remainder = buffered.sublist(_terminatorAt + 1);
+    clear();
+    if (remainder.isNotEmpty) {
+      _terminatorAt = remainder.indexOf(_terminator);
+      super.append(remainder);
+    }
+    return command;
   }
 
   @override
   void clear() {
     validated = false;
+    _terminatorAt = -1;
     super.clear();
   }
 
+  /// Runs [InboundCommandValidator.validate] over the command at the head of
+  /// the buffer, at most once per command.
   void validate(AtConnection connection) {
     if (validated) return;
     final len = length();
     if (len == 0) return;
-    // Defer validation until we have either a terminating `\n` or
-    // enough bytes (see [InboundCommandValidator.minBytesForValidation])
-    // to fully cover the longest possible verb+subcommand. Validating
-    // against a shorter partial buffer would reject the first fragment
-    // of a fragmented command (e.g. `'loo'` arriving before
-    // `'kup:publickey@alice\n'`) and bin the buffer, dropping the
-    // command bytes still in flight.
-    if (!isEnd() && len < InboundCommandValidator.minBytesForValidation) {
+    // Defer validation until we have either a complete command or enough
+    // bytes (see [InboundCommandValidator.minBytesForValidation]) to fully
+    // cover the longest possible verb+subcommand. Validating against a
+    // shorter partial buffer would reject the first fragment of a fragmented
+    // command (e.g. `'loo'` arriving before `'kup:publickey@alice\n'`) and
+    // bin the buffer, dropping the command bytes still in flight.
+    if (!hasCommand && len < InboundCommandValidator.minBytesForValidation) {
       return;
     }
-    InboundCommandValidator.validate(getData(), connection);
+    final buffered = getData();
+    InboundCommandValidator.validate(
+        hasCommand ? buffered.sublist(0, _terminatorAt) : buffered, connection);
     validated = true;
   }
 }

--- a/packages/at_secondary_server/pubspec.yaml
+++ b/packages/at_secondary_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_secondary
 description: Implementation of secondary server.
-version: 3.16.5
+version: 3.16.6
 repository: https://github.com/atsign-foundation/at_server
 homepage: https://www.example.com
 publish_to: none

--- a/packages/at_secondary_server/test/inbound_message_listener_test.dart
+++ b/packages/at_secondary_server/test/inbound_message_listener_test.dart
@@ -476,4 +476,173 @@ void main() async {
               '${fakeConnection.writes}');
     });
   });
+
+  group('A test to verify commands are framed one per terminator', () {
+    /// Feeds [flows] into a listener over [fakeConnection], one addData per
+    /// element with [gapMillis] between them, and returns the commands the
+    /// listener dispatched.
+    Future<List<String>> dispatchedFor(List<String> flows,
+        {int gapMillis = 0}) async {
+      final commands = <String>[];
+      InboundMessageListener(fakeConnection).listen(
+          (String command, InboundConnection connection) async =>
+              commands.add(command),
+          (List<int> data, InboundConnection connection) {});
+      for (final flow in flows) {
+        fakeConnection.socket.addData(flow);
+        if (gapMillis > 0) {
+          await Future.delayed(Duration(milliseconds: gapMillis));
+        }
+      }
+      await Future.delayed(Duration(milliseconds: 60));
+      return commands;
+    }
+
+    test('monitor then noop:0 in ONE flow are dispatched as two commands',
+        () async {
+      // Reproducer for a production bug. at_lookup runs `noop:0` heartbeats
+      // on the same connection it runs the monitor on. When two commands
+      // landed in one read event the buffer dispatched everything it held as
+      // a single command -- 'monitor\nnoop:0' -- which no verb syntax
+      // matches (the regexes are `^..$` without multiLine, and `.` does not
+      // cross a newline). The client got one error:AT0003 frame, the monitor
+      // was never registered and the noop never ran, on a connection that
+      // stayed open: a client reporting `listening` while permanently deaf.
+      expect(await dispatchedFor(['monitor\nnoop:0\n']), ['monitor', 'noop:0'],
+          reason: 'Both commands should be dispatched, in arrival order');
+      expect(fakeConnection.writes, isEmpty,
+          reason: 'Neither command is a syntax error, so this layer should '
+              'write nothing; the connection saw ${fakeConnection.writes}');
+    });
+
+    test('the other order is framed too (noop:0 then monitor)', () async {
+      // The bare `monitor` arm above fails in InboundCommandValidator (the
+      // first colon lands inside `noop:0`, so the verb reads as
+      // 'monitor\nnoop'), this one gets past it and fails in the verb
+      // syntax. Both orders have to be pinned: they break in different
+      // places.
+      expect(await dispatchedFor(['noop:0\nmonitor\n']), ['noop:0', 'monitor'],
+          reason: 'Both commands should be dispatched, in arrival order');
+      expect(fakeConnection.writes, isEmpty);
+    });
+
+    test('three commands in one flow are dispatched in order', () async {
+      expect(
+          await dispatchedFor(['from:@alice\nscan\ninfo\n']),
+          ['from:@alice', 'scan', 'info'],
+          reason: 'The drain loop should not stop after the first command');
+    });
+
+    test('a fragmented command followed by a pipelined one', () async {
+      // The fragment reassembly and the framing have to hold at once: the
+      // first flow ends mid-command and the second carries its tail AND a
+      // whole further command.
+      expect(
+          await dispatchedFor(['lookup:publi', 'ckey@alice\nnoop:0\n'],
+              gapMillis: 15),
+          ['lookup:publickey@alice', 'noop:0'],
+          reason: 'The tail of flow 1 and the head of flow 2 are one command; '
+              'what follows the terminator is a second one');
+      expect(fakeConnection.writes, isEmpty);
+    });
+
+    test('a partial command left after the terminator stays buffered',
+        () async {
+      // Flow 1 holds one complete command plus the first bytes of the next.
+      // The complete one goes out now; the partial must survive in the
+      // buffer until flow 2 completes it, rather than being dispatched
+      // truncated or binned.
+      expect(await dispatchedFor(['from:@alice\nnoo', 'p:0\n'], gapMillis: 15),
+          ['from:@alice', 'noop:0'],
+          reason: 'The trailing partial command must be preserved across '
+              'flows');
+      expect(fakeConnection.writes, isEmpty);
+    });
+
+    test('a pipelined command waits for the previous handler to finish',
+        () async {
+      // Pipelined commands are dispatched one at a time: a request-response
+      // protocol whose replies come back in completion order rather than
+      // arrival order would hand the client the wrong reply for its command.
+      final events = <String>[];
+      InboundMessageListener(fakeConnection).listen(
+          (String command, InboundConnection connection) async {
+            events.add('start:$command');
+            await Future.delayed(Duration(milliseconds: 20));
+            events.add('end:$command');
+          },
+          (List<int> data, InboundConnection connection) {});
+      fakeConnection.socket.addData('scan\ninfo\n');
+      await Future.delayed(Duration(milliseconds: 150));
+      expect(events, ['start:scan', 'end:scan', 'start:info', 'end:info'],
+          reason: 'info must not start until scan has finished');
+    });
+
+    test('a rejected command bins the rest of the pipeline', () async {
+      // `update` requires auth and `from:`/`scan` do not. The refusal has to
+      // stop the drain: dispatching the commands queued behind a rejected
+      // one would run them for a caller the validator has just refused.
+      AtSecondaryServerImpl.getInstance().currentAtSign = '@alice'.toAtsign();
+      final unauthenticated =
+          FakeInboundConnection(FakeSocket(), InboundConnectionMetadata());
+      final commands = <String>[];
+      InboundMessageListener(unauthenticated).listen(
+          (String command, InboundConnection connection) async =>
+              commands.add(command),
+          (List<int> data, InboundConnection connection) {});
+      unauthenticated.socket
+          .addData('from:@alice\nupdate:public:phone@alice 1234\nscan\n');
+      await Future.delayed(Duration(milliseconds: 60));
+      expect(commands, ['from:@alice'],
+          reason: 'update is refused unauthenticated, and scan is queued '
+              'behind it');
+      expect(unauthenticated.writes.length, 1,
+          reason: 'One error frame, for the refused update: '
+              '${unauthenticated.writes}');
+      expect(unauthenticated.writes.single, startsWith('error:'));
+    });
+
+    test('a command arriving DURING another command\'s handler is dispatched '
+        'after it, not alongside it', () async {
+      // The append signal for flow 2 lands while the drain loop is awaiting
+      // flow 1's handler, and is dropped. The running loop has to pick those
+      // bytes up when it comes back round, because nothing else will signal
+      // it: a dropped signal with no follow-up flow would leave the command
+      // sitting in the buffer for ever.
+      final events = <String>[];
+      InboundMessageListener(fakeConnection).listen(
+          (String command, InboundConnection connection) async {
+            events.add('start:$command');
+            await Future.delayed(Duration(milliseconds: 40));
+            events.add('end:$command');
+          },
+          (List<int> data, InboundConnection connection) {});
+      fakeConnection.socket.addData('scan\n');
+      await Future.delayed(Duration(milliseconds: 10));
+      fakeConnection.socket.addData('info\n');
+      await Future.delayed(Duration(milliseconds: 200));
+      expect(events, ['start:scan', 'end:scan', 'start:info', 'end:info'],
+          reason: 'info must be dispatched, and only once scan has finished');
+    });
+
+    test('an empty flow does not disturb the buffer', () async {
+      // A WebSocket client can deliver an empty message, which reaches the
+      // buffer as a zero-byte append. Asking an empty buffer for its last
+      // byte raises a StateError, which is an Error rather than an Exception
+      // — so it is not caught where a bad command is, and the connection is
+      // torn down for a message that said nothing.
+      expect(await dispatchedFor(['', 'scan\n'], gapMillis: 15), ['scan'],
+          reason: 'The empty flow should be inert, and the command after it '
+              'should still be dispatched');
+      expect(fakeConnection.closeCount, 0,
+          reason: 'An empty flow must not close the connection');
+      expect(fakeConnection.writes, isEmpty);
+    });
+
+    test('@exit mid-pipeline stops the drain', () async {
+      expect(await dispatchedFor(['scan\n@exit\nfrom:@alice\n']), ['scan'],
+          reason: '@exit closes the connection; anything queued behind it '
+              'must not be dispatched');
+    });
+  });
 }

--- a/packages/at_secondary_server/test/test_utils.dart
+++ b/packages/at_secondary_server/test/test_utils.dart
@@ -79,6 +79,9 @@ class FakeInboundConnection extends Fake implements InboundConnectionImpl {
   /// Every write the server-side code performs on this connection.
   final writes = <String>[];
 
+  /// How many times the server-side code has closed this connection.
+  int closeCount = 0;
+
   FakeInboundConnection(this.socket, this.metadata);
 
   @override
@@ -98,7 +101,9 @@ class FakeInboundConnection extends Fake implements InboundConnectionImpl {
   }
 
   @override
-  Future<void> close() async {}
+  Future<void> close() async {
+    closeCount++;
+  }
 }
 
 class MockInboundConnectionPool extends Mock implements InboundConnectionPool {}

--- a/tests/at_functional_test/test/monitor_command_framing_test.dart
+++ b/tests/at_functional_test/test/monitor_command_framing_test.dart
@@ -1,0 +1,109 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:at_functional_test/conf/config_util.dart';
+import 'package:at_functional_test/connection/outbound_connection_wrapper.dart';
+import 'package:at_functional_test/utils/auth_utils.dart';
+import 'package:test/test.dart';
+import 'package:uuid/uuid.dart';
+
+/// Functional coverage of inbound command framing: a client that writes
+/// `monitor` and `noop:0` in ONE socket write puts both commands in one read
+/// event, and both have to run.
+///
+/// That is the shape a notification connection carrying its own heartbeat
+/// has. Framed as a single command, `monitor:...\nnoop:0` matches no verb
+/// syntax — each is anchored `^...$` without `multiLine`, and `.` does not
+/// cross a newline — so the client gets one `error:AT0003` frame on a
+/// connection that stays open, with no monitor registered for it and the
+/// `noop:0` never run. The failure then presents as an atServer with nothing
+/// to say, which is why the notification below is the assertion that matters.
+///
+/// The monitor is read over a RAW socket rather than
+/// [OutboundConnectionFactory]: that wrapper's listener only surfaces
+/// responses beginning `data:`, `stream:`, `error:` or `@...@`
+/// (`OutboundMessageListener._isValidResponse`), and a monitor frame begins
+/// `notification:`, so the wrapper structurally cannot read one.
+void main() {
+  String atSign = ConfigUtil.getYaml()!['firstAtSignServer']['firstAtSignName'];
+  String host = ConfigUtil.getYaml()!['firstAtSignServer']['firstAtSignUrl'];
+  int port = ConfigUtil.getYaml()!['firstAtSignServer']['firstAtSignPort'];
+
+  test(
+      'a monitor and the noop:0 written with it are both executed, and the '
+      'monitor is delivered a notification', () async {
+    OutboundConnectionFactory owner = await OutboundConnectionFactory()
+        .initiateConnectionWithListener(atSign, host, port);
+    expect((await owner.authenticateConnection(authType: AuthType.cram)).trim(),
+        'data:success');
+
+    // The notification is created BEFORE the monitor connects and is replayed
+    // from a timestamp, so its delivery does not race the monitor's socket
+    // becoming ready.
+    int since = DateTime.now().toUtc().millisecondsSinceEpoch - 1000;
+    String notifiedKey = 'framing-${Uuid().v4().hashCode}.wavi';
+    expect(
+        (await owner.sendRequestToServer('notify:update:ttr:-1:$atSign:'
+                '$notifiedKey$atSign:framing-value'))
+            .trim(),
+        startsWith('data:'));
+
+    StringBuffer received = StringBuffer();
+    Completer<void> monitorAnswered = Completer<void>();
+    SecureSocket socket = await SecureSocket.connect(host, port);
+    bool cramSent = false;
+    bool monitorSent = false;
+
+    // Chunks are accumulated and matched against the whole buffer: the '@'
+    // prompt and the `from:` challenge can arrive coalesced in one read, so a
+    // startsWith on an individual chunk misses them.
+    socket.listen((data) {
+      received.write(utf8.decode(data));
+      String all = received.toString();
+      if (!cramSent && all.contains('data:_')) {
+        cramSent = true;
+        int start = all.indexOf('data:_') + 'data:'.length;
+        int end = all.indexOf('\n', start);
+        String challenge =
+            all.substring(start, end == -1 ? all.length : end).trim();
+        socket.write(
+            'cram:${AuthenticationUtils.getCRAMDigest(atSign, challenge)}\n');
+      } else if (cramSent && !monitorSent && all.contains('data:success')) {
+        monitorSent = true;
+        // ONE write, so both commands reach the atServer in one read event.
+        // Writing them separately, or flushing between them, would leave the
+        // framing unexercised.
+        socket.write('monitor:selfNotifications:$since\nnoop:0\n');
+      } else if (!monitorAnswered.isCompleted &&
+          all.contains('data:ok') &&
+          all.contains(notifiedKey)) {
+        monitorAnswered.complete();
+      }
+    });
+
+    socket.write('from:$atSign\n');
+    // Bounded rather than a fixed wait: green returns as soon as both the
+    // noop's reply and the notification are in, and red still reports what
+    // did arrive.
+    await monitorAnswered.future.timeout(Duration(seconds: 30),
+        onTimeout: () {});
+    await socket.close();
+    await owner.close();
+
+    String delivered = received.toString();
+    // The control: the connection got as far as authenticating, so what
+    // follows is about the framing and not about a socket that never worked.
+    expect(delivered, contains('data:success'),
+        reason: 'the monitor connection must have CRAM-authenticated. '
+            'Received: $delivered');
+    expect(delivered, contains('data:ok'),
+        reason: 'the noop:0 that arrived in the same read event as the '
+            'monitor must be executed. Received: $delivered');
+    expect(delivered, contains(notifiedKey),
+        reason: 'the monitor must be registered and deliver $notifiedKey. '
+            'Received: $delivered');
+    expect(delivered, isNot(contains('error:AT0003')),
+        reason: 'neither command is a syntax error. Received: $delivered');
+  }, timeout: Timeout(Duration(minutes: 2)));
+}


### PR DESCRIPTION
**- What I did**
- fix: frame inbound requests one per terminator, so two commands that arrive together are handled as two commands
- test: unit coverage of the framing, plus a functional test of the pipelined `monitor` and `noop:0` case

**- Why**
- What arrives on a connection is a byte stream, not a command, but the inbound buffer dispatched everything it was holding as a single command, and no verb syntax matches that
- So two commands written without waiting for the first response, landing in the same read event, got one `error:AT0003` frame between them and neither of them ran. The connection stayed open, since an invalid syntax exception doesn't close it
- Example - a client sends `monitor` and immediately follows it with `noop:0`, which is what a notification connection does when it carries its own heartbeat. Both land in one read event, the atServer treats `monitor\nnoop:0` as one command and rejects it, and the client then sits there believing it is listening while the atServer has no monitor for it at all

Not specific to `monitor`, and not specific to `noop:0`. Any two commands in one read event hit it.

**NB** No client currently does this; this PR is in part as a precaution for the future when some client DOES do this

**- How I did it**

See commits. `StreamableByteBuffer` records where the terminator is as bytes are appended, and `takeCommand()` hands out one command at a time, leaving anything after that terminator in the buffer as the start of the next command. The listener drains the buffer in arrival order and waits for each command's handler before taking the next one, so replies can't come back out of order. On trunk they can. Validation is per command rather than per buffer, and a verb split across two reads is still reassembled before it runs.

Nothing else changes: no verb handler, no response handler, no write path. A client which waits for each response sees what it saw before. The outbound listener already framed per boundary, so this brings the inbound side into line with it.

Note that `monitor:multiplexed` is still accepted and ignored, so a notification can still be written between a command on a monitor connection and its reply.

**- How to verify it**
Tests pass.

New in `packages/at_secondary_server/test/inbound_message_listener_test.dart`:
- monitor then noop:0 in ONE flow are dispatched as two commands
- the other order is framed too (noop:0 then monitor)
- three commands in one flow are dispatched in order
- a fragmented command followed by a pipelined one
- a partial command left after the terminator stays buffered
- a pipelined command waits for the previous handler to finish
- a command arriving DURING another command's handler is dispatched after it, not alongside it
- a rejected command bins the rest of the pipeline
- an empty flow does not disturb the buffer
- @exit mid-pipeline stops the drain

New in `tests/at_functional_test/test/monitor_command_framing_test.dart`:
- a monitor and the noop:0 written with it are both executed, and the monitor is delivered a notification

All eleven go red against trunk's listener.

**- Description for the changelog**
Two commands arriving in one read event are now dispatched as two commands rather than as one unparseable one.
