### PR TITLE
ci(at_server): drop the pub.dev credential setup-dart mints from the OIDC token

### DIFF
--- a/.github/workflows/at_server.yaml
+++ b/.github/workflows/at_server.yaml
@@ -47,6 +47,16 @@ jobs:
         with:
           sdk: ${{ matrix.dart-channel}}
 
+      # setup-dart mints an OIDC token for pub.dev whenever the job grants
+      # id-token: write, and configures pub to send it on every request. pub.dev
+      # refuses reads carrying a token it does not recognise, so every `dart pub
+      # get` below fails with "Insufficient permissions". Nothing in this repo
+      # publishes to pub.dev, so the credential has no other use here; the
+      # permission stays for the tag-gated attestation step. `|| true` because
+      # pub exits 65 when there was no token to remove.
+      - name: Drop the pub.dev credential minted from the OIDC token
+        run: dart pub token remove https://pub.dev || true
+
       # Runs dart lint rules and unit tests on at_persistence_root_server
       - name: Install dependencies in at_persistence_root_server
         working-directory: ${{ env.proot-working-directory }}


### PR DESCRIPTION
**- What I did**

Stopped the `unit_tests` job authenticating to pub.dev, so its `dart pub get` steps work again.

**- Why**
- The `setup-dart` mints a GitHub OIDC token for pub.dev whenever the job grants `id-token: write`, and configures pub to send it on every request
- pub.dev now refuses reads carrying a token it does not recognise, so the job's first `dart pub get` dies with `Insufficient permissions to the resource at the https://pub.dev package repository` and exit 69 — four consecutive runs, both channels:
  - [unit_tests (stable)](https://github.com/atsign-foundation/at_server/actions/runs/34477658864/job/102872286603)
  - [unit_tests (beta)](https://github.com/atsign-foundation/at_server/actions/runs/34477658864/job/102872286594)

Nothing in this repo publishes to pub.dev, so that credential has no use here.

**- How I did it**

One step after `setup-dart`: `dart pub token remove https://pub.dev || true`. `id-token: write` stays, because the tag-gated `actions/attest` step in the same job needs it. The `|| true` is important: pub exits 65 when there is no token to remove, and `run:` uses `bash -e`.

**- How to verify it**

Tests pass.
